### PR TITLE
Image path exporting hotfix

### DIFF
--- a/src/react-renderer/package-lock.json
+++ b/src/react-renderer/package-lock.json
@@ -13046,9 +13046,9 @@
       "integrity": "sha1-gV7R9uvGWSb4ZbMQwHE7yzMVzks="
     },
     "prettier": {
-      "version": "1.16.3",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-1.16.3.tgz",
-      "integrity": "sha512-kn/GU6SMRYPxUakNXhpP0EedT/KmaPzr0H5lIsDogrykbaxOpOfAFfk5XA7DZrJyMAv1wlMV3CPcZruGXVVUZw=="
+      "version": "1.16.4",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-1.16.4.tgz",
+      "integrity": "sha512-ZzWuos7TI5CKUeQAtFd6Zhm2s6EpAD/ZLApIhsF9pRvRtM1RFo61dM/4MSRUA0SuLugA/zgrZD8m0BaY46Og7g=="
     },
     "pretty-bytes": {
       "version": "4.0.2",

--- a/src/react-renderer/package.json
+++ b/src/react-renderer/package.json
@@ -9,7 +9,6 @@
     "debug": "^4.1.0",
     "fast-memoize": "^2.5.1",
     "lodash": "^4.17.11",
-    "prettier": "^1.16.4",
     "react": "^16.6.0",
     "react-dom": "^16.6.0",
     "react-fast-compare": "^2.0.4",
@@ -29,6 +28,7 @@
     "@types/node": "^10.12.2",
     "@types/react": "^16.4.18",
     "@types/react-dom": "^16.0.9",
+    "prettier": "^1.16.4",
     "tslint": "^5.12.1",
     "typescript": "^3.1.6"
   },

--- a/src/react-renderer/package.json
+++ b/src/react-renderer/package.json
@@ -9,6 +9,7 @@
     "debug": "^4.1.0",
     "fast-memoize": "^2.5.1",
     "lodash": "^4.17.11",
+    "prettier": "^1.16.4",
     "react": "^16.6.0",
     "react-dom": "^16.6.0",
     "react-fast-compare": "^2.0.4",

--- a/src/react-renderer/src/App.tsx
+++ b/src/react-renderer/src/App.tsx
@@ -28,9 +28,13 @@ class App extends React.Component<any, IState> {
   public sendPacket = (packet: string) => {
     this.ws.send(packet);
   };
-  public download = () => {
+  public downloadSVG = () => {
     if (this.canvas.current !== null) {
       this.canvas.current.downloadSVG();
+    }
+  };
+  public downloadPDF = () => {
+    if (this.canvas.current !== null) {
       this.canvas.current.downloadPDF();
     }
   };
@@ -82,7 +86,8 @@ class App extends React.Component<any, IState> {
       <div className="App">
         {!customButtons && (
           <ButtonBar
-            download={this.download}
+            downloadPDF={this.downloadPDF}
+            downloadSVG={this.downloadSVG}
             autostep={autostep}
             step={this.step}
             autoStepToggle={this.autoStepToggle}

--- a/src/react-renderer/src/App.tsx
+++ b/src/react-renderer/src/App.tsx
@@ -30,7 +30,8 @@ class App extends React.Component<any, IState> {
   };
   public download = () => {
     if (this.canvas.current !== null) {
-      this.canvas.current.download();
+      this.canvas.current.downloadSVG();
+      this.canvas.current.downloadPDF();
     }
   };
   public autoStepToggle = () => {

--- a/src/react-renderer/src/ButtonBar.tsx
+++ b/src/react-renderer/src/ButtonBar.tsx
@@ -6,7 +6,9 @@ interface IProps {
   autostep: boolean;
   layers: ILayer[];
 
-  download(): void;
+  downloadPDF(): void;
+
+  downloadSVG(): void;
   autoStepToggle(): void;
   step(): void;
   resample(): void;
@@ -19,7 +21,8 @@ class ButtonBar extends React.Component<IProps> {
       converged,
       autostep,
       autoStepToggle,
-      download,
+      downloadPDF,
+      downloadSVG,
       step,
       resample,
       toggleLayer,
@@ -32,7 +35,8 @@ class ButtonBar extends React.Component<IProps> {
         </button>
         <button onClick={step}>step</button>
         <button onClick={resample}>resample</button>
-        <button onClick={download}>download</button>
+        <button onClick={downloadPDF}>download PDF</button>
+        <button onClick={downloadSVG}>download SVG</button>
         {layers.map(({layer, enabled}: ILayer, key: number) => {
           return (
             <button onClick={() => toggleLayer(layer)} key={key}>

--- a/src/react-renderer/src/Canvas.tsx
+++ b/src/react-renderer/src/Canvas.tsx
@@ -86,8 +86,26 @@ class Canvas extends React.Component<IProps, IState> {
           const g = document.createElementNS("http://www.w3.org/2000/svg", "g");
           g.innerHTML = outer;
           g.setAttributeNS(null, "transform", `translate(${x},${y})`);
-
-          wrapper.remove();
+          // HACK: generate unique ids
+          const defs = g.getElementsByTagName("defs");
+          if (defs.length > 0) {
+            defs[0].querySelectorAll("*").forEach((node: any) => {
+              if (node.id !== "") {
+                const users = g.querySelectorAll(
+                  `[*|href="#${node.id}"]:not([href])`
+                );
+                users.forEach((user: any) => {
+                  const unique = `${i}-ns-${node.id}`;
+                  user.setAttributeNS(
+                    "http://www.w3.org/1999/xlink",
+                    "href",
+                    "#" + unique
+                  );
+                  node.setAttribute("id", unique);
+                });
+              }
+            });
+          }
           image.insertAdjacentElement("beforebegin", g);
           wrapper.remove();
           image.remove();
@@ -106,7 +124,6 @@ class Canvas extends React.Component<IProps, IState> {
       document.body.appendChild(downloadLink);
       downloadLink.click();
       document.body.removeChild(downloadLink);
-
     } else {
       Log.error("Could not find SVG domnode.");
     }

--- a/src/react-renderer/src/Canvas.tsx
+++ b/src/react-renderer/src/Canvas.tsx
@@ -113,21 +113,44 @@ class Canvas extends React.Component<IProps, IState> {
           Log.error(`Could not fetch ${uri}`);
         }
       }
-
-      const blob = new Blob([exportingNode.outerHTML], {
-        type: "image/svg+xml;charset=utf-8"
-      });
-      const url = URL.createObjectURL(blob);
-      const downloadLink = document.createElement("a");
-      downloadLink.href = url;
-      downloadLink.download = "illustration.svg";
-      document.body.appendChild(downloadLink);
-      downloadLink.click();
-      document.body.removeChild(downloadLink);
+      return exportingNode.outerHTML;
     } else {
       Log.error("Could not find SVG domnode.");
+      return "";
     }
   };
+
+  public downloadSVG = async () => {
+    const content = await this.download();
+    const blob = new Blob([content], {
+      type: "image/svg+xml;charset=utf-8"
+    });
+    const url = URL.createObjectURL(blob);
+    const downloadLink = document.createElement("a");
+    downloadLink.href = url;
+    downloadLink.download = "illustration.svg";
+    document.body.appendChild(downloadLink);
+    downloadLink.click();
+    document.body.removeChild(downloadLink);
+  }
+
+  public downloadPDF = async () => {
+    const content = await this.download();
+    const frame = document.createElement("iframe");
+    document.body.appendChild(frame);
+    const pri = frame.contentWindow;
+    frame.setAttribute("style", "height: 100%; width: 100%; position: absolute");
+    if(content && pri) {
+      console.log('Printing pdf now...');
+      pri.document.open();
+      pri.document.write(content);
+      pri.document.close();
+      pri.focus();
+      pri.print();
+    }
+    frame.remove();
+  }
+
   public renderEntity = ([name, shape]: [string, object], key: number) => {
     const component = componentMap[name];
     if (component === undefined) {

--- a/src/react-renderer/src/Canvas.tsx
+++ b/src/react-renderer/src/Canvas.tsx
@@ -57,12 +57,46 @@ class Canvas extends React.Component<IProps, IState> {
     this.props.sendPacket(update(updatedShapes));
   };
 
-  public download = () => {
+  public download = async () => {
     const domnode = ReactDOM.findDOMNode(this);
     if (domnode !== null && domnode instanceof Element) {
-      domnode.setAttribute("width", this.canvasSize[0].toString());
-      domnode.setAttribute("height", this.canvasSize[1].toString());
-      const blob = new Blob([domnode.outerHTML], {
+      const exportingNode = domnode.cloneNode(true) as any;
+      exportingNode.setAttribute("width", this.canvasSize[0].toString());
+      exportingNode.setAttribute("height", this.canvasSize[1].toString());
+
+      const images = exportingNode.getElementsByTagName("image");
+      for (let i = images.length - 1; i >= 0; i--) {
+        const image = images[i];
+        const uri = image.getAttribute("href");
+        const response = await fetch(uri);
+        const contents = await response.text();
+        if (response.ok) {
+          const width = image.getAttribute("width");
+          const height = image.getAttribute("height");
+          const x = image.getAttribute("x");
+          const y = image.getAttribute("y");
+
+          const wrapper = document.createElement("div");
+          wrapper.innerHTML = contents;
+
+          const s = wrapper.getElementsByTagName("svg")[0];
+          s.setAttributeNS(null, "width", width);
+          s.setAttributeNS(null, "height", height);
+          const outer = s.outerHTML;
+          const g = document.createElementNS("http://www.w3.org/2000/svg", "g");
+          g.innerHTML = outer;
+          g.setAttributeNS(null, "transform", `translate(${x},${y})`);
+
+          wrapper.remove();
+          image.insertAdjacentElement("beforebegin", g);
+          wrapper.remove();
+          image.remove();
+        } else {
+          Log.error(`Could not fetch ${uri}`);
+        }
+      }
+
+      const blob = new Blob([exportingNode.outerHTML], {
         type: "image/svg+xml;charset=utf-8"
       });
       const url = URL.createObjectURL(blob);
@@ -72,8 +106,7 @@ class Canvas extends React.Component<IProps, IState> {
       document.body.appendChild(downloadLink);
       downloadLink.click();
       document.body.removeChild(downloadLink);
-      domnode.setAttribute("width", "100%");
-      domnode.setAttribute("height", "100%");
+
     } else {
       Log.error("Could not find SVG domnode.");
     }

--- a/src/react-renderer/src/Image.tsx
+++ b/src/react-renderer/src/Image.tsx
@@ -18,7 +18,6 @@ class Image extends React.Component<IGPIPropsDraggable> {
     return (
       <image
         href={process.env.PUBLIC_URL + path}
-        xlinkHref={process.env.PUBLIC_URL + path}
         x={x - lengthX / 2}
         y={y - lengthY / 2}
         width={lengthX}

--- a/src/react-renderer/src/Label.tsx
+++ b/src/react-renderer/src/Label.tsx
@@ -4,9 +4,9 @@ import draggable from "./Draggable";
 import { IGPIPropsDraggable } from "./types";
 
 const styleLabel = (label : HTMLElement, color: string) => {
-  label.getElementsByTagName("g")[0].setAttribute("fill", color)
+  label.getElementsByTagName("g")[0].setAttribute("fill", color);
   return label.outerHTML
-}
+};
 
 class Label extends React.Component<IGPIPropsDraggable> {
   public render() {
@@ -15,7 +15,7 @@ class Label extends React.Component<IGPIPropsDraggable> {
     const { canvasSize } = this.props;
     const [x, y] = toScreen([shape.x.contents, shape.y.contents], canvasSize);
     const { w, h } = shape;
-    const color = toHex(shape.color.contents)
+    const color = toHex(shape.color.contents);
     return (
       <g
         transform={`translate(${x - w.contents / 2},${y - h.contents / 2})`}

--- a/src/react-renderer/src/Label.tsx
+++ b/src/react-renderer/src/Label.tsx
@@ -5,6 +5,9 @@ import { IGPIPropsDraggable } from "./types";
 
 const styleLabel = (label : HTMLElement, color: string) => {
   label.getElementsByTagName("g")[0].setAttribute("fill", color);
+  // HACK: pdf output seems to apply `stroke: black` automatically, so we make it explicit now
+  label.getElementsByTagName("g")[0].setAttribute("stroke", "none");
+  label.getElementsByTagName("g")[0].setAttribute("stroke-width", "0");
   return label.outerHTML
 };
 

--- a/src/react-renderer/src/Util.tsx
+++ b/src/react-renderer/src/Util.tsx
@@ -119,6 +119,7 @@ const tex2svg = memoize(
       } else {
         resolve({ output: undefined, width: 0, height: 0 });
       }
+      wrapper.remove();
     })
 );
 export const collectLabels = async (allShapes: any[]) => {


### PR DESCRIPTION
**BEFORE MERGING**: please try importing the SVG in
[illustration (12).zip](https://github.com/penrose/penrose/files/2906903/illustration.12.zip) into Illustrator. Make sure the brackets/parens show up, it should look like this:

![image](https://user-images.githubusercontent.com/2660634/53436341-0107aa00-39c9-11e9-9c85-dc70fe16f15c.png)


# Description
A quick hack to substitute inline SVG `<image>`s with their contents to allow for export portability. Puts all xlinks in the external images into their own unique namespaces.

Related issues: penrose/penrose-ide#6

Inline image before:
```svg
<image href="left-bracket.svg" x="490.5946350097656" y="340" width="10" height="20"></image>
```

Inline image after:
```svg
<g xmlns="http://www.w3.org/2000/svg" transform="translate(150.78616333007812,340)"><svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="10" height="20" viewBox="0 0 6 37" version="1.1"><!--latexit:AAAE9HjabVNrbFRFFD4zU0rpUnrb8igt0IvdKj6AbRW3iGBbyqLiLo/dbrfdLnX2
7uz20rv3bu6di2w3TSaK/MEYQ4gBFbXbPxQfiBpjGmOMxhglJto2mhCjP4wx/DAx
Jv4wMdHZh4iGmdzcM2fmnPnOd75J5gzd4T7fEsKkZlntEydi3uPMdnTLjHmt5DGm
cWfES21tQpfuiJdbuWZAp169rGxeXrf5tk5v1+13bLnzrru7e3fu7t//cOjgcGxs
XEtNGJbDh7ymaxiLK+o9K9eqw6HwtkmWd0blv5o36tUM6jhzDasalabmltVrBBZE
1IhlolYsF3VihaifW9e6vq19w8ZNHcIjVopVolE0iTbRLjaKTUKNJanDDN1kQ5pl
WHYka6XYENe5wWI5m9Fs0mCJLM2YelrXKJclRVKUs3GlMUm1yYxtuWZqbylw1LFc
W2MRdoJ3QnUs3rPVs227bygUPrJ/YCwULh8M56jGAj5VTlCQaFjoufe+HaOVMkya
ZbGKyZzhakDxfv8/ZiwUPliuW6lZ8Dyw68ERSYTDbd3MCOWQTLTnIQksFA66nErc
4fLO7J4+v4yrLBYHPHsH9wVurCWofi6tpMuZI5rFetEyriyMpSzNzTKTl5HEu305
nihQm+uawabrx1yHyRomaYbFpVnC7CQKZfam1S7pSalpy5afydWy9+aIAs06Tj6b
lCezlE84/98rOW+1F3d5ujdR0M2cRGpqlYvSrqFyS+X5HFNTui15MfLSoJqtS6yq
NkFtqnGpxPqSgB45EJx5VKyeeUysEa3RUDggAS4dOnzEE44MReU6rE8xSUw6YNCM
I9chWVhn35ZKKxVFrBXrokHLpJolmR4ZrWYoxv1VS3oTRyWhg7pW0gm188WEXzof
p+NK8008pyrUF5P+W/o7+wYqVy4wTzpTkjzXJZD+j65dPz/9x4jYIFPqx+Sdg1KH
xUl/1SppLbvdF+hW5QTRUOp0bl9AdJR6ejgug9zj40rLDXH8i3LWTfjLsjnA8izV
X32mX+enIrZlcYGgDpqgDTphK/SAH+JAYQJyUIAn4Rl4Fp6DM3AWnodz8AK8BC/D
RbgEr8Ob8Ba8De/Ce/A+zMMH8Clcha/gG/gBfoHfUA1qRK2oA3WhHrQT7UK70QAK
oig6iijSkY04yqOn0NPoFDqNLqAZdAldQfPoM/Q5uoq+xEU8h1/Db+DL+Ap+B8/j
T/AXeBFfwz/in/DP+Dr+Ff+O/8R/kVriIa2knahkB+klQRIlcaIRg5jEIVNkmpwk
p8kZcpa8SC6QV8gMmSUXyYfkY7JEviXfVXqAUfUpF+A/g3z/N2H8mSU=
-->
<defs>
<g>
<symbol overflow="visible" id="glyph0-0">
<path style="stroke:none;" d=""/>
</symbol>
<symbol overflow="visible" id="2-ns-glyph0-1">
<path style="stroke:none;" d="M 9.140625 8.96875 L 9.140625 7.53125 L 5.671875 7.53125 L 5.671875 -25.453125 L 9.140625 -25.453125 L 9.140625 -26.890625 L 4.234375 -26.890625 L 4.234375 8.96875 Z M 9.140625 8.96875 "/>
</symbol>
</g>
</defs>
<g id="surface1">
<g style="fill:rgb(0%,0%,0%);fill-opacity:1;">
  <use xlink:href="#2-ns-glyph0-1" x="-3.788" y="27.6482"/>
</g>
</g>
</svg></g>
```

Yes, you may notice that `id="glyph0-0"` is not unique, and neither is `<g id="surface1">`. However, it has minimal side effects right now, and would need a lot of extra hacks to prevent.

.