### PR TITLE
[new-style-fast] Improve namespace statics and port example Style pro…

### DIFF
--- a/src/sty/cart-test-pt.sty
+++ b/src/sty/cart-test-pt.sty
@@ -1,3 +1,12 @@
+global {
+  global.start = -100.0
+  global.setLength = 400.0
+}
+
+Colors {
+  Colors.orange = rgba(1.0, 0.25, 0.25, 0.5)
+}
+
 Set X {
   X.shape = Arrow {
     thickness = 10.0
@@ -9,17 +18,17 @@ Set X {
 
 -- TODO: have consts be calculated off of a global
 Set `domain` {
-    `domain`.shape.startX = -100.0
-    `domain`.shape.startY = -100.0
-    `domain`.shape.endX   = 300.0
-    `domain`.shape.endY   = -100.0
+    `domain`.shape.startX = global.start
+    `domain`.shape.startY = global.start
+    `domain`.shape.endX   = global.start + global.setLength
+    `domain`.shape.endY   = global.start
 }
 
 Set `codomain` {
-    `codomain`.shape.startX = -100.0
-    `codomain`.shape.startY = -100.0
-    `codomain`.shape.endX   = -100.0
-    `codomain`.shape.endY   = 300.0
+    `codomain`.shape.startX = global.start
+    `codomain`.shape.startY = global.start
+    `codomain`.shape.endX   = global.start
+    `codomain`.shape.endY   = global.start + global.setLength
 }
 
 -- Set `domain`; Set `codomain`
@@ -45,7 +54,7 @@ Point p {
         r     = 20.0
         x     = 130.0
         y     = 180.0
-        color = rgba(1.0, 0.25, 0.25, 0.5)
+        color = Colors.orange
         stroke-width = 0.0
     }
 

--- a/src/sty/continuousmap.sty
+++ b/src/sty/continuousmap.sty
@@ -1,6 +1,16 @@
+global {
+  global.strokeWidth = 1.5
+  global.padding = 20.0
+}
+
+Colors {
+  Colors.lightBlue = rgba(0.1, 0.1, 0.9, 0.2)
+  Colors.lightYellow = rgba(0.95, 0.96, 0.92, 0.5)
+}
+
 Set x {
     x.shape = Circle {
-        color = rgba(0.1, 0.1, 0.9, 0.2)
+        color = Colors.lightBlue
         stroke-style = "solid"
         stroke-width = 1.0
         rotation = 0.0
@@ -51,12 +61,12 @@ with Set X; Set Y; Set R1; Set R2 {
 
 Set `U` {
     override `U`.shape.stroke-style = "dashed"
-    override `U`.shape.stroke-width = 1.5
+    override `U`.shape.stroke-width = global.strokeWidth
 }
 
 Set `V` {
     override `V`.shape.stroke-style = "dashed"
-    override `V`.shape.stroke-width = 1.5
+    override `V`.shape.stroke-width = global.strokeWidth
 } 
 
 -- TODO: use subtyping for reals?
@@ -65,13 +75,13 @@ Set `Rn` {
       -- Works but is slow
       -- x = -100.0
       -- y = 0.0
-      color = rgba(0.95, 0.96, 0.92, 0.5)
+      color = Colors.lightYellow
       rotation = 0.0
-      stroke-width = 1.0
+      stroke-width = global.strokeWidth
     }
       
-    `Rn`.text.x = `Rn`.shape.x + `Rn`.shape.side / 2.0 - 20.0
-    `Rn`.text.y = `Rn`.shape.y + `Rn`.shape.side / 2.0 - 20.0
+    `Rn`.text.x = `Rn`.shape.x + `Rn`.shape.side / 2.0 - global.padding
+    `Rn`.text.y = `Rn`.shape.y + `Rn`.shape.side / 2.0 - global.padding
 
     delete `Rn`.labelFn
     delete `Rn`.outsideFn
@@ -81,7 +91,7 @@ Set `Rm`
 with Set `Rn` {
     -- TODO: factor this block out
     override `Rm`.shape = Square {
-        color = rgba(0.95, 0.96, 0.92, 0.5)
+        color = Colors.lightYellow
         y = `Rn`.shape.y
         x = `Rn`.shape.x + 400.0
         side  = `Rn`.shape.side
@@ -89,8 +99,8 @@ with Set `Rn` {
         stroke-width = 1.0
     }
 
-    `Rm`.text.x = `Rm`.shape.x + `Rm`.shape.side / 2.0 - 20.0
-    `Rm`.text.y = `Rm`.shape.y + `Rm`.shape.side / 2.0 - 20.0
+    `Rm`.text.x = `Rm`.shape.x + `Rm`.shape.side / 2.0 - global.padding
+    `Rm`.text.y = `Rm`.shape.y + `Rm`.shape.side / 2.0 - global.padding
 
     delete `Rm`.labelFn
     delete `Rm`.outsideFn

--- a/src/sty/surjection_computed.sty
+++ b/src/sty/surjection_computed.sty
@@ -1,3 +1,9 @@
+Colors {
+  Colors.black = rgba(0.0, 0.0, 0.0, 1.0)
+  Colors.lightBlue = rgba(0.1, 0.1, 0.9, 0.2)
+  Colors.darkBlue = rgba(0.05, 0.05, 0.6, 1.0)
+}
+
 Point p {
     p.shape = AnchorPoint { }
 }
@@ -43,7 +49,7 @@ with Set `codomain`, `domainOuter` {
   
     `domain`.left = Line {
         thickness = 2.0
-        color = rgba(0.0, 0.0, 0.0, 1.0)
+        color = Colors.black
         style = "dashed"
         startX = `domainOuter`.shape.startX + `domain`.left_margin * `domain`.outer_len
         startY = `domainOuter`.shape.startY
@@ -53,7 +59,7 @@ with Set `codomain`, `domainOuter` {
 
     `domain`.right = Line {
         thickness = 2.0
-        color = rgba(0.0, 0.0, 0.0, 1.0)      
+        color = Colors.black      
         style = "dashed"
         startX = `domainOuter`.shape.startX + `domain`.right_margin * `domain`.outer_len
         startY = `domainOuter`.shape.startY
@@ -75,7 +81,7 @@ with Set `codomain`, `domainOuter`{
   
     `image`.bottom = Line {
         thickness = 2.0
-        color = rgba(0.0, 0.0, 0.0, 1.0)
+        color = Colors.black
         style = "dashed"
         startX = `codomain`.shape.startX
         startY = `codomain`.shape.startY + `image`.bottom_margin * `image`.codomain_len
@@ -85,7 +91,7 @@ with Set `codomain`, `domainOuter`{
 
     `image`.top = Line {
         thickness = 2.0
-        color = rgba(0.0, 0.0, 0.0, 1.0)
+        color = Colors.black
         style = "dashed"
         startX = `codomain`.shape.startX
         startY = `codomain`.shape.startY + `image`.top_margin * `image`.codomain_len
@@ -104,7 +110,7 @@ where From(f, domain, image)
 with Set `domainOuter`; Set domain; Set image {
     f.shape = Curve {
         path = computeSurjectionLines(5, domain.left, domain.right, image.bottom, image.top)
-        color = rgba(0.05, 0.05, 0.6, 1.0)
+        color = Colors.darkBlue
     }
 
     f.text = Text {
@@ -121,6 +127,6 @@ with Set `domain`; Set `image` {
         y = (`image`.bottom.startY + `image`.top.startY) / 2.0
         w = `domain`.right.startX - `domain`.left.startX
         h = `image`.top.startY - `image`.bottom.startY
-        color = rgba(0.1, 0.1, 0.9, 0.2)
+        color = Colors.lightBlue
     }
 }

--- a/src/sty/tree.sty
+++ b/src/sty/tree.sty
@@ -2,7 +2,7 @@ Set x {
     x.shape = Text { string = x.label }
 }
 
--- TODO: Namespace behavior is making the Sty assignment "y." get overridden
+-- TODO: Selector behavior is making the Sty assignment "y." get overridden
 /*
 Set x; Set y {
    -- Try to make sure no labels overlap

--- a/src/sty/twopoints.sty
+++ b/src/sty/twopoints.sty
@@ -1,7 +1,16 @@
+global {
+  global.padding = 15.0
+}
+
+Colors {
+  Colors.black = rgba(0.0, 0.0, 0.0, 1.0)
+  Colors.pink = rgba(1.0, 0.2, 1.0, 0.5)
+}
+
 Point p {
   p.shape = Circle {
     r = 3.0
-    color = rgba(0.0, 0.0, 0.0, 1.0)
+    color = Colors.black
     stroke-width = 0
   }
 
@@ -11,23 +20,23 @@ Point p {
 Point `a` {
   `a`.shape.x = 0.0
   `a`.shape.y = 0.0
-  `a`.text.x = `a`.shape.x + 15.0
-  `a`.text.y = `a`.shape.y + 15.0
+  `a`.text.x = `a`.shape.x + global.padding
+  `a`.text.y = `a`.shape.y + global.padding
 }
 
 Point `b`
 with Point `a` {
   `b`.shape.x = `a`.shape.x + 100.0
   `b`.shape.y = `a`.shape.y + 200.0
-  `b`.text.x = `b`.shape.x + 15.0
-  `b`.text.y = `b`.shape.y + 15.0
+  `b`.text.x = `b`.shape.x + global.padding
+  `b`.text.y = `b`.shape.y + global.padding
 }
 
 Set X
 with Point `b` {
   X.shape = Circle {
     stroke-width = 0
-    color = rgba(1.0, 0.2, 1.0, 0.5)
+    color = Colors.pink
     r = norm_(X.shape.x - `b`.shape.x, X.shape.y -`b`.shape.y)
   }
 

--- a/src/sty/venn_comp.sty
+++ b/src/sty/venn_comp.sty
@@ -1,3 +1,8 @@
+Colors {
+  Colors.green = rgba(0.1, 1.0, 0.2, 0.4)
+  Colors.pink = rgba(1.0, 0.2, 1.0, 0.5)
+}
+
 Set x {
   x.shape = Circle {
     stroke-width = 0
@@ -11,11 +16,11 @@ Set x {
 }
 
 Set `A` {
-  `A`.shape.color = rgba(1.0, 0.2, 1.0, 0.5) -- red
+  `A`.shape.color = Colors.pink
 }
 
 Set `B` {
-  `B`.shape.color = rgba(0.1, 1.0, 0.2, 0.4) -- green
+  `B`.shape.color = Colors.green
 }
 
 Set x; Set y

--- a/src/sty/venn_comp_simple.sty
+++ b/src/sty/venn_comp_simple.sty
@@ -1,14 +1,24 @@
+global {
+  global.padding = 15.0
+}
+
+Colors {
+  Colors.black = rgba(0.0, 0.0, 0.0, 1.0)
+  Colors.red = rgba(1.0, 0.0, 0.0, 1.0)
+  Colors.lightGreen = rgba(0.1, 1.0, 0.2, 0.4)
+}
+
 Point p {
   p.shape = Circle {
     r = 3.0
-    color = rgba(0.0, 0.0, 0.0, 1.0)
+    color = Colors.black
     stroke-width = 0
   }
 
   p.text = Text {
     string = p.label
-    x = `p`.shape.x + 15.0
-    y = `p`.shape.y + 15.0
+    x = `p`.shape.x + global.padding
+    y = `p`.shape.y + global.padding
   }
 
   -- p.labelFn = encourage centerLabel(p.shape, p.text)
@@ -16,7 +26,7 @@ Point p {
 
 Set X {
   X.shape = Circle {
-    color = rgba(0.1, 1.0, 0.2, 0.4)
+    color = Colors.lightGreen
     stroke-width = 0
   }
 

--- a/src/sub/venn_comp_pt.sub
+++ b/src/sub/venn_comp_pt.sub
@@ -2,4 +2,8 @@ Point p
 Set X
 PointIn(p, X)
 
+-- Test namespace checking:
+-- Point global
+-- Set Colors
+
 AutoLabel All


### PR DESCRIPTION
…grams to use global/Colors namespaces. (Turns out converting StyVar to SubVar works out of the box for namespace impl)

# Description

Related issues: # (issue)

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

# Implementation strategy and design decisions

Include a high-level summary of the implementation strategy and list important design decisions made, if any.

# Examples with steps to reproduce them

# Checklist

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I ran [Haddock](https://github.com/penrose/penrose/wiki/Writing-and-generating-documentation#generating-html-documentation-site) and there were no errors when generating the HTML site
- [ ] My changes generate no new warnings
- [ ] New and existing tests pass locally using `stack test`
- [ ] My code follows the style guidelines of this project (e.g.: no HLint warnings)


# Open questions

Questions that require more discussion or to be addressed in future development:
