### PR TITLE
Testing surge deployment from Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,6 +36,14 @@ script:
    # Run tests
    stack --no-terminal test --ghc-options="$GHC_OPTIONS"
    set +ex
+ - |
+   mkdir -p ./docs
+   stack exec -- haddock --html src/*.hs  --hyperlinked-source --odir=./docs
+
+deploy:
+  provider: surge
+  project: ./docs/
+  domain: penrose.surge.sh 
 
 after_success:
  - |

--- a/src/Functions.hs
+++ b/src/Functions.hs
@@ -24,8 +24,8 @@ import qualified Data.MultiMap as MM
 data ArgVal a = GPI (Shape a) | Val (Value a)
      deriving (Eq, Show)
 
- -- | possible types in the argument of computation, constraint, or objectives.
- -- Used for type checking functions
+-- | possible types in the argument of computation, constraint, or objectives.
+-- Used for type checking functions
 data ArgType
     = GPIType ShapeTypeStr
     | ValueT ValueType


### PR DESCRIPTION
This is a test deployment for documentation (doc strings, not user doc) to travis using surge. This is only ideal over pushing back to Github pages because putting a Github pages (encrypted) token in a CI is more risky than surge, which is connected to fewer important things :) Surge in my mind is akin to read the docs, but doesn't require sphinx (python) or mkdocs.

If this seems to work okay, then we can customize the style to better match the main docs. I actually like the "old school" style that this ocean template has, so I think all we would need to do is some minor adjustment of the color scheme, and then we can link to this from penrose.github.io. If it even works at all!

To summarize the steps I took here:

  - added a command to travis script to generate the docs
  -  fixed a bug with the docstring that prevented it from rendering (at least in my Docker container)
  - added an (I hope) encrypted token to the travis environment to deploy
  - added a deploy section in the .travis.yml