### PR TITLE
Improve linalg paper style to match paper example

### DIFF
--- a/examples/linear-algebra-domain/linear-algebra-paper.sty
+++ b/examples/linear-algebra-domain/linear-algebra-paper.sty
@@ -1,8 +1,10 @@
 -- Global constants and sizes
 const {
-  const.vectorSpaceSize = 400.0
-  const.axisSize = const.vectorSpaceSize * 0.4
+  const.vectorSpaceSize = 350.0
+  const.axisSize = const.vectorSpaceSize * 0.5
   const.scaleRatio = 200.0
+  const.perpLen = 25.0
+  const.repelWeight = 0.7
 }
 
 -- Global RGB colors in common use
@@ -22,22 +24,18 @@ VectorSpace U {
     U.thickness = 2.0
     U.axisColor = Colors.gray
 
+    U.originX = ?
+    U.originY = ?
+    U.origin = (U.originX, U.originY)
+
     -- TODO: get rid of this?
     U.shape = Square {
+        x : U.originX
+	y : U.originY
         side : const.vectorSpaceSize
         color : Colors.none
-	-- stroke : Colors.black
+	stroke : Colors.black
     }
-
-    -- U.textX = Text {
-    --     string : "x"
-    --     color : Colors.darkGray
-    -- }
-
-    -- U.textY = Text {
-    --     string : "y"
-    --     color : Colors.darkGray
-    -- }
 
     -- TODO: double-headed arrows
     U.xAxisRight = Arrow {
@@ -90,10 +88,6 @@ VectorSpace U {
 Vector v
 with VectorSpace U
 where In(v,U) {
-   v.containFn = ensure contains(U.shape, v.shape)
-   v.containLabel = ensure contains(U.shape, v.text)
-   v.labelLocation = ensure nearHead(v.shape, v.text, 0.0 , 30.0)
-
   v.text = Text {
     string : v.label
     color : v.shape.color
@@ -104,10 +98,21 @@ where In(v,U) {
     startY : U.shape.y
     thickness : 3.0
     color : Colors.blue
+    arrowheadSize : 0.8
   }
 
    v.vector = (v.shape.endX - v.shape.startX, v.shape.endY - v.shape.startY)
    v.angle = angle(v.vector)
+
+   -- v.containFn = ensure contains(U.shape, v.shape)
+   -- v.containLabel = ensure contains(U.shape, v.text)
+   -- v.labelLocation = ensure nearHead(v.shape, v.text, 20.0, 20.0)
+
+   v.containFn = ensure contains(U.shape, v.shape)
+   v.containLabel = ensure contains(U.shape, v.text)
+   v.labelLocation = ensure atDist((v.shape.endX, v.shape.endY), v.text, 10.0)
+   -- This objective gives better visual results but causes vectors to be the same length?
+   -- v.labelAvoidFn = encourage repel(v.shape, v.text, const.repelWeight)
 
   v.layeringText1 = v.text above U.xAxisRight
   v.layeringText2 = v.text above U.xAxisLeft
@@ -118,30 +123,19 @@ where In(v,U) {
 Vector u; Vector v
 with VectorSpace U
 where Orthogonal(u, v); In(u, U); In(v, U) {
-      -- TODO: fix this angle calculation so it works when both vectors are in quadrants 2 or 3
-      LOCAL.angle = min(u.angle, v.angle)
-      LOCAL.len = 20.0
-
-      -- Scale by side len. Then translate so default square's corner is at (0,0).
-      -- Then rotate by the vector angle. Then translate to the local origin of the vector space.
-      LOCAL.shape = SquareTransform {
-	  -- TODO: unintuitive behavior; need to set these constants otherwise shape is offscreen
-	  x : 0.0
-	  y : 0.0
-	  side : 1.0
-	  rotation : 0.0
-
-	  transform : andThen(andThen(andThen(scale(LOCAL.len, LOCAL.len), translate(LOCAL.len / 2.0, LOCAL.len / 2.0)), rotate(LOCAL.angle)), translate(U.shape.x, U.shape.y))
-	  color : Colors.white
-	  strokeColor : Colors.black
-	  strokeWidth : 0.1
+      -- Draw perpendicular mark
+      LOCAL.perpMark = Curve {
+	   pathData : perpPath(u.shape, v.shape, U.origin, const.perpLen)
+	   strokeWidth : 2.0
+	   color : Colors.black
+	   fill : Colors.white
       }
 
-      -- LOCAL.perpFn = ensure equals(dot(u.vector, v.vector), 0.0)
+      -- Make sure vectors are orthogonal
       LOCAL.perpFn = encourage equal(dot(u.vector, v.vector), 0.0)
 
-      LOCAL.layering1 = v.shape above LOCAL.shape
-      LOCAL.layering2 = u.shape above LOCAL.shape
+      LOCAL.layering1 = v.shape above LOCAL.perpMark
+      LOCAL.layering2 = u.shape above LOCAL.perpMark
 }
 
 Vector `x2` {

--- a/examples/linear-algebra-domain/linear-algebra-paper.sty
+++ b/examples/linear-algebra-domain/linear-algebra-paper.sty
@@ -5,6 +5,10 @@ const {
   const.scaleRatio = 200.0
   const.perpLen = 25.0
   const.repelWeight = 0.7
+  const.arrowheadSize = 0.6
+  -- For unit mark
+  const.markerPadding = 15.0
+  const.barSize = 5.0
 }
 
 -- Global RGB colors in common use
@@ -24,8 +28,10 @@ VectorSpace U {
     U.thickness = 2.0
     U.axisColor = Colors.gray
 
-    U.originX = ?
-    U.originY = ?
+    -- U.originX = ?
+    -- U.originY = ?
+    U.originX = 0.0
+    U.originY = 0.0
     U.origin = (U.originX, U.originY)
 
     -- TODO: get rid of this?
@@ -37,41 +43,24 @@ VectorSpace U {
 	stroke : Colors.black
     }
 
-    -- TODO: double-headed arrows
-    U.xAxisRight = Arrow {
-        startX : U.shape.x
+    U.xAxis = Arrow {
+        startX : U.shape.x - const.axisSize
         startY : U.shape.y
         endX : U.shape.x + const.axisSize
         endY : U.shape.y
         thickness : U.thickness
         color : U.axisColor
+        arrowheadSize : const.arrowheadSize
     }
 
-    U.xAxisLeft = Arrow {
+    U.yAxis = Arrow {
         startX : U.shape.x
-        startY : U.shape.y
-        endX : U.shape.x - const.axisSize
-        endY : U.shape.y
-        thickness : U.thickness
-        color : U.axisColor
-    }
-
-    U.yAxisUp = Arrow {
-        startX : U.shape.x
-        startY : U.shape.y
+        startY : U.shape.y - const.axisSize
         endX : U.shape.x
         endY : U.shape.y + const.axisSize
         thickness : U.thickness
         color : U.axisColor
-    }
-
-    U.yAxisDown = Arrow {
-        startX : U.shape.x
-        startY : U.shape.y
-        endX : U.shape.x
-        endY : U.shape.y - const.axisSize
-        thickness : U.thickness
-        color : U.axisColor
+        arrowheadSize : const.arrowheadSize
     }
 
     U.text = Text {
@@ -98,7 +87,7 @@ where In(v,U) {
     startY : U.shape.y
     thickness : 3.0
     color : Colors.blue
-    arrowheadSize : 0.8
+    arrowheadSize : const.arrowheadSize
   }
 
    v.vector = (v.shape.endX - v.shape.startX, v.shape.endY - v.shape.startY)
@@ -114,10 +103,8 @@ where In(v,U) {
    -- This objective gives better visual results but causes vectors to be the same length?
    -- v.labelAvoidFn = encourage repel(v.shape, v.text, const.repelWeight)
 
-  v.layeringText1 = v.text above U.xAxisRight
-  v.layeringText2 = v.text above U.xAxisLeft
-  v.layeringText3 = v.text above U.yAxisUp
-  v.layeringText4 = v.text above U.yAxisDown
+  v.layeringText1 = v.text above U.xAxis
+  v.layeringText2 = v.text above U.yAxis
 }
 
 Vector u; Vector v
@@ -136,6 +123,48 @@ where Orthogonal(u, v); In(u, U); In(v, U) {
 
       LOCAL.layering1 = v.shape above LOCAL.perpMark
       LOCAL.layering2 = u.shape above LOCAL.perpMark
+}
+
+-- Usually, the unit vector shouldn't need to know about orthogonal vectors, but we need to position the unit mark so that it doesn't overlap with the "inside" of the two vectors
+Vector v
+with VectorSpace U; Vector w
+where In(v, U); Unit(v); Orthogonal(v, w) {
+
+      -- The start and end of the body of the unit marker line
+      v.offsetVec = unitMark(v.shape, w.shape, "body", const.markerPadding, const.barSize)
+      v.labelPosition = midpointOffset(v.offsetVec, w.shape, const.markerPadding)
+
+      v.unitMarkerLine = Curve {
+          pathData : pathFromPoints(v.offsetVec)
+	  strokeWidth : 2.0
+	  color : Colors.black
+	  fill : Colors.none
+      }
+
+      v.unitMarkerEnd1 = Curve {
+          pathData : unitMark(v.offsetVec, "start", const.markerPadding, const.barSize)
+      	  strokeWidth : 2.0
+      	  color : Colors.black
+      	  fill : Colors.none
+      }
+
+      v.unitMarkerEnd2 = Curve {
+          pathData : unitMark(v.offsetVec, "end", const.markerPadding, const.barSize)
+      	  strokeWidth : 2.0
+      	  color : Colors.black
+      	  fill : Colors.none
+      }
+
+      v.unitMarkerText = Text {
+          string : "1"
+	  x : get(v.labelPosition, 0)
+	  y : get(v.labelPosition, 1)
+	  color : Colors.black
+      }
+
+      v.layeringUnit1 = v.unitMarkerLine above U.xAxis
+      v.layeringUnit2 = v.unitMarkerLine above U.yAxis
+      -- v.unitLabelAvoidFn = encourage repel(v.unitMarkerLine, v.unitMarkerText, const.repelWeight)
 }
 
 Vector `x2` {

--- a/examples/linear-algebra-domain/linear-algebra.sty
+++ b/examples/linear-algebra-domain/linear-algebra.sty
@@ -18,6 +18,9 @@ const {
   const.repelWeight = 0.7
   const.textPadding = 15.0
   const.perpLen = 15.0
+  -- For unit mark
+  const.markerPadding = 15.0
+  const.barSize = 5.0
 }
 
 -- Global RGB colors in common use
@@ -435,4 +438,46 @@ where From(f, U, V); u2 := scale(c, u1); v1 := apply(f, u1); v2 := apply(f, u2);
       delete v3.containLabel
       delete v3.labelLocation
       delete v3.labelAvoidFn
+}
+
+-- Usually, the unit vector shouldn't need to know about orthogonal vectors, but we need to position the unit mark so that it doesn't overlap with the "inside" of the two vectors
+Vector v
+with VectorSpace U; Vector w
+where In(v, U); Unit(v); Orthogonal(v, w) {
+
+      -- The start and end of the body of the unit marker line
+      v.offsetVec = unitMark(v.shape, w.shape, "body", const.markerPadding, const.barSize)
+      v.labelPosition = midpointOffset(v.offsetVec, w.shape, const.markerPadding)
+
+      v.unitMarkerLine = Curve {
+          pathData : pathFromPoints(v.offsetVec)
+	  strokeWidth : 2.0
+	  color : Colors.black
+	  fill : Colors.none
+      }
+
+      v.unitMarkerEnd1 = Curve {
+          pathData : unitMark(v.offsetVec, "start", const.markerPadding, const.barSize)
+      	  strokeWidth : 2.0
+      	  color : Colors.black
+      	  fill : Colors.none
+      }
+
+      v.unitMarkerEnd2 = Curve {
+          pathData : unitMark(v.offsetVec, "end", const.markerPadding, const.barSize)
+      	  strokeWidth : 2.0
+      	  color : Colors.black
+      	  fill : Colors.none
+      }
+
+      v.unitMarkerText = Text {
+          string : "1"
+	  x : get(v.labelPosition, 0)
+	  y : get(v.labelPosition, 1)
+	  color : Colors.black
+      }
+
+      v.layeringUnit1 = v.unitMarkerLine above U.xAxis
+      v.layeringUnit2 = v.unitMarkerLine above U.yAxis
+      -- v.unitLabelAvoidFn = encourage repel(v.unitMarkerLine, v.unitMarkerText, const.repelWeight)
 }

--- a/examples/linear-algebra-domain/linear-algebra.sty
+++ b/examples/linear-algebra-domain/linear-algebra.sty
@@ -17,6 +17,7 @@ const {
   const.arrowheadSize = 0.5
   const.repelWeight = 0.7
   const.textPadding = 15.0
+  const.perpLen = 15.0
 }
 
 -- Global RGB colors in common use
@@ -53,10 +54,12 @@ VectorSpace U {
     U.thickness = 1.5
     U.axisColor = Colors.darkGray
     U.originX = 0.0
+    U.originY = 0.0
+    U.origin = (U.originX, U.originY)
 
     U.shape = Square {
 	x : U.originX
-	y : 0.0
+	y : U.originY
         side : const.vectorSpaceSize
         color : Colors.lightBlue
     }
@@ -357,37 +360,19 @@ where u := scale(c, v); In(u, U); In(v, U) {
 Vector u; Vector v
 with VectorSpace U
 where Orthogonal(u, v); In(u, U); In(v, U) {
-      -- TODO: fix this angle calculation so it works when both vectors are in quadrants 2 or 3
-      LOCAL.angle = min(u.angle, v.angle)
-      LOCAL.len = 20.0
-
-      -- Scale by side len. Then translate so default square's corner is at (0,0).
-      -- Then rotate by the vector angle. Then translate to the local origin of the vector space.
-      LOCAL.shape = SquareTransform {
-	  -- TODO: unintuitive behavior; need to set these constants otherwise shape is offscreen
-
-	  -- TODO: this currently isn't working because we commented out transforms in computedProperties (they were slowing down the system)
-
-	  -- x : 0.0
-	  -- y : 0.0
-	  -- side : 100.0
-	  -- rotation : 0.0
-
-	  x : 0.0
-	  y : 0.0
-	  side : 1.0
-	  rotation : 0.0
-	  transform : andThen(andThen(andThen(scale(LOCAL.len, LOCAL.len), translate(LOCAL.len / 2.0, LOCAL.len / 2.0)), rotate(LOCAL.angle)), translate(U.shape.x, U.shape.y))
-	  color : Colors.none
-	  strokeColor : Colors.black
-	  strokeWidth : 0.1
+      -- Draw perpendicular mark
+      LOCAL.perpMark = Curve {
+	   pathData : perpPath(u.shape, v.shape, U.origin, const.perpLen)
+	   strokeWidth : 2.0
+	   color : Colors.black
+	   fill : Colors.white
       }
 
-      -- LOCAL.perpFn = ensure equals(dot(u.vector, v.vector), 0.0)
+      -- Make sure vectors are orthogonal
       LOCAL.perpFn = encourage equal(dot(u.vector, v.vector), 0.0)
 
-      LOCAL.layering1 = v.shape above LOCAL.shape
-      LOCAL.layering2 = u.shape above LOCAL.shape
+      LOCAL.layering1 = v.shape above LOCAL.perpMark
+      LOCAL.layering2 = u.shape above LOCAL.perpMark
 }
 
 -- No label overlaps with any other label, vector, slider vector, or axis line. (This doesn't match the same vector twice, right?)

--- a/examples/linear-algebra-domain/twoVectorsPerp.sub
+++ b/examples/linear-algebra-domain/twoVectorsPerp.sub
@@ -3,5 +3,5 @@ Vector x1 ∈ X
 Vector x2 ∈ X
 Unit(x1)
 Orthogonal(x1, x2)
-Label x1 $\vec{x_1}$
-Label x2 $\vec{x_2}$
+Label x1 $x_1$
+Label x2 $x_2$

--- a/src/Penrose/Functions.hs
+++ b/src/Penrose/Functions.hs
@@ -991,6 +991,14 @@ perpPath [GPI r@("Line", _), GPI l@("Line", _), Val (TupV midpt), Val (FloatV si
       path = Closed $ [Pt ptL, Pt ptLR, Pt ptR, Pt midpt]
   in Val $ PathDataV [path]
 
+-- TODO: Merge withe the linelike selectors; this is duplicated code
+perpPath [GPI r@("Arrow", _), GPI l@("Arrow", _), Val (TupV midpt), Val (FloatV size)] = -- Euclidean
+  let seg1 = (getPoint "start" r, getPoint "end" r)
+      seg2 = (getPoint "start" l, getPoint "end" l)
+      (ptL, ptLR, ptR) = perpPathFlat size seg1 seg2
+      path = Closed $ [Pt ptL, Pt ptLR, Pt ptR, Pt midpt]
+  in Val $ PathDataV [path]
+
 perpPath [Val (ListV p), Val (ListV q), Val (ListV tailv), Val (ListV headv), Val (FloatV arcLen)] = -- Spherical
   let (p', q') = (normalize p, normalize q)
              -- TODO: cache these calculations bc they're recomputed many times in Ray, Triangle, etc.

--- a/src/Penrose/Functions.hs
+++ b/src/Penrose/Functions.hs
@@ -183,6 +183,8 @@ compDict =
     , ("angle", constComp angleFn)
     , ("sampleUniform", sampleUniformFn)
     , ("makePalette", constComp makePalette)
+    , ("unitMark", constComp unitMark)
+    , ("midpointOffset", constComp midpointOffset)
 
   , ("calcZSphere", constComp calcZSphere)
 
@@ -1150,6 +1152,7 @@ get' [Val (ListV xs), Val (IntV i)] =
        then error "out of bounds access in get'"
        else Val $ FloatV $ xs !! i'
 get' [Val (TupV (x1, x2)), index] = get' [Val (ListV [x1, x2]), index]
+get' [Val (PtV (x1, x2)), index] = get' [Val (ListV [x1, x2]), index]
 
 projectVec :: Autofloat a => String -> Pt2 a -> Pt2 a -> a -> [a] -> [a] -> [a] -> a -> [a]
 projectVec name hfov vfov r camera dir vec_math toScreen =
@@ -1300,6 +1303,50 @@ makePalette [Val (ColorV c1), Val (ColorV c2), Val (ColorV c3)] =
 
 makePalette [Val (ColorV c1), Val (ColorV c2), Val (ColorV c3), Val (ColorV c4)] = 
         Val $ PaletteV [c1, c2, c3, c4]
+
+-- padding: distance between arrow and unit marker
+-- size: length of bars on end of unit marker
+unitMark :: ConstCompFn
+-- TODO: Factor out the repeated computations below
+unitMark [GPI v@("Arrow", _), GPI w@("Arrow", _), Val (StrV "body"), Val (FloatV padding), Val (FloatV size)] =
+  let (start, end) = (getPoint "start" v, getPoint "end" v)
+      -- dir = normalize' $ end -: start
+      -- normalDir = rot90 dir
+      -- Assuming w is orthogonal to v, use its opposite dir as the normal, so the unit mark goes to the "outside" of the two vecs
+      (start2, end2) = (getPoint "start" w, getPoint "end" w)
+      dir = normalize' $ end2 -: start2
+      normalDir = (-1.0) *: dir
+      markStart = start +: padding *: normalDir
+      markEnd = end +: padding *: normalDir
+  in Val $ PtListV [markStart, markEnd]
+
+unitMark [Val (PtListV [start, end]), Val (StrV "start"), Val (FloatV padding), Val (FloatV size)] =
+  let dir = normalize' $ end -: start
+      normalDir = rot90 dir
+      markStart = start +: size *: normalDir
+      markEnd = start -: size *: normalDir
+      path = Open $ [Pt markStart, Pt markEnd]
+  in Val $ PathDataV [path]
+
+unitMark [Val (PtListV [start, end]), Val (StrV "end"), Val (FloatV padding), Val (FloatV size)] =
+  let dir = normalize' $ end -: start
+      normalDir = rot90 dir
+      markStart = end +: size *: normalDir
+      markEnd = end -: size *: normalDir
+      path = Open $ [Pt markStart, Pt markEnd]
+  in Val $ PathDataV [path]
+
+midpointOffset :: ConstCompFn
+-- TODO: Factor out the repeated computations below
+midpointOffset [Val (PtListV [start, end]), GPI w@("Arrow", _), Val (FloatV padding)] =
+  let (start2, end2) = (getPoint "start" w, getPoint "end" w) -- Use orthogonal vector to position label in the right direction
+      dir = normalize' $ end2 -: start2
+      normalDir = (-1.0) *: dir
+      -- dir = normalize' $ end -: start
+      -- normalDir = rot90 dir
+      midpointLoc = 0.5 *: (start +: end)
+      midpointOffsetLoc = midpointLoc +: padding *: normalDir
+  in Val $ TupV midpointOffsetLoc
 
 -- TODO: only works for color lists right now
 sampleUniformFn :: CompFn


### PR DESCRIPTION
# Description

Add support for unit vector marks and port the perpendicular mark to no longer use transforms (deprecated). 

# Implementation strategy and design decisions

Unit vector mark implementation is pretty messy because it requires a lot of inline vector operations, which style can't handle, and needs to know about the presence of the orthogonal vector so it doesn't overlap. Not sure how to resolve.

# Examples with steps to reproduce them

`runpenrose linear-algebra-domain/twoVectorsPerp.sub linear-algebra-domain/linear-algebra-paper.sty linear-algebra-domain/linear-algebra.dsl`

# Checklist

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I ran [Haddock](https://github.com/penrose/penrose/wiki/Writing-and-generating-documentation#generating-html-documentation-site) and there were no errors when generating the HTML site
- [ ] My changes generate no new warnings
- [ ] New and existing tests pass locally using `stack test`
- [ ] My code follows the style guidelines of this project (e.g.: no HLint warnings)

# Open questions

Questions that require more discussion or to be addressed in future development:
* Clean up unit mark implementation