### PR TITLE
Add Docker Development Environment

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,2 @@
+.stack-work
+**/node_modules

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,11 @@
+start-dev:
+	docker-compose -f docker-compose-dev.yml up
+
+recreate-dev:
+	docker-compose -f docker-compose-dev.yml build
+
+shell-dev:
+	docker-compose -f docker-compose-dev.yml exec penrose /bin/bash
+
+dev-build:
+	docker-compose -f docker-compose-dev.yml exec penrose sh -c "stack setup && stack build"

--- a/Makefile
+++ b/Makefile
@@ -7,5 +7,8 @@ recreate-dev:
 shell-dev:
 	docker-compose -f docker-compose-dev.yml exec penrose /bin/bash
 
+penrose:
+	docker-compose -f docker-compose-dev.yml exec penrose sh -c "$(MAKECMDGOALS)"
+
 dev-build:
 	docker-compose -f docker-compose-dev.yml exec penrose sh -c "stack setup && stack build"

--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -16,7 +16,7 @@ services:
       dockerfile: ./docker/Dockerfile-renderer.dev
     image: renderer-dev
     ports:
-      - "3000:3000"
+      - "3500:3500"
     volumes:
       - "./src/react-renderer:/home/node/react-renderer"
     tty: true # needed for ctrl-C graceful shutdown of whole system

--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -1,0 +1,34 @@
+version: '3.2'
+services:
+  penrose:
+    build:
+      context: .
+      dockerfile: ./docker/Dockerfile-penrose.dev
+    image: penrose-dev
+    ports:
+      - "9160:9160"
+    command: tail -F /dev/null # keepalive
+    volumes:
+      - ".:/home/penrose"
+  renderer:
+    build:
+      context: .
+      dockerfile: ./docker/Dockerfile-renderer.dev
+    image: renderer-dev
+    ports:
+      - "3000:3000"
+    volumes:
+      - "./src/react-renderer:/home/node/react-renderer"
+    tty: true # needed for ctrl-C graceful shutdown of whole system
+  domain-server:
+    build:
+      context: .
+      dockerfile: ./docker/Dockerfile-domains.dev
+    image: domains
+    ports:
+      - "9090:9090"
+    volumes:
+      - "./src:/home/node/src"
+    logging:
+      driver: "none"
+

--- a/docker/Dockerfile-domains.dev
+++ b/docker/Dockerfile-domains.dev
@@ -1,0 +1,13 @@
+FROM node:11.10.1
+
+WORKDIR /home/node
+
+RUN npm config set prefix "/home/node/.npm-packages"
+
+ENV PATH="=/home/node/.npm-packages/bin:${PATH}"
+
+WORKDIR /home/node/src
+
+ENTRYPOINT ["sh", "-c", "npx http-server . -p 9090 -d false -i false --cors -c-1"]
+
+EXPOSE 9090

--- a/docker/Dockerfile-penrose.dev
+++ b/docker/Dockerfile-penrose.dev
@@ -1,5 +1,11 @@
 FROM fpco/stack-build:lts-9.10
 
+RUN echo 'alias runpenrose=""' >> ~/.bashrc
+
+# Put runpenrose in PATH with default domain arg (to be docker compatible)
+RUN echo -e '#!/bin/bash\n/home/penrose/.stack-work/install/x86_64-linux/lts-9.10/8.0.2/bin/penrose --domain=0.0.0.0 "$@"' > /usr/bin/penrose && \
+    chmod +x /usr/bin/penrose
+
 WORKDIR /home/penrose
 
 EXPOSE 9160

--- a/docker/Dockerfile-penrose.dev
+++ b/docker/Dockerfile-penrose.dev
@@ -1,0 +1,5 @@
+FROM fpco/stack-build:lts-9.10
+
+WORKDIR /home/penrose
+
+EXPOSE 9160

--- a/docker/Dockerfile-renderer.dev
+++ b/docker/Dockerfile-renderer.dev
@@ -12,6 +12,6 @@ WORKDIR /home/node/react-renderer
 
 RUN npm install
 
-ENTRYPOINT ["sh", "-c", "npm start"]
+ENTRYPOINT ["sh", "-c", "PORT=3500 npm start"]
 
-EXPOSE 3000
+EXPOSE 3500

--- a/docker/Dockerfile-renderer.dev
+++ b/docker/Dockerfile-renderer.dev
@@ -1,0 +1,17 @@
+FROM node:11.10.1
+
+WORKDIR /home/node
+
+RUN npm config set prefix "/home/node/.npm-packages"
+
+ENV PATH="=/home/node/.npm-packages/bin:${PATH}"
+
+COPY ./src/react-renderer/package.json /home/node/react-renderer/package.json
+
+WORKDIR /home/node/react-renderer
+
+RUN npm install
+
+ENTRYPOINT ["sh", "-c", "npm start"]
+
+EXPOSE 3000

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,0 +1,29 @@
+# Docker Compose Workflow
+
+## Setting Up
+
+* Ensure docker is installed and the daemon is running.
+
+* Ensure you have GNU Make installed (the `make` command).
+
+* Run `make dev-build` to do initial dep, GHC installation
+
+* To shut down the system (while preserving your build cache), just `ctrl-C` out.
+
+## Developing The Renderer
+
+* Wait for `make start-dev` to finish such that you see the message `You can now view react-renderer in the browser`.
+
+* Enter `make shell-dev` in another terminal and run your desired domain.
+
+* Navigate to `localhost:3000` in the browser to see the renderer.
+
+## Developing The System
+
+All the files in `TOP` are mounted into the `penrose` container.
+
+Just use `make shell-dev` in another terminal to enter an interactive bash shell and run your stack/ghc build commands, and run penrose itself using `runpenrose`.
+
+## Everything Broke, Restart
+
+Just run `make recreate-dev` to recreate the environment. Note that this may require stack to reinstall all your deps when you use the system again.

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,14 +1,18 @@
 # Docker Compose Workflow
 
+**TODO: IDE inclusion**
+
 ## Setting Up
 
 * Ensure docker is installed and the daemon is running.
 
 * Ensure you have GNU Make installed (the `make` command).
 
-* Run `make dev-build` to do initial dep, GHC installation
+* Run `make start-dev` to start the containers.
 
-* To shut down the system (while preserving your build cache), just `ctrl-C` out.
+* Run `make dev-build` in another terminal to do initial dep, GHC installation
+
+* To shut down the containers (while preserving your build cache), just `ctrl-C` out of the `make start-dev` terminal.
 
 ## Developing The Renderer
 
@@ -16,7 +20,9 @@
 
 * Enter `make shell-dev` in another terminal and run your desired domain.
 
-* Navigate to `localhost:3000` in the browser to see the renderer.
+* Navigate to `localhost:3500` in the browser to see the renderer.
+
+* Edit your files locally, and you'll get auto-reloading as usual!
 
 ## Developing The System
 

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,7 +1,5 @@
 # Docker Compose Workflow
 
-**TODO: IDE inclusion**
-
 ## Setting Up
 
 * Ensure docker is installed and the daemon is running.
@@ -16,6 +14,8 @@
 
 ## Developing The Renderer
 
+* Run `make start-dev` if you haven't already.
+
 * Wait for `make start-dev` to finish such that you see the message `You can now view react-renderer in the browser`.
 
 * Enter `make shell-dev` in another terminal and run your desired domain.
@@ -26,9 +26,20 @@
 
 ## Developing The System
 
+* Run `make start-dev` if you haven't already.
+
 All the files in `TOP` are mounted into the `penrose` container.
 
-Just use `make shell-dev` in another terminal to enter an interactive bash shell and run your stack/ghc build commands, and run penrose itself using `runpenrose`.
+Rebuild using `make dev-build`, and run penrose using `make penrose [args]`.
+E,g:
+```
+make dev-build
+make penrose src/linear-algebra-domain/determinants.sub src/linear-algebra-domain/linear-algebra.sty src/linear-algebra-domain/linear-algebra.dsl
+```
+
+Alternatively, use `make shell-dev` in another terminal to enter an interactive bash shell and run your stack/ghc build commands, and run penrose itself using the `penrose` command.
+
+Note that the `penrose` command in both scenarios is aliased to include a `--domain=0.0.0.0` arg due to the way Docker works with IPs.
 
 ## Everything Broke, Restart
 


### PR DESCRIPTION
This pull adds a `docker-compose` orchestration and set of `Makefile` commands that should increase the portability of Penrose as a development environment via Docker.

Docker adds a system-level abstraction over the environment that Penrose is developed in. The correct version of `stack`, `nodejs`, etc are all included in the box.

All build and run commands executed through `make` are sent to docker containers via a virtual shell. There is also a shell command available that allows one to, essentially, `ssh` into the docker container and run additional tools like `ghc`'s profiling tool. The system doesn't have to be rebuilt every time a code change is made, since this setup mounts the local copy inside of the docker containers. `stack build` etc, when executed via shell or Makefile, behave normally and allow the developer to remain in their local environment while interfacing with the Docker container.

Details of usage and implementation are enclosed in the `docker/README.md` file.