### PR TITLE
New arrow style

### DIFF
--- a/opt-config/default.json
+++ b/opt-config/default.json
@@ -1,0 +1,1 @@
+{ "optMethod": "LBFGS" }

--- a/react-renderer/src/Util.tsx
+++ b/react-renderer/src/Util.tsx
@@ -3,48 +3,98 @@ import * as React from "react";
 declare const MathJax: any;
 import memoize from "fast-memoize";
 
+// const arrows = [
+//   {
+//     start: ,
+//     end:
+//   },
+//   {
+//     start:,
+//     end:
+//   }
+// ]
+
 export const StartArrowhead = (props: {
   id: string;
   color: string;
   opacity: number;
 }) => {
   return (
+    // COMBAK: Style 1 deprecated for now
+    // <marker
+    //   id={props.id}
+    //   markerUnits="strokeWidth"
+    //   markerWidth="12"
+    //   markerHeight="12"
+    //   viewBox="0 0 12 12"
+    //   refX="6"
+    //   refY="6"
+    //   orient="auto"
+    // >
+    //   <path
+    //     d="M10,10 A30,30,0,0,0,2,6 A30,30,0,0,0,10,2 L7.5,6 z"
+    //     fill={props.color}
+    //     fillOpacity={props.opacity}
+    //   />
+    // </marker>
+
+    // Style 2
     <marker
       id={props.id}
       markerUnits="strokeWidth"
-      markerWidth="12"
-      markerHeight="12"
-      viewBox="0 0 12 12"
-      refX="6"
-      refY="6"
+      markerWidth="30"
+      markerHeight="14"
+      viewBox="0 0 30 14"
+      refX="21.46"
+      refY="7"
       orient="auto"
     >
       <path
-        d="M10,10 A30,30,0,0,0,2,6 A30,30,0,0,0,10,2 L7.5,6 z"
+        d="M19.1 7 29.05 2.94 27.09 7 29.05 11.06 19.1 7z"
         fill={props.color}
         fillOpacity={props.opacity}
       />
     </marker>
   );
 };
+
 export const EndArrowhead = (props: {
   id: string;
   color: string;
   opacity: number;
 }) => {
   return (
+    // COMBAK: Style 1 deprecated for now
+    // <marker
+    //   id={props.id}
+    //   markerUnits="strokeWidth"
+    //   markerWidth="12"
+    //   markerHeight="12"
+    //   viewBox="0 0 12 12"
+    //   refX="6"
+    //   refY="6"
+    //   orient="auto"
+    // >
+    //   <path
+    //     d="M2,2 A30,30,0,0,0,10,6 A30,30,0,0,0,2,10 L4.5,6 z"
+    //     fill={props.color}
+    //     fillOpacity={props.opacity}
+    //   />
+    // </marker>
+
+    // Style 2
     <marker
       id={props.id}
       markerUnits="strokeWidth"
-      markerWidth="12"
-      markerHeight="12"
-      viewBox="0 0 12 12"
-      refX="6"
-      refY="6"
+      markerWidth="30"
+      markerHeight="14"
+      viewBox="0 0 30 14"
+      refX="21.46"
+      refY="7"
       orient="auto"
     >
       <path
-        d="M2,2 A30,30,0,0,0,10,6 A30,30,0,0,0,2,10 L4.5,6 z"
+        d="M29.05 7 19.1 11.06 21.46 7 19.1 2.94 29.05 7z"
         fill={props.color}
         fillOpacity={props.opacity}
       />


### PR DESCRIPTION
# Description

Related issues: #207 TOG-paper request

This PR adds another style for arrows, which is modeled after arrow #2 of Illustrator.

# Implementation strategy and design decisions
- Started using `auto-start-reverse` to avoid manual rotation of marker paths
- As a result, unified `Start/EndArrowhead` into just `Arrowhead` with auto-orientation
- Added another arrowhead style
- Arrow styles can now be added to a dictionary located in `Util.tsx` called `arrows`, and the `Arrowhead` component takes in an extra property `style: string` that specifies which arrowhead to use. The arrowheads are indexed by string values. The current convention is `arrowhead-[0-9]+`. The default value is `arrowhead-2`, which is the new style. 
- The arrowhead style property is currently not propagated to the Style level
  
# Examples with steps to reproduce them
![image](https://user-images.githubusercontent.com/11740102/64207887-9352a400-ce6b-11e9-8db7-678b93555753.png)
![image](https://user-images.githubusercontent.com/11740102/64209997-08c07380-ce70-11e9-8033-63539f0ce32d.png)

# Checklist

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I ran [Haddock](https://github.com/penrose/penrose/wiki/Writing-and-generating-documentation#generating-html-documentation-site) and there were no errors when generating the HTML site
- [ ] My changes generate no new warnings
- [ ] New and existing tests pass locally using `stack test`
- [ ] My code follows the style guidelines of this project (e.g.: no HLint warnings)


# Open questions

The current implementation will not place arrowheads exactly at the end of the path, but rather placing the reference center (`refX, refY`) at the end of the path. This is a general problem with SVG markers, and here is a proposed implementation: https://www.w3.org/TR/svg-markers/#MarkerKnockout. 

This proposal doesn't seem to be implemented by any vendor yet.