### PR TITLE
Fix continuous map example.

### DIFF
--- a/examples/set-theory-domain/continuousmap.sub
+++ b/examples/set-theory-domain/continuousmap.sub
@@ -2,6 +2,7 @@ AutoLabel All
 
 Set A
 Set U
+Label U $f^{-1}(V)$
 Set Rn
 Label Rn $\mathbb{R}^n$
 IsSubset(U, A)
@@ -9,7 +10,6 @@ IsSubset(A, Rn)
 
 Set B
 Set V
-Label V $f^{-1}(U)$
 Set Rm
 Label Rm $\mathbb{R}^m$
 IsSubset(V, B)


### PR DESCRIPTION
# Description

f^{-1} should be in the domain, not the codomain. Per Munkres: "A function f \colon X \to Y is said to be continuous if for each open subset V of Y, the set f^{-1}(V) is an open subset of X."

Before:
![continuous map before](https://user-images.githubusercontent.com/21694516/77474609-68b74100-6de5-11ea-85ee-14a7054ae618.png)

After:
![continuous map after](https://user-images.githubusercontent.com/21694516/77474401-09593100-6de5-11ea-85a9-eea757df5c5c.png)

# Checklist

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I ran [Haddock](https://github.com/penrose/penrose/wiki/Writing-and-generating-documentation#generating-html-documentation-site) and there were no errors when generating the HTML site
- [x] My changes generate no new warnings
- [x] New and existing tests pass locally using `stack test`
- [x] My code follows the style guidelines of this project (e.g.: no HLint warnings)