### PR TITLE
Use file extensions instead of order in command line arguments

### DIFF
--- a/USAGE.txt
+++ b/USAGE.txt
@@ -1,6 +1,6 @@
 Usage:
   penrose --version
-  penrose [--port=PORT --domain=NAME --config=PATH] <substance> <style> <element>
+  penrose [--port=PORT --domain=NAME --config=PATH] <input>...
   penrose [--port=PORT --domain=NAME] editor [-v]
   penrose runAPI 
 

--- a/src/Penrose/ShadowMain.hs
+++ b/src/Penrose/ShadowMain.hs
@@ -17,7 +17,7 @@ import           Control.Monad              (forM_, when)
 import           Control.Monad.Trans
 import           Data.Aeson
 import qualified Data.ByteString.Lazy.Char8 as B
-import qualified Data.List                  as L (intercalate)
+import qualified Data.List                  as L (intercalate, isSuffixOf)
 import qualified Data.List.Split            as LS (splitOn)
 import qualified Data.Map.Strict            as M
 import qualified Data.Text.Lazy             as T
@@ -79,10 +79,12 @@ processArgs args
       then let isVerbose = args `isPresent` longOption "verbose"
            in Server.serveEditor domain (read port) isVerbose
       else do
-        subFile <- args `getArgOrExit` argument "substance"
-        styFile <- args `getArgOrExit` argument "style"
-        elementFile <- args `getArgOrExit` argument "element"
-        penroseRenderer subFile styFile elementFile domain config $ read port
+        let inputs = args `getAllArgs` argument "input"
+        let files = (\x -> filter (x `L.isSuffixOf`)) <$> [".sub", ".sty", ".dsl"] <*> pure inputs
+        if any ((/= 1) . length) files
+          then exitWithUsage argPatterns
+          else let [[subFile], [styFile], [elementFile]] = files
+               in penroseRenderer subFile styFile elementFile domain config $ read port
 
 --------------------------------------------------------------------------------
 -- CLI wrapper


### PR DESCRIPTION
# Description

Related issues: #360 

This pull request change the way the input files are handled in the command line. The type of the source file was previously associated according to their order in the command line. With this change the type will be derived from the file extension. Each type is required to have only one associated input file.
