### PR TITLE
Fixing layering issues in web-runtime

### DIFF
--- a/examples/set-theory-domain/venn-opt-test.sty
+++ b/examples/set-theory-domain/venn-opt-test.sty
@@ -10,6 +10,7 @@ forall Set x {
     ensure minSize(x.shape)
     ensure maxSize(x.shape)
     encourage sameCenter(x.text, x.shape)
+    x.textLayering = x.text above x.shape
 }
 
 forall Set x; Set y

--- a/examples/vizdoc/near.sty
+++ b/examples/vizdoc/near.sty
@@ -1,0 +1,33 @@
+Colors {
+    Colors.black = rgba(0.0, 0.0, 0.0, 1.0)
+    Colors.none = rgba(0.0, 0.0, 0.0, 0.0)
+    Colors.gray = rgba(0.6, 0.6, 0.6, 1.0)
+    Colors.red = rgba(1.0, 0.0, 0.0, 1.0)
+    Colors.lightblue = rgba(0.580, 0.910, 1.0, 1.0)
+    Colors.darkblue = rgba(0.078, 0.255, 0.788, 1.0)
+}
+
+Circ x {
+  x.shape = Circle {
+    strokeWidth : 2.0
+    strokeColor : Colors.darkblue
+    strokeStyle : "solid"
+    color: Colors.lightblue
+    x: 0.0
+    r: 50.0
+  }
+}
+
+
+Circ `A` 
+with Circ `B`{
+  -- override `C`.shape.x = -400.0
+  -- override `B`.shape.x = 300.0
+  encourage sameCenter(`A`.shape, `B`.shape)
+  LOCAL.layering = `A`.shape above `B`.shape
+    override `B`.shape.color = Colors.red
+  -- ensure smallerThan(`A`.shape, `B`.shape)
+  -- ensure minSize(`A`.shape)
+  --encourage above(`B`.shape, `C`.shape)
+}
+

--- a/examples/vizdoc/near.sub
+++ b/examples/vizdoc/near.sub
@@ -1,0 +1,3 @@
+Circ A
+Circ B
+AutoLabel All

--- a/examples/vizdoc/shapes.dsl
+++ b/examples/vizdoc/shapes.dsl
@@ -1,0 +1,12 @@
+type Ell
+type Rad
+type Point
+type Box
+type Circ
+type Rect 
+type Sq
+type Arr
+type Arrhead
+type Lin
+type Txt
+type Img

--- a/react-renderer/src/Evaluator.ts
+++ b/react-renderer/src/Evaluator.ts
@@ -48,9 +48,13 @@ export const evalTranslation = (s: State): State => {
     [[], trans]
   );
 
+  // Sort the shapes by ordering - note the null assertion
+  const sortedShapesEvaled = s.shapeOrdering.map((name) =>
+  shapesEvaled.find(({ properties }) => properties.name.contents === name)!);
+
   // Update the state with the new list of shapes and translation
   // TODO: check how deep of a copy this is by, say, changing varyingValue of the returned state and see if the argument changes
-  return { ...s, shapes: shapesEvaled, translation: transEvaled };
+  return { ...s, shapes: sortedShapesEvaled, translation: transEvaled };
 };
 
 const doneFloat = (n: number): TagExpr<number> => ({


### PR DESCRIPTION
# Description

Issue #355 

Previously in web-runtime, shapes were not being sorted by ordering after each optimizer step, which caused layering keywords like `above` to behave unexpectedly when rendering diagrams. The fix ensures shape sorting after each step. I also updated the set theory example (`runpenrose set-theory-domain/tree.sub set-theory-domain/venn-opt-test.sty set-theory-domain/setTheory.dsl`) to explicitly define layering relationship between a Set shape and a Set text, which became necessary after the fix. I also included the original diagram mentioned in the relevant issue to show that the problem is fixed (`runpenrose vizdoc/near.sub vizdoc/near.sty vizdoc/shapes.dsl 
`).


# Implementation strategy and design decisions

Copied the function used in Canvas to originally sort the shapes to the Evaluator inside the `evalTranslation` function.

# Examples with steps to reproduce them

<img width="435" alt="Screen Shot 2020-07-10 at 8 32 39 PM" src="https://user-images.githubusercontent.com/40800240/87212850-c452ff00-c2ee-11ea-8fc3-917bfedd95b4.png">

`runpenrose set-theory-domain/tree.sub set-theory-domain/venn-opt-test.sty set-theory-domain/setTheory.dsl`

<img width="310" alt="Screen Shot 2020-07-10 at 8 34 51 PM" src="https://user-images.githubusercontent.com/40800240/87212866-ddf44680-c2ee-11ea-8ce7-14b98bfa8fb7.png">


`runpenrose set-theory-domain/tree.sub set-theory-domain/tree.sty set-theory-domain/setTheory.dsl`

<img width="210" alt="Screen Shot 2020-07-10 at 8 47 39 PM" src="https://user-images.githubusercontent.com/40800240/87212856-ca48e000-c2ee-11ea-8f3c-168f7fdd40cf.png">

`runpenrose vizdoc/near.sub vizdoc/near.sty vizdoc/shapes.dsl 
`

# Open questions

In most diagrams, text is layered above the shape in a given object in Substance. It could be useful to implement this as the default setting, to prevent the user from having to write out the same layering in every Style file. Currently the default layering is unpredictable and depends on `Translation` order.
