### PR TITLE
Refactoring `procBlock`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,6 @@ alloy
 node_modules/
 *~
 .stack-work/
+Substance 
+Style
+build/

--- a/src/Functions.hs
+++ b/src/Functions.hs
@@ -11,8 +11,12 @@ type ObjFnOn a = [Obj' a] -> [a] -> a
 type ConstrFnOn a = [Obj' a] -> [a] -> a
 type ObjFn = forall a. (Autofloat a) => [Obj' a] -> [a] -> a
 type ConstrFn = forall a. (Autofloat a) => [Obj' a] -> [a] -> a
+type ObjFnInfo a = (ObjFnOn a, Weight a, [Name], [a])
+type ConstrFnInfo a = (ConstrFnOn a, Weight a, [Name], [a])
 type Weight a = a
 type PairConstrV a = forall a . (Autofloat a) => [[a]] -> a -- takes pairs of "packed" objs
+
+data FnInfo a = ObjFnInfo a | ConstrFnInfo a
 
 -- | 'constrFuncDict' stores a mapping from the name of constraint functions to the actual implementation
 constrFuncDict :: forall a. (Autofloat a) => M.Map String (ConstrFnOn a)
@@ -194,8 +198,8 @@ repel' x y = 1 / distsq x y + epsd
 
 -- TODO move this elsewhere? (also applies to polyline)
 bezierBbox :: (Floating a, Ord a) => CubicBezier' a -> ((a, a), (a, a)) -- poly Point type?
-bezierBbox cb = let path = pathcb' cb 
-                    (xs, ys) = (map fst path, map snd path) 
+bezierBbox cb = let path = pathcb' cb
+                    (xs, ys) = (map fst path, map snd path)
                     lower_left = (minimum xs, minimum ys)
                     top_right = (maximum xs, maximum ys) in
                     (lower_left, top_right)
@@ -206,8 +210,8 @@ centerLabel :: ObjFn
 -- TODO smarter bezier/polyline label function
 -- TODO specify rotation on labels?
 centerLabel [CB' bez, L' lab] _ = -- use the float input? just for testing
-            let ((lx, ly), (rx, ry)) = bezierBbox bez 
-                (xmargin, ymargin) = (-10, 30) 
+            let ((lx, ly), (rx, ry)) = bezierBbox bez
+                (xmargin, ymargin) = (-10, 30)
                 midbez = ((lx + rx) / 2 + xmargin, (ly + ry) / 2 + ymargin) in
             distsq midbez (getX lab, getY lab)
 
@@ -431,7 +435,7 @@ noSubset [[x1, y1, s1], [x2, y2, s2]] = let offset = 10 in -- max/min dealing wi
          -(dist (x1, y1) (x2, y2)) + max s2 s1 - min s2 s1 + offset
 
 -- the first (circular) set is the subset of the second (circular) set, and thus smaller than the second.
--- The distance between the centers of the sets must be less than the difference between 
+-- The distance between the centers of the sets must be less than the difference between
 -- the radius of the outer set and the radius of the inner set.
 -- TODO: test for equal sets? (function is minimized if sets have same radii and location)
 strictSubset :: PairConstrV a

--- a/src/Runtime.hs
+++ b/src/Runtime.hs
@@ -65,8 +65,6 @@ data State = State { objs :: [Obj]
                    }  deriving (Typeable)
 
 type Config = M.Map String S.Expr
-type ObjFnInfo a = (ObjFnOn a, Weight a, [Name], [a])
-type ConstrFnInfo a = (ConstrFnOn a, Weight a, [Name], [a])
 
 -- | Datatypes for computation. ObjComp is gathered in pre-compilation and passed to functions that evaluate the computation.
 -- | object name, function name, list of args (TODO resolve them WRT pattern matching)
@@ -162,19 +160,19 @@ circPack cir params = Circ' { xc' = xc1, yc' = yc1, r' = r1, namec' = namec cir,
                                 else (params !! 0, params !! 1, params !! 2)
 
 ellipsePack :: (Autofloat a) => Ellipse -> [a] -> Ellipse' a
-ellipsePack e params = Ellipse' { xe' = xe1, ye' = ye1, rx' = rx1, ry' = ry1, namee' = namee e, 
+ellipsePack e params = Ellipse' { xe' = xe1, ye' = ye1, rx' = rx1, ry' = ry1, namee' = namee e,
                                   colore' = colore e }
          where (xe1, ye1, rx1, ry1) = if not $ length params == 4 then error "wrong # params to pack circle"
                                 else (params !! 0, params !! 1, params !! 2, params !! 3)
 
 sqPack :: (Autofloat a) => Square -> [a] -> Square' a
-sqPack sq params = Square' { xs' = xs1, ys' = ys1, side' = side1, names' = names sq, 
+sqPack sq params = Square' { xs' = xs1, ys' = ys1, side' = side1, names' = names sq,
                              sels' = sels sq, colors' = colors sq, ang' = ang sq}
          where (xs1, ys1, side1) = if not $ length params == 3 then error "wrong # params to pack square"
                                 else (params !! 0, params !! 1, params !! 2)
 
 rectPack :: (Autofloat a) => Rect -> [a] -> Rect' a
-rectPack rct params = Rect' { xr' = xs1, yr' = ys1, sizeX' = len, sizeY' = wid, namer' = namer rct, 
+rectPack rct params = Rect' { xr' = xs1, yr' = ys1, sizeX' = len, sizeY' = wid, namer' = namer rct,
                               selr' = selr rct, colorr' = colorr rct, angr' = angr rct}
          where (xs1, ys1, len, wid) = if not $ length params == 4 then error "wrong # params to pack rect"
                                 else (params !! 0, params !! 1, params !! 2, params !! 3)
@@ -258,14 +256,14 @@ computeOn objDict comp =
                            Just function -> let objRes = applyAndSet objDict comp function obj in
                                             M.insert objName objRes objDict
 
--- | Look up the arguments to a computation, apply the computation, 
+-- | Look up the arguments to a computation, apply the computation,
 -- | and set the property in the object to the result.
 applyAndSet :: (Autofloat a) => M.Map Name (Obj' a) -> ObjComp -> CompFn a -> Obj' a -> Obj' a
-applyAndSet objDict comp function obj = 
+applyAndSet objDict comp function obj =
           let (objName, objProperty, fname, args) = (oName comp, oProp comp, fnName comp, fnParams comp) in
           -- Style computations rely on the order of object inputs being the same as program arguments.
           let (constArgs, objectArgs) = partitionEithers $ map (styExprToCompExpr objDict) args in
-          let res = function constArgs (concat objectArgs) in 
+          let res = function constArgs (concat objectArgs) in
           -- TODO: for multiple objects, might not be in right order. alphabetize?
           set objProperty obj res
 
@@ -283,12 +281,12 @@ styExprToCompExpr objs e = case e of
                 S.Cons _ _     -> error "computatons don't support object constructors (?)"
                 S.CompArgs _ _ -> error "computations don't support nested computations"
 
--- e.g. for an object named "domain", returns "domain" as well as secondary shapes "domain_shape1", "domain_shape100", etc. will also return things like "domain_shape1_extra" 
+-- e.g. for an object named "domain", returns "domain" as well as secondary shapes "domain_shape1", "domain_shape100", etc. will also return things like "domain_shape1_extra"
 -- TODO: assumes secondary objects are named in Style with "shape.*" and assigned internal names "$Substanceidentifier_shape.*"
 -- Maybe add the ability to pass in "expected" types, or to synthesize types and then check if they match?
 lookupAll :: Name -> M.Map Name (Obj' a) -> [Obj' a]
 lookupAll name objs = map snd $ M.toList $ M.filterWithKey (objOrSecondaryShape name) objs
-           where objOrSecondaryShape name inName _ = name == inName 
+           where objOrSecondaryShape name inName _ = name == inName
                                                     || (name ++ secondaryIndicator) `isPrefixOf` inName
                  secondaryIndicator = "_shape"
 
@@ -297,7 +295,7 @@ lookupAll name objs = map snd $ M.toList $ M.filterWithKey (objOrSecondaryShape 
 defName = "default"
 
 -- default shapes at base types (not obj)
-defSolidArrow = SolidArrow { startx = 100, starty = 100, endx = 200, endy = 200, 
+defSolidArrow = SolidArrow { startx = 100, starty = 100, endx = 200, endy = 200,
                                 thickness = 10, selsa = False, namesa = defName, colorsa = black }
 defPt = Pt { xp = 100, yp = 100, selp = False, namep = defName }
 defSquare = Square { xs = 100, ys = 100, side = defaultRad,
@@ -305,23 +303,23 @@ defSquare = Square { xs = 100, ys = 100, side = defaultRad,
 defRect = Rect { xr = 100, yr = 100, sizeX = defaultRad, sizeY = defaultRad + 200,
                           selr = False, namer = defName, colorr = black, angr = 0.0}
 defText = Label { xl = -100, yl = -100, wl = 0, hl = 0, textl = defName, sell = False, namel = defName }
-defLabel = Label { xl = -100, yl = -100, wl = 0, hl = 0, textl = defName, sell = False, 
+defLabel = Label { xl = -100, yl = -100, wl = 0, hl = 0, textl = defName, sell = False,
                         namel = labelName defName }
 defCirc = Circ { xc = 100, yc = 100, r = defaultRad, selc = False, namec = defName, colorc = black }
-defEllipse = Ellipse { xe = 100, ye = 100, rx = defaultRad, ry = defaultRad, 
+defEllipse = Ellipse { xe = 100, ye = 100, rx = defaultRad, ry = defaultRad,
                             namee = defName, colore = black }
 defCurve = CubicBezier { colorcb = black, pathcb = path, namecb = defName, stylecb = "solid" }
     where path = [(10, 100), (300, 100)]
 
 -- default shapes
-defaultSolidArrow, defaultPt, defaultSquare, defaultRect, 
+defaultSolidArrow, defaultPt, defaultSquare, defaultRect,
                    defaultCirc, defaultText, defaultEllipse :: String -> Obj
 defaultSolidArrow name = A $ setName name defSolidArrow
 defaultPt name = P $ setName name defPt
 defaultSquare name = S $ setName name defSquare
 defaultRect name = R $ setName name defRect
 -- Set both the text and name fields to the same thing (unlike labels)
-defaultText text = L $ setName text defText { textl = text } 
+defaultText text = L $ setName text defText { textl = text }
 defaultCirc name = C $ setName name defCirc
 defaultEllipse name = E $ setName name defEllipse
 defaultCurve name = CB $ setName name defCurve
@@ -329,7 +327,7 @@ defaultCurve name = CB $ setName name defCurve
 -- If an object's name is X and it is labeled "Set X", the label name is "Label_X" and the text is "Set X"
 -- "Auto" is reserved text that labels the object with the Substance name; in this case it would be "X"
 defaultLabel :: String -> String -> Obj
-defaultLabel objName labelText = 
+defaultLabel objName labelText =
              L $ setName (labelName objName) defLabel { textl = checkAuto objName labelText }
              where checkAuto o "Auto" = o
                    checkAuto o t = t
@@ -353,10 +351,10 @@ shapeAndFn dict name =
         thd4 (_, _, a, _) = a
         frth4 (_, _, _, a) = a
 
-getShape :: (Autofloat a) => (String, (S.StyObj, Config)) ->
+getShape :: (Autofloat a) => (String, (S.StyType, Config)) ->
                              ([Obj], [ObjFnInfo a], [ConstrFnInfo a], [ObjComp])
 
-getShape (oName, (objType, config)) = 
+getShape (oName, (objType, config)) =
          -- We don't need the object type to typecheck the computation, because we have the object's name and
          -- it's stored as an Obj (can pattern-match)
          let (computations, config_nocomps) = compsAndVars oName config in
@@ -390,13 +388,13 @@ getShape (oName, (objType, config)) =
 -- TODO: should initX get its type? should this function use objProperties?
 -- Given a config, separates the computations and the vars and returns both
 compsAndVars :: Name -> Config -> ([ObjComp], Config)
-compsAndVars n config = 
+compsAndVars n config =
          let comps = map snd $ M.toList $ M.mapMaybeWithKey toComp config in
          let config_nocomps = M.mapMaybe notComp config in -- could use M.partition
          (comps, config_nocomps)
          where toComp :: Property -> S.Expr -> Maybe ObjComp
                toComp propertyName expr = case expr of
-                             S.CompArgs fn args -> Just $ ObjComp { oName = n, oProp = propertyName, 
+                             S.CompArgs fn args -> Just $ ObjComp { oName = n, oProp = propertyName,
                                                                     fnName = fn, fnParams = args }
                              _                  -> Nothing
                notComp :: S.Expr -> Maybe S.Expr
@@ -411,8 +409,8 @@ noneWord = "None"
 autoWord = "Auto"
 labelWord = "text"
 
-labelSetting :: Maybe S.Expr -> S.StyObj -> Name -> LabelSetting
-labelSetting s_expr objType objName = 
+labelSetting :: Maybe S.Expr -> S.StyType -> Name -> LabelSetting
+labelSetting s_expr objType objName =
              case objType of
                   S.NoShape -> NoLabel
                   _ -> case s_expr of
@@ -510,7 +508,7 @@ declMapObjfn = centerMap
 map4 :: (a -> b) -> (a, a, a, a) -> (b, b, b, b)
 map4 f (w, x, y, z) = (f w, f x, f y, f z)
 
-genAllObjs :: (Autofloat a) => ([C.SubDecl], [C.SubConstr]) -> S.StyDict 
+genAllObjs :: (Autofloat a) => ([C.SubDecl], [C.SubConstr]) -> S.StyDict
                                -> ([Obj], [ObjFnInfo a], [ConstrFnInfo a], [ObjComp])
 -- TODO figure out how the types work. also add weights
 genAllObjs (decls, constrs) stys = (concat objss, concat objFnss, concat constrFnss, concat compss)
@@ -1136,7 +1134,7 @@ zeroGrad (C' c) = C $ Circ { xc = r2f $ xc' c, yc = r2f $ yc' c, r = r2f $ r' c,
                              selc = selc' c, namec = namec' c, colorc = colorc' c }
 zeroGrad (E' e) = E $ Ellipse { xe = r2f $ xe' e, ye = r2f $ ye' e, rx = r2f $ rx' e, ry = r2f $ ry' e,
                               namee = namee' e, colore = colore' e }
-zeroGrad (S' s) = S $ Square { xs = r2f $ xs' s, ys = r2f $ ys' s, side = r2f $ side' s, sels = sels' s, 
+zeroGrad (S' s) = S $ Square { xs = r2f $ xs' s, ys = r2f $ ys' s, side = r2f $ side' s, sels = sels' s,
                              names = names' s, colors = colors' s, ang = ang' s }
 zeroGrad (R' r) = R $ Rect { xr = r2f $ xr' r, yr = r2f $ yr' r, sizeX = r2f $ sizeX' r, sizeY = r2f $ sizeY' r,
                            selr = selr' r, namer = namer' r, colorr = colorr' r, angr = angr' r }
@@ -1162,8 +1160,8 @@ addGrad (E e) = E' $ Ellipse' { xe' = r2f $ xe e, ye' = r2f $ ye e, rx' = r2f $ 
                              namee' = namee e, colore' = colore e }
 addGrad (S s) = S' $ Square' { xs' = r2f $ xs s, ys' = r2f $ ys s, side' = r2f $ side s, sels' = sels s,
                             names' = names s, colors' = colors s, ang' = ang s }
-addGrad (R r) = R' $ Rect' { xr' = r2f $ xr r, yr' = r2f $ yr r, sizeX' = r2f $ sizeX r, 
-                           sizeY' = r2f $ sizeY r, selr' = selr r, namer' = namer r, 
+addGrad (R r) = R' $ Rect' { xr' = r2f $ xr r, yr' = r2f $ yr r, sizeX' = r2f $ sizeX r,
+                           sizeY' = r2f $ sizeY r, selr' = selr r, namer' = namer r,
                            colorr' = colorr r, angr' = angr r }
 addGrad (L l) = L' $ Label' { xl' = r2f $ xl l, yl' = r2f $ yl l, wl' = r2f $ wl l, hl' = r2f $ hl l,
                               textl' = textl l, sell' = sell l, namel' = namel l }
@@ -1267,7 +1265,7 @@ stepWithObjective objs fixed stateParams t state = (steppedState, objFnApplied, 
 appGrad :: (Autofloat a) => (forall b . (Autofloat b) => [b] -> b) -> [a] -> [a]
 appGrad f l = grad f l
 
-appGrad' :: (Autofloat' a) => 
+appGrad' :: (Autofloat' a) =>
          (forall b . (Autofloat b) => [b] -> b) -> [a] -> [a]
 appGrad' f l = grad f l
 

--- a/src/Style.hs
+++ b/src/Style.hs
@@ -278,9 +278,9 @@ attribute = identifier -- TODO: Naming convention - same as identifiers?
 -- Type aliases for readability in this section
 -- | 'StyContext' maintains the current output of the translater
 type StyContext a =
-    (StyDict, -- | dictionary mapping Substance ID to Style objects
-    [(ObjFnOn a, Weight a, [Name], [a])],    -- | List of objective functions
-    [(ConstrFnOn a, Weight a, [Name], [a])]) -- | List of constraints
+    (StyDict,         -- | dictionary mapping Substance ID to Style objects
+    [ObjFnInfo a],    -- | List of objective functions
+    [ConstrFnInfo a]) -- | List of constraints
 
 -- | A dictionary storing properties of a Style object, e.g. "start" for 'Arrow'
 type Properties = M.Map String Expr

--- a/src/Style.hs
+++ b/src/Style.hs
@@ -403,8 +403,8 @@ procBlock (dict, objFns, constrFns) ((Selector C.AllT []) : [], stmts) =
 -- assignments
 procBlock (dict, objFns, constrFns) (selector : [], stmts) =
     let mapsAndSpecs  = dict `matchWith` selector
-        newDict       = foldl (addShapes stmts) dict $ mapsAndSpecs
-        varmaps       = map fst $ mapsAndSpecs
+        newDict       = foldl (addShapes stmts) dict mapsAndSpecs
+        varmaps       = map fst mapsAndSpecs
         newObjFns     = concatMap (genFns procObjFn stmts)    varmaps
         newConstrFns  = concatMap (genFns procConstrFn stmts) varmaps
     in (newDict, objFns ++ newObjFns, constrFns ++ newConstrFns)
@@ -421,7 +421,7 @@ procBlock (dict, objFns, constrFns) (selector : [], stmts) =
 -- because it is not clear that which Substance object the shapes associate with
 procBlock (dict, objFns, constrFns) (selectors, stmts) =
     let mapsAndSpecs  = dict `matchWithAll` selectors
-        mergedMaps    = mergeMaps $ map (map fst) $ mapsAndSpecs
+        mergedMaps    = tr "mergedMaps: " $ mergeMaps $ map (map fst) mapsAndSpecs
         newObjFns     = concatMap (genFns procObjFn stmts)    mergedMaps
         newConstrFns  = concatMap (genFns procConstrFn stmts) mergedMaps
     in (dict, objFns ++ newObjFns, constrFns ++ newConstrFns)
@@ -429,7 +429,7 @@ procBlock (dict, objFns, constrFns) (selectors, stmts) =
         -- makes sure we don't bind same name with multiple Substance ids
         -- in a list of comma-separated selectors
         isOneToOne :: [VarMap] -> Bool
-        isOneToOne validMaps varmaps =
+        isOneToOne varmaps =
             let flatMap      = nub $ concatMap M.toAscList varmaps
                 bijection    = bijectify flatMap
             in  flatMap == bijection

--- a/src/Substance.hs
+++ b/src/Substance.hs
@@ -104,7 +104,7 @@ data SubConstr
 
 -- | 'substanceParser' is the top-level parser function. The parser contains a list of functions that parse small parts of the language. When parsing a source program, these functions are invoked in a top-down manner.
 substanceParser :: Parser [SubStmt]
-substanceParser = between sc eof subProg
+substanceParser = between scn eof subProg
 
 -- | 'subProg' parses the entire Substance program, which is a collection of statments
 subProg :: Parser [SubStmt]

--- a/src/Utils.hs
+++ b/src/Utils.hs
@@ -40,8 +40,8 @@ defaultWeight :: Floating a => a
 defaultWeight = 1
 
 -- Debug flags
-debug = False
-debugStyle = False
+debug = True
+debugStyle = True
 debugLineSearch = False
 debugObj = False -- turn on/off output in obj fn or constraint
 

--- a/src/Utils.hs
+++ b/src/Utils.hs
@@ -23,20 +23,8 @@ type Autofloat' a = (RealFloat a, Floating a, Real a, Show a, Ord a, Typeable a)
 
 type Pt2 a = (a, a)
 
-divLine = putStr "\n--------\n\n"
-
--- don't use r2f outside of zeroGrad or addGrad, since it doesn't interact well w/ autodiff
-r2f :: (Fractional b, Real a) => a -> b
-r2f = realToFrac
-
-toList :: a -> [a]
-toList x = [x]
-
-trd :: (a, b, c) -> c
-trd (_, _, x) = x
-
-tuplify2 :: [a] -> (a,a)
-tuplify2 [x,y] = (x,y)
+--------------------------------------------------------------------------------
+-- Parameters of the system
 
 stepsPerSecond :: Int
 stepsPerSecond = 100000
@@ -51,6 +39,7 @@ ptRadius = 4 -- The size of a point on canvas
 defaultWeight :: Floating a => a
 defaultWeight = 1
 
+-- Debug flags
 debug = False
 debugStyle = False
 debugLineSearch = False
@@ -63,11 +52,39 @@ subsetSizeDiff = 10.0
 epsd :: Floating a => a -- to prevent 1/0 (infinity). put it in the denominator
 epsd = 10 ** (-10)
 
+-- TODO: check naming convention of this
+labelName :: String -> String
+labelName name = "_Label_" ++ name
+
+--------------------------------------------------------------------------------
+-- General helper functions
+
+divLine :: IO ()
+divLine = putStr "\n--------\n\n"
+
+-- don't use r2f outside of zeroGrad or addGrad, since it doesn't interact well w/ autodiff
+r2f :: (Fractional b, Real a) => a -> b
+r2f = realToFrac
+
+-- | Wrap a list around anything
+toList :: a -> [a]
+toList x = [x]
+
+-- | similar to fst and snd, get the third element in a tuple
+trd :: (a, b, c) -> c
+trd (_, _, x) = x
+
+-- | transform from a 2-element list to a 2-tuple
+tuplify2 :: [a] -> (a,a)
+tuplify2 [x,y] = (x,y)
+
+-- | generic cartesian product of elements in a list
+cartesianProduct :: [[a]] -> [[a]]
+cartesianProduct = foldr f [[]] where f l a = [ x:xs | x <- l, xs <- a ]
+
+-- | given a side of a rectangle, compute the length of the half half diagonal
 halfDiagonal :: (Floating a) => a -> a
 halfDiagonal side = 0.5 * dist (0, 0) (side, side)
-
-labelName :: String -> String
-labelName name = "Label_" ++ name
 
 -- | `compose2` is used to compose with a function that takes in
 -- two arguments. As if now, it is used to compose `penalty` with

--- a/src/client.js
+++ b/src/client.js
@@ -270,7 +270,7 @@ $.getScript('snap.svg.js', function()
 		// TODO fix this!
                     var sizeX = obj.sizeX;
 		    var sizeY = obj.sizeY;
-                    var rect = s.rect(dx + obj.xr - sizeX/2, dy - obj.yr - sizeY/2, sizeX, sizeY); 
+                    var rect = s.rect(dx + obj.xr - sizeX/2, dy - obj.yr - sizeY/2, sizeX, sizeY);
 		// isn't this bottom left?
                     rect.data("name", obj.namer)
                     var color = obj.colorr;
@@ -351,7 +351,7 @@ $.getScript('snap.svg.js', function()
             });
         };
         ws.onmessage = function(event) {
-            // console.log(event.data)
+            console.log(event.data)
             var now  = new Date().getTime()
             var diff = (now - lastTime);
             var obj = jQuery.parseJSON(event.data)

--- a/src/sty/surjection.sty
+++ b/src/sty/surjection.sty
@@ -1,8 +1,8 @@
 global {
     objective toLeft(A, B)
     objective sameHeight(A, B)
-    objective sameX(A, B) 
-    constraint sameSizeAs(A, B) 
+    objective sameX(A, B)
+    constraint sameSizeAs(A, B)
 }
 
 Set s {
@@ -17,15 +17,15 @@ Value f p q {
     shape = Arrow {
         start = p
         end   = q
-        label = None
+        text = None
         test = p
     }
 }
 
 
 Point p {
-    shape = Dot { 
-        label = None 
+    shape = Dot {
+        text = None
     }
 }
 
@@ -39,5 +39,3 @@ In p S, In q S {
     objective sameX(p, q)
     objective repel(p, q)
 }
-
-

--- a/src/sty/tree.sty
+++ b/src/sty/tree.sty
@@ -1,6 +1,6 @@
 -- Tree.sty
 Set x { 
-    shape = Text { }
+    shape = Text { text = None }
 }
 
 Subset x y {
@@ -9,7 +9,7 @@ Subset x y {
     shape =  Arrow {
         start = x.shape
         end   = y.shape
-        label = None
+        text  = None
     }
 }
 

--- a/src/sty/venn_comp_simple.sty
+++ b/src/sty/venn_comp_simple.sty
@@ -1,6 +1,5 @@
-Point `B` {
-  shape = Dot { label = Auto }
-  objective centerLabel(B, B.label)
+Point `A` {
+  shape = Dot {}
 }
 
 Set A {


### PR DESCRIPTION
Refactored `procBlock` and some aliasing for readability of `Style`
* added underscore to all internal ids for labels
* modified tree.sty due to changes in label definition
* separated out selector logic.
* different `procBlock` cases
    * case 1: just one `global` selector -> process objs and constrs
once
    * case 2: just one selector -> the original logic
    * case 3: a list of comma separated selectors -> objs and constrs only and compute valid combinations among the selctors
