### PR TITLE
Change "engine" to run on autodiff types only

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,3 +46,5 @@ dist-newstyle/
 examples/plugins/alloy/__temp.als__
 .java-version
 temp.als
+.*.sw*
+

--- a/UserGuide.md
+++ b/UserGuide.md
@@ -1,0 +1,2 @@
+In `penrose/react-renderer/src`, run `npm start`
+In `penrose/examples/` run `runpenrose my.sub my.sty my.domain`

--- a/examples/ThoughtsAndIssues.txt
+++ b/examples/ThoughtsAndIssues.txt
@@ -1,0 +1,22 @@
+Should whitespace be ignored in notation?
+
+When a constructor's arguments are not named, the error message is cryptic
+
+Should be possible to specify floating point numbers in any standard way (e.g., 0. instead of 0.0)
+
+Should be possible to specify colors in hex
+
+Should be possible to use notation in Style
+
+Make it clearer what the canvas size is, and make it possible to set the canvas size
+
+Maybe do automatic "upgrades" of integer to float in Style?
+
+Shouldn't be forced to put open brace ({) on same line as block name in Style
+
+Should allow local scoping, i.e., variables defined within a scope should be referencable within that scope without the scope name.  E.g., Global { width = 1.23; height = width/2.0; }
+(More generally: just think about scoping, and how we can perhaps have shorter references)
+
+Substance should support Unicode characters
+
+Should be possible to use arbitrary Unicode characters in notation

--- a/examples/hyperbolic-domain/PoincareDisk.sty
+++ b/examples/hyperbolic-domain/PoincareDisk.sty
@@ -1,0 +1,36 @@
+Global {
+   Global.width = 800.0
+   Global.height = 700.0
+   Global.pointSize = Global.width/100.0
+   Global.thinStroke = Global.width/200.0
+   Global.planeSize = 0.9*Global.height
+}
+
+Colors {
+   Colors.black = rgba( 0.0, 0.0, 0.0, 1.0 )
+   Colors.blue = rgba( 0.8, 0.7, 1.0, 0.2 )
+}
+
+forall HyperbolicPlane H {
+   H.diskShape = Circle {
+      x : 0.0
+      y : 0.0
+      r : Global.planeSize/2.0
+      color : Colors.blue
+      strokeWidth : Global.thinStroke
+      strokeColor : Colors.black
+      strokeStyle : "dashed"
+      strokeDashArray : "20,10,5,5,5,10"
+   }
+}
+
+forall Point p; HyperbolicPlane H
+where In( p, H ) {
+   p.dotShape = Circle {
+      r : Global.pointSize/2.0
+      strokeWidth : 0.0
+      color : Colors.black
+   }
+
+   ensure contains( H.diskShape, p.dotShape )
+}

--- a/examples/hyperbolic-domain/PoincareDisk.sty
+++ b/examples/hyperbolic-domain/PoincareDisk.sty
@@ -34,3 +34,19 @@ where In( p, H ) {
 
    ensure contains( H.diskShape, p.dotShape )
 }
+
+
+-- TODO: Fix that we can't add new functions with new names w/o backend complaining
+
+forall IdealPoint p; HyperbolicPlane H
+where In( p, H ) {
+   p.angle = ?
+
+   p.dotShape = Circle {
+      x : 630.0*cos(p.angle)/2.0
+      y : 630.0*sin(p.angle)/2.0
+      r : Global.pointSize
+      strokeWidth : 0.0
+      color : Colors.black
+   }
+}

--- a/examples/hyperbolic-domain/hyperbolic-example.sub
+++ b/examples/hyperbolic-domain/hyperbolic-example.sub
@@ -1,0 +1,10 @@
+HyperbolicPlane H
+IdealPoint p, q
+Horocycle g, h
+
+p ∈ H
+q ∈ H
+
+IsCenter( p, g )
+IsCenter( q, h )
+

--- a/examples/hyperbolic-domain/hyperbolic-example.sub
+++ b/examples/hyperbolic-domain/hyperbolic-example.sub
@@ -7,4 +7,3 @@ q ∈ H
 
 IsCenter( p, g )
 IsCenter( q, h )
-

--- a/examples/hyperbolic-domain/hyperbolic.dsl
+++ b/examples/hyperbolic-domain/hyperbolic.dsl
@@ -1,0 +1,16 @@
+type HyperbolicPlane
+type Point
+type IdealPoint
+type Segment
+type Horocycle
+
+IdealPoint <: Point
+
+predicate In: Point * HyperbolicPlane
+predicate IsCenter: IdealPoint * Horocycle
+
+constructor MakeSegment: Point endpoint1 * Point endpoint2 -> Segment
+
+notation "{ a, b }" ~ "MakeSegment( a, b )"
+notation "p ∈ H" ~ "In( p, H )"
+

--- a/examples/runHyperbolic
+++ b/examples/runHyperbolic
@@ -1,0 +1,1 @@
+/Users/kmcrane/.local/bin/penrose hyperbolic-domain/hyperbolic-example.sub hyperbolic-domain/PoincareDisk.sty hyperbolic-domain/hyperbolic.dsl

--- a/examples/set-theory-domain/venn.sty
+++ b/examples/set-theory-domain/venn.sty
@@ -63,6 +63,7 @@ forall Set x {
 
 forall Set x; Set y
 where IsSubset(x, y) {
+      -- TODO / NOTE: This version of `repel` doesn't yet work in the new runtime
     encourage repel(x.hue, y.hue, 1.0, "angle")
 
     ensure contains(y.shape, x.shape, 5.0)

--- a/react-renderer/.dir-locals.el
+++ b/react-renderer/.dir-locals.el
@@ -1,0 +1,3 @@
+;; Turn off emacs lockfiles for this project only so the hot reload works (otherwise crashes every time a file is edited)
+;; https://stackoverflow.com/questions/62567370/reactjs-local-server-crashes-after-editing-file-in-emacs-even-without-saving
+((nil . ((create-lockfiles . nil)))) 

--- a/react-renderer/package-lock.json
+++ b/react-renderer/package-lock.json
@@ -1297,7 +1297,7 @@
     },
     "@types/json5": {
       "version": "0.0.29",
-      "resolved": "https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz",
+      "resolved": "http://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz",
       "integrity": "sha1-7ihweulOEdK4J7y+UnC86n8+ce4="
     },
     "@types/lodash": {
@@ -2459,7 +2459,7 @@
     },
     "babel-plugin-istanbul": {
       "version": "4.1.6",
-      "resolved": "https://registry.npmjs.org/babel-plugin-istanbul/-/babel-plugin-istanbul-4.1.6.tgz",
+      "resolved": "http://registry.npmjs.org/babel-plugin-istanbul/-/babel-plugin-istanbul-4.1.6.tgz",
       "integrity": "sha512-PWP9FQ1AhZhS01T/4qLSKoHGY/xvkZdVBGlKM/HuxxS3+sC66HhTNR7+MpbO/so/cz/wY94MeSWJuP1hXIPfwQ==",
       "requires": {
         "babel-plugin-syntax-object-rest-spread": "^6.13.0",
@@ -2506,7 +2506,7 @@
     },
     "babel-plugin-syntax-object-rest-spread": {
       "version": "6.13.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-syntax-object-rest-spread/-/babel-plugin-syntax-object-rest-spread-6.13.0.tgz",
+      "resolved": "http://registry.npmjs.org/babel-plugin-syntax-object-rest-spread/-/babel-plugin-syntax-object-rest-spread-6.13.0.tgz",
       "integrity": "sha1-/WU28rzhODb/o6VFjEkDpZe7O/U="
     },
     "babel-plugin-transform-es2015-modules-commonjs": {
@@ -3130,7 +3130,7 @@
     },
     "browserify-aes": {
       "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/browserify-aes/-/browserify-aes-1.2.0.tgz",
+      "resolved": "http://registry.npmjs.org/browserify-aes/-/browserify-aes-1.2.0.tgz",
       "integrity": "sha512-+7CHXqGuspUn/Sl5aO7Ea0xWGAtETPXNSAjHo48JfLdPWcMng33Xe4znFvQweqc/uzk5zSOI3H52CYnjCfb5hA==",
       "requires": {
         "buffer-xor": "^1.0.3",
@@ -3164,7 +3164,7 @@
     },
     "browserify-rsa": {
       "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/browserify-rsa/-/browserify-rsa-4.0.1.tgz",
+      "resolved": "http://registry.npmjs.org/browserify-rsa/-/browserify-rsa-4.0.1.tgz",
       "integrity": "sha1-IeCr+vbyApzy+vsTNWenAdQTVSQ=",
       "requires": {
         "bn.js": "^4.1.0",
@@ -4260,7 +4260,7 @@
     },
     "create-hash": {
       "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/create-hash/-/create-hash-1.2.0.tgz",
+      "resolved": "http://registry.npmjs.org/create-hash/-/create-hash-1.2.0.tgz",
       "integrity": "sha512-z00bCGNHDG8mHAkP7CtT1qVu+bFQUPjYq/4Iv3C3kWjTFV10zIjfSoeqXo9Asws8gwSHDGj/hl2u4OGIjapeCg==",
       "requires": {
         "cipher-base": "^1.0.1",
@@ -4272,7 +4272,7 @@
     },
     "create-hmac": {
       "version": "1.1.7",
-      "resolved": "https://registry.npmjs.org/create-hmac/-/create-hmac-1.1.7.tgz",
+      "resolved": "http://registry.npmjs.org/create-hmac/-/create-hmac-1.1.7.tgz",
       "integrity": "sha512-MJG9liiZ+ogc4TzUwuvbER1JRdgvUFSB5+VR/g5h82fGaIRWMWddtKBHi7/sVhfjQZ6SehlyhvQYrcYkaUIpLg==",
       "requires": {
         "cipher-base": "^1.0.3",
@@ -4320,7 +4320,7 @@
     },
     "css-color-names": {
       "version": "0.0.4",
-      "resolved": "https://registry.npmjs.org/css-color-names/-/css-color-names-0.0.4.tgz",
+      "resolved": "http://registry.npmjs.org/css-color-names/-/css-color-names-0.0.4.tgz",
       "integrity": "sha1-gIrcLnnPhHOAabZGyyDsJ762KeA="
     },
     "css-declaration-sorter": {
@@ -4985,7 +4985,7 @@
     },
     "diffie-hellman": {
       "version": "5.0.3",
-      "resolved": "https://registry.npmjs.org/diffie-hellman/-/diffie-hellman-5.0.3.tgz",
+      "resolved": "http://registry.npmjs.org/diffie-hellman/-/diffie-hellman-5.0.3.tgz",
       "integrity": "sha512-kqag/Nl+f3GwyK25fhUMYj81BUOrZ9IuJsjIcDE5icNM9FJHAVm3VcUDxdLPoQtTuUylWm6ZIknYJwwaPxsUzg==",
       "requires": {
         "bn.js": "^4.1.0",
@@ -5145,7 +5145,7 @@
     },
     "duplexer": {
       "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.1.tgz",
+      "resolved": "http://registry.npmjs.org/duplexer/-/duplexer-0.1.1.tgz",
       "integrity": "sha1-rOb/gIwc5mtX0ev5eXessCM0z8E="
     },
     "duplexify": {
@@ -9096,7 +9096,7 @@
     },
     "jest-get-type": {
       "version": "22.4.3",
-      "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-22.4.3.tgz",
+      "resolved": "http://registry.npmjs.org/jest-get-type/-/jest-get-type-22.4.3.tgz",
       "integrity": "sha512-/jsz0Y+V29w1chdXVygEKSz2nBoHoYqNShPe+QgxSNjAuP1i8+k4LbQNrfoliKej0P45sivkSCh7yiD6ubHS3w=="
     },
     "jest-haste-map": {
@@ -15257,7 +15257,7 @@
     },
     "sha.js": {
       "version": "2.4.11",
-      "resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.11.tgz",
+      "resolved": "http://registry.npmjs.org/sha.js/-/sha.js-2.4.11.tgz",
       "integrity": "sha512-QMEp5B7cftE7APOjk5Y6xgrbWu+WkLVQwk8JNjZ8nKRciZaByEW6MubieAiToS7+dwvrjGhH8jRXz3MVd0AYqQ==",
       "requires": {
         "inherits": "^2.0.1",
@@ -16339,7 +16339,7 @@
     },
     "through": {
       "version": "2.3.8",
-      "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
+      "resolved": "http://registry.npmjs.org/through/-/through-2.3.8.tgz",
       "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU="
     },
     "through2": {
@@ -18892,7 +18892,7 @@
     },
     "wrap-ansi": {
       "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
+      "resolved": "http://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
       "integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
       "requires": {
         "string-width": "^1.0.1",

--- a/react-renderer/src/Canvas.tsx
+++ b/react-renderer/src/Canvas.tsx
@@ -6,6 +6,9 @@ import { loadImages } from "./Util";
 import { insertPending } from "./PropagateUpdate";
 import { collectLabels } from "./utills/CollectLabels";
 import { evalTranslation, decodeState } from "./Evaluator";
+import { walkTranslationConvert } from "./EngineUtils";
+import { scalar } from "@tensorflow/tfjs";
+import { differentiable } from "./Optimizer";
 
 interface ICanvasProps {
   lock: boolean;
@@ -44,20 +47,32 @@ class Canvas extends React.Component<ICanvasProps> {
    */
   public static processData = async (data: any) => {
     const state: State = decodeState(data);
-    const stateEvaled: State = evalTranslation(state);
-    // TODO: return types
+
+    // Make sure that the state decoded from backend conforms to the types in types.d.ts, otherwise the typescript checking is just not valid for e.g. Tensors
+    // convert all TagExprs (tagged Done or Pending) in the translation to Tensors (autodiff types)
+    const translationAD = walkTranslationConvert(state.translation);
+    const stateAD = {
+      ...state,
+      translation: translationAD,
+      varyingValues: state.varyingValues.map(e => differentiable(e))
+    };
+
+    // After the pending values load, they only use the evaluated shapes (all in terms of numbers)
+    // The results of the pending values are then stored back in the translation as autodiff types
+    const stateEvaled: State = evalTranslation(stateAD);
+    // TODO: add return types
     const labeledShapes: any = await collectLabels(stateEvaled.shapes);
     const labeledShapesWithImgs: any = await loadImages(labeledShapes);
     const sortedShapes: any = await Canvas.sortShapes(
       labeledShapesWithImgs,
       data.shapeOrdering
     );
-
     const nonEmpties = await sortedShapes.filter(Canvas.notEmptyLabel);
     const processed = await insertPending({
       ...stateEvaled,
       shapes: nonEmpties,
     });
+
     return processed;
   };
 
@@ -265,7 +280,7 @@ class Canvas extends React.Component<ICanvasProps> {
       ctm: !this.props.lock ? (this.svg.current as any).getScreenCTM() : null,
     });
   };
-  
+
   public render() {
     const {
       substanceMetadata,
@@ -296,12 +311,12 @@ class Canvas extends React.Component<ICanvasProps> {
         <desc>
           {`This diagram was created with Penrose (https://penrose.ink)${
             penroseVersion ? " version " + penroseVersion : ""
-          } on ${new Date()
-            .toISOString()
-            .slice(
-              0,
-              10
-            )}. If you have any suggestions on making this diagram more accessible, please contact us.\n`}
+            } on ${new Date()
+              .toISOString()
+              .slice(
+                0,
+                10
+              )}. If you have any suggestions on making this diagram more accessible, please contact us.\n`}
           {substanceMetadata && `${substanceMetadata}\n`}
           {styleMetadata && `${styleMetadata}\n`}
           {elementMetadata && `${elementMetadata}\n`}

--- a/react-renderer/src/Circle.tsx
+++ b/react-renderer/src/Circle.tsx
@@ -14,6 +14,14 @@ class Circle extends React.Component<IGPIProps> {
     const strokeAlpha = shape.strokeColor.contents.contents[3];
     const thickness = shape.strokeWidth.contents;
 
+    let dashArray = "7,5";
+    if( "strokeDashArray" in shape )
+    {
+       if( shape.strokeDashArray ) {
+          dashArray = shape.strokeDashArray.contents;
+       }
+    }
+
     return (
       <circle
         cx={x}
@@ -23,7 +31,7 @@ class Circle extends React.Component<IGPIProps> {
         fillOpacity={fillAlpha}
         stroke={strokeColor}
         strokeOpacity={strokeAlpha}
-        strokeDasharray={shape.strokeStyle.contents === "dashed" ? "7, 5" : ""}
+        strokeDasharray={shape.strokeStyle.contents === "dashed" ? dashArray : ""}
         strokeWidth={thickness}
       >
         <title>{shape.name.contents}</title>

--- a/react-renderer/src/Circle.tsx
+++ b/react-renderer/src/Circle.tsx
@@ -15,11 +15,10 @@ class Circle extends React.Component<IGPIProps> {
     const thickness = shape.strokeWidth.contents;
 
     let dashArray = "7,5";
-    if( "strokeDashArray" in shape )
-    {
-       if( shape.strokeDashArray ) {
-          dashArray = shape.strokeDashArray.contents;
-       }
+    if ("strokeDashArray" in shape) {
+      if (shape.strokeDashArray) {
+        dashArray = shape.strokeDashArray.contents;
+      }
     }
 
     return (

--- a/react-renderer/src/Computations.ts
+++ b/react-renderer/src/Computations.ts
@@ -1,0 +1,103 @@
+import { range } from "lodash";
+import { randFloat } from "./Util";
+import { Tensor, scalar, stack, cos, sin } from "@tensorflow/tfjs";
+import { dist } from "./Constraints"
+
+/**
+ * Static dictionary of computation functions
+ * TODO: consider using `Dictionary` type so all runtime lookups are type-safe, like here https://codeburst.io/five-tips-i-wish-i-knew-when-i-started-with-typescript-c9e8609029db
+ * TODO: think about user extension of computation dict and evaluation of functions in there
+ */
+
+// NOTE: These all need to be written in terms of autodiff types (tensors)
+export const compDict = {
+  rgba: (r: Tensor, g: Tensor, b: Tensor, a: Tensor): IColorV<Tensor> => {
+    return {
+      tag: "ColorV",
+      contents: {
+        tag: "RGBA",
+        contents: [r, g, b, a],
+      },
+    };
+  },
+
+  hsva: (h: Tensor, s: Tensor, v: Tensor, a: Tensor): IColorV<Tensor> => {
+    return {
+      tag: "ColorV",
+      contents: {
+        tag: "HSVA",
+        contents: [h, s, v, a],
+      },
+    };
+  },
+
+  // Accepts degrees; converts to radians
+  cos: (d: Tensor): Value<Tensor> => {
+    return { tag: "FloatV", contents: cos(d.mul(scalar(Math.PI)).div(scalar(180))) };
+  },
+
+  // Accepts degrees; converts to radians
+  sin: (d: any) => {
+    return { tag: "FloatV", contents: sin(d.mul(scalar(Math.PI)).div(scalar(180))) };
+  },
+
+  dot: (v: any, w: any) => {
+    const [tv, tw] = [stack(v), stack(w)];
+    return { tag: "FloatV", contents: tv.dot(tw) };
+  },
+
+  lineLength: ([type, props]: [string, any]) => {
+    const [p1, p2] = arrowPts(props);
+    return { tag: "FloatV", contents: dist(p1, p2) };
+  },
+
+  len: ([type, props]: [string, any]) => {
+    const [p1, p2] = arrowPts(props);
+    return { tag: "FloatV", contents: dist(p1, p2) };
+  },
+
+  // TODO: The functions below need to be written in terms of autodiff types
+
+  orientedSquare: (arr1: any, arr2: any, pt: any, len: number) => {
+    throw Error("need to rewrite this function in terms of autodiff types");
+
+    console.log("orientedSquare", arr1, arr2, pt, len);
+    const elems = [{ tag: "Pt", contents: [100, 100] },
+    { tag: "Pt", contents: [200, 200] },
+    { tag: "Pt", contents: [300, 150] }];
+    const path = { tag: "Open", contents: elems };
+    return { tag: "PathDataV", contents: [path] };
+  },
+
+  sampleColor: (alpha: number, colorType: string) => {
+    throw Error("need to rewrite this function in terms of autodiff types");
+
+    if (colorType === "rgb") {
+      const rgb = range(3).map((_) => randFloat(0.1, 0.9));
+      return {
+        tag: "ColorV",
+        contents: {
+          tag: "RGBA",
+          contents: [...rgb, alpha],
+        },
+      };
+    } else if (colorType === "hsv") {
+      const h = randFloat(0, 360);
+      return {
+        tag: "ColorV",
+        contents: {
+          tag: "HSVA",
+          contents: [h, 100, 80, alpha], // HACK: for the color to look good
+        },
+      };
+    } else throw new Error("unknown color type");
+  },
+
+};
+
+const arrowPts = ({ startX, startY, endX, endY }: any): [Tensor, Tensor] =>
+  [stack([startX.contents, startY.contents]), stack([endX.contents, endY.contents])]
+
+export const checkComp = (fn: string, args: ArgVal<Tensor>[]) => {
+  if (!compDict[fn]) throw new Error(`Computation function "${fn}" not found`);
+};

--- a/react-renderer/src/Constraints.ts
+++ b/react-renderer/src/Constraints.ts
@@ -13,14 +13,13 @@ export const objDict = {
     return distsq(center(s1), center(s2));
   },
 
-
-  below: ([t1, bottom]: [string, any], [t2, top]: [string, any], offset = 100) => 
+  below: ([t1, bottom]: [string, any], [t2, top]: [string, any], offset = 100) =>
     square(top.y.contents.sub(bottom.y.contents).sub(scalar(offset))),
-    // can this be made more efficient (code-wise) by calling "above" and swapping arguments? - stella
+  // can this be made more efficient (code-wise) by calling "above" and swapping arguments? - stella
 
 
   centerLabel: ([t1, arr]: [string, any], [t2, text1]: [string, any], w: number): Tensor => {
-    if (typesAre([t1,t2], ["Arrow", "Text"])) {
+    if (typesAre([t1, t2], ["Arrow", "Text"])) {
       const mx = arr.startX.contents.add(arr.endX.contents).div(scalar(2.0));
       const my = arr.startY.contents.add(arr.endY.contents).div(scalar(2.0));
       // entire equation is (mx - lx) ^ 2 + (my + 1.1 * text.h - ly) ^ 2 from Functions.hs - split it into two halves below for readability
@@ -96,7 +95,7 @@ export const constrDict = {
       const d = dist(center(s1), center(s2));
       const textR = maximum(s2.w.contents, s2.h.contents);
       return d.sub(s1.r.contents).add(textR);
-    } else if (t1 === "Square" && t2 === "Circle"){
+    } else if (t1 === "Square" && t2 === "Circle") {
       // dist (outerx, outery) (innerx, innery) - (0.5 * outer.side - inner.radius)
       const sq = stack([s1.x.contents, s1.y.contents]);
       const d = dist(sq, center(s2));
@@ -187,8 +186,9 @@ export const looseIntersect = (center1: Tensor, r1: Tensor, center2: Tensor, r2:
   dist(center1, center2).sub(r1.add(r2).sub(scalar(padding)));
 // dist (x1, y1) (x2, y2) - (s1 + s2 - 10)
 
+// HACK: need to annotate the types of x and y to be Tensor
 export const center = (props: any): Tensor =>
-  stack([props.x.contents, props.y.contents]); // HACK: need to annotate the types of x and y to be Tensor
+  stack([props.x.contents, props.y.contents]);
 
 export const dist = (p1: Tensor, p2: Tensor): Tensor => p1.sub(p2).norm();
 
@@ -198,7 +198,6 @@ export const distsq = (p1: Tensor, p2: Tensor): Tensor => {
   const dp = p1.sub(p2);
   return dp.dot(dp);
 }
-
 
 // with epsilon to avoid NaNs
 export const normalize = (v: Tensor): Tensor => v.div(v.norm().add(epsd));

--- a/react-renderer/src/EngineUtils.ts
+++ b/react-renderer/src/EngineUtils.ts
@@ -1,0 +1,284 @@
+// Utils that are unrelated to the engine, but autodiff/opt/etc only
+
+import { sc } from "./Optimizer";
+import { Tensor, scalar } from "@tensorflow/tfjs";
+import { mapValues } from 'lodash';
+
+// TODO: Is there a way to write these mapping/conversion functions with less boilerplate?
+
+// Generic utils for mapping over values
+
+function mapTup2<T, S>(
+  f: (arg: T) => S,
+  t: [T, T]
+): [S, S] {
+  // TODO: Polygon seems to be getting through with null to the frontend with previously working set examples -- not sure why?
+  // TODO: Should do null checks more systematically across the translation
+  if (t[0] === null || t[1] === null) {
+    console.error("null elements in polygon");
+    return [scalar(0.0), scalar(0.0)] as unknown as [S, S];
+  }
+
+  return [f(t[0]), f(t[1])];
+};
+
+function mapTup4<T, S>(
+  f: (arg: T) => S,
+  t: [T, T, T, T]
+): [S, S, S, S] {
+  return [f(t[0]), f(t[1]), f(t[2]), f(t[3])];
+};
+
+function mapTup2LList<T, S>(
+  f: (arg: T) => S,
+  xss: [T, T][][]
+): [S, S][][] {
+  return xss.map(xs => xs.map(t => [f(t[0]), f(t[1])]));
+};
+
+// Mapping over values
+
+function mapFloat<T, S>(
+  f: (arg: T) => S,
+  v: IFloatV<T>
+): IFloatV<S> {
+  return {
+    tag: "FloatV",
+    contents: f(v.contents)
+  };
+};
+
+function mapPt<T, S>(
+  f: (arg: T) => S,
+  v: IPtV<T>
+): IPtV<S> {
+  return {
+    tag: "PtV",
+    contents: mapTup2(f, v.contents) as [S, S]
+  };
+};
+
+function mapPtList<T, S>(
+  f: (arg: T) => S,
+  v: IPtListV<T>
+): IPtListV<S> {
+  return {
+    tag: "PtListV",
+    contents: v.contents.map(t => mapTup2(f, t))
+  };
+};
+
+function mapList<T, S>(
+  f: (arg: T) => S,
+  v: IListV<T>
+): IListV<S> {
+  return {
+    tag: "ListV",
+    contents: v.contents.map(f)
+  };
+};
+
+function mapTup<T, S>(
+  f: (arg: T) => S,
+  v: ITupV<T>
+): ITupV<S> {
+  return {
+    tag: "TupV",
+    contents: mapTup2(f, v.contents)
+  };
+};
+
+function mapLList<T, S>(
+  f: (arg: T) => S,
+  v: ILListV<T>
+): ILListV<S> {
+  return {
+    tag: "LListV",
+    contents: v.contents.map(e => e.map(f))
+  };
+};
+
+function mapHMatrix<T, S>(
+  f: (arg: T) => S,
+  v: IHMatrixV<T>
+): IHMatrixV<S> {
+  const m = v.contents;
+  return {
+    tag: "HMatrixV",
+    contents: { // TODO: This could probably be a generic map over object values
+      xScale: f(m.xScale),
+      xSkew: f(m.xSkew),
+      yScale: f(m.yScale),
+      ySkew: f(m.ySkew),
+      dx: f(m.dx),
+      dy: f(m.dy),
+    }
+  };
+};
+
+function mapPolygon<T, S>(
+  f: (arg: T) => S,
+  v: IPolygonV<T>
+): IPolygonV<S> {
+  const xs0 = mapTup2LList(f, v.contents[0]);
+  const xs1 = mapTup2LList(f, v.contents[1]);
+  const xs2 = [mapTup2(f, v.contents[2][0]), mapTup2(f, v.contents[2][1])] as [[S, S], [S, S]];
+  const xs3 = v.contents[3].map(e => mapTup2(f, e));
+
+  return {
+    tag: "PolygonV",
+    contents: [xs0, xs1, xs2, xs3]
+  };
+};
+
+function mapColorInner<T, S>(
+  f: (arg: T) => S,
+  v: Color<T>
+): Color<S> {
+  if (v.tag === "RGBA") {
+    const rgb = v.contents;
+    return {
+      tag: "RGBA",
+      contents: mapTup4(f, rgb)
+    };
+  } else if (v.tag === "HSVA") {
+    const hsv = v.contents;
+    return {
+      tag: "HSVA",
+      contents: mapTup4(f, hsv)
+    };
+  } else {
+    throw Error("unexpected color tag");
+  }
+};
+
+function mapColor<T, S>(
+  f: (arg: T) => S,
+  v: IColorV<T>
+): IColorV<S> {
+  return {
+    tag: "ColorV",
+    contents: mapColorInner(f, v.contents)
+  };
+};
+
+function mapPalette<T, S>(
+  f: (arg: T) => S,
+  v: IPaletteV<T>
+): IPaletteV<S> {
+  return {
+    tag: "PaletteV",
+    contents: v.contents.map(e => mapColorInner(f, e))
+  };
+};
+
+// Utils for converting types of values
+
+// Expects `f` to be a function between numeric types (e.g. number -> Tensor, Tensor -> number, AD var -> Tensor ...)
+// Coerces any non-numeric types
+export function mapValueNumeric<T, S>(
+  f: (arg: T) => S,
+  v: Value<T>
+): Value<S> {
+  const nonnumericValueTypes = ["IntV", "BoolV", "StrV", "ColorV", "PaletteV", "FileV", "StyleV"];
+
+  if (v.tag === "FloatV") {
+    return mapFloat(f, v);
+  } else if (v.tag === "PtV") {
+    return mapPt(f, v);
+  } else if (v.tag === "PtListV") {
+    return mapPtList(f, v);
+  } else if (v.tag === "ListV") {
+    return mapList(f, v);
+  } else if (v.tag === "TupV") {
+    return mapTup(f, v);
+  } else if (v.tag === "LListV") {
+    return mapLList(f, v);
+  } else if (v.tag === "HMatrixV") {
+    return mapHMatrix(f, v);
+  } else if (v.tag === "PolygonV") {
+    return mapPolygon(f, v);
+  } else if (v.tag === "ColorV") {
+    return mapColor(f, v);
+  } else if (v.tag === "PaletteV") {
+    return mapPalette(f, v);
+  } else if (nonnumericValueTypes.includes(v.tag)) {
+    return v as Value<S>;
+  } else {
+    throw Error(`unimplemented conversion from autodiff types for numeric types for value type '${v.tag}'`);
+  }
+};
+
+export const valueAutodiffToNumber = (v: Value<Tensor>): Value<number> => mapValueNumeric(sc, v);
+
+export const valueNumberToAutodiff = (v: Value<number>): Value<Tensor> => mapValueNumeric(scalar, v);
+
+// Walk translation to convert all TagExprs (tagged Done or Pending) in the state to Tensors
+// (This is because, when decoded from backend, it's not yet in Tensor form -- although this code could be phased out if the translation becomes completely generated in the frontend)
+// TODO: Make this generic, to map over translation
+
+export function mapTagExpr<T, S>(
+  f: (arg: T) => S,
+  e: TagExpr<T>
+): TagExpr<S> {
+  if (e.tag === "Done") {
+    return {
+      tag: "Done",
+      contents: mapValueNumeric(f, e.contents)
+    };
+  } else if (e.tag === "Pending") {
+    return {
+      tag: "Pending",
+      contents: mapValueNumeric(f, e.contents)
+    };
+  } else if (e.tag === "OptEval") {
+    // We don't convert expressions because any numbers encountered in them will be converted by the evaluator as needed
+    return e;
+  } else {
+    throw Error("unrecognized tag");
+  }
+};
+
+export function mapGPIExpr<T, S>(
+  f: (arg: T) => S,
+  e: GPIExpr<T>
+): GPIExpr<S> {
+  const propDict = Object.entries(e[1])
+    .map(([prop, val]) =>
+      [prop, mapTagExpr(f, val)]
+    );
+
+  return [e[0], Object.fromEntries(propDict)];
+};
+
+export function mapTranslation<T, S>(
+  f: (arg: T) => S,
+  trans: Translation
+): Translation {
+  const newTrMap = Object.entries(trans.trMap)
+    .map(([name, fdict]) => {
+
+      const fdict2 = Object.entries(fdict)
+        .map(([prop, val]) => {
+          if (val.tag === "FExpr") {
+            return [prop, { tag: "FExpr", contents: mapTagExpr(f, val.contents) }];
+          } else if (val.tag === "FGPI") {
+            return [prop, { tag: "FGPI", contents: mapGPIExpr(f, val.contents) }];
+          } else {
+            throw Error("unknown tag on field expr");
+          }
+        });
+
+      return [name, Object.fromEntries(fdict2)];
+    });
+
+  return {
+    ...trans,
+    trMap: Object.fromEntries(newTrMap)
+  };
+};
+
+// TODO: Did this actually fix the original problem with color conversion?
+export const walkTranslationConvert = (trans: Translation): Translation => {
+  return mapTranslation(scalar, trans);
+};

--- a/react-renderer/src/Evaluator.ts
+++ b/react-renderer/src/Evaluator.ts
@@ -1,18 +1,11 @@
-import {
-  values,
-  pickBy,
-  range,
-  map,
-  mapKeys,
-  concat,
-  PropertyPath,
-  zip,
-} from "lodash";
+import { values, pickBy, concat, zip } from "lodash";
 import { mapValues } from "lodash";
-import { dist, randFloat } from "./Util";
+import { mapMap } from "./Util";
+import { valueAutodiffToNumber } from "./EngineUtils";
 import seedrandom from "seedrandom";
-import { Tensor, Variable, scalar, pad2d, stack } from "@tensorflow/tfjs";
-import { sc, scalarValue, differentiable, evalEnergyOn } from "./Optimizer";
+import { Tensor, Variable, scalar } from "@tensorflow/tfjs";
+import { sc, differentiable, evalEnergyOn } from "./Optimizer";
+import { compDict, checkComp } from "./Computations";
 
 ////////////////////////////////////////////////////////////////////////////////
 // Evaluator
@@ -30,24 +23,24 @@ import { sc, scalarValue, differentiable, evalEnergyOn } from "./Optimizer";
 export const evalTranslation = (s: State): State => {
   // Update the stale varyingMap from the translation. TODO: Where is the right place to do this?
   s.varyingMap = genVaryMap(s.varyingPaths, s.varyingValues);
-  const varyingMapList = zip(s.varyingPaths, s.varyingValues) as [Path, number][];
+  const varyingMapList = zip(s.varyingPaths, s.varyingValues) as [Path, Tensor][];
 
   // Insert all varying vals
   const trans = insertVaryings(s.translation, varyingMapList);
 
   // Find out all the GPI expressions in the translation
   const shapeExprs = s.shapePaths.map(
-    (p: Path) => findExpr(trans, p) as IFGPI<number>
+    (p: Path) => findExpr(trans, p) as IFGPI<Tensor>
   );
 
   // Evaluate each of the shapes
   const [shapesEvaled, transEvaled] = shapeExprs.reduce(
-    ([currShapes, tr]: [Shape[], Translation], e: IFGPI<number>) =>
+    ([currShapes, tr]: [Shape[], Translation], e: IFGPI<Tensor>) =>
       evalShape(e, tr, s.varyingMap, currShapes),
     [[], trans]
   );
 
-  // Sort the shapes by ordering - note the null assertion
+  // Sort the shapes by ordering--note the null assertion
   const sortedShapesEvaled = s.shapeOrdering.map((name) =>
     shapesEvaled.find(({ properties }) => properties.name.contents === name)!);
 
@@ -56,7 +49,7 @@ export const evalTranslation = (s: State): State => {
   return { ...s, shapes: sortedShapesEvaled, translation: transEvaled };
 };
 
-const doneFloat = (n: number): TagExpr<number> => ({
+const doneFloat = (n: Tensor): TagExpr<Tensor> => ({
   tag: "Done",
   contents: { tag: "FloatV", contents: n },
 });
@@ -70,10 +63,10 @@ const doneFloat = (n: number): TagExpr<number> => ({
  */
 export const insertVaryings = (
   trans: Translation,
-  varyingMap: [Path, number][]
+  varyingMap: [Path, Tensor][]
 ): Translation => {
   return varyingMap.reduce(
-    (tr: Translation, [path, val]: [Path, number]) =>
+    (tr: Translation, [path, val]: [Path, Tensor]) =>
       insertExpr(path, doneFloat(val), tr),
     trans
   );
@@ -98,104 +91,9 @@ const evalFn = (
 ): FnDone<Tensor> => {
   return {
     name: fn.fname,
-    args: evalExprs(fn.fargs, trans, varyingMap, true) as ArgVal<Tensor>[],
+    args: evalExprs(fn.fargs, trans, varyingMap) as ArgVal<Tensor>[],
     optType: fn.optType,
   };
-};
-
-/**
- * Static dictionary of computation functions
- * TODO: consider using `Dictionary` type so all runtime lookups are type-safe, like here https://codeburst.io/five-tips-i-wish-i-knew-when-i-started-with-typescript-c9e8609029db
- * TODO: think about user extension of computation dict and evaluation of functions in there
- */
-const compDict = {
-  rgba: (r: number, g: number, b: number, a: number): IColorV<number> => {
-    return {
-      tag: "ColorV",
-      contents: {
-        tag: "RGBA",
-        contents: [r, g, b, a],
-      },
-    };
-  },
-
-  hsva: (h: number, s: number, v: number, a: number): IColorV<number> => {
-    return {
-      tag: "ColorV",
-      contents: {
-        tag: "HSVA",
-        contents: [h, s, v, a],
-      },
-    };
-  },
-
-  cos: (d: number): IFloatV<number> => {
-    return { tag: "FloatV", contents: Math.cos((d * Math.PI) / 180) };
-  },
-
-  sin: (d: number): IFloatV<number> => {
-    return { tag: "FloatV", contents: Math.sin((d * Math.PI) / 180) };
-  },
-
-  lineLength: ([type, props]: [string, any]) => {
-    const [p1, p2] = arrowPts(props);
-    return { tag: "FloatV", contents: dist(p1, p2) }; // TODO: Shouldn't this be written in terms of tf.js?
-  },
-
-  len: ([type, props]: [string, any]) => {
-    const [p1, p2] = arrowPts(props);
-    return { tag: "FloatV", contents: dist(p1, p2) };
-  },
-
-  orientedSquare: (arr1: any, arr2: any, pt: any, len: number) => {
-    console.log("orientedSquare", arr1, arr2, pt, len);
-    // TODO/NOTE: For now, this function is written in numbers only, since in the example, this functiondoes not appear downstream from the optimization
-    // But really the right thing to do is to write this in tensors and write a curve tensor-to-number conversion function (Where does that need to happen, anyway?)
-
-    const elems = [{ tag: "Pt", contents: [100, 100] },
-    { tag: "Pt", contents: [200, 200] },
-    { tag: "Pt", contents: [300, 150] }];
-    const path = { tag: "Open", contents: elems };
-    return { tag: "PathDataV", contents: [path] };
-  },
-
-  dot: (v: any, w: any) => {
-    const [tv, tw] = [stack(v), stack(w)];
-    return { tag: "FloatV", contents: tv.dot(tw) };
-  },
-
-  sampleColor: (alpha: number, colorType: string) => {
-    if (colorType === "rgb") {
-      const rgb = range(3).map((_) => randFloat(0.1, 0.9));
-      return {
-        tag: "ColorV",
-        contents: {
-          tag: "RGBA",
-          contents: [...rgb, alpha],
-        },
-      };
-    } else if (colorType === "hsv") {
-      const h = randFloat(0, 360);
-      return {
-        tag: "ColorV",
-        contents: {
-          tag: "HSVA",
-          contents: [h, 100, 80, alpha], // HACK: for the color to look good
-        },
-      };
-    } else throw new Error("unknown color type");
-  },
-
-};
-
-const arrowPts = ({ startX, startY, endX, endY }: Properties) =>
-  [
-    [startX.contents, startY.contents],
-    [endX.contents, endY.contents],
-  ] as [[number, number], [number, number]];
-
-const checkComp = (fn: string, args: ArgVal<number>[]) => {
-  if (!compDict[fn]) throw new Error(`Computation function "${fn}" not found`);
 };
 
 /**
@@ -208,19 +106,28 @@ const checkComp = (fn: string, args: ArgVal<number>[]) => {
  * TODO: update trans
  */
 export const evalShape = (
-  shapeExpr: IFGPI<number>,
+  shapeExpr: IFGPI<Tensor>, // <number>?
   trans: Translation,
   varyingVars: VaryMap,
   shapes: Shape[]
 ): [Shape[], Translation] => {
 
   const [shapeType, propExprs] = shapeExpr.contents;
+
   // Make sure all props are evaluated to values instead of shapes
-  const props = mapValues(propExprs, (prop: TagExpr<number>) =>
-    prop.tag === "OptEval"
-      ? (evalExpr(prop.contents, trans, varyingVars, false) as IVal<number>).contents
-      : prop.contents
-  );
+  const props = mapValues(propExprs, (prop: TagExpr<Tensor>): Value<number> => {
+    if (prop.tag === "OptEval") {
+      // For display, evaluate expressions with autodiff types (incl. varying vars as AD types), then convert to numbers
+      // (The tradeoff for using autodiff types is that evaluating the display step will be a little slower, but then we won't have to write two versions of all computations)
+      const res: Value<Tensor> = (evalExpr(prop.contents, trans, varyingVars) as IVal<Tensor>).contents;
+      const resDisplay: Value<number> = valueAutodiffToNumber(res);
+      return resDisplay;
+    } else if (prop.tag === "Done") {
+      return valueAutodiffToNumber(prop.contents);
+    } else { // Pending expressions are just converted because they get converted back to numbers later
+      return valueAutodiffToNumber(prop.contents);
+    }
+  });
 
   const shape: Shape = { shapeType, properties: props };
 
@@ -238,10 +145,9 @@ export const evalShape = (
 export const evalExprs = (
   es: Expr[],
   trans: Translation,
-  varyingVars?: VaryMap<number | Tensor>,
-  autodiff = false
-): ArgVal<number | Tensor>[] =>
-  es.map((e) => evalExpr(e, trans, varyingVars, autodiff));
+  varyingVars?: VaryMap<Tensor>
+): ArgVal<Tensor>[] =>
+  es.map((e) => evalExpr(e, trans, varyingVars));
 
 /**
  * Evaluate the input expression to a value.
@@ -257,9 +163,8 @@ export const evalExprs = (
 export const evalExpr = (
   e: Expr,
   trans: Translation,
-  varyingVars?: VaryMap<number | Tensor>,
-  autodiff = false
-): ArgVal<number | Tensor> => {
+  varyingVars?: VaryMap<Tensor>
+): ArgVal<Tensor> => {
 
   switch (e.tag) {
     case "IntLit": {
@@ -272,18 +177,20 @@ export const evalExpr = (
 
     case "BoolLit": {
       return { tag: "Val", contents: { tag: "BoolV", contents: e.contents } }
-    } break
-      ;
+    } break;
+
     case "AFloat": {
       if (e.contents.tag === "Vary") {
         throw new Error("encountered an unsubstituted varying value");
       } else {
         const val = e.contents.contents;
+
         return {
           tag: "Val",
+          // Fixed number is stored in translation as number, made differentiable when encountered
           contents: {
             tag: "FloatV",
-            contents: autodiff ? differentiable(val) : val,
+            contents: scalar(val),
           },
         };
       }
@@ -291,7 +198,7 @@ export const evalExpr = (
 
     case "Tuple": {
       const [e1, e2] = e.contents;
-      const [val1, val2] = evalExprs([e1, e2], trans, varyingVars, autodiff);
+      const [val1, val2] = evalExprs([e1, e2], trans, varyingVars);
 
       // TODO: Is there a neater way to do this check? (`checkListElemType` in GenOptProblem.hs)
       if (val1.tag === "Val" && val2.tag === "Val") {
@@ -318,37 +225,37 @@ export const evalExpr = (
         contents: [uOp, expr],
       } = e as IUOp;
       // TODO: use the type system to narrow down Value to Float and Int?
-      const arg = evalExpr(expr, trans, varyingVars, autodiff).contents;
+      const arg = evalExpr(expr, trans, varyingVars).contents;
       return {
         tag: "Val",
         // HACK: coerce the type for now to let the compiler finish
-        contents: evalUOp(uOp, arg as IFloatV<number> | IIntV<number>),
+        contents: evalUOp(uOp, arg as IFloatV<Tensor> | IIntV<Tensor>),
       }
     } break;
 
     case "BinOp": {
       const [binOp, e1, e2] = e.contents;
-      const [val1, val2] = evalExprs([e1, e2], trans, varyingVars, autodiff);
+      const [val1, val2] = evalExprs([e1, e2], trans, varyingVars);
       return {
         tag: "Val",
         // HACK: coerce the type for now to let the compiler finish
         contents: evalBinOp(
           binOp,
-          val1.contents as Value<number | Tensor>,
-          val2.contents as Value<number | Tensor>
+          val1.contents as Value<Tensor>,
+          val2.contents as Value<Tensor>
         ),
       }
     } break;
 
     case "EPath": {
-      return resolvePath(e.contents, trans, varyingVars, autodiff);
+      return resolvePath(e.contents, trans, varyingVars);
     } break;
 
     case "CompApp": {
       const [fnName, argExprs] = e.contents;
       // eval all args
       // TODO: how should computations be written? TF numbers?
-      const args = evalExprs(argExprs, trans, varyingVars, autodiff) as ArgVal<number>[];
+      const args = evalExprs(argExprs, trans, varyingVars) as ArgVal<Tensor>[];
       const argValues = args.map((a) => argValue(a));
       checkComp(fnName, args);
       // retrieve comp function from a global dict and call the function
@@ -359,14 +266,6 @@ export const evalExpr = (
       throw new Error(`cannot evaluate expression of type ${e.tag}`);
     }
   }
-};
-
-const differentiableValue = (v: Value<number | Tensor>): Value<Tensor> => {
-  if ((v.tag === "FloatV" || v.tag === "IntV") && typeof v.contents === "number") {
-    return { ...v, contents: differentiable(v.contents) } as
-      | IFloatV<Tensor>
-      | IIntV<Tensor>;
-  } else return v as Value<Tensor>;
 };
 
 /**
@@ -381,10 +280,9 @@ const differentiableValue = (v: Value<number | Tensor>): Value<Tensor> => {
 export const resolvePath = (
   path: Path,
   trans: Translation,
-  varyingMap?: VaryMap<number | Tensor>,
-  autodiff = false
-): ArgVal<number | Tensor> => {
-  const floatVal = (v: number | Tensor): ArgVal<Tensor | number> => ({
+  varyingMap?: VaryMap<Tensor>
+): ArgVal<Tensor> => {
+  const floatVal = (v: Tensor): ArgVal<Tensor> => ({
     tag: "Val",
     contents: {
       tag: "FloatV",
@@ -394,8 +292,6 @@ export const resolvePath = (
   // HACK: this is a temporary way to consistently compare paths. We will need to make varymap much more efficient
   let varyingVal = varyingMap?.get(JSON.stringify(path));
   if (varyingVal) {
-    // When we look up a varying value, it will always be an autodiff-type, so convert autodiff-types to numbers if autodiff is off (in case a rendered value depends on some arithmetic that relies on a varying value)
-    if (!autodiff) { return floatVal(sc(varyingVal)); }
     return floatVal(varyingVal);
   } else {
     const gpiOrExpr = findExpr(trans, path);
@@ -406,7 +302,7 @@ export const resolvePath = (
         // TODO: cache results
         const evaledProps = mapValues(props, (p, propName) => {
           if (p.tag === "OptEval") {
-            return (evalExpr(p.contents, trans, varyingMap, autodiff) as IVal<number | Tensor>).contents;
+            return (evalExpr(p.contents, trans, varyingMap) as IVal<Tensor>).contents;
           } else {
             const propPath: IPropertyPath = {
               tag: "PropertyPath",
@@ -417,21 +313,21 @@ export const resolvePath = (
             if (varyingVal) {
               return { tag: "FloatV", contents: varyingVal };
             } else {
-              return autodiff ? differentiableValue(p.contents) : p.contents;
+              return p.contents;
             }
           }
         });
 
         return {
           tag: "GPI",
-          contents: [type, evaledProps] as GPI<number | Tensor>,
+          contents: [type, evaledProps] as GPI<Tensor>,
         };
       }
 
       default: {
-        const expr: TagExpr<number> = gpiOrExpr;
+        const expr: TagExpr<Tensor> = gpiOrExpr;
         if (expr.tag === "OptEval") {
-          return evalExpr(expr.contents, trans, varyingMap, autodiff);
+          return evalExpr(expr.contents, trans, varyingMap);
         } else {
           // TODO: Should exprs be converted from tensors to numbers here?
           return { tag: "Val", contents: expr.contents }
@@ -442,8 +338,8 @@ export const resolvePath = (
   }
 };
 
-// HACX: remove the type wrapper for the argument
-export const argValue = (e: ArgVal<number | Tensor>) => {
+// HACK: remove the type wrapper for the argument
+export const argValue = (e: ArgVal<Tensor>) => {
   switch (e.tag) {
     case "GPI": // strip the `GPI` tag
       return e.contents;
@@ -452,9 +348,6 @@ export const argValue = (e: ArgVal<number | Tensor>) => {
   }
 };
 
-const bothTensors = (v1: IFloatV<number | Tensor>, v2: IFloatV<number | Tensor>): boolean =>
-  typeof v1.contents === "number" && typeof v2.contents === "number";
-
 /**
  * Evaluate a binary operation such as +, -, *, /, or ^.
  * @param op a binary operater
@@ -462,9 +355,9 @@ const bothTensors = (v1: IFloatV<number | Tensor>, v2: IFloatV<number | Tensor>)
  */
 export const evalBinOp = (
   op: BinaryOp,
-  v1: Value<number | Tensor>,
-  v2: Value<number | Tensor>
-): Value<number | Tensor> => {
+  v1: Value<Tensor>,
+  v2: Value<Tensor>
+): Value<Tensor> => {
 
   let returnType: "FloatV" | "IntV";
   // TODO: deal with Int ops/conversion for binops
@@ -476,58 +369,23 @@ export const evalBinOp = (
 
     switch (op) {
       case "BPlus":
-        if (typeof v1.contents === "number" && typeof v2.contents === "number") {
-          res = v1.contents + v2.contents;
-        } else if (!(typeof v1.contents === "number") && !(typeof v2.contents === "number")) {
-          res = v1.contents.addStrict(v2.contents);
-        } else {
-          throw Error("Types don't match for v1, v2");
-        }
+        res = v1.contents.addStrict(v2.contents);
         break;
 
       case "BMinus":
-        if (typeof v1.contents === "number" && typeof v2.contents === "number") {
-          res = v1.contents - v2.contents;
-        } else if (!(typeof v1.contents === "number") && !(typeof v2.contents === "number")) {
-          res = v1.contents.subStrict(v2.contents);
-        } else {
-          console.error("v1, v2", v1, v2);
-          throw Error("Types don't match for v1, v2");
-        }
+        res = v1.contents.subStrict(v2.contents);
         break;
 
       case "Multiply":
-        if (typeof v1.contents === "number" && typeof v2.contents === "number") {
-          res = v1.contents * v2.contents;
-        } else if (!(typeof v1.contents === "number") && !(typeof v2.contents === "number")) {
-          res = v1.contents.mulStrict(v2.contents);
-        } else {
-          throw Error("Types don't match for v1, v2");
-        }
+        res = v1.contents.mulStrict(v2.contents);
         break;
 
       case "Divide":
-        if (typeof v1.contents === "number" && typeof v2.contents === "number") {
-          if (v2.contents === 0) throw new Error("divided by zero");
-          res = v1.contents / v2.contents;
-        } else if (!(typeof v1.contents === "number") && !(typeof v2.contents === "number")) {
-          // two tensors
-          res = v1.contents.divStrict(v2.contents);
-        } else {
-          throw Error("Types don't match for v1, v2");
-        }
+        res = v1.contents.divStrict(v2.contents);
         break;
 
       case "Exp":
-        if (typeof v1.contents === "number" && typeof v2.contents === "number") {
-          if (v2.contents === 0) throw new Error("divided by zero");
-          res = Math.pow(v1.contents, v2.contents);
-        } else if (!(typeof v1.contents === "number") && !(typeof v2.contents === "number")) {
-          // two tensors
-          res = v1.contents.powStrict(v2.contents);
-        } else {
-          throw Error("Types don't match for v1, v2");
-        }
+        res = v1.contents.powStrict(v2.contents);
         break;
     }
 
@@ -552,19 +410,15 @@ export const evalBinOp = (
  */
 export const evalUOp = (
   op: UnaryOp,
-  arg: IFloatV<number | Tensor> | IIntV<number>
-): Value<number | Tensor> => {
+  arg: IFloatV<Tensor> | IIntV<Tensor>
+): Value<Tensor> => {
 
   if (arg.tag === "FloatV") {
     switch (op) {
       case "UPlus":
         throw new Error("unary plus is undefined");
       case "UMinus":
-        if (typeof arg.contents === "number") {
-          return { ...arg, contents: -arg.contents };
-        } else {
-          return { ...arg, contents: arg.contents.neg() }; // tensor
-        }
+        return { ...arg, contents: arg.contents.neg() };
     }
   } else { // IntV
     switch (op) {
@@ -588,13 +442,15 @@ export const evalUOp = (
 export const findExpr = (
   trans: Translation,
   path: Path
-): TagExpr<number> | IFGPI<number> => {
+): TagExpr<Tensor> | IFGPI<Tensor> => {
   let name, field, prop;
+
   switch (path.tag) {
     case "FieldPath":
       [name, field] = path.contents;
       // Type cast to field expression
       const fieldExpr = trans.trMap[name.contents][field];
+
       switch (fieldExpr.tag) {
         case "FGPI":
           return fieldExpr;
@@ -627,7 +483,7 @@ export const findExpr = (
 // TODO: Is it inefficient (space/time) to copy the whole translation every time an expression is inserted?
 export const insertExpr = (
   path: Path,
-  expr: TagExpr<number>,
+  expr: TagExpr<Tensor>,
   initTrans: Translation
 ): Translation => {
   const trans = { ...initTrans };
@@ -641,7 +497,7 @@ export const insertExpr = (
     case "PropertyPath":
       // TODO: why do I need to typecast this path? Maybe arrays are not checked properly in TS?
       [name, field, prop] = (path as IPropertyPath).contents;
-      const gpi = trans.trMap[name.contents][field] as IFGPI<number>;
+      const gpi = trans.trMap[name.contents][field] as IFGPI<Tensor>;
       const [, properties] = gpi.contents;
       properties[prop] = expr;
       return trans;
@@ -703,7 +559,7 @@ export const encodeState = (state: State): any => {
 
 export const genVaryMap = (
   varyingPaths: Path[],
-  varyingValues: number[] | Variable[]
+  varyingValues: Variable[]
 ) => {
   if (varyingValues.length !== varyingPaths.length) {
     console.log(varyingPaths, varyingValues);

--- a/react-renderer/src/Util.tsx
+++ b/react-renderer/src/Util.tsx
@@ -179,14 +179,14 @@ export const hsvToRGB = (
   return h < 60
     ? hsv2rgb(c, x, 0, m)
     : h < 120
-    ? hsv2rgb(x, c, 0, m)
-    : h < 180
-    ? hsv2rgb(0, c, x, m)
-    : h < 240
-    ? hsv2rgb(0, x, c, m)
-    : h < 300
-    ? hsv2rgb(x, 0, c, m)
-    : hsv2rgb(c, 0, x, m);
+      ? hsv2rgb(x, c, 0, m)
+      : h < 180
+        ? hsv2rgb(0, c, x, m)
+        : h < 240
+          ? hsv2rgb(0, x, c, m)
+          : h < 300
+            ? hsv2rgb(x, 0, c, m)
+            : hsv2rgb(c, 0, x, m);
 };
 
 export const toHex = (color: any): string => {
@@ -275,3 +275,9 @@ export const roundTo = (n: number, digits: number) => {
 
   return n3;
 };
+
+// https://stackoverflow.com/questions/31084619/map-a-javascript-es6-map
+// Basically Haskell's mapByValue (?)
+export function mapMap(map: Map<any, any>, fn: any) {
+  return new Map(Array.from(map, ([key, value]) => [key, fn(value, key, map)]));
+}

--- a/react-renderer/src/types/types.d.ts
+++ b/react-renderer/src/types/types.d.ts
@@ -7,9 +7,7 @@ interface LabelData {
   height: number;
 }
 
-type Translation = ITrans<number>; // TODO: number type might be different
-// type VaryMap<T = number> = [Path, T][];
-type VaryMap<T = number> = Map<string, T>;
+type VaryMap<T = Tensor> = Map<string, T>;
 
 type FnDone<T> = IFnDone<T>;
 interface IFnDone<T> {
@@ -42,7 +40,7 @@ interface IState {
   policyParams: any; // TODO: types
   oConfig: any; // TODO: types
   pendingPaths: Path[];
-  varyingValues: number[];
+  varyingValues: Tensor[];
   translation: Translation;
   shapeOrdering: string[];
   shapes: Shape[];
@@ -66,6 +64,7 @@ interface CompNode<T> {
   value: Value<T> | undefined;
 }
 
+// These are numbers, not autodiff types, since shapes are only for display (unlike GPIs)
 type Properties = { [k: string]: Value<number> };
 
 ////////////////////////////////////////////////////////////////////////////
@@ -92,6 +91,7 @@ interface IVal<T> {
 }
 
 // type Translation<T> = ITrans<T>;
+type Translation = ITrans<Tensor>;
 
 interface ITrans<T> {
   // TODO: compGraph
@@ -128,15 +128,6 @@ interface IPending<T> {
   tag: "Pending";
   contents: Value<T>;
 }
-
-// interface Expr {
-//   tag: string;
-//   contents: any;
-// }
-
-// interface IIntLit extends Expr {
-//   tag: "IntLit";
-// }
 
 type Expr =
   | IIntLit
@@ -308,8 +299,8 @@ type Value<T> =
   | IPtV<T>
   | IPathDataV<T>
   | IPtListV<T>
-  | IPaletteV<T>
   | IColorV<T>
+  | IPaletteV<T>
   | IFileV<T>
   | IStyleV<T>
   | IListV<T>
@@ -355,12 +346,12 @@ interface IPtListV<T> {
 
 interface IPaletteV<T> {
   tag: "PaletteV";
-  contents: Color[];
+  contents: Color<T>[];
 }
 
 interface IColorV<T> {
   tag: "ColorV";
-  contents: Color;
+  contents: Color<T>;
 }
 
 interface IFileV<T> {
@@ -395,7 +386,8 @@ interface IHMatrixV<T> {
 
 interface IPolygonV<T> {
   tag: "PolygonV";
-  contents: [[T, T][][], [T, T][][], [[T, T], [T, T]], [T, T][]];
+  contents: [[T, T][][], [T, T][][],
+    [[T, T], [T, T]], [T, T][]];
 }
 
 type SubPath<T> = IClosed<T> | IOpen<T>;
@@ -421,16 +413,16 @@ interface IHMatrix<T> {
   dy: T;
 }
 
-type Color = IRGBA | IHSVA;
+type Color<T> = IRGBA<T> | IHSVA<T>;
 
-interface IRGBA {
+interface IRGBA<T> {
   tag: "RGBA";
-  contents: [number, number, number, number];
+  contents: [T, T, T, T];
 }
 
-interface IHSVA {
+interface IHSVA<T> {
   tag: "HSVA";
-  contents: [number, number, number, number];
+  contents: [T, T, T, T];
 }
 
 type Elem<T> =

--- a/react-renderer/tsconfig.json
+++ b/react-renderer/tsconfig.json
@@ -4,7 +4,7 @@
     "outDir": "build/dist",
     "module": "esnext",
     "target": "es5",
-    "lib": ["es5", "es6", "es7", "dom"],
+      "lib": ["es5", "es6", "es7", "esnext", "dom"],
     "sourceMap": true,
     "allowJs": true,
     "jsx": "react",

--- a/react-renderer/tsfmt.json
+++ b/react-renderer/tsfmt.json
@@ -1,0 +1,7 @@
+{
+  "indentSize": 2,
+  "tabSize": 2,
+  "insertSpaceAfterOpeningAndBeforeClosingTemplateStringBraces": false,
+  "placeOpenBraceOnNewLineForFunctions": false,
+  "placeOpenBraceOnNewLineForControlBlocks": false
+}


### PR DESCRIPTION
# Description

Previously, the "engine" had the option of using `number` or `Tensor` types in the evaluator via the `autodiff` flag, because we needed the former type for displaying shapes (evaluating the translation) and the latter type for optimization (evaluating the energy).

While concise, the design started to cause some challenges:

* Computations appear in both kinds of evaluation, thus had to be written with both numeric types
* Lots of code duplication in the evaluator, since it needs to interpret expressions on both numeric types and deal with mismatches
* Hard to debug if a single number of the wrong type gets into the wrong evaluation phase (e.g. `number`s in the optimization)

Therefore, this PR changes all evaluation + optimization-related functions and types to be on autodiff types only (in this case, Tensors). 

The tradeoff is that the display step may take slightly longer and use more space, since it requires doing all work on autodiff types (which are objects that store a good amount of information), then converting them to numbers. However, that tradeoff is acceptable because the engine does much more optimization-type evaluation than display-type evaluation.

# Implementation strategy and design decisions

The new pipeline is as follows:

- decode state from backend `JSON`, which gives us numbers 
  - note that the deserialization is the _least type-safe_ part of our code [0]
- **in the initial state, convert all `Value<number>` into `Value<Tensor>` to store in the `Translation`, which now only holds `Tensors`**
  - the `varyingValues` are also converted to be all `Tensor`s, as are the pending values (label dimensions) after they are calculated
  - expressions (`OptEval`) that can be evaluated at optimization-time are **not** converted; if a `number` is encountered in evaluation, it's converted on the spot in `evalExpr`
- *all* evaluation happens on `Tensors`
  - in the optimization, it just uses the `Tensors` stored in the translation
  - for displaying shapes via `evalTranslation`, it also does all computations on `Tensors`, and **does a final conversion pass from `Value<Tensor>` to `Value<number>`**

In general, numeric values are converted to tf `Scalars` via the `scalar` function (so they just tensors, *not* variables in the optimization), unless they are varying values, in which case they are converted to tf `Variable`s.

Most changes are in `Evaluator` and `types.d.ts`, with some changes in `PropagateUpdate` and `Canvas`, and new files `EngineUtils` and `Computations`.

Also, the diff is a little misleading because I changed my editor's indentation, but I kept it because I will probably use this indentation in the future.

[0] If something is deserialized with the wrong type (e.g. the deserializer doesn't know that something is supposed to be a `Tensor`, not a `number`), our types are gone at runtime, so there are no guarantees and the wrong type just gets everywhere.

# Examples with steps to reproduce them

* Test inline computation with `Tensor`s: `runpenrose hyperbolic-domain/hyperbolic-example.sub hyperbolic-domain/PoincareDisk.sty hyperbolic-domain/hyperbolic.dsl`

<img src="https://user-images.githubusercontent.com/2762356/91365140-71fe6c80-e7ce-11ea-8ff8-deef5c19907c.png" width=400>

The following three are successfully-repro'ed examples from the [wiki page](https://github.com/penrose/penrose/wiki/Contributing-to-the-web-runtime) for `web-runtime` working examples.

* Test labels, pending values, varying values, and optimization: `runpenrose set-theory-domain/tree.sub set-theory-domain/venn-opt-test.sty set-theory-domain/setTheory.dsl`

* `runpenrose set-theory-domain/tree.sub set-theory-domain/tree.sty set-theory-domain/setTheory.dsl`

* `runpenrose set-theory-domain/continuousmap.sub set-theory-domain/continuousmap.sty set-theory-domain/setTheory.dsl`

# Checklist

- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I ran [Haddock](https://github.com/penrose/penrose/wiki/Writing-and-generating-documentation#generating-html-documentation-site) and there were no errors when generating the HTML site
- [x] My changes generate no new warnings
- [ ] New and existing tests pass locally using `stack test`
- [ ] My code follows the style guidelines of this project (e.g.: no HLint warnings)

# Open questions

Questions that require more discussion or to be addressed in future development:

- [ ] In the future, the system should use a custom autodiff type that is easily swappable (i.e. not `Tensor`s). Using `Tensor`s is a stopgap until `web-perf` and @strout18's macro code get merged.
- [ ] I wasn't sure if tf `Variable`s needed to have their gradients cleared after each step, so for safety, I did that in `Optimizer` at the end of each `stepEP`. In general, when we use custom AD vars, we may need to clear them.
- [ ] I wasn't super careful about the distinction between tf `Scalar`s and `Variable`. Hopefully this generates the right computational graph when we use custom AD vars.
- [ ] Maybe just convert Shapes from autofloats to numbers, instead of converting the whole translation? (@wodeni's suggestion)