### PR TITLE
Add Circleci Support

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -51,10 +51,13 @@ jobs:
 
 workflows:
   version: 2.1
-  build_and_deploy:
+  build_deploy:
     jobs:
       - build
       - aws-ecr/build_and_push_image:
+          filters:
+            tags:
+              only: /^v.*/
           requires:
             - build
           account-url: AWS_ECR_ACCOUNT_URL

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,74 @@
+version: 2.1
+orbs:
+  aws-ecr: circleci/aws-ecr@3.0.0
+  aws-ecs: circleci/aws-ecs@0.0.6
+jobs:
+  build:
+    docker:
+      - image: fpco/stack-build:lts
+    #    parallelism: 4
+    steps:
+      - checkout
+      - restore_cache:
+          # Read about caching dependencies: https://circleci.com/docs/2.0/caching/
+          name: Restore Cached Dependencies
+          keys:
+            - penrose-cache-{{ checksum "penrose.cabal" }}
+      - run:
+          name: Manually install Alex and Happy
+          command: stack install alex happy
+      - run:
+          name: Resolve/Update Dependencies
+          command: stack build
+      - run:
+          name: Run tests
+          command: stack test
+      - run:
+          name: Install executable
+          command: stack install
+      - save_cache:
+          name: Cache Dependencies
+          key: penrose-cache-{{ checksum "penrose.cabal" }}
+          paths:
+            - ".stack"
+            - ".stack-work"
+            - "$HOME/.ghc"
+            - "$HOME/.cabal"
+            - "$HOME/.stack"
+
+      - store_artifacts:
+          # Upload test summary for display in Artifacts: https://circleci.com/docs/2.0/artifacts/
+          path: ~/.local/bin/penrose
+          destination: penrose-bin
+      - persist_to_workspace:
+          root: ~/.local/bin
+          paths:
+            - penrose
+      - persist_to_workspace:
+          root: .
+          paths:
+            - src/
+
+workflows:
+  version: 2.1
+  build_and_deploy:
+    jobs:
+      - build
+      - aws-ecr/build_and_push_image:
+          requires:
+            - build
+          account-url: AWS_ECR_ACCOUNT_URL
+          aws-access-key-id: AWS_ACCESS_KEY
+          aws-secret-access-key: AWS_SECRET_ACCESS_KEY
+          region: AWS_REGION
+          repo: penrose
+          dockerfile: Dockerfile.circleci
+          attach-workspace: true
+      - aws-ecs/deploy-service-update:
+          requires:
+            - aws-ecr/build_and_push_image
+          family: penrose-service
+          cluster-name: penrose-cluster
+          aws-access-key-id: $AWS_ACCESS_KEY
+          aws-secret-access-key: $AWS_SECRET_ACCESS_KEY
+          aws-region: $AWS_REGION

--- a/Dockerfile.circleci
+++ b/Dockerfile.circleci
@@ -1,0 +1,12 @@
+FROM ubuntu
+
+RUN mkdir -p /opt/penrose
+COPY . /opt/penrose/
+WORKDIR /opt/penrose
+RUN apt-get update && apt-get install -y \
+  ca-certificates \
+  libgmp-dev
+
+ENTRYPOINT ["./penrose"]
+EXPOSE 9160
+CMD ["--domain=0.0.0.0","src/sty/venn.sty","src/set-theory-domain/setTheory.dsl"]

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Penrose [![Build Status](https://travis-ci.org/penrose/penrose.svg?branch=master)](https://travis-ci.org/penrose/penrose)
+# Penrose [![CircleCI](https://circleci.com/gh/penrose/penrose/tree/master.svg?style=svg)](https://circleci.com/gh/penrose/penrose/tree/master)
 
 **Penrose is an early-stage system that is still in development.** Our system is not ready for contributions or public use yet, but hopefully will be soon. Send us an email if you're interested in collaborating.
 

--- a/scripts/domain-server.sh
+++ b/scripts/domain-server.sh
@@ -5,4 +5,4 @@
 scriptdir="$(dirname "$0")"
 cd "$scriptdir"
 
-http-server ../src -p 9090 -d false -i false --cors -c-1 || echo "Please run npm install -g http-server"
+npx http-server ../src -p 9090 -d false -i false --cors -c-1 || echo "Ensure npx is able to run"


### PR DESCRIPTION
This adds circleci support to our repository. There are two features:

* **Automated building and testing**: we can create binaries and test our builds automatically.

* **Continuous tagged deployment**: If you tag your commit (preferably before pushing) following the format `vx.x` where `x` is an integer, Circleci will deploy the tagged commit to our AWS cluster.