### PR TITLE
[ready to merge] Changed base image for production

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,7 +5,7 @@ orbs:
 jobs:
   build:
     docker:
-      - image: fpco/stack-build:lts-9.10
+      - image: fpco/stack-build:lts
     #    parallelism: 4
     steps:
       - checkout

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,7 +5,7 @@ orbs:
 jobs:
   build:
     docker:
-      - image: fpco/stack-build:lts
+      - image: fpco/stack-build:lts-9.10
     #    parallelism: 4
     steps:
       - checkout

--- a/Dockerfile.circleci
+++ b/Dockerfile.circleci
@@ -1,11 +1,8 @@
-FROM ubuntu
+FROM fpco/stack-build:lts-9.10
 
 RUN mkdir -p /opt/penrose
 COPY . /opt/penrose/
 WORKDIR /opt/penrose
-RUN apt-get update && apt-get install -y \
-  ca-certificates \
-  libgmp-dev
 
 ENTRYPOINT ["./penrose"]
 EXPOSE 9160


### PR DESCRIPTION
Our production image (`Dockerfile.circleci`) broke because some linked system library changed. We use the generic `ubuntu` base image so a new pull probably caused the error to manifest:

```
./penrose: error while loading shared libraries: libblas.so.3: cannot open shared object file: No such file or directory
```

(You can reproduce this by going to circleci and downloading the `penrose-bin` build artifact. Rename it to `penrose` and put it in TOP, then run `docker build -f Dockerfile.circleci .`. Then `docker run -it [the hash]`.)

The solution (though heavy-handed) is to switch our base image so that we inherit from one that has lots of Haskell deps preinstalled: `fpco/stack-build:lts-9.10`. I'm sure there's a lightweight production copy around somewhere too but I'd rather be safe for now.

This is ready to merge.