### PR TITLE
(ready to merge) Add rudimentary metadata interfaces

### DIFF
--- a/src/react-renderer/src/Circle.tsx
+++ b/src/react-renderer/src/Circle.tsx
@@ -24,11 +24,12 @@ class Circle extends React.Component<IGPIPropsDraggable> {
         fillOpacity={fillAlpha}
         stroke={strokeColor}
         strokeOpacity={strokeAlpha}
-        strokeDasharray={ shape.strokeStyle.contents === "dashed" ? "7, 5" : "" }
+        strokeDasharray={shape.strokeStyle.contents === "dashed" ? "7, 5" : ""}
         strokeWidth={thickness}
         onMouseDown={onClick}
       >
         <title>{shape.name.contents}</title>
+        <desc>Circle representing {shape.name.contents}</desc>
       </circle>
     );
   }

--- a/src/react-renderer/src/CircleTransform.tsx
+++ b/src/react-renderer/src/CircleTransform.tsx
@@ -4,37 +4,40 @@ import draggable from "./Draggable";
 import { IGPIPropsDraggable } from "./types";
 
 class CircleTransform extends React.Component<IGPIPropsDraggable> {
-    public render() {
-	const { shape } = this.props;
-	const { canvasSize } = this.props;
-	const { onClick } = this.props;
+  public render() {
+    const { shape } = this.props;
+    const { canvasSize } = this.props;
+    const { onClick } = this.props;
 
-	const fillColor = toHex(shape.color.contents);
-	const fillAlpha = shape.color.contents[3];
-	const strokeColor = toHex(shape.strokeColor.contents);
-	const strokeAlpha = shape.strokeColor.contents[3];
-	const thickness = shape.strokeWidth.contents;
+    const fillColor = toHex(shape.color.contents);
+    const fillAlpha = shape.color.contents[3];
+    const strokeColor = toHex(shape.strokeColor.contents);
+    const strokeAlpha = shape.strokeColor.contents[3];
+    const thickness = shape.strokeWidth.contents;
 
-	const transformStr = svgTransformString(shape.transformation.contents, canvasSize);
+    const transformStr = svgTransformString(
+      shape.transformation.contents,
+      canvasSize
+    );
 
- 	return (
-		<circle
-		  cx={-0.0}
-		  cy={-0.0}
-		  r={1.0}
-		  fill={fillColor}
-		  fillOpacity={fillAlpha}
-		  stroke={strokeColor}
-		  strokeOpacity={strokeAlpha}
-		  strokeDasharray={ shape.strokeStyle.contents === "dashed" ? "7, 5" : "" }
-		  strokeWidth={thickness}
-		  onMouseDown={onClick}
-
-            	  transform={transformStr}
-		>
-		  <title>{shape.name.contents}</title>
-		</circle>
-	);
-    }
+    return (
+      <circle
+        cx={-0.0}
+        cy={-0.0}
+        r={1.0}
+        fill={fillColor}
+        fillOpacity={fillAlpha}
+        stroke={strokeColor}
+        strokeOpacity={strokeAlpha}
+        strokeDasharray={shape.strokeStyle.contents === "dashed" ? "7, 5" : ""}
+        strokeWidth={thickness}
+        onMouseDown={onClick}
+        transform={transformStr}
+      >
+        <title>{shape.name.contents}</title>
+        <desc>Circle representing {shape.name.contents}</desc>
+      </circle>
+    );
+  }
 }
 export default draggable(CircleTransform);


### PR DESCRIPTION
When supplied with some metadata (there are defaults as well), the renderer can add more info to the SVG for accessibility and traceability when the file goes out in the "wild".

Example:

```html
<desc>This diagram was created with Penrose (https://penrose.ink) on 2019-06-12. If you have any suggestions on making this diagram more accessible, please contact us.
Produced with the substance code:
"Set A, B, C, D, E, F, G

IsSubset(B, A)
IsSubset(C, A)
IsSubset(D, B)
IsSubset(E, B)
IsSubset(F, C)
IsSubset(G, C)

NotIntersecting(E, D)
NotIntersecting(F, G)
NotIntersecting(B, C)

AutoLabel All
"
Using style program "tree".
Using element program "set theory".
</desc>
```

The first line appears on all exports, and the next three sections depend on what the IDE supplies.

Once style, element, and Penrose get version numbers, this feature will be even more useful.