### PR TITLE
Make docker image smaller

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,7 +5,7 @@ orbs:
 jobs:
   build:
     docker:
-      - image: fpco/stack-build:lts-13.24
+      - image: fpco/stack-build-small:lts-13.24
     #    parallelism: 4
     steps:
       - checkout

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,7 +5,7 @@ orbs:
 jobs:
   build:
     docker:
-      - image: fpco/stack-build:lts
+      - image: fpco/stack-build:lts-13.24
     #    parallelism: 4
     steps:
       - checkout

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,7 +5,7 @@ orbs:
 jobs:
   build:
     docker:
-      - image: fpco/stack-build-small:lts-13.24
+      - image: fpco/stack-build:lts-13.24
     #    parallelism: 4
     steps:
       - checkout

--- a/Dockerfile.circleci
+++ b/Dockerfile.circleci
@@ -1,4 +1,4 @@
-FROM fpco/stack-build:lts-13.24
+FROM fpco/stack-build-small:lts-13.24
 
 RUN mkdir -p /opt/penrose
 COPY . /opt/penrose/

--- a/docker/Dockerfile-penrose.dev
+++ b/docker/Dockerfile-penrose.dev
@@ -1,4 +1,4 @@
-FROM fpco/stack-build-small:lts-13.24
+FROM fpco/stack-build:lts-13.24
 
 RUN echo 'alias runpenrose=""' >> ~/.bashrc
 

--- a/docker/Dockerfile-penrose.dev
+++ b/docker/Dockerfile-penrose.dev
@@ -1,4 +1,4 @@
-FROM fpco/stack-build:lts-13.24
+FROM fpco/stack-build-small:lts-13.24
 
 RUN echo 'alias runpenrose=""' >> ~/.bashrc
 


### PR DESCRIPTION
This PR changes the base images used for deployment to AWS (`stack-build` := `stack-build-small`) which I believe will be significant enough of a change to make AWS happy again.