### PR TITLE
Style 1.01: add local vars and vectors/matrices

### DIFF
--- a/examples/geometry-domain/euclidean-simple.sty
+++ b/examples/geometry-domain/euclidean-simple.sty
@@ -21,89 +21,87 @@
 
 Colors {
     -- Keenan palette
-    Colors.black = rgba(0.0, 0.0, 0.0, 1.0)
+    black = rgba(0.0, 0.0, 0.0, 1.0)
 
-    Colors.darkpurple = rgba(0.549,0.565,0.757, 1.0)
-    Colors.purple2 = rgba(0.106, 0.122, 0.54, 0.2)
-    Colors.lightpurple = rgba(0.816,0.824, 0.902, 1.0)
+    darkpurple = rgba(0.549,0.565,0.757, 1.0)
+    purple2 = rgba(0.106, 0.122, 0.54, 0.2)
+    lightpurple = rgba(0.816,0.824, 0.902, 1.0)
 
-    Colors.verylightpurple = rgba(0.953, 0.957, 0.977, 1.0)
-    Colors.purple3 = rgba(0.557, 0.627, 0.769, 1.0)
+    verylightpurple = rgba(0.953, 0.957, 0.977, 1.0)
+    purple3 = rgba(0.557, 0.627, 0.769, 1.0)
 
-    Colors.midnightblue = rgba(0.14, 0.16, 0.52, 1.0)
-    Colors.lightslategray = rgba(0.50, 0.51, 0.69, 1.0)
-    Colors.silver = rgba(0.71, 0.72, 0.79, 1.0)
-    Colors.gainsboro = rgba(0.87, 0.87, 0.87, 1.0)
+    midnightblue = rgba(0.14, 0.16, 0.52, 1.0)
+    lightslategray = rgba(0.50, 0.51, 0.69, 1.0)
+    silver = rgba(0.71, 0.72, 0.79, 1.0)
+    gainsboro = rgba(0.87, 0.87, 0.87, 1.0)
 
-    Colors.darkgray = rgba(0.1, 0.1, 0.1, 1.0)
-    Colors.mediumgray = rgba(0.5, 0.5, 0.5, 1.0)
-    Colors.gray = rgba(0.8, 0.8, 0.8, 1.0)
-    Colors.red = rgba(1.0, 0.0, 0.0, 1.0)
-    Colors.pink = rgba(1.0, 0.4, 0.7, 1.0)
-    Colors.yellow = rgba(1.0, 1.0, 0.0, 1.0)
-    Colors.orange = rgba(1.0, 0.6, 0.0, 1.0)
-    Colors.lightorange = rgba(1.0, 0.6, 0.0, 0.25)
-    Colors.green = rgba(0.0, 1.0, 0.0, 1.0)
-    Colors.blue = rgba(0.0, 0.0, 1.0, 1.0)
-    Colors.sky = rgba(0.325, 0.718, 0.769, 1.0)
-    Colors.lightsky = rgba(0.325, 0.718, 0.769, 0.25)
-    Colors.lightblue = rgba(0.0, 0.0, 1.0, 0.25)
-    Colors.cyan = rgba(0.0, 1.0, 1.0, 1.0)
-    Colors.purple = rgba(0.5, 0.0, 0.5, 1.0)
-    Colors.white = rgba(1.0, 1.0, 1.0, 1.0)
-    Colors.none = rgba(0.0, 0.0, 0.0, 0.0)
-    Colors.bluegreen = rgba(0.44, 0.68, 0.60, 1.0)
+    darkgray = rgba(0.1, 0.1, 0.1, 1.0)
+    mediumgray = rgba(0.5, 0.5, 0.5, 1.0)
+    gray = rgba(0.8, 0.8, 0.8, 1.0)
+    red = rgba(1.0, 0.0, 0.0, 1.0)
+    pink = rgba(1.0, 0.4, 0.7, 1.0)
+    yellow = rgba(1.0, 1.0, 0.0, 1.0)
+    orange = rgba(1.0, 0.6, 0.0, 1.0)
+    lightorange = rgba(1.0, 0.6, 0.0, 0.25)
+    green = rgba(0.0, 1.0, 0.0, 1.0)
+    blue = rgba(0.0, 0.0, 1.0, 1.0)
+    sky = rgba(0.325, 0.718, 0.769, 1.0)
+    lightsky = rgba(0.325, 0.718, 0.769, 0.25)
+    lightblue = rgba(0.0, 0.0, 1.0, 0.25)
+    cyan = rgba(0.0, 1.0, 1.0, 1.0)
+    purple = rgba(0.5, 0.0, 0.5, 1.0)
+    white = rgba(1.0, 1.0, 1.0, 1.0)
+    none = rgba(0.0, 0.0, 0.0, 0.0)
+    bluegreen = rgba(0.44, 0.68, 0.60, 1.0)
 }
 
 const {
-    const.pi = 3.14159
-    const.arrowheadSize = 0.65
-    const.strokeWidth = 1.75
-    const.textPadding = 7.0
-    const.textPadding2 = 25.0
-    const.repelWeight = 0.7 -- TODO: Reverted from 0.0
-    const.repelWeight2 = 0.5
-    const.fontSize = "18pt"
-    const.containPadding = 50.0
-    const.rayLength = 100.0
-    const.pointSize = 4.0
-    const.pointStroke = 0.0
-    const.thetaRadius = 40.0
+    pi = 3.14159
+    arrowheadSize = 0.65
+    strokeWidth = 1.75
+    textPadding = 7.0
+    textPadding2 = 25.0
+    repelWeight = 0.7 -- TODO: Reverted from 0.0
+    repelWeight2 = 0.5
+    fontSize = "18pt"
+    containPadding = 50.0
+    rayLength = 100.0
+    pointSize = 4.0
+    pointStroke = 0.0
+    thetaRadius = 40.0
 
-    const.label = "E^2"
-    const.text = Text {
-	x : (const.dim / 2.0) - const.textPadding2
-	y : (const.dim / 2.0) - const.textPadding2
-	string : const.label
-	fontSize : const.fontSize
+    label = "E^2"
+    text = Text {
+	x : (dim / 2.0) - textPadding2
+	y : (dim / 2.0) - textPadding2
+	string : label
+	fontSize : fontSize
     }
 
-    const.dim = 400.0
+    dim = 400.0
 
     -- inner: #f3f4f9, outer: #8e93c4
-    const.plane = Rectangle {
+    plane = Rectangle {
     	    angle : 0.0
 	    color : Colors.verylightpurple
 	    strokeColor : Colors.purple3
 	    strokeWidth : 2.0
 	    x : 0.0
 	    y : 0.0
-	    w : const.dim
-	    h : const.dim
+	    w : dim
+	    h : dim
     }
 
-   const.textLayering = const.text above const.plane
+   textLayering = text above plane
 }
 
 Point p {
       p.x = ?
       p.y = ?
-      p.vec = [p.x, p.y]
-      p.tup = (p.x, p.y)
+      p.vec = (p.x, p.y)
 
        p.shape = Circle {
-         x : get(p.vec, 0)
-	 y : get(p.vec, 1)
+         center: p.vec
          r : const.pointSize
 	 color : Colors.black
 	 strokeWidth : 0.0
@@ -111,8 +109,6 @@ Point p {
        }
 
        p.text = Text {
-         x : ?
-         y : ?
          string : p.label
          rotation : 0.0
          color : Colors.black
@@ -120,16 +116,16 @@ Point p {
        }
 
        -- TODO: put these constraints back in
-       p.labelFnMargin = ensure atDist(p.shape, p.text, const.textPadding)
+       ensure atDist(p.shape, p.text, const.textPadding)
 
        -- TODO: the problem is that this ensures the padding is const? Or is > padding okay?
        -- There's a choice of whether to put padding on the point or the text for containment
        
-       p.posFn = ensure contains(const.plane, p.shape, const.containPadding)
-       p.labelFn = ensure contains(const.plane, p.text, 0.0)
+       ensure contains(const.plane, p.shape, const.containPadding)
+       ensure contains(const.plane, p.text, 0.0)
 
-       p.layering1 = p.shape above const.plane
-       p.layering2 = p.text above const.plane
+       p.shape above const.plane
+       p.text above const.plane
 }
 
 Segment e
@@ -140,23 +136,21 @@ with Point p; Point q {
      e.color = Colors.black
 
      e.shape = Line {
-     	     startX : p.shape.x
-     	     startY : p.shape.y
-     	     endX : q.shape.x
-     	     endY : q.shape.y
+     	     start : p.shape.center
+     	     end : q.shape.center
 	     color : e.color
 	     thickness : const.strokeWidth
 	     stroke : "none"
 	     style : "solid"
      }
 
-     e.layering1 = p.shape above e.shape
-     e.layering2 = q.shape above e.shape
+     p.shape above e.shape
+     q.shape above e.shape
 
-     LOCAL.labelAvoidFn_p = encourage repel(e.shape, p.text, const.repelWeight)
-     LOCAL.labelAvoidFn_q = encourage repel(e.shape, q.text, const.repelWeight)
+     encourage repel(e.shape, p.text, const.repelWeight)
+     encourage repel(e.shape, q.text, const.repelWeight)
 
-     e.layering = e.shape above const.plane
+     e.shape above const.plane
 }
 
 Point `A` {
@@ -183,7 +177,7 @@ Point `C` {
 -- with Triangle t; Angle theta; Point p; Point q; Point r {
 
 --      e.color = Colors.black
---      e.proj_pt = project(q.tup, p.tup, r.tup)
+--      e.proj_pt = project(q.vec, p.vec, r.vec)
 
 --      e.shape = Line {
 --      	     startX : p.x
@@ -215,9 +209,9 @@ Point `C` {
 
 --       -- BA is the existing segment; C is an existing point that defines the angle
 --       -- p's location is really another altitude of the angle ACB
---       override p.tup = project(a.tup, c.tup, b.tup) 
---       override p.x = get(p.tup, 0)
---       override p.y = get(p.tup, 1)
+--       override p.vec = project(a.vec, c.vec, b.vec) 
+--       override p.x = get(p.vec, 0)
+--       override p.y = get(p.vec, 1)
 -- }
 
 -- Triangle t
@@ -273,7 +267,7 @@ Point `C` {
 
 --     override S.color = setOpacity(Colors.midnightblue, 0.4)
 
---     S.path = squareAt(p.tup, q.tup)
+--     S.path = squareAt(p.vec, q.vec)
 
 --     override S.shape = Curve {
 -- 	    pathData : polygonFromPoints(S.path)
@@ -285,13 +279,13 @@ Point `C` {
 --     }
 
 --     -- Position the points at the corner of the square
---     override r.tup = get(S.path, 2)
---     override r.x = get(r.tup, 0)
---     override r.y = get(r.tup, 1)
+--     override r.vec = get(S.path, 2)
+--     override r.x = get(r.vec, 0)
+--     override r.y = get(r.vec, 1)
 
---     override s.tup = get(S.path, 3)
---     override s.x = get(s.tup, 0)
---     override s.y = get(s.tup, 1)
+--     override s.vec = get(S.path, 3)
+--     override s.x = get(s.vec, 0)
+--     override s.y = get(s.vec, 1)
 -- }
 
 -- -- These more specific matches are so we can figure out which third point of the triangle to push the square away from
@@ -301,21 +295,21 @@ Point `C` {
 -- where S := MkSquare(p, q, r, s); Disjoint(S, T); T := MkTriangle(c, q, p)
 -- with Point p; Point q; Point r; Point s; Triangle T; Point c {
 
---     override S.path = squareAt(p.tup, q.tup, c.tup)
+--     override S.path = squareAt(p.vec, q.vec, c.vec)
 -- }
 
 -- Square S
 -- where S := MkSquare(p, q, r, s); Disjoint(S, T); T := MkTriangle(q, p, c)
 -- with Point p; Point q; Point r; Point s; Triangle T; Point c {
 
---     override S.path = squareAt(p.tup, q.tup, c.tup)
+--     override S.path = squareAt(p.vec, q.vec, c.vec)
 -- }
 
 -- Square S
 -- where S := MkSquare(p, q, r, s); Disjoint(S, T); T := MkTriangle(p, c, q)
 -- with Point p; Point q; Point r; Point s; Triangle T; Point c {
 
---     override S.path = squareAt(p.tup, q.tup, c.tup)
+--     override S.path = squareAt(p.vec, q.vec, c.vec)
 -- }
 
 -- Angle theta
@@ -345,18 +339,16 @@ Point `C` {
 Angle theta
 where theta := InteriorAngle(q, p, r); Right(theta)
 with Point p; Point q; Point r {
-
       theta.perpSize = 13.0
 
       -- override theta.shape = Curve {
-      -- 		 pathData : perpPath(q.tup, p.tup, r.tup, theta.perpSize)
+      -- 		 pathData : perpPath(q.vec, p.vec, r.vec, theta.perpSize)
       -- 		 strokeWidth : 1.25
       -- 		 color : Colors.black
       -- 		 fill : setOpacity(Colors.white, 0.5)
       -- }
 
-      theta.perpFn = ensure perpendicular(q.tup, p.tup, r.tup)
-
+      ensure perpendicular(q.vec, p.vec, r.vec)
 }
 
 -- Ray r {
@@ -463,9 +455,9 @@ with Point p; Point q; Point r {
 --       r.markLayering6 = r.perpMark below r.shape
 --       r.markLayering7 = r.perpMark below m.shape
 
---      LOCAL.labelAvoidFn_Mark = encourage repel(r.shape, m.text, const.repelWeight)
---      LOCAL.labelAvoidFn_Ray = encourage repel(r.perpMark, m.text, const.repelWeight)
---      LOCAL.labelAvoidFn_Seg = encourage repel(s.shape, m.text, const.repelWeight)
+--      labelAvoidFn_Mark = encourage repel(r.shape, m.text, const.repelWeight)
+--      labelAvoidFn_Ray = encourage repel(r.perpMark, m.text, const.repelWeight)
+--      labelAvoidFn_Seg = encourage repel(s.shape, m.text, const.repelWeight)
 -- }
 
 -- -- TODO: trying to just add a repel function on the point that's not in a segment... this might be too many repels for the ones that are in a segment though
@@ -473,44 +465,44 @@ with Point p; Point q; Point r {
 -- -- TODO: should we use const.repelWeight below?
 
 -- Ray r; Point p {
---     LOCAL.labelAvoidFn = encourage repel(r.shape, p.text, const.repelWeight)
---     LOCAL.layering = r.shape below p.shape
+--     labelAvoidFn = encourage repel(r.shape, p.text, const.repelWeight)
+--     layering = r.shape below p.shape
 -- }
 
 -- Segment s; Point p {
 --      -- TODO: Maybe the optimization would be faster if I used lines instead of curves for the segments?	
---      LOCAL.labelAvoidFn_p = encourage repel(s.shape, p.text, const.repelWeight)
+--      labelAvoidFn_p = encourage repel(s.shape, p.text, const.repelWeight)
 -- }
 
 -- Triangle t; Point p {
---     LOCAL.layering1 = t.shape below p.shape
---     LOCAL.layering2 = t.shape below p.text
+--     layering1 = t.shape below p.shape
+--     layering2 = t.shape below p.text
 -- }
 
 -- Square s; Point p {
---     LOCAL.layering1 = s.shape below p.shape
---     LOCAL.layering2 = s.shape below p.text
+--     layering1 = s.shape below p.shape
+--     layering2 = s.shape below p.text
 -- }
 
 -- Rectangle r; Point p {
---     LOCAL.layering1 = r.shape below p.shape
---     LOCAL.layering2 = r.shape below p.text
+--     layering1 = r.shape below p.shape
+--     layering2 = r.shape below p.text
 -- }
 
 -- Triangle t; Segment e {
---     LOCAL.layering1 = t.shape below e.shape
+--     layering1 = t.shape below e.shape
 -- }
 
 -- Square s; Segment e {
---     LOCAL.layering1 = s.shape below e.shape
+--     layering1 = s.shape below e.shape
 -- }
 
 -- Rectangle r; Segment e {
---     LOCAL.layering1 = r.shape below e.shape
+--     layering1 = r.shape below e.shape
 -- }
 
 -- Triangle t; Angle theta {
--- 	 LOCAL.layering = theta.shape above t.shape
+-- 	 layering = theta.shape above t.shape
 -- }
 
 -- -- TODO: Appendices removed for now

--- a/examples/hyperbolic-domain/PoincareDisk.sty
+++ b/examples/hyperbolic-domain/PoincareDisk.sty
@@ -15,8 +15,7 @@ Colors {
 
 forall HyperbolicPlane H {
    H.diskShape = Circle {
-      x : 0.0
-      y : 0.0
+      center : (0.0, 0.)
       r : Global.planeSize/2.0
       color : Colors.blue
       strokeWidth : Global.thinStroke
@@ -44,8 +43,7 @@ where In( p, H ) {
    p.angle = ?
 
    p.dotShape = Circle {
-      x : 630.0*cos(p.angle)/2.0
-      y : 630.0*sin(p.angle)/2.0
+      center : (630.0*cos(p.angle)/2.0, 630.0*sin(p.angle)/2.0)
       r : Global.pointSize
       strokeWidth : 0.0
       color : Colors.black

--- a/examples/linear-algebra-domain/linear-algebra-paper-simple.sty
+++ b/examples/linear-algebra-domain/linear-algebra-paper-simple.sty
@@ -1,178 +1,212 @@
--- Global constants and sizes
 const {
-  const.vectorSpaceSize = 350.0
-  const.axisSize = const.vectorSpaceSize * 0.5
-  const.scaleRatio = 200.0
-  const.perpLen = 25.0
-  const.repelWeight = 0.7
-  const.arrowheadSize = 0.6
+  perpLen = 20.0
   -- For unit mark
-  const.markerPadding = 15.0
-  const.barSize = 5.0
+  markerPadding = 15.0
+  barSize = 5.0
+  vectorSpaceSize = 350.0
+  repelWeight = 0.7
+  arrowheadSize = 0.7
+  lineThickness = 1.
 }
 
--- Global RGB colors in common use
-Colors {
-    Colors.black = rgba(0.0, 0.0, 0.0, 1.0)
-    Colors.white = rgba(1.0, 1.0, 1.0, 1.0)
-    Colors.lightBlue = rgba(0.1, 0.1, 0.9, 0.1)
-    Colors.darkBlue = rgba(0.05, 0.05, 0.6, 0.5)
-    Colors.darkGray = rgba(0.4, 0.4, 0.4, 1.0)
-    Colors.gray = rgba(0.6, 0.6, 0.6, 1.0)
-    Colors.green = rgba(0.0, 0.8, 0.0, 1.0)
-    Colors.blue = rgba(0.0, 0.0, 1.0, 1.0)
-    Colors.none = rgba(0.0, 0.0, 0.0, 0.0)
+C {
+    -- black = #000000
+    black = rgba(0.,0.,0.,1.)
+    white = rgba(1., 1., 1., 1.)
+    lightBlue = rgba(1e-1, 0.1, 0.9, 1.0)
+    darkBlue = rgba(lightBlue.r / 2., lightBlue.g / 2., lightBlue.b / 2., 0.5)
+    darkGray = rgba(0.4, 0.4, 0.4, 1.)
+    gray = rgba(0.6, 0.6, 0.6, 1.)
+    green = rgba(0., 0.8, 0., 1.)
+    -- blue = #0000ff
+    none = rgba(0., 0., 0., 0.)
 }
 
-VectorSpace U {
-    U.thickness = 2.0
-    U.axisColor = Colors.gray
+-- Just some weird definitions to test parser. Not used in rest of program
+testing {
+  -- COMBAK: Test that plugins still run
+  -- pluginVar = "ddg"["a"]["length"]
+        x = { 1, {2, 3} }
+        y = [-2., const.perpLen, const.markerPadding + 3]
+        a = (-1.0, ?)
+        a1 = (-1.0, 2.) + (1e5, 2.0)
+        m = (a, (-1., 2.))
+        v = (a + (2., 900.))  / (4.0 + 3.)
+        -- z = Colors.black.g
+        asum = a[1] + a[0]
+        c = 0
+        b = 1
+        msum = m[1][0] + m[c][b]
+        nv = -v
+        t1 = x[1][b]
 
-    -- U.originX = ?
-    -- U.originY = ?
-    U.originX = 0.0
-    U.originY = 0.0
-    U.origin = (U.originX, U.originY)
+        -- test parser access of matrix
+        -- test0 = f(0)[1]
+        -- test1 = makeMatrix((1, 0.0, 5.0), (-1, -9., -4.))[2][0]
+        -- test2 = (makeVector(-1, 3.0) + (3.4, 2.1))[0]
+}
 
-    -- TODO: get rid of this?
+forall VectorSpace U {
+    axisSize = const.vectorSpaceSize / 2.0 -- This should get promoted to float
+    U.origin = (0., 0.)
+    o = U.origin
+    U.axisColor = C.gray
+
     U.shape = Square {
-        x : U.originX
-	y : U.originY
+        center : U.origin
         side : const.vectorSpaceSize
-        color : Colors.none
-	stroke : Colors.black
+        color : C.none
+        strokeColor : C.none
+        -- strokeWidth : 2.0
     }
 
-    U.xAxis = Arrow {
-        startX : U.shape.x - const.axisSize
-        startY : U.shape.y
-        endX : U.shape.x + const.axisSize
-        endY : U.shape.y
-        thickness : U.thickness
+    U.xAxis = Line {
+        start : (o[0] - axisSize, o[1]) -- TODO This gets mis-parsed as a matrix access
+        end : (o[0] + axisSize, o[1])
+        thickness : const.lineThickness
+        style : "solid"
         color : U.axisColor
-        arrowheadSize : const.arrowheadSize
+        leftArrowhead: True
+        rightArrowhead: True
+        arrowheadSize : const.arrowheadSize * 2.
     }
 
-    U.yAxis = Arrow {
-        startX : U.shape.x
-        startY : U.shape.y - const.axisSize
-        endX : U.shape.x
-        endY : U.shape.y + const.axisSize
-        thickness : U.thickness
-        color : U.axisColor
-        arrowheadSize : const.arrowheadSize
+    U.yAxis = Line {
+           start : (o[0], o[1] - axisSize)
+             end : (o[0], o[1] + axisSize)
+       thickness : const.lineThickness
+           style : "solid"
+           color : U.axisColor
+           leftArrowhead: True
+           rightArrowhead: True
+        arrowheadSize : const.arrowheadSize * 2.
     }
 
     U.text = Text {
         string : U.label
-        x : U.shape.x - const.axisSize
-        y : U.shape.y + const.axisSize
+        center : (U.origin[0] - axisSize, U.origin[1] + axisSize)
         color : U.axisColor
     }
-
-    -- U.xLabelLocation = ensure nearHead(U.xAxisRight, U.textX, 20.0, 0.0)
-    -- U.yLabelLocation = ensure nearHead(U.yAxisUp, U.textY, 0.0, 20.0)
 }
 
-Vector v
-with VectorSpace U
-where In(v,U) {
-  v.text = Text {
-    string : v.label
-    color : v.shape.color
+forall Vector u; VectorSpace U
+where In(u,U) {
+  u.text = Text {
+    -- center : (?, ?) -- This should be done automatically
+    string : u.label
+    color : u.arrow.color
   }
 
-  v.shape = Arrow {
-    startX : U.shape.x
-    startY : U.shape.y
+  u.arrow = Arrow {
+    start : U.origin
+    end : (?, ?)
     thickness : 3.0
-    color : Colors.blue
+    color : C.lightBlue
     arrowheadSize : const.arrowheadSize
   }
 
-   v.vector = (v.shape.endX - v.shape.startX, v.shape.endY - v.shape.startY)
-   v.angle = angle(v.vector)
+   u.vector = u.arrow.end - u.arrow.start -- Vector sugar for subtraction
 
-   -- v.containFn = ensure contains(U.shape, v.shape)
-   -- v.containLabel = ensure contains(U.shape, v.text)
-   -- v.labelLocation = ensure nearHead(v.shape, v.text, 20.0, 20.0)
+   ensure contains(U.shape, u.arrow)
+   ensure contains(U.shape, u.text)
+   ensure atDist(u.arrow, u.text, 15.0)
+   ensure minSize(u.arrow)
 
-   -- TODO: Put these back in
-
-   -- ensure contains(U.shape, v.shape)
-   -- ensure contains(U.shape, v.text)
-   -- ensure atDist((v.shape.endX, v.shape.endY), v.text, 10.0)
-
-   -- This objective gives better visual results but causes vectors to be the same length?
-   -- v.labelAvoidFn = encourage repel(v.shape, v.text, const.repelWeight)
-
-  v.text above U.xAxis
-  v.text above U.yAxis
+  layer u.text above U.xAxis
+  layer u.text above U.yAxis
 }
 
-Vector u; Vector v
+forall Vector u; Vector v
 with VectorSpace U
 where Orthogonal(u, v); In(u, U); In(v, U) {
-      -- Draw perpendicular mark
-      LOCAL.perpMark = Curve {
-	   pathData : orientedSquare(u.shape, v.shape, U.origin, const.perpLen)
-	   strokeWidth : 2.0
-	   color : Colors.black
-	   fill : Colors.white
+      startR = u.arrow.start -- TODO: Do we want destructuring syntax like vec2[] [startR, endR] = [u.arrow.start, u.arrow.end]
+      endR = u.arrow.end
+      startL = v.arrow.start
+      endL = v.arrow.end
+      dirR = normalize(endR - startR)  -- Syntax sugar for vectors (better in Style because JS doesn't allow it!)
+      dirL = normalize(endL - startL)
+      ptL = startR + const.perpLen * dirL
+      ptR = startR + const.perpLen * dirR
+      ptLR = ptL + const.perpLen * dirR
+      pts = [startR, ptL, ptLR, ptR]
+
+      -- toPath = functions.pathFromPoints -- COMBAK: Add ability to alias function names
+
+      -- Draw perpendicular mark -- NOTE: local shapes should still be drawn
+      perpMark = Curve {
+           pathData : pathFromPoints("closed", pts)
+           strokeWidth : 2.0
+           color : C.black
+           fill : C.white
       }
 
-      -- Make sure vectors are orthogonal
-      -- encourage equal(dot(u.vector, v.vector), 0.0)
+      -- Make sure vectors are orthogonal (use ensure?)
+      -- eq = functions.equal
+      encourage equal(dot(u.vector, v.vector), 0.0) -- NOTE: Have to import Penrose fns
 
-      layer v.shape above LOCAL.perpMark
-      layer u.shape above LOCAL.perpMark
+-- COMBAK: Test parsing the expressions that involve local vars 
+      layer v.arrow above perpMark
+      layer u.arrow above perpMark
 }
 
--- Usually, the unit vector shouldn't need to know about orthogonal vectors, but we need to position the unit mark so that it doesn't overlap with the "inside" of the two vectors
+forall Vector v
+with VectorSpace U; Vector w
+where In(v, U); Unit(v); Orthogonal(v, w) {
+      -- Usually, the unit vector shouldn't need to know about orthogonal vectors
+      -- but we need to position the unit mark so it doesn't overlap with the "inside" of the two vectors
 
--- TODO: Put this back in
+      strokeWidth = 2.0
+      padding = 15.0 -- COMBAK: What is this?
+      -- toPath = functions.pathFromPoints -- COMBAK
 
--- Vector v
--- with VectorSpace U; Vector w
--- where In(v, U); Unit(v); Orthogonal(v, w) {
+      -- The start and end of the body of the unit marker line
+      -- NOTE: We need to have lists of vectors
+      dir = normalize(w.arrow.end - w.arrow.start)
+      normal = -dir
+      markStart = v.arrow.start + padding * normal
+      markEnd = v.arrow.end + padding * normal
+      v.markerLine = [markStart, markEnd]
 
---       -- The start and end of the body of the unit marker line
---       v.offsetVec = unitMark(v.shape, w.shape, "body", const.markerPadding, const.barSize)
---       v.labelPosition = midpointOffset(v.offsetVec, w.shape, const.markerPadding)
+      v.unitMarkerLine = Curve {
+          pathData : pathFromPoints("open", v.markerLine)
+          strokeWidth : strokeWidth
+          color : C.black
+          fill : C.none
+      }
 
---       v.unitMarkerLine = Curve {
---           pathData : pathFromPoints(v.offsetVec)
--- 	  strokeWidth : 2.0
--- 	  color : Colors.black
--- 	  fill : Colors.none
---       }
+      -- Could use normal instead, just doing this to demonstrate how to use matrices
+      rot90CW = ((0., 1.), (-1., 0.))
+      markNormal = mul(rot90CW, normalize(v.arrow.end - v.arrow.start)) -- TODO: Do we want syntactic sugar for matrix-vector multiplication? Or a better name?
+      c = const.barSize
+      halfvec = c * markNormal
 
---       v.unitMarkerEnd1 = Curve {
---           pathData : unitMark(v.offsetVec, "start", const.markerPadding, const.barSize)
---       	  strokeWidth : 2.0
---       	  color : Colors.black
---       	  fill : Colors.none
---       }
+      v.unitMarkerEnd1 = Curve {
+          pathData : pathFromPoints("open", [markStart - halfvec, markStart + halfvec]) -- TODO: Can we infer this type if it's written anonymously?
+          strokeWidth : strokeWidth
+          color : C.black
+          fill : C.none
+      }
 
---       v.unitMarkerEnd2 = Curve {
---           pathData : unitMark(v.offsetVec, "end", const.markerPadding, const.barSize)
---       	  strokeWidth : 2.0
---       	  color : Colors.black
---       	  fill : Colors.none
---       }
+      v.unitMarkerEnd2 = Curve {
+          pathData : pathFromPoints("open", [markEnd - halfvec, markEnd + halfvec])
+          strokeWidth : strokeWidth
+          color : C.black
+          fill : C.none
+      }
 
---       v.unitMarkerText = Text {
---           string : "1"
--- 	  x : get(v.labelPosition, 0)
--- 	  y : get(v.labelPosition, 1)
--- 	  color : Colors.black
---       }
+      midpointLoc = (v.markerLine[0] + v.markerLine[1]) / 2.
+      labelPos = midpointLoc + const.markerPadding * normal
 
---       layer v.unitMarkerLine above U.xAxis
---       layer v.unitMarkerLine above U.yAxis
---       -- encourage repel(v.unitMarkerLine, v.unitMarkerText, const.repelWeight)
--- }
+      v.unitMarkerText = Text {
+          string : "1"
+          center : labelPos
+          color : C.black
+      }
 
-Vector `x2` {
-       override `x2`.shape.color = Colors.green
+      layer v.unitMarkerLine above U.xAxis
+      layer v.unitMarkerLine above U.yAxis
+}
+
+forall Vector `x2` {
+       override `x2`.arrow.color = C.green
 }

--- a/examples/mesh-set-domain/DomainInterop.sty
+++ b/examples/mesh-set-domain/DomainInterop.sty
@@ -4,13 +4,13 @@
 -- | Set Style program
 
 const {
-      const.subsetColor = sampleColor(0.2, "rgb")
-      const.repelWeight = 0.0
+      subsetColor = sampleColor(0.2, "rgb")
+      repelWeight = 0.0
 }
 
 Set x {
     x.shape = Circle {
-        strokeWidth : 0
+        strokeWidth : 0.0
     }
 
     x.text = Text {
@@ -18,80 +18,80 @@ Set x {
 	color : setOpacity(x.shape.color, 1.0)
     }
 
-    x.labelFn = ensure contains(x.shape, x.text)
-    x.minSizeFn = ensure minSize(x.shape)
-    x.maxSizeFn = ensure maxSize(x.shape)
-    -- x.labelPosFn = encourage sameCenter(x.text, x.shape)
-    LOCAL.layering  = x.shape below x.text
+    ensure contains(x.shape, x.text)
+    ensure contains(x.shape, x.text)
+    ensure minSize(x.shape)
+    ensure maxSize(x.shape)
+    -- encourage sameCenter(x.text, x.shape)
+    x.shape below x.text
 }
 
 Set x; Set y
 where IsSubset(x, y) {
-    LOCAL.containFn = ensure contains(y.shape, x.shape, 5.0)
-    LOCAL.sizeFn    = ensure smallerThan(x.shape, y.shape)
-    LOCAL.outsideFn = ensure outsideOf(y.text, x.shape) -- Is this not working?
-    LOCAL.layering  = x.shape above y.shape
-    -- LOCAL.layering1  = y.text below x.shape
+    ensure contains(y.shape, x.shape, 5.0)
+    ensure smallerThan(x.shape, y.shape)
+    ensure outsideOf(y.text, x.shape) -- Is this not working?
+    x.shape above y.shape
+    -- layering1  = y.text below x.shape
 }
 
 Set x; Set y
 where NotIntersecting(x, y) {
-    LOCAL.notIntersectFn = ensure disjoint(x.shape, y.shape)
+    ensure disjoint(x.shape, y.shape)
 }
 
 Set x; Set y
 where Intersect(x, y) {
-    LOCAL.overlapFn = ensure overlapping(x.shape, y.shape)
-    LOCAL.labelFn1  = ensure outsideOf(y.text, x.shape)
-    LOCAL.labelFn2  = ensure outsideOf(x.text, y.shape)
+    ensure overlapping(x.shape, y.shape)
+    ensure outsideOf(y.text, x.shape)
+    ensure outsideOf(x.text, y.shape)
 }
 
 Point p {
     p.offset = 10.0
     p.shape = Circle {
-        strokeWidth : 0
+        strokeWidth : 0.0
         color : rgba(0.0, 0.0, 0.0, 1.0)
         r : 3.0
     }
 
     p.text = Text {
         string : p.label
-        x : p.shape.x + p.offset
-        y : p.shape.y + p.offset
+        center : p.shape.center + (p.offset, p.offset)
     }
 }
 
 Point p
 with Set A
 where PointIn(A, p) {
-    LOCAL.containsFn = ensure contains(A.shape, p.shape, 0.3 * A.shape.r)
-    LOCAL.layeringShape = p.shape above A.shape
-    LOCAL.layeringText = p.text above A.shape
+    ensure contains(A.shape, p.shape, 0.3 * A.shape.r)
+    p.shape above A.shape
+    p.text above A.shape
 }
 
 Point p
 with Set A
 where PointNotIn(A, p) {
 -- where Not(PointIn(A, p)) {
-    LOCAL.notContainsFn = ensure disjoint(A.shape, p.shape)
+    ensure disjoint(A.shape, p.shape)
 }
 
 -- Put all the text on top of everything
 Set x; Set y {
-    LOCAL.labelRepelFn = encourage repel(x.text, y.text, const.repelWeight)
-    LOCAL.layering = x.shape below y.text
+    encourage repel(x.text, y.text, const.repelWeight)
+    x.shape below y.text
 }
 
 Point p; Point q {
-      -- LOCAL.shapeRepelFn = encourage repel(p.shape, q.shape, G.repelWeight2)
-      LOCAL.labelRepelFn = encourage repel(p.text, q.text, const.repelWeight)
+     -- encourage repel(p.shape, q.shape, G.repelWeight2)
+     encourage repel(p.text, q.text, const.repelWeight)
 }
 
 Set x; Point p {
-    LOCAL.layering1 = p.shape above x.shape
-    LOCAL.layering2 = p.text above x.shape
+    p.shape above x.shape
+    p.text above x.shape
 
-      LOCAL.labelRepelFn = encourage repel(p.text, x.text, const.repelWeight)
+     encourage repel(p.text, x.text, const.repelWeight)
 }
 
 --------------------------------------
@@ -136,7 +136,7 @@ global {
     -- These numbers (weights on inRange and the range itself) have been heavily tweaked
     -- And it makes convergence hard
     -- global.scaleFactor = ?
-    -- global.optFn = ensure inRange(global.scaleFactor, 75.0, 150.0)
+    ensure inRange(global.scaleFactor, 75.0, 150.0)
     global.scaleFactor = 70.0
     -- global.offset = 150.0
 }
@@ -188,8 +188,7 @@ SimplicialComplex K {
        -- K.size_y = ddg[K.name]["size_y"] * global.scaleFactor + K.box_padding
 
        K.shape = Rectangle {
-           x : K.center_x
-	       y : K.center_y
+           center : (K.center_x, K.center_y)
 	       w : K.size_x
 	       h : K.size_y
 	       rotation : 0.0
@@ -201,39 +200,37 @@ SimplicialComplex K {
        K.padding = 25.0
 
        K.text = Text {
-	 x : K.shape.x - K.shape.w / 2.0 + K.padding
-	 y : K.shape.y - K.shape.h / 2.0 + K.padding
+	 center : (K.shape.center[0] - K.shape.w / 2.0 + K.padding, K.shape.center[1] - K.shape.h / 2.0 + K.padding)
 	 string : K.label
 	 rotation : 0.0
 	 color : Colors.black
        }
 
-       K.labelFn = encourage centerLabel(K.shape, K.text)
+     encourage centerLabel(K.shape, K.text)
 
-       K.layerTextFn = K.text above K.shape
+       K.text above K.shape
 
        -- Expression label
        K.expr_padding = 25.0
 
        K.const_text = Text {
-       	 x : K.shape.x 
-       	 y : K.shape.y - (K.size_y / 2.0) - K.expr_padding
+       	 center : (K.shape.center[0], K.shape.center[1] - (K.size_y / 2.0) - K.expr_padding)
        	 string : "\\text{ }"
        	 rotation : 0.0
        	 color : global.starColor
        }
 
-       K.const_layerFn = K.const_text above K.shape
+       K.const_text above K.shape
 }
 
 -- TODO: this generates a (K1, K2) and (K2, K1) match
 SimplicialComplex K1; SimplicialComplex K2 {
-	 LOCAL.padding = 30.0
+	 padding = 30.0
 
 	 -- TODO: improve this for rectangles by not just using the x size
-	 LOCAL.overlapFn = ensure disjoint(K1.shape, K2.shape, LOCAL.padding)
-	 LOCAL.alignFn = ensure sameHeight(K1.shape, K2.shape)
-	 -- LOCAL.distFn = ensure distBetween(K1.shape, K2.shape, LOCAL.padding)
+	 ensure disjoint(K1.shape, K2.shape, padding)
+	 ensure sameHeight(K1.shape, K2.shape)
+	 -- distFn = ensure distBetween(K1.shape, K2.shape, padding)
 }
 
 Vertex v 
@@ -245,8 +242,7 @@ with SimplicialComplex K {
        -- v.ypos = ddg[v.name]["y"] * global.scaleFactor
 
        v.shape = Circle { 
-         x : v.xpos -- avoid "x <- f(x)" in override
-	 y : v.ypos
+         center : (v.xpos, v.ypos) -- avoid "x <- f(x)" in override
          r : global.selectedRadius
 	 color : Colors.black
 	 strokeWidth : 0.0
@@ -254,21 +250,21 @@ with SimplicialComplex K {
 
        -- NOTE: by default, this starts with an empty string, so we only label user-declared vertices
        v.text = Text {
-	 x : ? -- v.shape.x + global.padding
-	 y : ? -- v.shape.y + global.padding
+	 center : (?, ?) -- v.shape.x + global.padding
+	                 -- v.shape.y + global.padding
 	 string : v.label
 	 -- string : " " -- TODO: the frontend does not deal with empty strings well! Doesn't seem to generate a label with dimensions. See above for how to get around this
 	 rotation : 0.0
 	 color : v.shape.color
        }
 
-       v.layerFnShape = v.shape above K.shape
-       v.layerFnText = v.text above K.shape
+       v.shape above K.shape
+       v.text above K.shape
 
-       v.posFn = ensure contains(K.shape, v.shape, v.shape.r) -- padding
+     ensure contains(K.shape, v.shape, v.shape.r) -- padding
 
-       v.labelFnMargin = ensure atDist(v.shape, v.text, global.labelPadding2)
-       v.labelFn = ensure contains(K.shape, v.text, 0.0)
+     ensure atDist(v.shape, v.text, global.labelPadding2)
+     ensure contains(K.shape, v.text, 0.0)
 }
 
 -- Style a distinguished vertex (only if it's a result)
@@ -282,7 +278,7 @@ with SimplicialComplex K {
       override v.shape.color = global.closureColor
 
       v.offset = 10.0
-      v.labelCloseFn = encourage near(v.text, v.shape, v.offset)
+     encourage near(v.text, v.shape, v.offset)
 
       /*
        -- Optimize the label padding, only for the distinguished vertex
@@ -293,58 +289,55 @@ with SimplicialComplex K {
 
       v.offset = 30.0
       -- This is trying to place the labels but it's very slow, goes from 40s to 3min
-      v.labelInComplexFn = ensure contains(K.shape, v.text)
+     ensure contains(K.shape, v.text)
       -- Label's color might need to be programmatically set depending on its location
 
       v.padding_range = 20.0
-      v.labelRangeXFn = ensure inRange(v.padding_x, v.shape.x - v.padding_range, v.shape.x + v.padding_range)
-      v.labelRangeYFn = ensure inRange(v.padding_y, v.shape.y - v.padding_range, v.shape.y + v.padding_range) */
+     ensure inRange(v.padding_x, v.shape.x - v.padding_range, v.shape.x + v.padding_range)
+     ensure inRange(v.padding_y, v.shape.y - v.padding_range, v.shape.y + v.padding_range) */
 }
 
 Vertex v; Edge e
 where InVS(v, K); InES(e, K)
 with SimplicialComplex K {
-     LOCAL.offset = 5.0
+     offset = 5.0
      -- Make sure the label doesn't overlap with any edge
      -- TODO: this is NaNing
-     -- LOCAL.edgeLabelFn = ensure disjoint(v.text, e.shape, LOCAL.offset)
+     ensure disjoint(v.text, e.shape, offset)
 }
 
 Vertex v; Edge e
 where DeclaredV(v); InVS(v, K); InES(e, K)
 with SimplicialComplex K {
-     LOCAL.offset = 5.0
+     offset = 5.0
      -- Make sure the label doesn't overlap with any edge
      -- TODO: this is NaNing
-     LOCAL.edgeLabelFn = ensure disjoint(v.text, e.shape, LOCAL.offset)
+     ensure disjoint(v.text, e.shape, offset)
 }
 
 Edge e
 where e := MkEdge(v1, v2); InES(e, K)
 with Vertex v1; Vertex v2; SimplicialComplex K {
      e.shape = Line { 
-     	     startX : v1.shape.x
-     	     startY : v1.shape.y
-     	     endX : v2.shape.x
-     	     endY : v2.shape.y
+     	     start : v1.shape.center
+     	     end : v2.shape.center
 	     color : Colors.black
 	     thickness : global.edgeStroke
      }
 
      e.text = Text {
-       x : ?
-       y : ?
+       center : (?, ?)
        string : e.label
        rotation : 0.0
        color : Colors.black
      }
 
-     e.closeFn = encourage nearPt(e.text, average2(v1.xpos, v2.xpos), average2(v1.ypos, v2.ypos))
-     e.nonoverlapFn = ensure disjoint(e.text, e.shape, 5.0)
+     encourage nearPt(e.text, average2(v1.xpos, v2.xpos), average2(v1.ypos, v2.ypos))
+     ensure disjoint(e.text, e.shape, 5.0)
 
-     e.layering1 = v1.shape above e.shape
-     e.layering2 = v2.shape above e.shape
-     e.layering3 = e.shape above K.shape
+     v1.shape above e.shape
+     v2.shape above e.shape
+     e.shape above K.shape
 }
 
 -- Style a distinguished edge (only if it's declared to be a result)
@@ -355,15 +348,15 @@ with Vertex v1; Vertex v2; SimplicialComplex K {
      override e.shape.color = global.closureColor
 
      e.text = Text {
-       x : average2(e.shape.startX, e.shape.endX) + global.padding
-       y : average2(e.shape.startY, e.shape.endY) + global.padding
+     -- TODO: Vectorize this
+       center : (average2(e.shape.start[0], e.shape.end[0]) + global.padding, average2(e.shape.start[1], e.shape.end[1]) + global.padding)
        -- string : e.label
        string : "\\text{ }" 
        rotation : 0.0
        color : e.shape.color
      }
 
-     e.layerFnText = e.text above K.shape
+     e.text above K.shape
 }
 
 Face f -- 255,552 substitutions = 22 e * 22 e * 22 e * 12 f * 2 sc
@@ -382,16 +375,15 @@ with Edge e1; Edge e2; Edge e3; SimplicialComplex K {
 
      f.text = Text {
        -- Makes assumptions about vertex order in constructor
-       x : average([e1.shape.startX, e2.shape.startX, e3.shape.startX])
-       y : average([e1.shape.startY, e2.shape.startY, e3.shape.startY])
+       center : (average([e1.shape.start[0], e2.shape.start[0], e3.shape.start[0]]), average([e1.shape.start[1], e2.shape.start[1], e3.shape.start[1]]))
        string : f.label
        rotation : 0.0
        color : Colors.black
      }
 
-     f.layerFnText = f.text above K.shape
+     f.text above K.shape
 
-     f.layeringShape = f.shape above K.shape
+     f.shape above K.shape
 }
 
 -- Style and label a distinguished face
@@ -407,8 +399,8 @@ with SimplicialComplex K {
 Vertex v; Edge e; Face f
 where InVS(v, K); InES(e, K); InFS(f, K)
 with SimplicialComplex K {
-      LOCAL.textLayering1 = v.text above f.shape 
-      LOCAL.textLayering2 = v.text above e.shape
+      v.text above f.shape 
+      v.text above e.shape
 }
 
 -- Only label the (last) result of an operation
@@ -419,40 +411,39 @@ where Result(e) {
 }
 
 Edge e; Face f {
-     LOCAL.layering = e.shape above f.shape
-     LOCAL.layeringText = e.text above f.shape
+     e.shape above f.shape
+     e.text above f.shape
 }
 
 Vertex v; Vertex w {
-       LOCAL.repelFn = encourage repel(v.shape, w.shape, 1.0)
+     encourage repel(v.shape, w.shape, 1.0)
 }
 
 --------------------------------------
 -- | above this line, concatenate the two .sty files for Sets and Meshes
 
-Point p; Vertex v
+forall Point p; Vertex v
 where Identified(p, v) {
-   LOCAL.shape = Line {
-      startX: p.shape.x
-      startY: p.shape.y
-      endX: v.shape.x
-      endY: v.shape.y
+
+   shape = Line {
+      start : p.shape.center
+      end : v.shape.center
       color: setOpacity(Colors.black, 0.25)
       thickness : 2.0
-      style: "dashed"
+      style : "dashed"
    }
 
-   LOCAL.layering1 = LOCAL.shape above p.shape
-   LOCAL.layering2 = LOCAL.shape above v.shape
+   layer shape above p.shape
+   layer shape above v.shape
    
    -- rather than worry about the two diagrams colliding, just add some penalty that tries to make all the connecting lines fairly long
    -- p.vector = (p.shape.x, p.shape.y)
    -- v.vector = (v.shape.x, v.shape.y)
-   LOCAL.vec = (p.shape.x - v.shape.x, p.shape.y - v.shape.y)
+   vec = p.shape.center - v.shape.center
 
    -- TODO: encourage or ensure?
    -- TODO: make this better
-   -- LOCAL.lenFn = encourage equal(norm_(p.shape.x - v.shape.x, p.shape.y - v.shape.y), 100.0)
+   -- lenFn = encourage equal(norm_(p.shape.x - v.shape.x, p.shape.y - v.shape.y), 100.0)
 }
 
 Set s; Edge e
@@ -464,6 +455,5 @@ where Identified(e, s) {
 -- TODO: hack for position; assuming there's only one face
 Set s; Face f
 where Identified(f, s) {
-    s.shape.x = 200.0
-    s.shape.y = 0.0
+    s.shape.center = (200.0, 0.0)
 }

--- a/examples/set-theory-domain/continuousmap.sty
+++ b/examples/set-theory-domain/continuousmap.sty
@@ -24,16 +24,16 @@ Set x {
     }
 
     x.labelFn = ensure contains(x.shape, x.text)
-    LOCAL.layering = x.shape below x.text
+    x.shape below x.text
 }
 
 -- Selector ordering matters!
 Set x; Set y
 where IsSubset(x, y) {
-  LOCAL.containFn = ensure contains(y.shape, x.shape, 10.0)
+  ensure contains(y.shape, x.shape, 10.0)
   -- y.sizeFn    = ensure smallerThan(x.shape, y.shape)
-  LOCAL.outsideFn = ensure outsideOf(y.text, x.shape, 1.0)
-  LOCAL.layering = x.shape above y.shape
+  y.outsideFn = ensure outsideOf(y.text, x.shape, 1.0)
+  x.shape above y.shape
 }
 
 Map f
@@ -42,10 +42,8 @@ with Set X; Set Y; Set R1; Set R2 {
   f.padding = 20.0
 
     f.shape = Arrow {
-      startX : R1.shape.x + (R1.shape.side) / 2.0 + f.padding
-      startY : R1.shape.y
-      endX : R2.shape.x - (R2.shape.side) / 2.0 - f.padding
-      endY : R2.shape.y
+      start : (R1.shape.center[0] + R1.shape.side / 2.0 + f.padding, R1.shape.center[1])
+      end : (R2.shape.center[0] - R2.shape.side / 2.0 - f.padding, R2.shape.center[1])
       thickness : 2.0
       color : Colors.black
         -- style : "curved"
@@ -59,7 +57,7 @@ with Set X; Set Y; Set R1; Set R2 {
       rotation : 0.0
     }
 
-    f.labelFn  = encourage centerLabel(f.shape, f.text, 5.0)
+    encourage centerLabel(f.shape, f.text, 5.0)
 
     -- Unused?
     -- f.centerFn = encourage centerArrow(f.shape, R1.shape, R2.shape)
@@ -87,14 +85,13 @@ Set `Rn` {
       strokeColor : Colors.black
     }
 
-    `Rn`.text.x = `Rn`.shape.x + `Rn`.shape.side / 2.0 - Const.padding
-    `Rn`.text.y = `Rn`.shape.y + `Rn`.shape.side / 2.0 - Const.padding
+    override `Rn`.text.center = (`Rn`.shape.center[0] + `Rn`.shape.side / 2.0 - Const.padding, `Rn`.shape.center[1] + `Rn`.shape.side / 2.0 - Const.padding)
 
     delete `Rn`.labelFn
     delete `Rn`.outsideFn
 
-    `Rn`.minSizeFn = ensure minSize(`Rn`.shape)
-    `Rn`.maxSizeFn = ensure maxSize(`Rn`.shape)
+    ensure minSize(`Rn`.shape)
+    ensure maxSize(`Rn`.shape)
 }
 
 Set `Rm`
@@ -102,16 +99,14 @@ with Set `Rn` {
     -- TODO: factor this block out
     override `Rm`.shape = Square {
         color : Colors.lightYellow
-        y : `Rn`.shape.y
-        x : `Rn`.shape.x + 400.0
+        center : (`Rn`.shape.center[0] + 400.0, `Rn`.shape.center[1])
         side  : `Rn`.shape.side
         rotation : 0.0
         strokeWidth : 1.0
         strokeColor : Colors.black
     }
 
-    `Rm`.text.x = `Rm`.shape.x + `Rm`.shape.side / 2.0 - Const.padding
-    `Rm`.text.y = `Rm`.shape.y + `Rm`.shape.side / 2.0 - Const.padding
+     override `Rm`.text.center = (`Rm`.shape.center[0] + `Rm`.shape.side / 2.0 - Const.padding, `Rm`.shape.center[1] + `Rm`.shape.side / 2.0 - Const.padding)
 
     delete `Rm`.labelFn
     delete `Rm`.outsideFn
@@ -119,6 +114,6 @@ with Set `Rn` {
     -- This doesn't seem to work
     --    `Rm`.posFn = encourage topRightOf(`Rm`.text, `Rm`.shape)
 
-    `Rm`.minSizeFn = ensure minSize(`Rm`.shape)
-    `Rm`.maxSizeFn = ensure maxSize(`Rm`.shape)
+    ensure minSize(`Rm`.shape)
+    ensure maxSize(`Rm`.shape)
 }

--- a/examples/set-theory-domain/tree.sty
+++ b/examples/set-theory-domain/tree.sty
@@ -4,62 +4,35 @@
 
 Set x; Set y {
    -- Try to make sure no labels overlap
-   LOCAL.genRepelFn = encourage repel(x.shape, y.shape, 5.0)
+   encourage repel(x.shape, y.shape, 5.0)
 }
 
 -- TODO: Phase this back in
 
 Set x; Set y
 where IsSubset(x, y) {
-    LOCAL.arrow = Arrow {
+    arrow = Arrow {
       thickness : 2.0
       color : rgba(0.0, 0.0, 0.0, 1.0)
     }
 
     -- Draw the arrow from y to x
-    LOCAL.centerFn = encourage centerArrow(LOCAL.arrow, x.shape, y.shape)
+    encourage centerArrow(arrow, x.shape, y.shape)
 
     -- Position y above x
-    LOCAL.aboveFn = encourage above(y.shape, x.shape)
+    encourage above(y.shape, x.shape)
 
     -- Have sets 'fight' to be aligned with the superset's x-position
-    LOCAL.equalFn = encourage equal(x.shape.x, y.shape.x)
+    encourage equal(x.shape.center[0], y.shape.center[0])
 }
 
 /*
--- This one currently causes convergence to become very slow but works eventually
+-- TODO: This one currently causes convergence to become very slow but works eventually
 
 Set x1; Set x2
 where IsSubset(x1, S); IsSubset(x2, S)
 with Set S {
    -- If two sets are direct subsets of the same set, give them the same y-position
-   LOCAL.heightFn = ensure sameHeight(x1.shape, x2.shape)
+   heightFn = ensure sameHeight(x1.shape, x2.shape)
 }
 */
-
-/* What matches are generated here?
-
-Expected matches: [S; x1, x2] => [A; B, C], [B; D, E], [C; F, G]
-Note it also generates these matches:
-                  (2) [A; C, B], [B; E, D], [C; G, F]
-
-Proposed principles:
-
-- If the selector-writer uses different names for things of the same type, the same thing will never be matched
-  i.e. "Set X; Set Y" <| "Set A; Set B" won't ever yield substitution [A => X, B => X] or [A => Y, B => Y]
-  [Has been implemented]
-
-- only take one permutation of the substitutions?
-  but what if you have, say,
-  "Set A, B; IsSubset(A, B); IsSubset(B, A)" <| "Set X, Y where IsSubset(X, Y)"
-  eliminating permutations will eliminate one of the substitutions [X => A, Y => B], [X => B, Y => A]
-
-Do these principles contradict any matching functionality that we might want later?
-Can we solve this problem with a compiler/program directive?
-e.g. -DiffPatternSameVar -AllPermutations
-Or some kind of syntax in the selector or variable?
-Is there some way to automatically detect which case we're in, or distinguish them?
-No permutations in the "same position" in a Substance stmt?
-Eliminate permutations where the objective functions are symmetric???
-  e.g. here, sameHeight and repel are symm.
-  So does it matter?  */

--- a/examples/set-theory-domain/venn-comp-test.sty
+++ b/examples/set-theory-domain/venn-comp-test.sty
@@ -9,8 +9,7 @@ Colors {
 
 const {
       const.circle = Circle {
-                   x : 0.0
-                   y : 0.0
+                   center : (0., 0.)
                    r : 100.0
                    color : Colors.none
                    strokeWidth : 5.0
@@ -23,8 +22,7 @@ forall Set x {
        x.angle = ?       
 
     x.shape = Circle {
-            x : x.r * cos(x.angle)
-            y : x.r * sin(x.angle)
+            center : (x.r * cos(x.angle), x.r * sin(x.angle))
             strokeWidth : 0.0
     }
 

--- a/examples/set-theory-domain/venn-opt-test.sty
+++ b/examples/set-theory-domain/venn-opt-test.sty
@@ -1,6 +1,6 @@
 forall Set x {
     x.shape = Circle {
-        strokeWidth : 0
+        strokeWidth : 0.0
     }
 
     x.text = Text {
@@ -47,17 +47,14 @@ where Intersecting(x, y) {
 forall Point p {
     p.offset = 20.0
     p.shape = Circle {
-        x : ?
-        y : ?
-        strokeWidth : 0
+        strokeWidth : 0.0
         color : rgba(0.0, 0.0, 0.0, 1.0)
         r : 3.0
     }
 
     p.text = Text {
         string : p.label
-        x : p.shape.x + p.offset
-        y : p.shape.y + p.offset
+        center : p.shape.center + (p.offset, p.offset)
     }
 
     -- TODO: Why isn't the offset working?
@@ -68,12 +65,12 @@ forall Point p {
 Point p
 with Set A
 where PointIn(A, p) {
-    p.containsFn = ensure contains(A.shape, p.shape, 0.3 * A.shape.r)
+    ensure contains(A.shape, p.shape, 0.3 * A.shape.r)
     p.layering = p.shape above A.shape
 }
 
 Point p
 with Set A
 where Not(PointIn(A, p)) {
-    p.notContainsFn = ensure disjoint(A.shape, p.shape)
+    ensure disjoint(A.shape, p.shape)
 }

--- a/examples/set-theory-domain/venn-small.sty
+++ b/examples/set-theory-domain/venn-small.sty
@@ -1,47 +1,45 @@
 forall Set x {
     x.shape = Circle {
-        x : ?
-        y : ?
+        -- center : (?, ?)
         r : ?
         -- r : 100.0
-        strokeWidth : 0
+        strokeWidth : 0.0
     }
 
     x.text = Text {
         string : x.label
     }
 
-    LOCAL.c = 20.0
+    c = 20.0
 
     x.debugShape = Arrow {
-        startX: x.text.x
-        startY: x.text.y
-        endX: x.text.x + LOCAL.c * derivative(x.text.x)
-        endY: x.text.y + LOCAL.c * derivative(x.text.y)
+        start: x.text.center
+        end: (x.text.center[0] + c * derivative(x.text.center[0]), x.text.center[1] + c * derivative(x.text.center[1]))
         color: rgba(1.0, 0.0, 0.0, 0.5)
         arrowheadSize: 0.5
         thickness: 3.0
         style: "dashed"
     }
 
-    LOCAL.d = 20.0
+    d = 20.0
 
     x.debugShape2 = Arrow {
-        startX: x.text.x
-        startY: x.text.y
-        endX: x.text.x + LOCAL.d * derivativePreconditioned(x.text.x)
-        endY: x.text.y + LOCAL.d * derivativePreconditioned(x.text.y)
+        start: x.text.center
+        end: (x.text.center[0] + c * derivativePreconditioned(x.text.center[0]), x.text.center[1] + c * derivativePreconditioned(x.text.center[1]))
         color: rgba(0.0, 0.0, 1.0, 0.5)
         arrowheadSize: 0.5
         thickness: 3.0
         style: "dashed"
     }
 
-    ensure contains(x.shape, x.text) -- NEW
-    encourage sameCenter(x.text, x.shape) -- OLD
+    x.containFn = ensure contains(x.shape, x.text)
+    ensure contains(x.shape, x.text)
+    encourage sameCenter(x.text, x.shape)
 
     ensure minSize(x.shape)
     ensure maxSize(x.shape)
+
+    layer x.text above x.shape
 }
 
 forall Set x; Set y
@@ -49,6 +47,6 @@ where IsSubset(x, y) {
     ensure smallerThan(x.shape, y.shape)
     ensure outsideOf(y.text, x.shape)
 
-    ensure contains(y.shape, x.shape, 5.0) -- NEW
-    x.shape above y.shape
+    ensure contains(y.shape, x.shape, 5.0)
+    layer x.shape above y.shape
 }

--- a/examples/style-1.1/Colors.sty
+++ b/examples/style-1.1/Colors.sty
@@ -1,0 +1,13 @@
+-- Global RGB colors in common use
+-- Note that these are not scoped at another level of nesting!
+Colors {
+    color black = #000000
+    color white = rgba(1, 1, 1, 1)
+    color lightBlue = rgba(1e-1, 0.1, 0.9, 1e-1)
+    color darkBlue = rgba(lightBlue.r / 2, lightBlue.g / 2, lightBlue.b / 2, 0.5)
+    color darkGray = rgba(0.4, 0.4, 0.4, 1)
+    color gray = rgba(0.6, 0.6, 0.6, 1)
+    color green = rgba(0, 0.8, 0, 1.)
+    color blue = #0000ff
+    color none = rgba(0, 0, 0, 0)
+}

--- a/examples/style-1.1/OrthogonalVectors-original-ts-functions.sty
+++ b/examples/style-1.1/OrthogonalVectors-original-ts-functions.sty
@@ -1,0 +1,166 @@
+import Colors as C
+import Vectors -- TODO: do something with this import?
+
+OrthogonalVectors {
+    const {
+      scalar perpLen = 25.0
+      -- For unit mark
+      scalar markerPadding = 15.0
+      scalar barSize = 5.0
+    }
+
+    functions {
+        function dot = << (v: VarAD[], w: VarAD[]): IFloatV<VarAD> => {
+                           return { tag: "FloatV", contents: ops.vdot(v, w) };
+                         } >>
+
+        objective equal = << (x: VarAD, y: VarAD) => squared(sub(x, y)) >>
+
+        function perpPathFlat = << (len: VarAD, [startR, endR]: [VecAD, VecAD], 
+                                   [startL, endL]: [VecAD, VecAD]): [VecAD, VecAD, VecAD] => {
+                   const dirR = ops.vnormalize(ops.vsub(endR, startR));
+                   const dirL = ops.vnormalize(ops.vsub(endL, startL));
+                   const ptL = ops.vmove(startR, len, dirL); // ops.vadd(startR, ops.vmul(len, dirL));
+                   const ptR = ops.vmove(startR, len, dirR); // ops.vadd(startR, ops.vmul(len, dirR));
+                   const ptLR = ops.vadd(ptL, ops.vmul(len, dirR));
+                   return [ptL, ptLR, ptR];
+                 } >>
+
+         -- Local functions should be able to call other local functions, like perpPathFlat, that are defined in the file
+        function orientedSquare = << ([t1, s1]: [string, any], [t2, s2]: [string, any], 
+                                           intersection: Pt2, len: VarAD): IPathDataV<VarAD> => {
+               if ((t1 === "Arrow" || t1 === "Line") && (t2 === "Arrow" || t2 === "Line")) {
+                 const [seg1, seg2]: any = [linePts(s1), linePts(s2)];
+                 const [ptL, ptLR, ptR] = perpPathFlat(len, seg1, seg2);
+
+                 const elems: Elem<VarAD>[] =
+                   [{ tag: "Pt", contents: toPt(ptL) },
+                   { tag: "Pt", contents: toPt(ptLR) },
+                   { tag: "Pt", contents: toPt(ptR) },
+                   { tag: "Pt", contents: intersection }];
+                 const path: SubPath<VarAD> = { tag: "Closed", contents: elems };
+
+                 return { tag: "PathDataV", contents: [path] };
+               } else {
+                 throw Error("orientedSquare undefined for types ${t1}, ${t2}");
+               } >>
+
+        function pathFromPoints = << (pts: [Pt2]): IPathDataV<VarAD> => {
+              const elems: Elem<VarAD>[] = pts.map(e => ({ tag: "Pt", contents: e }));
+              const path: SubPath<VarAD> = { tag: "Open", contents: elems };
+              return { tag: "PathDataV", contents: [path] };
+            } >>
+
+        function midpointOffset = << ([start, end]: [Pt2, Pt2], [t1, s1]: [string, any], padding: VarAD): ITupV<VarAD> => {
+             if (t1 === "Arrow" || t1 === "Line") {
+               const [start1, end1] = linePts(s1);
+               // TODO: Cache these operations in Style!
+               const dir = ops.vnormalize(ops.vsub(end1, start1));
+               const normalDir = ops.vneg(dir);
+               const midpointLoc = ops.vmul(constOf(0.5), ops.vadd(start, end));
+               const midpointOffsetLoc = ops.vmove(midpointLoc, padding, normalDir);
+               return {
+                 tag: "TupV",
+                 contents: toPt(midpointOffsetLoc)
+               };
+             } else {
+               throw Error("unsupported shape ${t1} in midpointOffset");
+             }
+           } 
+       >>
+
+       function unitMark = <<   ([t1, s1]: [string, any], [t2, s2]: [string, any], 
+                                t: string, padding: VarAD, barSize: VarAD): IPtListV<VarAD> => {
+           const [start1, end1] = linePts(s1);
+           const [start2, end2] = linePts(s2);
+
+           const dir = ops.vnormalize(ops.vsub(end2, start2));
+           const normalDir = ops.vneg(dir);
+           const markStart = ops.vmove(start1, padding, normalDir);
+           const markEnd = ops.vmove(end1, padding, normalDir);
+
+           return {
+             tag: "PtListV",
+             contents: [markStart, markEnd].map(toPt)
+           };
+         } >>             
+
+       function unitMark2 = << ([start, end]: [Pt2, Pt2], t: string, 
+                               padding: VarAD, size: VarAD): IPtListV<VarAD> => {
+           const dir = ops.vnormalize(ops.vsub(end, start));
+           const normalDir = rot90(toPt(dir));
+           const base = t === "start" ? start : end;
+           const [markStart, markEnd] = [ops.vmove(base, size, normalDir), ops.vmove(base, neg(size), normalDir)];
+           return {
+             tag: "PtListV",
+             contents: [markStart, markEnd].map(toPt)
+           };
+         } >>
+    }
+
+    forall Vector u; Vector v
+    with VectorSpace U
+    where Orthogonal(u, v); In(u, U); In(v, U) {
+          -- Draw perpendicular mark -- NOTE: local shapes should still be drawn
+          shape perpMark = Curve {
+               pathData : orientedSquare(u.shape, v.shape, U.origin, const.perpLen)
+               strokeWidth : 2.0
+               color : C.black
+               fill : C.white
+          }
+
+          -- Make sure vectors are orthogonal (use ensure?)
+          encourage equal(dot(u.vector, v.vector), 0.0)
+
+          layer v.shape above LOCAL.perpMark
+          layer u.shape above LOCAL.perpMark
+    }
+
+    forall Vector v
+    with VectorSpace U; Vector w
+    where In(v, U); Unit(v); Orthogonal(v, w) {
+          -- Usually, the unit vector shouldn't need to know about orthogonal vectors
+          -- but we need to position the unit mark so it doesn't overlap with the "inside" of the two vectors
+
+          -- The start and end of the body of the unit marker line
+          -- NOTE: We need to have lists of vectors
+          vec2[] v.offsetVec = unitMark(v.shape, w.shape, "body", const.markerPadding, const.barSize)
+          -- NOTE: TupV needs to be converted to vector
+          vec2 v.labelPosition = midpointOffset(v.offsetVec, w.shape, const.markerPadding)
+          vec2 strokeWidth = 2
+
+          shape v.unitMarkerLine = Curve {
+              pathData : pathFromPoints(v.offsetVec)
+              strokeWidth : strokeWidth
+              color : C.black
+              fill : C.none
+          }
+
+          shape v.unitMarkerEnd1 = Curve {
+              pathData : pathFromPoints(unitMark2(v.offsetVec, "start", const.markerPadding, const.barSize))
+              strokeWidth : strokeWidth
+              color : C.black
+              fill : C.none
+          }
+
+          shape v.unitMarkerEnd2 = Curve {
+              pathData : pathFromPoints(unitMark2(v.offsetVec, "end", const.markerPadding, const.barSize))
+              strokeWidth : strokeWidth
+              color : C.black
+              fill : C.none
+          }
+
+          shape v.unitMarkerText = Text {
+              string : "1"
+              center : v.labelPosition
+              color : C.black
+          }
+
+          layer v.unitMarkerLine above U.xAxis
+          layer v.unitMarkerLine above U.yAxis
+    }
+
+    forall Vector `x2` {
+           override `x2`.shape.color = C.green
+    }
+}

--- a/examples/style-1.1/OrthogonalVectors.sty
+++ b/examples/style-1.1/OrthogonalVectors.sty
@@ -1,0 +1,118 @@
+import Colors as C
+import Vectors -- TODO: do something with this import?
+import Penrose.Math as M -- Can you import a specific name, like "dot"?
+
+OrthogonalVectors {
+    const {
+      scalar perpLen = 25.0
+      -- For unit mark
+      scalar markerPadding = 15.0
+      scalar barSize = 5.0
+    }
+
+    /*
+    functions {
+        objective equal = {{ (x: VarAD, y: VarAD) => squared(sub(x, y)) }}
+
+        function pathFromPoints = {{
+            (setting: string, pts: [Pt2]): IPathDataV<VarAD> => {
+                const elems: Elem<VarAD>[] = pts.map(e => ({ tag: "Pt", contents: e }));
+                const path: SubPath<VarAD> = { tag: setting, contents: elems };
+                return { tag: "PathDataV", contents: [path] };
+            } 
+        }} 
+    }
+
+    forall Vector u; Vector v
+    with VectorSpace U
+    where Orthogonal(u, v); In(u, U); In(v, U) {
+          vec2 startR = u.shape.start -- TODO: Do we want destructuring syntax like vec2[] [startR, endR] = [u.shape.start, u.shape.end]
+          vec2 endR = u.shape.end
+          vec2 startL = v.shape.start
+          vec2 endL = v.shape.end
+          vec2 dirR = normalize(endR - startR)  -- Syntax sugar for vectors (better in Style because JS doesn't allow it!)
+          vec2 dirL = normalize(endL - startL)
+          vec2 ptL = startR + const.perpLen * dirL
+          vec2 ptR = startR + const.perpLen * dirR
+          vec2 ptLR = ptL + len * dirR
+          vec2[] pts = [ptL, ptLR, ptR]
+
+          function toPath = functions.pathFromPoints
+
+          -- Draw perpendicular mark -- NOTE: local shapes should still be drawn
+          shape perpMark = Curve {
+               pathData : toPath("closed", pts)
+               strokeWidth : 2.0
+               color : C.black
+               fill : C.white
+          }
+
+          -- Make sure vectors are orthogonal (use ensure?)
+          function eq = functions.equal
+          encourage eq(M.dot(u.vector, v.vector), 0.0) -- NOTE: Have to import Penrose fns
+
+          layer v.shape above LOCAL.perpMark
+          layer u.shape above LOCAL.perpMark
+    }
+
+    forall Vector v
+    with VectorSpace U; Vector w
+    where In(v, U); Unit(v); Orthogonal(v, w) {
+          -- Usually, the unit vector shouldn't need to know about orthogonal vectors
+          -- but we need to position the unit mark so it doesn't overlap with the "inside" of the two vectors
+
+          scalar strokeWidth = 2
+          function toPath = functions.pathFromPoints
+
+          -- The start and end of the body of the unit marker line
+          -- NOTE: We need to have lists of vectors
+          vec2 dir = normalize(w.shape.end - w.shape.start)
+          vec2 normal = -dir
+          vec2 markStart = v.shape.start + padding * normal
+          vec2 markEnd = v.shape.end + padding * normal
+          vec2[] v.markerLine = [markStart, markEnd]
+
+          shape v.unitMarkerLine = Curve {
+              pathData : toPath("open", v.markerLine)
+              strokeWidth : strokeWidth
+              color : C.black
+              fill : C.none
+          }
+
+          matrix2x2 rot90CW = ((0, 1), (-1, 0))
+          vec2 markNormal = mul(rot90CW, normal) -- TODO: Do we want syntactic sugar for matrix-vector multiplication? Or a better name?
+          function c = const.barSize
+          vec2 halfvec = c * markNormal
+
+          shape v.unitMarkerEnd1 = Curve {
+              pathData : toPath("open", [markStart - halfvec, markStart + halfvec]) -- TODO: Can we infer this type if it's written anonymously?
+              strokeWidth : strokeWidth
+              color : C.black
+              fill : C.none
+          }
+
+          shape v.unitMarkerEnd2 = Curve {
+              pathData : toPath("open", [markEnd - halfvec, markEnd + halfvec])
+              strokeWidth : strokeWidth
+              color : C.black
+              fill : C.none
+          }
+
+          vec2 midpointLoc = (v.markerLine[0] + v.markerLine[1]) / 2
+          vec2 labelPos = midpointLoc + const.markerPadding * normal
+
+          shape v.unitMarkerText = Text {
+              string : "1"
+              center : labelPos
+              color : C.black
+          }
+
+          layer v.unitMarkerLine above U.xAxis
+          layer v.unitMarkerLine above U.yAxis
+    }
+
+    forall Vector `x2` {
+           override `x2`.shape.color = C.green
+    }
+    */
+}

--- a/examples/style-1.1/Vectors.sty
+++ b/examples/style-1.1/Vectors.sty
@@ -1,0 +1,105 @@
+import Colors as C
+import Penrose.Constraints as Constraints -- NOTE: Our functions should be imported
+
+Vectors {
+    const {
+      scalar vectorSpaceSize = 350
+      scalar repelWeight = 0.7
+      scalar arrowheadSize = 0.6
+      scalar lineThickness = 1
+    }
+
+    functions { -- For now, module order matters
+        -- Implicitly in scope: Penrose types.d.ts, Autodiff (ops, fns), Constraints (constrDict), various utils files...
+        -- Should our importable stuff be consolidated?
+        constraint contains = << ([t1, s1]: [string, any], [t2, s2]: [string, any], offset: VarAD) => {
+             if (t1 === "Square" && t2 === "Text") {
+                const a1 = ops.vdist(fns.center(s1), fns.center(s2));
+                const a2 = div(s1.side.contents, constOf(2.0));
+                const a3 = div(s2.w.contents, constOf(2.0)); // TODO: Implement w/ exact text dims
+                const c = offset ? offset : constOf(0.0);
+                return add(add(sub(a1, a2), a3), c);
+
+              } else if (t1 === "Square" && t2 === "Arrow") {
+                const [[startX, startY], [endX, endY]] = linePts(s2);
+                const [x, y] = fns.center(s1);
+                const r = div(s1.side.contents, constOf(2.0));
+                const f = constOf(0.75); // 0.25 padding
+                //     (lx, ly) = ((x - side / 2) * 0.75, (y - side / 2) * 0.75)
+                //     (rx, ry) = ((x + side / 2) * 0.75, (y + side / 2) * 0.75)
+                // in inRange startX lx rx + inRange startY ly ry + inRange endX lx rx +
+                //    inRange endY ly ry
+                const [lx, ly] = [mul(sub(x, r), f), mul(sub(y, r), f)];
+                const [rx, ry] = [mul(add(x, r), f), mul(add(y, r), f)];
+                return addN([constrDict.inRange(startX, lx, rx),
+                constrDict.inRange(startY, ly, ry),
+                constrDict.inRange(endX, lx, rx),
+                constrDict.inRange(endY, ly, ry)]);
+              } else throw new Error(`${[t1, t2]} not supported for contains`);                         
+        } >>
+    }
+
+    forall VectorSpace U {
+        scalar axisSize = const.vectorSpaceSize / 2 -- This should get promoted to float
+        vec2 U.origin = (?, ?)
+        vec2 o = U.origin
+
+        U.shape = Square {
+            center : U.origin
+            side : const.vectorSpaceSize
+            color : C.none
+            stroke : C.black
+        }
+
+        shape U.xAxis = Arrow {
+               start : (o.x - axisSize, o.y)
+                 end : (o.x + axisSize, o.y)
+           thickness : const.lineThickness
+               style : "solid"
+               color : U.axisColor
+            arrowheadSize : const.arrowheadSize
+        }
+
+        shape U.yAxis = Arrow {
+               start : (o.x, o.y + axisSize)
+                 end : (o.x, o.y + axisSize)
+           thickness : const.lineThickness
+               style : "solid"
+               color : U.axisColor
+            arrowheadSize : const.arrowheadSize
+        }
+
+        U.text = Text {
+            string : U.label
+            center : (U.origin.x - axisSize, U.origin.y + axisSize)
+            color : U.axisColor
+        }
+    }
+
+    forall Vector u, VectorSpace U
+    where In(u,U) {
+      shape u.text = Text {
+        -- center : (?, ?) -- This should be done automatically
+        string : u.label
+        color : u.shape.color
+      }
+
+      shape u.arrow = Arrow {
+        start : U.origin
+        end : (?, ?)
+        thickness : 3.0
+        color : C.blue
+        arrowheadSize : const.arrowheadSize
+      }
+
+       vec2 u.vector = u.arrow.end - u.arrow.start -- Vector sugar for subtraction
+
+       function contains = functions.contains
+       ensure contains(U.shape, u.shape)
+       ensure contains(U.shape, u.text)
+       ensure Constraints.atDist(u.shape, u.text, 5.0)
+
+      layer u.text above U.xAxis
+      layer u.text above U.yAxis
+    }
+}

--- a/penrose-web/src/contrib/Constraints.ts
+++ b/penrose-web/src/contrib/Constraints.ts
@@ -36,7 +36,7 @@ export const objDict = {
   above: ([t1, top]: [string, any], [t2, bottom]: [string, any], offset = 100) =>
     // (getY top - getY bottom - offset) ^ 2
     squared(
-      sub(sub(top.y.contents, bottom.y.contents),
+      sub(sub(top.center.contents[1], bottom.center.contents[1]),
         varOf(offset))),
 
   sameCenter: ([t1, s1]: [string, any], [t2, s2]: [string, any]) =>
@@ -78,19 +78,19 @@ export const objDict = {
 
   // can this be made more efficient (code-wise) by calling "above" and swapping arguments? - stella
   below: ([t1, bottom]: [string, any], [t2, top]: [string, any], offset = 100) =>
-    squared(sub(sub(top.y.contents, bottom.y.contents), constOfIf(offset))),
+    squared(sub(sub(top.center.contents[1], bottom.center.contents[1]), constOfIf(offset))),
 
   centerLabel: ([t1, s1]: [string, any], [t2, s2]: [string, any], w: number): VarAD => {
 
     if (typesAre([t1, t2], ["Arrow", "Text"])) {
       const arr = s1;
       const text1 = s2;
-      const mx = div(add(arr.startX.contents, arr.endX.contents), constOf(2.0));
-      const my = div(add(arr.startY.contents, arr.endY.contents), constOf(2.0));
+      const mx = div(add(arr.start.contents[0], arr.end.contents[0]), constOf(2.0));
+      const my = div(add(arr.start.contents[1], arr.end.contents[1]), constOf(2.0));
 
       // entire equation is (mx - lx) ^ 2 + (my + 1.1 * text.h - ly) ^ 2 from Functions.hs - split it into two halves below for readability
-      const lh = squared(sub(mx, text1.x.contents));
-      const rh = squared(sub(add(my, mul(text1.h.contents, constOf(1.1))), text1.y.contents));
+      const lh = squared(sub(mx, text1.center.contents[0]));
+      const rh = squared(sub(add(my, mul(text1.h.contents, constOf(1.1))), text1.center.contents[1]));
       return mul(add(lh, rh), constOfIf(w));
 
     } else if (typesAre([t1, t2], ["Rectangle", "Text"])) {
@@ -128,6 +128,13 @@ export const constrDict = {
 
   minSize: ([shapeType, props]: [string, any]) => {
     const limit = 20;
+
+    if (shapeType === "Line" || shapeType === "Arrow") {
+      const minLen = 50;
+      const vec = ops.vsub(props.end.contents, props.start.contents);
+      return sub(constOf(minLen), ops.vnorm(vec));
+    }
+
     switch (shapeType) {
       case "Circle":
         return sub(constOf(limit), props.r.contents);
@@ -172,7 +179,7 @@ export const constrDict = {
 
     } else if (t1 === "Square" && t2 === "Circle") {
       // dist (outerx, outery) (innerx, innery) - (0.5 * outer.side - inner.radius)
-      const sq = [s1.x.contents, s1.y.contents];
+      const sq = s1.center.contents;
       const d = ops.vdist(sq, fns.center(s2));
       return sub(d, sub(mul(constOf(0.5), s1.side.contents), s2.r.contents));
 
@@ -183,10 +190,34 @@ export const constrDict = {
       //   getNum l "w" / 2 + padding
 
       const a1 = ops.vdist(fns.center(s1), fns.center(s2));
-      const a2 = div(s1.w.contents, varOf(2.0));
-      const a3 = div(s2.w.contents, varOf(2.0));
-      return add(add(sub(a1, a2), a3), offset);
+      const a2 = div(s1.w.contents, constOf(2.0));
+      const a3 = div(s2.w.contents, constOf(2.0));
+      const c = offset ? offset : constOf(0.0);
+      return add(add(sub(a1, a2), a3), c);
 
+    } else if (t1 === "Square" && t2 === "Text") {
+      const a1 = ops.vdist(fns.center(s1), fns.center(s2));
+      const a2 = div(s1.side.contents, constOf(2.0));
+      const a3 = div(s2.w.contents, constOf(2.0)); // TODO: Implement w/ exact text dims
+      const c = offset ? offset : constOf(0.0);
+      return add(add(sub(a1, a2), a3), c);
+
+    } else if (t1 === "Square" && t2 === "Arrow") {
+      const [[startX, startY], [endX, endY]] = linePts(s2);
+      const [x, y] = fns.center(s1);
+
+      const r = div(s1.side.contents, constOf(2.0));
+      const f = constOf(0.75); // 0.25 padding
+      //     (lx, ly) = ((x - side / 2) * 0.75, (y - side / 2) * 0.75)
+      //     (rx, ry) = ((x + side / 2) * 0.75, (y + side / 2) * 0.75)
+      // in inRange startX lx rx + inRange startY ly ry + inRange endX lx rx +
+      //    inRange endY ly ry
+      const [lx, ly] = [mul(sub(x, r), f), mul(sub(y, r), f)];
+      const [rx, ry] = [mul(add(x, r), f), mul(add(y, r), f)];
+      return addN([constrDict.inRange(startX, lx, rx),
+      constrDict.inRange(startY, ly, ry),
+      constrDict.inRange(endX, lx, rx),
+      constrDict.inRange(endY, ly, ry)]);
     } else throw new Error(`${[t1, t2]} not supported for contains`);
 
   },
@@ -258,6 +289,13 @@ export const constrDict = {
     // TODO: Account for the size/radius of the initial point, rather than just the center
 
     if (t2 === "Text") {
+      let pt;
+      if (t1 === "Arrow") { // Position label close to the arrow's end
+        pt = { x: s1.end.contents[0], y: s1.end.contents[1] };
+      } else { // Only assume shape1 has a center
+        pt = { x: s1.center.contents[0], y: s1.center.contents[1] };
+      }
+
       // Get polygon of text (box)
       // TODO: Make this a GPI property
       // TODO: Do this properly; Port the matrix stuff in `textPolygonFn` / `textPolygonFn2` in Shapes.hs
@@ -274,12 +312,12 @@ export const constrDict = {
       const textPts = [[halfWidth, halfHeight], [nhalfWidth, halfHeight],
       [nhalfWidth, nhalfHeight], [halfWidth, nhalfHeight]].map(p => ops.vadd(textCenter, p));
 
-      const pt = { x: s1.x.contents, y: s1.y.contents };
       const rect = {
         minX: textPts[1][0], maxX: textPts[0][0],
         minY: textPts[2][1], maxY: textPts[0][1]
       };
 
+      // TODO: Rewrite this with `ifCond`
       // If the point is inside the box, push it outside w/ `noIntersect`
       if (pointInBox(pt, rect)) {
         return noIntersect(textCenter, text.w.contents, fns.center(s1), constOf(2.0));
@@ -295,11 +333,15 @@ export const constrDict = {
     }
   },
 
-  perpendicular: (q: ITupV<VarAD>, p: ITupV<VarAD>, r: ITupV<VarAD>): VarAD => {
-    const v1 = ops.vsub(q.contents, p.contents);
-    const v2 = ops.vsub(r.contents, p.contents);
+  perpendicular: (q: VarAD[], p: VarAD[], r: VarAD[]): VarAD => {
+    const v1 = ops.vsub(q, p);
+    const v2 = ops.vsub(r, p);
     const dotProd = ops.vdot(v1, v2);
     return equalHard(dotProd, constOf(0.0));
+  },
+
+  inRange: (x: VarAD, x0: VarAD, x1: VarAD) => {
+    return mul(sub(x, x0), sub(x, x1));
   },
 
 };
@@ -346,8 +388,8 @@ const centerArrow2 = (arr: any, center1: VarAD[], center2: VarAD[], [o1, o2]: Va
     end = ops.vadd(center2, ops.vmul(o2, dir));
   }
 
-  const fromPt = [arr.startX.contents, arr.startY.contents];
-  const toPt = [arr.endX.contents, arr.endY.contents];
+  const fromPt = arr.start.contents;
+  const toPt = arr.end.contents;
 
   return add(ops.vdistsq(fromPt, start), ops.vdistsq(toPt, end));
 }

--- a/penrose-web/src/contrib/Functions.ts
+++ b/penrose-web/src/contrib/Functions.ts
@@ -2,7 +2,7 @@ import { range, maxBy } from "lodash";
 import { randFloat } from "utils/Util";
 import { mapTup2 } from "engine/EngineUtils";
 import { linePts, getStart, getEnd } from "utils/OtherUtils";
-import { ops, fns, varOf, numOf, constOf, add, addN, max, div, mul, cos, sin } from "engine/Autodiff";
+import { ops, fns, varOf, numOf, constOf, add, addN, max, div, mul, cos, sin, neg } from "engine/Autodiff";
 
 /**
  * Static dictionary of computation functions
@@ -34,7 +34,11 @@ export const compDict = {
       };
     }
 
-    throw Error(`variable ${varName} not found in optDebugInfo! Are you sure it's a varying variable?`);
+    console.error(`variable ${varName} not found in optDebugInfo! Are you sure it's a varying variable?`);
+    return {
+      tag: "FloatV",
+      contents: constOf(0.0)
+    };
   },
 
   // NOTE: This is a special system function. Don't change it!
@@ -56,7 +60,11 @@ export const compDict = {
       };
     }
 
-    throw Error(`variable ${varName} not found in optDebugInfo! Are you sure it's a varying variable?`);
+    console.error(`variable ${varName} not found in optDebugInfo! Are you sure it's a varying variable?`);
+    return {
+      tag: "FloatV",
+      contents: constOf(0.0)
+    };
   },
 
   // Assuming lists only hold floats
@@ -128,17 +136,81 @@ export const compDict = {
     };
   },
 
-  orientedSquare: (arr1: any, arr2: any, pt: any, len: VarAD): IPathDataV<VarAD> => {
-    // TODO: Write the full function; this is just a fixed path for testing
-    checkFloat(len);
+  normalize: (v: VarAD[]): IVectorV<VarAD> => {
+    return {
+      tag: "VectorV",
+      contents: ops.vnormalize(v)
+    }
+  },
 
-    const elems: Elem<VarAD>[] =
-      [{ tag: "Pt", contents: mapTup2(constOf, [100, 100]) },
-      { tag: "Pt", contents: mapTup2(constOf, [200, 200]) },
-      { tag: "Pt", contents: mapTup2(constOf, [300, 150]) }];
-    const path: SubPath<VarAD> = { tag: "Open", contents: elems };
-
+  pathFromPoints: (pathType: string, pts: [Pt2]): IPathDataV<VarAD> => {
+    const pathTypeStr = pathType === 'closed' ? "Closed" : "Open";
+    const elems: Elem<VarAD>[] = pts.map(e => ({ tag: "Pt", contents: e }));
+    const path: SubPath<VarAD> = { tag: pathTypeStr, contents: elems };
     return { tag: "PathDataV", contents: [path] };
+  },
+
+  unitMark: ([t1, s1]: [string, any], [t2, s2]: [string, any], t: string, padding: VarAD, barSize: VarAD): IPtListV<VarAD> => {
+    const [start1, end1] = linePts(s1);
+    const [start2, end2] = linePts(s2);
+
+    const dir = ops.vnormalize(ops.vsub(end2, start2));
+    const normalDir = ops.vneg(dir);
+    const markStart = ops.vmove(start1, padding, normalDir);
+    const markEnd = ops.vmove(end1, padding, normalDir);
+
+    return {
+      tag: "PtListV",
+      contents: [markStart, markEnd].map(toPt)
+    };
+  },
+
+  unitMark2: ([start, end]: [Pt2, Pt2], t: string, padding: VarAD, size: VarAD): IPtListV<VarAD> => {
+    const dir = ops.vnormalize(ops.vsub(end, start));
+    const normalDir = rot90(toPt(dir));
+    const base = t === "start" ? start : end;
+    const [markStart, markEnd] = [ops.vmove(base, size, normalDir), ops.vmove(base, neg(size), normalDir)];
+    return {
+      tag: "PtListV",
+      contents: [markStart, markEnd].map(toPt)
+    };
+  },
+
+  midpointOffset: ([start, end]: [Pt2, Pt2], [t1, s1]: [string, any], padding: VarAD): ITupV<VarAD> => {
+    if (t1 === "Arrow" || t1 === "Line") {
+      const [start1, end1] = linePts(s1);
+      // TODO: Cache these operations in Style!
+      const dir = ops.vnormalize(ops.vsub(end1, start1));
+      const normalDir = ops.vneg(dir);
+      const midpointLoc = ops.vmul(constOf(0.5), ops.vadd(start, end));
+      const midpointOffsetLoc = ops.vmove(midpointLoc, padding, normalDir);
+      return {
+        tag: "TupV",
+        contents: toPt(midpointOffsetLoc)
+      };
+    } else {
+      throw Error("unsupported shape ${t1} in midpointOffset");
+    }
+  },
+
+  // Given two orthogonal segments that intersect at startR (or startL, should be the same point)
+  // and a size, make three points that describe a perpendicular mark at the angle where the segments intersect.
+  orientedSquare: ([t1, s1]: [string, any], [t2, s2]: [string, any], intersection: Pt2, len: VarAD): IPathDataV<VarAD> => {
+    if ((t1 === "Arrow" || t1 === "Line") && (t2 === "Arrow" || t2 === "Line")) {
+      const [seg1, seg2]: any = [linePts(s1), linePts(s2)];
+      const [ptL, ptLR, ptR] = perpPathFlat(len, seg1, seg2);
+
+      const elems: Elem<VarAD>[] =
+        [{ tag: "Pt", contents: toPt(ptL) },
+        { tag: "Pt", contents: toPt(ptLR) },
+        { tag: "Pt", contents: toPt(ptR) },
+        { tag: "Pt", contents: intersection }];
+      const path: SubPath<VarAD> = { tag: "Closed", contents: elems };
+
+      return { tag: "PathDataV", contents: [path] };
+    } else {
+      throw Error("orientedSquare undefined for types ${t1}, ${t2}");
+    }
   },
 
   triangle: ([t1, l1]: any, [t2, l2]: any, [t3, l3]: any): IPathDataV<VarAD> => {
@@ -211,6 +283,17 @@ export const compDict = {
     };
   },
 
+  // Matrix-vector multiplication (where `v` is implicitly treated as a column vector)
+  mul: (m: VarAD[][], v: VarAD[]): IVectorV<VarAD> => {
+    if (!m.length) { throw Error("empty matrix"); }
+    if (!v.length) { throw Error("empty vector"); }
+
+    return {
+      tag: "VectorV",
+      contents: m.map(row => ops.vdot(row, v))
+    };
+  },
+
 };
 
 export const checkComp = (fn: string, args: ArgVal<VarAD>[]) => {
@@ -225,9 +308,36 @@ const checkFloat = (x: any) => {
   }
 }
 
+const toPt = (v: VecAD): Pt2 => {
+  if (v.length !== 2) {
+    throw Error("expected vector of length 2");
+  }
+  return [v[0], v[1]];
+};
+
+const perpPathFlat = (len: VarAD, [startR, endR]: [VecAD, VecAD], [startL, endL]: [VecAD, VecAD]): [VecAD, VecAD, VecAD] => {
+  // perpPathFlat :: Autofloat a => a -> (Pt2 a, Pt2 a) -> (Pt2 a, Pt2 a) -> (Pt2 a, Pt2 a, Pt2 a)
+  // perpPathFlat size (startR, endR) (startL, endL) =
+  //   let dirR = normalize' $ endR -: startR
+  //       dirL = normalize' $ endL -: startL
+  //       ptL = startR +: (size *: dirL)
+  //       ptR = startR +: (size *: dirR)
+  //       ptLR = startR +: (size *: dirL) +: (size *: dirR)
+  //   in (ptL, ptLR, ptR)
+  const dirR = ops.vnormalize(ops.vsub(endR, startR));
+  const dirL = ops.vnormalize(ops.vsub(endL, startL));
+  const ptL = ops.vmove(startR, len, dirL); // ops.vadd(startR, ops.vmul(len, dirL));
+  const ptR = ops.vmove(startR, len, dirR); // ops.vadd(startR, ops.vmul(len, dirR));
+  const ptLR = ops.vadd(ptL, ops.vmul(len, dirR));
+  return [ptL, ptLR, ptR];
+};
+
+const rot90 = ([x, y]: Pt2): Pt2 => {
+  return [neg(y), x];
+};
+
 // returns the point in `candidates` farthest from the points in `pts` (by sum)
 // Note: With the current autodiff system you cannot make discrete choices -- TODO debug why this code doesn't terminate in objective/gradient compilation
-
 // Do not use!
 const furthestFrom = (pts: VarAD[][], candidates: VarAD[][]): VarAD[] => {
   if (!pts || pts.length === 0) { throw Error("Expected nonempty point list"); }

--- a/penrose-web/src/engine/Autodiff.ts
+++ b/penrose-web/src/engine/Autodiff.ts
@@ -733,11 +733,15 @@ export const ops = {
   dist: (c1: VarAD, c2: VarAD) => ops.vnorm([c1, c2]),
 
   vadd: (v1: VarAD[], v2: VarAD[]): VarAD[] => {
+    if (v1.length !== v2.length) { throw Error("expected vectors of same length"); }
+
     const res = _.zipWith(v1, v2, add);
     return res;
   },
 
   vsub: (v1: VarAD[], v2: VarAD[]): VarAD[] => {
+    if (v1.length !== v2.length) { throw Error("expected vectors of same length"); }
+
     const res = _.zipWith(v1, v2, sub);
     return res;
   },
@@ -757,6 +761,10 @@ export const ops = {
     return v.map((e) => mul(c, e));
   },
 
+  vneg: (v: VarAD[]): VarAD[] => {
+    return ops.vmul(constOf(-1.0), v);
+  },
+
   vdiv: (v: VarAD[], c: VarAD): VarAD[] => {
     return v.map((e) => div(e, c));
   },
@@ -767,21 +775,33 @@ export const ops = {
   },
 
   vdist: (v: VarAD[], w: VarAD[]): VarAD => {
+    if (v.length !== w.length) { throw Error("expected vectors of same length"); }
+
     return ops.vnorm(ops.vsub(v, w));
   },
 
-  vdistsq: (v: VarAD[], w: VarAD[]): VarAD => {
-    return ops.vnormsq(ops.vsub(v, w));
-  },
+  vdistsq:
+    (v: VarAD[], w: VarAD[]): VarAD => {
+      if (v.length !== w.length) { throw Error("expected vectors of same length"); }
+
+      return ops.vnormsq(ops.vsub(v, w));
+    },
 
   // Note: if you want to compute a normsq, use that instead, it generates a smaller computational graph
   vdot: (v1: VarAD[], v2: VarAD[]): VarAD => {
+    if (v1.length !== v2.length) { throw Error("expected vectors of same length"); }
+
     const res = _.zipWith(v1, v2, mul);
     return _.reduce(res, (x, y) => add(x, y, true), variableAD(0.0));
   },
 
   vsum: (v: VarAD[]): VarAD => {
     return _.reduce(v, (x, y) => add(x, y, true), variableAD(0.0));
+  },
+
+  // v + c * u
+  vmove: (v: VarAD[], c: VarAD, u: VarAD[]) => {
+    return ops.vadd(v, ops.vmul(c, u));
   },
 };
 
@@ -791,7 +811,7 @@ export const fns = {
   },
 
   center: (props: any): VarAD[] => {
-    return [props.x.contents, props.y.contents];
+    return props.center.contents;
   },
 };
 

--- a/penrose-web/src/engine/Evaluator.ts
+++ b/penrose-web/src/engine/Evaluator.ts
@@ -286,7 +286,7 @@ export const evalExpr = (
       return {
         tag: "Val",
         // HACK: coerce the type for now to let the compiler finish
-        contents: evalUOp(uOp, arg as IFloatV<VarAD> | IIntV<VarAD>),
+        contents: evalUOp(uOp, arg as IFloatV<VarAD> | IIntV),
       };
     }
 
@@ -623,7 +623,7 @@ export const argValue = (e: ArgVal<VarAD>) => {
   }
 };
 
-export const intToFloat = (v: IIntV<number>): IFloatV<VarAD> => {
+export const intToFloat = (v: IIntV): IFloatV<VarAD> => {
   return { tag: "FloatV", contents: constOf(v.contents) };
 };
 
@@ -763,7 +763,7 @@ export const evalBinOp = (
  */
 export const evalUOp = (
   op: UnaryOp,
-  arg: IFloatV<VarAD> | IIntV<VarAD> | IVectorV<VarAD>
+  arg: IFloatV<VarAD> | IIntV | IVectorV<VarAD>
 ): Value<VarAD> => {
   if (arg.tag === "FloatV") {
     switch (op) {

--- a/penrose-web/src/layers/BoundingBoxLayer.tsx
+++ b/penrose-web/src/layers/BoundingBoxLayer.tsx
@@ -10,11 +10,7 @@ class BoundingBoxLayer extends React.Component<ILayerProps> {
         {shapes.map(({ shapeType, properties }: Shape, key: number) => {
           // TODO: add bb support to other shapes
           if (shapeType === "Text") {
-            const [x, y] = toScreen(
-              [
-                properties.x.contents as number,
-                properties.y.contents as number,
-              ],
+            const [x, y] = toScreen(properties.center.contents as [number, number],
               canvasSize
             );
             const w = properties.w.contents as number;

--- a/penrose-web/src/shapes/Arrow.tsx
+++ b/penrose-web/src/shapes/Arrow.tsx
@@ -8,11 +8,11 @@ class Arrow extends React.Component<IGPIProps> {
     const { shape, canvasSize } = this.props;
     const style = shape.style.contents;
     const [sx, sy] = toScreen(
-      [shape.startX.contents, shape.startY.contents],
+      shape.start.contents,
       canvasSize
     );
     const [ex, ey] = toScreen(
-      [shape.endX.contents, shape.endY.contents],
+      shape.end.contents,
       canvasSize
     );
     const color = toHex(shape.color.contents);
@@ -41,9 +41,8 @@ class Arrow extends React.Component<IGPIProps> {
           size={arrowheadSize}
         />
         <path
-          d={`M${sx} ${sy} L${
-            Math.abs(offsetX) < Math.abs(ex - sx) ? ex - offsetX : ex
-          } ${Math.abs(offsetY) < Math.abs(ey - sy) ? ey - offsetY : ey}`}
+          d={`M${sx} ${sy} L${Math.abs(offsetX) < Math.abs(ex - sx) ? ex - offsetX : ex
+            } ${Math.abs(offsetY) < Math.abs(ey - sy) ? ey - offsetY : ey}`}
           fill={color}
           stroke={color}
           fillOpacity={alpha}

--- a/penrose-web/src/shapes/Circle.tsx
+++ b/penrose-web/src/shapes/Circle.tsx
@@ -7,7 +7,7 @@ class Circle extends React.Component<IGPIProps> {
     const { shape } = this.props;
 
     const { canvasSize } = this.props;
-    const [x, y] = toScreen([shape.x.contents, shape.y.contents], canvasSize);
+    const [x, y] = toScreen(shape.center.contents, canvasSize);
     const fillColor = toHex(shape.color.contents);
     const fillAlpha = shape.color.contents.contents[3];
     const strokeColor = toHex(shape.strokeColor.contents);

--- a/penrose-web/src/shapes/Ellipse.tsx
+++ b/penrose-web/src/shapes/Ellipse.tsx
@@ -6,7 +6,7 @@ class Ellipse extends React.Component<IGPIProps> {
   public render() {
     const { shape } = this.props;
     const { canvasSize } = this.props;
-    const [x, y] = toScreen([shape.x.contents, shape.y.contents], canvasSize);
+    const [x, y] = toScreen(shape.center.contents, canvasSize);
 
     const fillColor = toHex(shape.color.contents);
     const fillAlpha = shape.color.contents.contents[3];

--- a/penrose-web/src/shapes/Image.tsx
+++ b/penrose-web/src/shapes/Image.tsx
@@ -6,7 +6,7 @@ class Image extends React.Component<IGPIProps> {
   public render() {
     const { shape } = this.props;
     const { canvasSize } = this.props;
-    const [x, y] = toScreen([shape.x.contents, shape.y.contents], canvasSize);
+    const [x, y] = toScreen(shape.center.contents, canvasSize);
     const [w, h] = [shape.w.contents, shape.h.contents];
     const path = shape.path.contents;
     const opacity = shape.opacity.contents;

--- a/penrose-web/src/shapes/Label.tsx
+++ b/penrose-web/src/shapes/Label.tsx
@@ -24,7 +24,7 @@ class Label extends React.Component<IGPIProps> {
     const { shape } = this.props;
 
     const { canvasSize } = this.props;
-    const [x, y] = toScreen([shape.x.contents, shape.y.contents], canvasSize);
+    const [x, y] = toScreen(shape.center.contents, canvasSize);
     const { w, h } = shape;
     const color = toHex(shape.color.contents);
     return (

--- a/penrose-web/src/shapes/Line.tsx
+++ b/penrose-web/src/shapes/Line.tsx
@@ -8,11 +8,11 @@ class Line extends React.Component<IGPIProps> {
     const { shape, canvasSize } = this.props;
     const style = shape.style.contents;
     const [sx, sy] = toScreen(
-      [shape.startX.contents, shape.startY.contents],
+      shape.start.contents,
       canvasSize
     );
     const [ex, ey] = toScreen(
-      [shape.endX.contents, shape.endY.contents],
+      shape.end.contents,
       canvasSize
     );
 

--- a/penrose-web/src/shapes/Rectangle.tsx
+++ b/penrose-web/src/shapes/Rectangle.tsx
@@ -6,7 +6,7 @@ class Rectangle extends React.Component<IGPIProps> {
   public render() {
     const { shape } = this.props;
     const { canvasSize } = this.props;
-    const [x, y] = toScreen([shape.x.contents, shape.y.contents], canvasSize);
+    const [x, y] = toScreen(shape.center.contents, canvasSize);
     const fillColor = toHex(shape.color.contents);
     const fillAlpha = shape.color.contents.contents[3];
     const strokeColor = toHex(shape.strokeColor.contents);
@@ -25,7 +25,7 @@ class Rectangle extends React.Component<IGPIProps> {
         strokeOpacity={strokeAlpha}
         strokeDasharray={shape.strokeStyle.contents === "dashed" ? "7, 5" : ""}
         strokeWidth={thickness}
-        // transform={`rotate(${180 - shape.rotation.contents}, ${x}, ${y})`}
+      // transform={`rotate(${180 - shape.rotation.contents}, ${x}, ${y})`}
       >
         <title>{shape.name.contents}</title>
       </rect>

--- a/penrose-web/src/shapes/Square.tsx
+++ b/penrose-web/src/shapes/Square.tsx
@@ -6,7 +6,7 @@ class Square extends React.Component<IGPIProps> {
   public render() {
     const { shape } = this.props;
     const { canvasSize } = this.props;
-    const [x, y] = toScreen([shape.x.contents, shape.y.contents], canvasSize);
+    const [x, y] = toScreen([shape.center.contents[0], shape.center.contents[1]], canvasSize);
     const color = toHex(shape.color.contents);
     const alpha = shape.color.contents.contents[3];
     const strokeColor = toHex(shape.strokeColor.contents);

--- a/penrose-web/src/types/types.d.ts
+++ b/penrose-web/src/types/types.d.ts
@@ -343,7 +343,7 @@ type ILocalVar = string;
 
 type Value<T> =
   | IFloatV<T>
-  | IIntV<T>
+  | IIntV
   | IBoolV<T>
   | IStrV<T>
   | IPtV<T>
@@ -366,7 +366,7 @@ interface IFloatV<T> {
   contents: T;
 }
 
-interface IIntV<T> {
+interface IIntV {
   tag: "IntV";
   contents: number;
 }

--- a/penrose-web/src/types/types.d.ts
+++ b/penrose-web/src/types/types.d.ts
@@ -42,6 +42,7 @@ interface IState {
   pendingPaths: Path[];
   varyingValues: number[];
   translation: Translation;
+  originalTranslation: Translation;
   shapeOrdering: string[];
   shapes: Shape[];
   varyingMap: VaryMap;
@@ -137,6 +138,7 @@ type Expr =
   | IAFloat
   | IStringLit
   | IBoolLit
+  | IEvar
   | IEPath
   | ICompApp
   | IObjFn
@@ -146,6 +148,10 @@ type Expr =
   | IUOp
   | IList
   | ITuple
+  | IVector
+  | IMatrix
+  | IVectorAccess
+  | IMatrixAccess
   | IListAccess
   | ICtor
   | ILayering
@@ -170,6 +176,11 @@ interface IStringLit {
 interface IBoolLit {
   tag: "BoolLit";
   contents: boolean;
+}
+
+interface IEVar {
+  tag: "EVar";
+  contents: LocalVar;
 }
 
 interface IEPath {
@@ -218,6 +229,26 @@ interface ITuple {
   contents: [Expr, Expr];
 }
 
+interface IVector {
+  tag: "Vector";
+  contents: Expr[];
+}
+
+interface IMatrix {
+  tag: "Matrix";
+  contents: Expr[];
+}
+
+interface IVectorAccess {
+  tag: "VectorAccess";
+  contents: [Path, Expr];
+}
+
+interface IMatrixAccess {
+  tag: "MatrixAccess";
+  contents: [Path, Expr[]];
+}
+
 interface IListAccess {
   tag: "ListAccess";
   contents: [Path, number];
@@ -262,7 +293,9 @@ type PropertyDecl = IPropertyDecl;
 
 type IPropertyDecl = [string, Expr];
 
-type Path = IFieldPath | IPropertyPath;
+type Path = IFieldPath | IPropertyPath | IAccessPath;
+// Unused
+// | ITypePropertyPath;
 
 interface IFieldPath {
   tag: "FieldPath";
@@ -273,6 +306,16 @@ interface IPropertyPath {
   tag: "PropertyPath";
   contents: [BindingForm, string, string];
 }
+
+interface IAccessPath {
+  tag: "AccessPath";
+  contents: [Path, number[]];
+}
+
+// Unused
+// interface ITypePropertyPath {
+//   tag: "TypePropertyPath";
+// }
 
 type Var = IVarConst;
 
@@ -294,6 +337,10 @@ type StyVar = IStyVar;
 
 type IStyVar = string;
 
+type LocalVar = ILocalVar;
+
+type ILocalVar = string;
+
 type Value<T> =
   | IFloatV<T>
   | IIntV<T>
@@ -307,6 +354,8 @@ type Value<T> =
   | IFileV<T>
   | IStyleV<T>
   | IListV<T>
+  | IVectorV<T>
+  | IMatrixV<T>
   | ITupV<T>
   | ILListV<T>
   | IHMatrixV<T>
@@ -370,6 +419,16 @@ interface IStyleV<T> {
 interface IListV<T> {
   tag: "ListV";
   contents: T[];
+}
+
+interface IVectorV<T> {
+  tag: "VectorV";
+  contents: T[];
+}
+
+interface IMatrixV<T> {
+  tag: "MatrixV";
+  contents: T[][];
 }
 
 interface ITupV<T> {
@@ -619,13 +678,9 @@ type VarAD = IVarAD;
 
 // ----- Types for generalizing our system autodiff
 
-// This (IVecAD) type is unused, but could be useful at some point
-interface IVecAD {
-  tag: "VecAD";
-  contents: VarAD[];
-}
+type VecAD = VarAD[];
 
-type VecAD = IVecAD;
+type Pt2 = [VarAD, VarAD];
 
 type GradGraphs = IGradGraphs;
 

--- a/penrose-web/src/ui/Canvas.tsx
+++ b/penrose-web/src/ui/Canvas.tsx
@@ -52,7 +52,8 @@ class Canvas extends React.Component<ICanvasProps> {
     const translationAD = makeTranslationDifferentiable(state.translation);
     const stateAD = {
       ...state,
-      translation: translationAD,
+      originalTranslation: state.originalTranslation,
+      translation: translationAD
     };
 
     // After the pending values load, they only use the evaluated shapes (all in terms of numbers)
@@ -309,12 +310,12 @@ class Canvas extends React.Component<ICanvasProps> {
         <desc>
           {`This diagram was created with Penrose (https://penrose.ink)${
             penroseVersion ? " version " + penroseVersion : ""
-          } on ${new Date()
-            .toISOString()
-            .slice(
-              0,
-              10
-            )}. If you have any suggestions on making this diagram more accessible, please contact us.\n`}
+            } on ${new Date()
+              .toISOString()
+              .slice(
+                0,
+                10
+              )}. If you have any suggestions on making this diagram more accessible, please contact us.\n`}
           {substanceMetadata && `${substanceMetadata}\n`}
           {styleMetadata && `${styleMetadata}\n`}
           {elementMetadata && `${elementMetadata}\n`}

--- a/penrose-web/src/utils/OtherUtils.ts
+++ b/penrose-web/src/utils/OtherUtils.ts
@@ -169,11 +169,9 @@ export const floatVal = (v: VarAD): ArgVal<VarAD> => ({
 //   return (...args: any[]) => toPenalty(constrDict[name]);
 // };
 
-export const linePts = ({ startX, startY, endX, endY }: any): [VarAD[], VarAD[]] =>
-  [[startX.contents, startY.contents], [endX.contents, endY.contents]];
+export const linePts = ({ start, end }: any): [VarAD[], VarAD[]] =>
+  [start.contents, end.contents];
 
-export const getStart = ({ startX, startY }: any): VarAD[] =>
-  [startX.contents, startY.contents];
+export const getStart = ({ start }: any): VarAD[] => start.contents;
 
-export const getEnd = ({ endX, endY }: any): VarAD[] =>
-  [endX.contents, endY.contents];
+export const getEnd = ({ end }: any): VarAD[] => end.contents;

--- a/penrose-web/src/utils/Util.tsx
+++ b/penrose-web/src/utils/Util.tsx
@@ -53,16 +53,20 @@ export const arrowheads = {
 export const bBoxDims = (properties: Properties, shapeType: string) => {
   let [w, h] = [0, 0];
   if (shapeType === "Circle") {
-    [w, h] = [(properties.r.contents as number) * 2, (properties.r.contents as number) * 2];}
+    [w, h] = [(properties.r.contents as number) * 2, (properties.r.contents as number) * 2];
+  }
   else if (shapeType === "Square") {
-    [w, h] = [properties.side.contents as number, properties.side.contents as number];}
+    [w, h] = [properties.side.contents as number, properties.side.contents as number];
+  }
   else if (shapeType === "Ellipse") {
-    [w, h] = [(properties.rx.contents as number) * 2, (properties.ry.contents as number) * 2];}
+    [w, h] = [(properties.rx.contents as number) * 2, (properties.ry.contents as number) * 2];
+  }
   else if (shapeType === "Arrow" || shapeType === "Line") {
-    const [sx, sy, ex, ey] = [properties.startX.contents as number, properties.startY.contents as number, 
-      properties.endX.contents as number, properties.endY.contents as number];
+    const [[sx, sy], [ex, ey]] = [properties.start.contents as [number, number],
+    properties.end.contents as [number, number]];
     const padding = 50; // Because arrow may be horizontal or vertical, and we don't want the size to be zero in that case
-    [w, h] = [Math.max(Math.abs(ex - sx), padding), Math.max(Math.abs(ey - sy), padding)];}
+    [w, h] = [Math.max(Math.abs(ex - sx), padding), Math.max(Math.abs(ey - sy), padding)];
+  }
   else if (shapeType === "Curve") {
     [w, h] = [20, 20] // todo find a better measure for this... check with max?
   }
@@ -100,31 +104,31 @@ export const makeViewBoxes = (shapes: IShape[], selectedShape: number, setSelect
         right: 0,
       }}>
         {shapes.map(({ properties, shapeType }: Shape, key: number) => {
-		  // If the inspector is crashing around here, then probably the shape doesn't have the width/height properties, so add a special case as below
-		  // console.log("properties, shapeType", properties, shapeType, properties.w, properties.h);
+          // If the inspector is crashing around here, then probably the shape doesn't have the width/height properties, so add a special case as below
+          // console.log("properties, shapeType", properties, shapeType, properties.w, properties.h);
           const [w, h] = bBoxDims(properties, shapeType);
           return (
-          <ShapeItem
-            key={`shapePreview-${key}`}
-            selected={selectedShape === key}
-            onClick={() => setSelectedShape(key)}
-          >
-            <div>
-              <svg viewBox={`0 0 ${w} ${h}`} width="50" height="50">
-                {React.createElement(staticMap[shapeType], {
-                  shape: {
-                    ...properties,
-                    x: { tag: "FloatV", contents: 0 },
-                    y: { tag: "FloatV", contents: 0 },
-                  },
-                  canvasSize: [w, h],
-                })}
-              </svg>
-            </div>
-            <div style={{ margin: "0.5em" }}>
-              <span>{properties.name.contents}</span>
-            </div>
-          </ShapeItem>);
+            <ShapeItem
+              key={`shapePreview-${key}`}
+              selected={selectedShape === key}
+              onClick={() => setSelectedShape(key)}
+            >
+              <div>
+                <svg viewBox={`0 0 ${w} ${h}`} width="50" height="50">
+                  {React.createElement(staticMap[shapeType], {
+                    shape: {
+                      ...properties,
+                      x: { tag: "FloatV", contents: 0 },
+                      y: { tag: "FloatV", contents: 0 },
+                    },
+                    canvasSize: [w, h],
+                  })}
+                </svg>
+              </div>
+              <div style={{ margin: "0.5em" }}>
+                <span>{properties.name.contents}</span>
+              </div>
+            </ShapeItem>);
         })}
       </ul>
     </div>
@@ -262,14 +266,14 @@ export const hsvToRGB = (
   return h < 60
     ? hsv2rgb(c, x, 0, m)
     : h < 120
-    ? hsv2rgb(x, c, 0, m)
-    : h < 180
-    ? hsv2rgb(0, c, x, m)
-    : h < 240
-    ? hsv2rgb(0, x, c, m)
-    : h < 300
-    ? hsv2rgb(x, 0, c, m)
-    : hsv2rgb(c, 0, x, m);
+      ? hsv2rgb(x, c, 0, m)
+      : h < 180
+        ? hsv2rgb(0, c, x, m)
+        : h < 240
+          ? hsv2rgb(0, x, c, m)
+          : h < 300
+            ? hsv2rgb(x, 0, c, m)
+            : hsv2rgb(c, 0, x, m);
 };
 
 export const toHex = (color: any): string => {

--- a/src/Penrose/API.hs
+++ b/src/Penrose/API.hs
@@ -19,7 +19,7 @@ import           Data.List                  (deleteFirstsBy, partition, (\\))
 import qualified Data.Map.Strict            as M
 import           Data.Maybe                 (mapMaybe)
 import           Data.Version               (showVersion)
-import           Debug.Trace                (traceShowId)
+import           Debug.Trace                (trace, traceShowId)
 import           GHC.Generics
 import           Paths_penrose              (version)
 import           Penrose.Element
@@ -35,6 +35,7 @@ import           Penrose.Substance
 import           Penrose.Sugarer
 import           Penrose.Util
 import           System.IO.Unsafe           (unsafePerformIO)
+import           Text.Show.Pretty      (pPrint, ppShow)
 
 --------------------------------------------------------------------------------
 -- Types for decoding API calls
@@ -87,7 +88,7 @@ compileTrio substance style element
         return (subOutPlugin, styVals)
   -- Compilation phase
   let optConfig = defaultOptConfig
-  state <- compileStyle styProg subOut' styVals optConfig
+  state <- {- trace ("Style AST: \n" ++ ppShow styProg) $ -} compileStyle styProg subOut' styVals optConfig
   return (state, env)
 
 -- | Given Substance and ELement programs, return a context after parsing Substance and ELement.
@@ -127,9 +128,11 @@ resample initState numSamples
   | numSamples == 1 = Right $ resampleOne initState 
   | numSamples > 1 =
      -- NOTE: resampling will not work if the frontend has a new function name (issue #352) because of evalEnergyOn for resampling
-    let newState = resampleBest numSamples initState
-        (newShapes, _, _) = evalTranslation newState
-    in Right $ newState {shapesr = newShapes}
+    Left $ RuntimeError "Only 1 resample supported."
+    -- NOTE: Deprecated since we've deprecated backend `evalExpr`
+    -- let newState = resampleBest numSamples initState
+    --     (newShapes, _, _) = evalTranslation newState
+    -- in Right $ newState {shapesr = newShapes}
   | otherwise = Left $ RuntimeError "At least 1 sample should be requested."
 
 getVersion :: String -- ^ the current version of the Penrose binary

--- a/src/Penrose/Env.hs
+++ b/src/Penrose/Env.hs
@@ -63,27 +63,10 @@ data SourcePosition = SourcePosition
   , row    :: Int -- ^ row number of the symbol
   } deriving (Show, Eq)
 
-rws, attribs, attribVs, shapes :: [String] -- list of reserved words
-rws = ["avoid", "as"] ++ dsll
-
--- ++ types ++ attribs ++ shapes ++ colors
-attribs = ["shape", "color", "label", "scale", "position"]
-
-attribVs = shapes
-
-shapes =
-  [ "Auto"
-  , "None"
-  , "Circle"
-  , "Box"
-  , "SolidArrow"
-  , "SolidDot"
-  , "HollowDot"
-  , "Cross"
-  ]
-
+-- TODO: clarify the list of reserved word in each language
+rws, labelrws, dsll :: [String] -- list of reserved words
+rws = ["True", "False", "ensure", "encourage"] 
 labelrws = ["Label", "AutoLabel", "NoLabel"]
-
 dsll =
   [ "tconstructor"
   , "vconstructor"
@@ -102,7 +85,6 @@ dsll =
   , "associativity"
   ]
 
--- colors =  ["Random", "Black", "Red", "Blue", "Yellow"]
 upperId, lowerId, identifier :: Parser String
 identifier = (lexeme . try) (p >>= checkId)
   where
@@ -229,6 +211,9 @@ parens = between (symbol "(") (symbol ")")
 
 brackets :: Parser a -> Parser a
 brackets = between (symbol "[") (symbol "]")
+
+quotes :: Parser a -> Parser a
+quotes = between (symbol "\"") (symbol "\"")
 
 -- | 'integer' parses an integer.
 integer :: Parser Integer

--- a/src/Penrose/Functions.hs
+++ b/src/Penrose/Functions.hs
@@ -196,6 +196,7 @@ compDict =
     , ("sampleUniform", sampleUniformFn)
     , ("makePalette", constComp makePalette)
     , ("unitMark", constComp unitMark)
+    , ("unitMark2", constComp unitMark2)
     , ("midpointOffset", constComp midpointOffset)
 
   , ("calcZSphere", constComp calcZSphere)
@@ -1393,21 +1394,20 @@ unitMark [GPI v@("Arrow", _), GPI w@("Arrow", _), Val (StrV "body"), Val (FloatV
       markEnd = end +: padding *: normalDir
   in Val $ PtListV [markStart, markEnd]
 
-unitMark [Val (PtListV [start, end]), Val (StrV "start"), Val (FloatV padding), Val (FloatV size)] =
+unitMark2 :: ConstCompFn
+unitMark2 [Val (PtListV [start, end]), Val (StrV "start"), Val (FloatV padding), Val (FloatV size)] =
   let dir = normalize' $ end -: start
       normalDir = rot90 dir
       markStart = start +: size *: normalDir
       markEnd = start -: size *: normalDir
-      path = Open $ [Pt markStart, Pt markEnd]
-  in Val $ PathDataV [path]
+  in Val $ PtListV [markStart, markEnd]
 
-unitMark [Val (PtListV [start, end]), Val (StrV "end"), Val (FloatV padding), Val (FloatV size)] =
+unitMark2 [Val (PtListV [start, end]), Val (StrV "end"), Val (FloatV padding), Val (FloatV size)] =
   let dir = normalize' $ end -: start
       normalDir = rot90 dir
       markStart = end +: size *: normalDir
       markEnd = end -: size *: normalDir
-      path = Open $ [Pt markStart, Pt markEnd]
-  in Val $ PathDataV [path]
+  in Val $ PtListV [markStart, markEnd]
 
 midpointOffset :: ConstCompFn
 -- TODO: Factor out the repeated computations below

--- a/src/Penrose/GenOptProblem.hs
+++ b/src/Penrose/GenOptProblem.hs
@@ -281,6 +281,10 @@ declaredVarying :: (Autofloat a) => TagExpr a -> Bool
 declaredVarying (OptEval (AFloat Vary)) = True
 declaredVarying _                       = False
 
+isVarying :: (Autofloat a) => Expr -> Bool
+isVarying (AFloat Vary) = True
+isVarying _ = False
+
 sumMap :: Floating b => (a -> b) -> [a] -> b -- common pattern in objective functions
 sumMap f l = sum $ map f l
 
@@ -296,9 +300,11 @@ pathToList (PropertyPath (BSubVar (VarConst name)) field property) =
   [name, field, property]
 pathToList _ = error "pathToList should not handle Sty vars"
 
-isFieldPath :: Path -> Bool
-isFieldPath (FieldPath _ _)      = True
-isFieldPath (PropertyPath _ _ _) = False
+isFieldOrAccessPath :: Path -> Bool
+isFieldOrAccessPath (FieldPath _ _)      = True
+isFieldOrAccessPath (AccessPath (FieldPath _ _) _) = True
+isFieldOrAccessPath (AccessPath (PropertyPath _ _ _) _) = False
+isFieldOrAccessPath (PropertyPath _ _ _) = False
 
 bvarToString :: BindingForm -> String
 bvarToString (BSubVar (VarConst s)) = s
@@ -420,44 +426,26 @@ lookupPropertyWithVarying bvar field property trans varyMap =
     Just varyVal -> varyVal
     Nothing      -> lookupProperty bvar field property trans
 
-lookupProperty ::
-     (Autofloat a)
-  => BindingForm
-  -> Field
-  -> Property
-  -> Translation a
-  -> TagExpr a
-lookupProperty bvar field property trans =
-  let name = trName bvar
-  in case lookupField bvar field trans of
-       FExpr e
-        -- to deal with path synonyms, e.g. `y.f = some GPI with property p; z.f = y.f; z.f.p = some value`
-        -- if we're looking for `z.f.p` and we find out that `z.f = y.f`, then look for `y.f.p` instead
-        -- NOTE: this makes a recursive call!
-        ->
-         case e of
-           OptEval (EPath (FieldPath bvarSynonym fieldSynonym)) ->
-             if bvar == bvarSynonym && field == fieldSynonym
-               then error
-                      ("nontermination in lookupProperty with path '" ++
-                       pathStr3 name field property ++ "' set to itself")
-               else lookupProperty bvarSynonym fieldSynonym property trans
-        -- the only thing that might have properties is another field path
-           _ ->
-             error
-               ("path '" ++
-                pathStr3 name field property ++ "' has no properties")
-       FGPI ctor properties ->
-         case M.lookup property properties of
-           Nothing ->
-             error
-               ("path '" ++
-                pathStr3 name field property ++ "'s property does not exist")
-           Just texpr -> texpr
-
 lookupPaths :: (Autofloat a) => [Path] -> Translation a -> [a]
 lookupPaths paths trans = map lookupPath paths
   where
+    -- Have to look up AccessPaths first, since they make a recursive call, and are not invalid paths themselves 
+    lookupPath p@(AccessPath (FieldPath b f) [i]) =
+       case lookupField b f trans of
+         FExpr (OptEval (Vector es)) -> if es !! i == AFloat (Vary) 
+                                        then error ("expected non-?: " ++ show p ++ ", " ++ show es)
+                                        else r2f $ floatOf $ es !! i
+         FExpr (Done (VectorV es)) -> es !! i
+         xs -> error ("varying path \"" ++
+             pathStr p ++ "\" is invalid: is '" ++ show xs ++ "'")
+    lookupPath p@(AccessPath (PropertyPath b f pr) [i]) =
+       case lookupProperty b f pr trans of
+         OptEval (Vector es) -> if es !! i == AFloat (Vary) 
+                                then error ("expected non-?: " ++ show p ++ ", " ++ show es)
+                                else r2f $ floatOf $ es !! i
+         Done (VectorV es) -> es !! i
+         xs -> error ("varying path \"" ++
+             pathStr p ++ "\" is invalid: is '" ++ show xs ++ "'")
     lookupPath p@(FieldPath v field) =
       case lookupField v field trans of
         FExpr (OptEval (AFloat (Fix n))) -> r2f n
@@ -474,6 +462,7 @@ lookupPaths paths trans = map lookupPath paths
           error
             ("varying path \"" ++
              pathStr p ++ "\" is invalid: is '" ++ show xs ++ "'")
+    floatOf (AFloat (Fix f)) = f
 
 -- TODO: resolve label logic here?
 shapeExprsToVals ::
@@ -513,10 +502,28 @@ shapes2floats shapes varyMap varyingPaths =
   where
     lookupPathFloat ::
          (Autofloat a) => [Shape a] -> VaryMap a -> [a] -> Path -> [a]
+
+    lookupPathFloat shapes varyMap acc p@(AccessPath fp@(FieldPath b f) [i]) =
+      case M.lookup p varyMap of
+        Just (Done (FloatV num)) -> num : acc
+        Just _ ->
+          error
+            ("wrong type for varying field path (expected float): " ++ show fp)
+        Nothing ->
+          error
+            ("could not find varying field path '" ++ show fp ++ "' in varyMap: " ++ show varyMap)
+                    
+    lookupPathFloat shapes varyMap acc p@(AccessPath (PropertyPath s field property) [i]) =
+      let subID = bvarToString s
+          shapeName = getShapeName subID field
+          res = getVec (findShape shapeName shapes) property
+      in (res !! i) : acc
+
     lookupPathFloat shapes _ acc (PropertyPath s field property) =
       let subID = bvarToString s
           shapeName = getShapeName subID field
       in getNum (findShape shapeName shapes) property : acc
+
     lookupPathFloat _ varyMap acc fp@(FieldPath _ _) =
       case M.lookup fp varyMap of
         Just (Done (FloatV num)) -> num : acc
@@ -525,7 +532,10 @@ shapes2floats shapes varyMap varyingPaths =
             ("wrong type for varying field path (expected float): " ++ show fp)
         Nothing ->
           error
-            ("could not find varying field path '" ++ show fp ++ "' in varyMap")
+            ("could not find varying field path '" ++ show fp ++ "' in varyMap: " ++ show varyMap)
+
+    floatOf (AFloat (Fix f)) = f
+
 
 --------------------------------- Analyzing the translation
 --- Find varying (float) paths
@@ -544,6 +554,22 @@ unoptimizedFloatProperties =
   , "arrowheadSize"
   ]
 
+optimizedVectorProperties :: [String]
+optimizedVectorProperties =
+  [ "start"
+  , "end"
+  , "center"
+  ]
+
+-- Look for nested varying variables, given the path to its parent var (e.g. `x.r` => (-1.2, ?)) => `x.r`[1] is varying
+findNestedVarying :: (Autofloat a) => TagExpr a -> Path -> [Path]
+findNestedVarying (OptEval (Vector es)) p = map (\(e, i) -> AccessPath p [i]) $ filter (\(e, i) -> isVarying e) $ zip es ([0..] :: [Int])
+-- COMBAK: This should search, but for now we just don't handle nested varying vars in these
+findNestedVarying (OptEval (Matrix _)) p = []
+findNestedVarying (OptEval (List _)) p = []
+findNestedVarying (OptEval (Tuple _ _)) p = []
+findNestedVarying _ _ = []
+
 -- If any float property is not initialized in properties,
 -- or it's in properties and declared varying, it's varying
 findPropertyVarying ::
@@ -559,21 +585,28 @@ findPropertyVarying name field properties floatProperty acc =
     Nothing ->
       if floatProperty `elem` unoptimizedFloatProperties
         then acc
+        else if floatProperty `elem` optimizedVectorProperties
+        then let paths = findNestedVarying (OptEval $ Vector [AFloat Vary, AFloat Vary]) (mkPath [name, field, floatProperty]) 
+             -- Return paths for both elements, COMBAK: This hardcodes that unset vectors have 2 elements, need to generalize
+             in paths ++ acc
         else mkPath [name, field, floatProperty] : acc
     Just expr ->
       if declaredVarying expr
         then mkPath [name, field, floatProperty] : acc
-        else acc
+        else let paths = findNestedVarying expr (mkPath [name, field, floatProperty]) -- Handles vectors
+             in paths ++ acc
 
 findFieldVarying ::
      (Autofloat a) => String -> Field -> FieldExpr a -> [Path] -> [Path]
 findFieldVarying name field (FExpr expr) acc =
   if declaredVarying expr
     then mkPath [name, field] : acc -- TODO: deal with StyVars
-    else acc
+    else let paths = findNestedVarying expr (mkPath [name, field])
+         in paths ++ acc
 findFieldVarying name field (FGPI typ properties) acc =
-  let ctorFloats = propertiesOf FloatT typ
+  let ctorFloats = propertiesOf FloatT typ ++ propertiesOf VectorT typ
       varyingFloats = filter (not . isPending typ) ctorFloats
+      -- This splits up vector-typed properties into one path for each element
       vs = foldr (findPropertyVarying name field properties) [] varyingFloats
   in vs ++ acc
 
@@ -946,7 +979,7 @@ evalExpr (i, n) arg trans varyMap g =
           error "avoidfn should not be an objfn arg (or in the children of one)"
         PluginAccess _ _ _ ->
           error "plugin access should not be evaluated at runtime"
-            -- xs -> error ("unmatched case in evalExpr with argument: " ++ show xs)
+        xs -> error ("unmatched case in evalExpr with argument: " ++ show xs)
 
 checkListElemType :: (Autofloat a) => ArgVal a -> a
 checkListElemType (Val (FloatV x)) = x
@@ -1189,6 +1222,8 @@ initProperty shapeType (properties, g) pID (typ, sampleF) =
       autoRndVal = Done v
   in case M.lookup pID properties of
        Just (OptEval (AFloat Vary)) -> (M.insert pID autoRndVal properties, g')
+       -- TODO: This hardcodes an uninitialized 2D vector to be initialized/inserted
+       Just (OptEval (Vector [AFloat Vary, AFloat Vary])) -> (M.insert pID autoRndVal properties, g')
        Just (OptEval e) -> (properties, g)
        Just (Done v) -> (properties, g)
        -- TODO: pending properties are only marked if the Style source does not set them explicitly
@@ -1197,6 +1232,7 @@ initProperty shapeType (properties, g) pID (typ, sampleF) =
          if isPending shapeType pID
            then (M.insert pID (Pending v) properties, g')
            else (M.insert pID autoRndVal properties, g')
+       _ -> error ("not handled: " ++ pID ++ ", " ++ show (M.lookup pID properties))
 
 initShape ::
      (Autofloat a)
@@ -1226,11 +1262,13 @@ initShapes trans shapePaths gen = foldl' initShape (trans, gen) shapePaths
 
 resampleFields :: (Autofloat a) => [Path] -> StdGen -> ([a], StdGen)
 resampleFields varyingPaths g =
-  let varyingFields = filter isFieldPath varyingPaths
+  let varyingFields = filter isFieldOrAccessPath varyingPaths
   in randomsIn g (fromIntegral $ length varyingFields) canvasDims
 
 -- sample varying fields only (from the range defined by canvas dims) and store them in the translation
 -- example: A.val = OPTIMIZED
+-- This also samples varying access paths, e.g.
+-- Circle { center : (1.1, ?) ... } <-- the latter is an access path that gets initialized here
 initFields ::
      (Autofloat a)
   => [Path]
@@ -1238,7 +1276,7 @@ initFields ::
   -> StdGen
   -> (Translation a, StdGen)
 initFields varyingPaths trans g =
-  let varyingFields = filter isFieldPath varyingPaths
+  let varyingFields = filter isFieldOrAccessPath varyingPaths
       (sampledVals, g') =
         randomsIn g (fromIntegral $ length varyingFields) canvasDims
       trans' = insertPaths varyingFields (map (Done . FloatV) sampledVals) trans
@@ -1302,7 +1340,7 @@ genOptProblemAndState trans optConfig
 -- | 'compileStyle' runs the main Style compiler on the AST of Style and output from the Substance compiler and outputs the initial state for the optimization problem. This function is a top-level function used by "Server" and "ShadowMain"
 -- TODO: enable logger
 compileStyle ::
-     StyProg
+     HeaderBlocks
   -> C.SubOut
   -> [J.StyVal]
   -> OptConfig
@@ -1409,6 +1447,10 @@ castTranslation t =
               FloatV x -> FloatV (r2f x)
               PtV (x, y) -> PtV (r2f x, r2f y)
               PtListV pts -> PtListV $ castPtList pts
+              VectorV xs -> VectorV $ map r2f xs
+              MatrixV xs -> MatrixV $ map (map r2f) xs
+              TupV x -> TupV $ r2 x
+              LListV xs -> LListV $ map (map r2f) xs
               PathDataV d -> PathDataV $ map castPath d
                           -- More boilerplate not involving floats
               IntV x -> IntV x
@@ -1425,6 +1467,7 @@ castTranslation t =
                   , (app2 r2f p1, app2 r2f p2)
                   , castPtList samples)
       in res
+      where r2 (x, y) = (r2f x, r2f y)
     castPath ::
          SubPath Double
       -> (forall a. Autofloat a =>
@@ -1462,7 +1505,7 @@ resampleVState varyPaths shapes g =
   let (resampledShapes, rng') = sampleShapes g shapes
       (resampledFields, rng'') = resampleFields varyPaths rng'
         -- make varying map using the newly sampled fields (we do not need to insert the shape paths)
-      varyMapNew = mkVaryMap (filter isFieldPath $ varyPaths) resampledFields
+      varyMapNew = mkVaryMap (filter isFieldOrAccessPath $ varyPaths) resampledFields
       varyingState = shapes2floats resampledShapes varyMapNew $ varyPaths
   in ((resampledShapes, varyingState, resampledFields), rng'')
 
@@ -1473,7 +1516,7 @@ updateVState s ((resampledShapes, varyingState', fields'), g) =
       uninitVals = map toTagExpr $ shapes2vals polyShapes $ uninitializedPaths s
       trans' = insertPaths (uninitializedPaths s) uninitVals (transr s)
                     -- TODO: shapes', rng' = sampleConstrainedState (rng s) (shapesr s) (constrs s)
-      varyMapNew = mkVaryMap (filter isFieldPath $ varyingPaths s) fields'
+      varyMapNew = mkVaryMap (filter isFieldOrAccessPath $ varyingPaths s) fields'
         -- TODO: this is not necessary for now since the label dimensions do not change, but added for completeness
       pendingPaths = findPending trans'
   in s

--- a/src/Penrose/Style.hs
+++ b/src/Penrose/Style.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE GADTs #-}
 -- | The "Style" module contains the compiler for the Style language,
 -- and functions to traverse the Style AST.
 
@@ -25,7 +26,44 @@ import           Data.Maybe                       (catMaybes, fromMaybe,
 import           Data.Tuple                       (swap)
 import           Data.Typeable
 import           Debug.Trace
-import           Penrose.Env
+import Penrose.Env
+    (validChar,  aps,
+      backticks,
+      braces,
+      brackets,
+      checkT,
+      colon,
+      comma,
+      def,
+      dot,
+      doubleQuotedString,
+      eq,
+      float,
+      integer,
+      isSubtype,
+      isSubtypeArrow,
+      lexeme,
+      newline',
+      parens,
+      question,
+      quotes,
+      rword,
+      scn,
+      semi',
+      symbol,
+      tryChoice,
+      typesEq,
+      var,
+      Arg(..),
+      BaseParser,
+      Parser,
+      ParserError(StyleError),
+      T(..),
+      TypeCtorApp(TypeCtorApp, constructorInvokerPos, argCons, nameCons),
+      TypeVar(TypeVar, typeVarPos, typeVarName),
+      ValConstructor(tvc, tlsvc),
+      Var(..),
+      VarEnv(errors, varMap, operators, valConstructors) )
 import           Penrose.Functions
 import           Penrose.Shapes                   hiding (get)
 import qualified Penrose.Substance                as C
@@ -38,6 +76,27 @@ import           Text.Megaparsec.Char
 import qualified Text.Megaparsec.Char.Lexer       as L
 import           Text.Show.Pretty                 (ppShow)
 
+--------------------------------------------------------------------------------
+-- Import Parser
+
+-- Module name, optional alias
+data Import = Import ModulePath (Maybe String)
+data ModulePath = ModulePath String (Maybe String)
+type Imports = [Import]
+
+-- parseImports :: String -> String -> VarEnv -> Either CompilerError Imports
+
+imports :: Parser Imports
+imports = importStmt `endBy` newline' -- zero or multiple import statements
+
+importStmt :: Parser Import
+importStmt = symbol "import" >> (Import <$> modulePath <*> optional importAlias) 
+
+importAlias :: Parser String
+importAlias = symbol "as" >> identifier
+
+modulePath :: Parser ModulePath
+modulePath = ModulePath <$> identifier <*> optional dotId
 
 --------------------------------------------------------------------------------
 -- Plugin Parser
@@ -82,7 +141,7 @@ stringLiteral = doubleQuotedString
 -------------------- Style Program grammar
 
 -- | A variable in Style
-newtype StyVar  = StyVar String
+newtype StyVar = StyVar String
     deriving (Show, Eq, Ord, Typeable)
 
 -- | A header of a block is either a selector or a namespace declaration
@@ -92,8 +151,18 @@ data Header = Select Selector | Namespace StyVar
 -- | A Style block contains a list of statements
 type Block = [Stmt]
 
+-- | A block with a header
+type HeaderBlock = (Header, Block)
+
+-- | Blocks with headers
+type HeaderBlocks = [HeaderBlock]
+
+-- | A top-level module in Style that contains multiple header blocks
+data ModuleBlock = Module String HeaderBlocks deriving (Show, Eq, Typeable)
+
 -- | A Style program is a collection of (header, block) pairs
-type StyProg = [(Header, Block)]
+type StyProg = HeaderBlocks
+-- type StyProg = [ModuleBlock]
 
 -------------------- Style selector grammar
 -- TODO: write a NOTE about the namespace situation between Substance and Style.
@@ -166,17 +235,21 @@ data Selector = Selector {
 
 type Field = String
 
+data StyType = TypeOf String | ListOf String deriving (Show, Eq, Typeable)
+
 -- | A path consist of a Substance or Style id, a shape name, and (optionally)
 -- a property name
 data Path
     = FieldPath BindingForm Field                 -- example: x.val
     | PropertyPath BindingForm Field Property     -- example: x.shape.center
+    | LocalVar String -- example: x (declared locally in the same block)
+    | AccessPath Path [Int] -- COMBAK: Hack so we can refer to anonymous varying vars within structures (vectors, matrices, tuples, lists) -- e.g. `$LOCAL_<id>.o [0]` or `V.shape.center [1]`. This is only used internally; Style doesn't parse into it. Currently only implemented for 2-vectors.
     -- NOTE: Style writer must use backticks in the block to indicate Substance variables
     deriving (Show, Eq, Typeable, Ord)
 
 -- | A statement in the Style language
 data Stmt
-    = Assign Path Expr
+    = PathAssign (Maybe StyType) Path Expr
     | Override Path Expr
     | Delete Path
     | AnonAssign Expr -- Anonymous statement; expression which is automatically given a name by the compiler (LOCAL.id)
@@ -205,6 +278,10 @@ data Expr
     | UOp UnaryOp Expr
     | List [Expr]
     | Tuple Expr Expr
+    | Vector [Expr]
+    | Matrix [Expr]
+    | VectorAccess Path Expr -- ^ Reference to vector, index
+    | MatrixAccess Path [Expr] -- ^ Reference to vector, index, index
     | ListAccess Path Integer
     | Ctor String [PropertyDecl] -- Shouldn't be using this, since we have PropertyDict
     | Layering Path Path -- ^ first GPI is *below* the second GPI
@@ -224,25 +301,86 @@ data BinaryOp = BPlus | BMinus | Multiply | Divide | Exp
 --------------------------------------------------------------------------------
 -- Style Parser
 
+
+rws, styleTypes, styleLits :: [String] 
+rws = styleLits
+styleLits = ["True", "False"]
+styleTypes 
+    = [
+        "scalar",
+        "int",
+        "bool",
+        "string",
+        "path",
+        "color",
+        "file",
+        "style",
+        "shape",
+        "vec2",
+        "vec3",
+        "vec4",
+        "mat2x2",
+        "mat3x3",
+        "mat4x4",
+        "function",
+        "objective",
+        "constraint"
+        ]
+
+upperId, lowerId, identifier :: Parser String
+identifier = (lexeme . try) (p >>= checkId)
+  where
+    p = (:) <$> letterChar <*> many validChar
+
+upperId = (lexeme . try) (p >>= checkId)
+  where
+    p = (:) <$> upperChar <*> many validChar
+
+lowerId = (lexeme . try) (p >>= checkId)
+  where
+    p = (:) <$> lowerChar <*> many validChar
+
+checkId :: String -> Parser String
+checkId x =
+  if x `elem` rws
+    then fail $ "keyword " ++ show x ++ " cannot be an identifier"
+    else return x
+
+styleTypeWord :: Parser String
+styleTypeWord = (lexeme . try) (lowerId >>= check)
+  where
+    check t = if t `elem` styleTypes
+              then return t
+              else fail $ "type " ++ show t ++ " is not a valid Style type" 
+styleType :: Parser StyType
+styleType = TypeOf <$> styleTypeWord <|> ListOf <$> styleTypeWord <* symbol "[]"
+
 -- | 'parseStyle' runs the actual parser function: 'styleParser', taking in a program String and parse it into an AST.
 parseStyle :: String -> String -> VarEnv -> Either CompilerError StyProg
 parseStyle styFile styIn env =
   case runParser (styleParser env) styFile styIn of
-    Left err  -> Left $ StyleParse $ (errorBundlePretty err)
+    Left err  -> Left $ StyleParse $ errorBundlePretty err
     Right res -> Right res
 
 -- | 'styleParser' is the top-level function that parses a Style proram
 styleParser :: VarEnv -> BaseParser StyProg
 styleParser env = evalStateT styleParser' $ Just env
-styleParser' = between scn eof styProg
+    where styleParser' = between scn eof styProg
 
 -- | `styProg` parses a Style program, consisting of a collection of one or
--- more blocks
+-- more module bolocks
 styProg :: Parser StyProg
 styProg =
     plugins >>  -- ignore plugin statements
+    imports >>  -- ignore import statements
     some headerBlock
-    where headerBlock = (,) <$> header <*> braces block <* scn
+    -- some moduleBlock
+
+moduleBlock :: Parser ModuleBlock
+moduleBlock = Module <$> upperId <*> braces (some headerBlock)
+
+headerBlock :: Parser HeaderBlock
+headerBlock = (,) <$> header <*> braces block <* scn
 
 header :: Parser Header
 header = tryChoice [Select <$> selector, Namespace <$> styVar]
@@ -265,6 +403,7 @@ selector = do
           namespace = rword "as" >> identifier
           withAndWhere = runPermutation $ (,) <$> toPermutationWithDefault [] wth <*> toPermutationWithDefault [] whr
 
+-- TODO: uppercase only?
 styVar :: Parser StyVar
 styVar = StyVar <$> identifier
 
@@ -341,15 +480,17 @@ block :: Parser [Stmt]
 block = stmt `sepEndBy` newline'
 
 stmt :: Parser Stmt
-stmt = tryChoice [assign, anonAssign, override, delete]
+stmt = tryChoice [pathAssign, anonAssign, override, delete]
 
 -- Only certain kinds of "imperative" expressions can be anonymous (i.e. `1+5` can't be)
 anonExpr :: Parser Expr
 anonExpr = tryChoice [layeringExpr, objFn, constrFn]
 
-anonAssign, assign, override, delete :: Parser Stmt
+anonAssign, pathAssign, override, delete :: Parser Stmt
 anonAssign = AnonAssign <$> anonExpr
-assign   = Assign   <$> path <*> (eq >> expr)
+-- TODO: this will prevent `shape` from being a valid id in any path
+pathAssign = PathAssign <$> pure Nothing <*> path <*> (eq >> expr)
+-- pathAssign = PathAssign <$> optional styleType <*> path <*> (eq >> expr)
 override = Override <$> (rword "override" >> path) <*> (eq >> expr)
 delete   = Delete   <$> (rword "delete"   >> path)
 
@@ -357,24 +498,30 @@ expr :: Parser Expr
 expr = tryChoice [
            constructor,
            layeringExpr,
-           arithmeticExpr,
            objFn,
            constrFn,
+           arithmeticExpr,
            transformExpr, -- COMBAK: ordering
            compFn,
            list,
            tuple,
+           vector,
+        --    matrix, -- TODO: will never get to this case because vector and matrix have the same types
            stringLit,
            boolLit
        ]
 
 pluginAccess :: Parser Expr
-pluginAccess = do
-    plugin <- identifier
-    name   <- bExpr
-    key    <- bExpr
-    return $ PluginAccess plugin name key
-    where bExpr = brackets expr
+pluginAccess = PluginAccess <$> quotes identifier <*> bExpr <*> bExpr
+
+vectorAccess :: Parser Expr
+vectorAccess = VectorAccess <$> path <*> bExpr 
+
+matrixAccess :: Parser Expr
+matrixAccess = MatrixAccess <$> path <*> ((:) <$> bExpr <*> some bExpr)
+
+bExpr :: Parser Expr
+bExpr = brackets expr
 
 arithmeticExpr :: Parser Expr
 arithmeticExpr = makeExprParser aTerm aOperators
@@ -384,7 +531,11 @@ aTerm = tryChoice
     [
         compFn,
         pluginAccess,
+        matrixAccess,
+        vectorAccess,
         parens arithmeticExpr,
+        vector,
+        matrix,
         AFloat <$> annotatedFloat,
         EPath  <$> path,
         IntLit . fromIntegral <$> integer
@@ -447,10 +598,14 @@ tOperators =
         -- Lowest precedence
     ]
 
-path :: Parser Path
-path = try (PropertyPath <$> bindingForm <*> dotId <*> dotId) <|>
-       FieldPath <$> bindingForm <*> dotId
-       where dotId = dot >> identifier
+path, propertyPath, fieldPath, localVar :: Parser Path
+path = tryChoice [propertyPath, fieldPath, localVar]
+propertyPath = PropertyPath <$> bindingForm <*> dotId <*> dotId
+fieldPath = FieldPath <$> bindingForm <*> dotId
+localVar = LocalVar <$> identifier
+
+dotId :: Parser String
+dotId = dot >> identifier
 
 compFn, objFn, constrFn :: Parser Expr
 compFn   = CompApp <$> identifier <*> exprsInParens
@@ -460,9 +615,11 @@ constrFn = ConstrFn <$> (rword "ensure" >> identifier) <*> exprsInParens
 exprsInParens :: Parser [Expr]
 exprsInParens = parens $ expr `sepBy` comma
 
-list, tuple :: Parser Expr
+list, tuple, vector, matrix :: Parser Expr
 list = List <$> brackets (expr `sepBy1` comma)
-tuple = parens (Tuple <$> expr <*> (comma >> expr))
+tuple = braces (Tuple <$> expr <*> (comma >> expr))
+vector = Vector <$> parens (expr `sepBy1` comma)
+matrix = Matrix <$> parens (vector `sepBy1` comma)
 
 constructor :: Parser Expr
 constructor = do
@@ -482,7 +639,12 @@ stringLit :: Parser Expr
 stringLit = StringLit <$> (symbol "\"" >> manyTill L.charLiteral (try (symbol "\"")))
 
 annotatedFloat :: Parser AnnoFloat
-annotatedFloat = (question *> pure Vary) <|> Fix <$> float
+annotatedFloat = tryChoice [vary, floatNum, trailingFloat]
+    where 
+        vary = question *> pure Vary
+        floatNum = Fix <$> float
+        trailingFloat = Fix <$> (fromIntegral <$> integer) <* dot
+
 
 ------------------------------------------------------------------------
 -------- STYLE COMPILER
@@ -704,7 +866,7 @@ checkNamespace name varEnv =
 
 -- Returns a sel env for each selector in the Style program, in the same order
 -- TODO: add these judgments to the paper
-checkSels :: VarEnv -> StyProg -> [SelEnv]
+checkSels :: VarEnv -> HeaderBlocks -> [SelEnv]
 checkSels varEnv prog =
           let selEnvs = map (checkPair varEnv) prog in
           let errors = concatMap sErrors selEnvs in
@@ -727,15 +889,22 @@ checkSels varEnv prog =
 -- A substitution θ has form [y → x], binding Sty vars to Sub vars (currently not expressions).
 type Subst = M.Map StyVar Var
 
-type LocalVarId = (Int, Int)
--- Index of the block, paired with the index of the current substitution
--- Should be unique across blocks and substitutions
+type NamespaceName = String
+
+data LocalVarSubst = 
+     LocalVarId (Int, Int)
+     -- Index of the block, paired with the index of the current substitution
+     -- Should be unique across blocks and substitutions
+     | NamespaceId NamespaceName
+     -- Namespace's name, e.g. things that are parsed as local vars (e.g. Const { red ... }) get turned into paths "Const.red"
 
 localKeyword :: String
-localKeyword = "LOCAL"
+localKeyword = "$LOCAL"
 
-mkLocalVarName :: LocalVarId -> String
-mkLocalVarName (blockNum, substNum) = localKeyword ++ "_b" ++ show blockNum ++ "_s" ++ show substNum
+-- Local 
+mkLocalVarName :: LocalVarSubst -> String
+mkLocalVarName (LocalVarId (blockNum, substNum)) = localKeyword ++ "_block" ++ show blockNum ++ "_subst" ++ show substNum
+mkLocalVarName (NamespaceId namespace) = namespace
 
 ----- Substitution helper functions
 
@@ -785,20 +954,13 @@ uniqueKeysAndVals subst =
 
 -- TODO: return "maybe" if a substitution fails?
 
-substituteBform :: Maybe LocalVarId -> Subst -> BindingForm -> BindingForm
+substituteBform :: Maybe LocalVarSubst -> Subst -> BindingForm -> BindingForm
 -- Variable in backticks in block or selector (e.g. `X`)
 substituteBform _ subst sv@(BSubVar _) = sv
 
--- If the Style variable is "LOCAL", then resolve it to a unique id for the block and selector
--- Otherwise, look up the substitution for the Style variable and return a Substance variable
+-- Look up the substitution for the Style variable and return a Substance variable
 substituteBform lv subst sv@(BStyVar sv'@(StyVar vn)) =
-   if vn == localKeyword
-   then case lv of
-        -- lv = Nothing: substituting into selector, so local vars don't matter
-        -- lv = Just (i, j): substituting into block, so local vars matter
-        Nothing -> error "LOCAL keyword found without a subst/block id. It should not be used in a selector."
-        Just localVarId -> BSubVar $ VarConst $ mkLocalVarName localVarId
-   else case M.lookup sv' subst of
+        case M.lookup sv' subst of
         Just subVar -> BSubVar subVar -- Returns result of mapping if it exists (y -> x)
         Nothing     -> sv -- error $ "No subst found for Sty var '" ++ vn ++ "'"
                        -- TODO: no substitutions for namespaces
@@ -833,24 +995,27 @@ substituteRels subst rels = map (substituteRel subst) rels
 
 ----- Substs for the translation semantics (more tree-walking on blocks, just changing binding forms)
 
-substitutePath :: LocalVarId -> Subst -> Path -> Path
+substitutePath :: LocalVarSubst -> Subst -> Path -> Path
 substitutePath lv subst path =
     case path of
     FieldPath    bVar field      -> FieldPath    (substituteBform (Just lv) subst bVar) field
     PropertyPath bVar field prop -> PropertyPath (substituteBform (Just lv) subst bVar) field prop
+    LocalVar v -> FieldPath (BSubVar $ VarConst $ mkLocalVarName lv) v
+    -- Note that the local var becomes a path
+    -- Use of local var 'v' (on right-hand side of '=' sign in Style) gets transformed into field path reference 'LOCAL_<ids>.v'
+    -- where <ids> is a string generated to be unique to this selector match for this block
 
-substituteField :: LocalVarId -> Subst -> PropertyDecl -> PropertyDecl
+substituteField :: LocalVarSubst -> Subst -> PropertyDecl -> PropertyDecl
 substituteField lv subst (PropertyDecl field expr) = PropertyDecl field $ substituteBlockExpr lv subst expr
 
-
 -- DEPRECATED
--- substituteLayering :: LocalVarId -> Subst -> LExpr -> LExpr
+-- substituteLayering :: LocalVarSubst -> Subst -> LExpr -> LExpr
 -- substituteLayering lv subst (LId bVar) = LId $ substituteBform (Just lv) subst bVar
 -- substituteLayering lv subst (LPath path) = LPath $ substitutePath lv subst path
 -- substituteLayering lv subst (LayeringOp op lex1 lex2) =
 --                    LayeringOp op (substituteLayering lv subst lex1) (substituteLayering lv subst lex1)
 
-substituteBlockExpr :: LocalVarId -> Subst -> Expr -> Expr
+substituteBlockExpr :: LocalVarSubst -> Subst -> Expr -> Expr
 substituteBlockExpr lv subst expr =
     case expr of
     EPath path        -> EPath $ substitutePath lv subst path
@@ -873,17 +1038,26 @@ substituteBlockExpr lv subst expr =
     PluginAccess pluginName e1 e2 -> PluginAccess pluginName (substituteBlockExpr lv subst e1) (substituteBlockExpr lv subst e2)
     Tuple e1 e2 -> Tuple (substituteBlockExpr lv subst e1) (substituteBlockExpr lv subst e2)
     ThenOp e1 e2 -> ThenOp (substituteBlockExpr lv subst e1) (substituteBlockExpr lv subst e2)
+    Vector es           -> Vector $ map (substituteBlockExpr lv subst) es
+    Matrix es           -> Matrix $ map (substituteBlockExpr lv subst) es
+    VectorAccess e1 e2 -> VectorAccess (substitutePath lv subst e1) (substituteBlockExpr lv subst e2)
+    MatrixAccess e1 es -> MatrixAccess (substitutePath lv subst e1) (map (substituteBlockExpr lv subst) es)
 
-substituteLine :: LocalVarId -> Subst -> Stmt -> Stmt
+substituteLine :: LocalVarSubst -> Subst -> Stmt -> Stmt
 substituteLine lv subst line =
     case line of
-    Assign   path expr -> Assign (substitutePath lv subst path) (substituteBlockExpr lv subst expr)
+    PathAssign t path expr -> PathAssign t (substitutePath lv subst path) (substituteBlockExpr lv subst expr)
     Override path expr -> Override (substitutePath lv subst path) (substituteBlockExpr lv subst expr)
     Delete   path      -> Delete $ substitutePath lv subst path
+    _ -> error "Case should not be reached (anonymous statement should be substituted for a local one in `nameAnonStatements`)"
 
 -- Assumes a full substitution
-substituteBlock :: (Subst, Int) -> (Block, Int) -> Block
-substituteBlock (subst, substNum) (block, blockNum) = map (substituteLine (blockNum, substNum) subst) block
+substituteBlock :: (Subst, Int) -> (Block, Int) -> Maybe NamespaceName -> Block
+substituteBlock (subst, substNum) (block, blockNum) name = 
+                let lvsubst = case name of
+                              Nothing -> LocalVarId (blockNum, substNum)
+                              Just nm -> NamespaceId nm
+                in map (substituteLine lvsubst subst) block
 
 ----- Filter with relational statements
 
@@ -1066,7 +1240,7 @@ find_substs_sel _ _ _ (Namespace _, _) = [] -- No substitutions for a namespace 
 
 -- TODO: add note on prog, header judgment to paper?
 -- Find a list of substitutions for each selector in the Sty program.
-find_substs_prog :: VarEnv -> C.SubEnv -> C.SubProg -> StyProg -> [SelEnv] -> [[Subst]]
+find_substs_prog :: VarEnv -> C.SubEnv -> C.SubProg -> HeaderBlocks -> [SelEnv] -> [[Subst]]
 find_substs_prog varEnv subEnv subProg styProg selEnvs =
     let sels = map fst styProg in
     let selsWithEnvs = zip sels selEnvs in
@@ -1144,6 +1318,7 @@ addWarn tr warn = tr { warnings = warnings tr ++ [warn] }
 pathStr :: Path -> String
 pathStr (FieldPath bvar field) = intercalate "." [show bvar, field]
 pathStr (PropertyPath bvar field property) = intercalate "." [show bvar, field, property]
+pathStr (AccessPath p indices) = pathStr p ++ "[" ++ intercalate "," (map show indices) ++ "]"
 
 pathStr2 :: Name -> Field -> String
 pathStr2 name field = intercalate "." [name, field]
@@ -1305,6 +1480,27 @@ addPath override trans path expr =
        let name   = trName bvar
            trans' = addProperty override trans name field property expr in
        Right trans'
+    -- a.x[0] = e
+    AccessPath (FieldPath bvar field) [i] -> 
+        case (lookupField bvar field trans, expr) of
+        (FExpr (OptEval (Vector es)), Done (FloatV n)) -> 
+              let es' = replaceAtIndex i (AFloat $ Fix $ r2f n) es
+                  name   = trName bvar
+                  trans' = addField override trans name field (OptEval (Vector es')) in
+                  Right trans'
+        _ -> error "expected access of vector with at least one varying float, putting in a float"
+    -- a.x.y[0] = e
+    AccessPath (PropertyPath bvar field property) [i] -> 
+        case (lookupProperty bvar field property trans, expr) of
+        (OptEval (Vector es), Done (FloatV n)) -> 
+              let es' = replaceAtIndex i (AFloat $ Fix $ r2f n) es
+                  name   = trName bvar
+                  trans' = addProperty override trans name field property (OptEval (Vector es')) in
+                  Right trans'
+        _ -> error "expected access of vector with at least one varying float, putting in a float"
+
+replaceAtIndex :: Int -> a -> [a] -> [a]
+replaceAtIndex n item ls = a ++ (item:b) where (a, (_:b)) = splitAt n ls
 
 addPaths :: (Autofloat a) => OverrideFlag -> Translation a -> [(Path, TagExpr a)] -> Either [Error] (Translation a)
 addPaths override = foldM (\trans (p, e) -> addPath override trans p e) 
@@ -1325,31 +1521,33 @@ addPaths override = foldM (\trans (p, e) -> addPath override trans p e)
 translateLine :: (Autofloat a) => Translation a -> Stmt -> Either [Error] (Translation a)
 translateLine trans stmt =
     case stmt of
-    Assign path expr   -> addPath False trans path (OptEval expr)
+    PathAssign _ path expr   -> addPath False trans path (OptEval expr)
     Override path expr -> addPath True trans path (OptEval expr)
     Delete path        -> deletePath trans path
 
 -- Judgment 25. D |- |B ~> D' (modified to be: theta; D |- |B ~> D')
-translateBlock :: (Autofloat a) => (Block, Int) -> Translation a -> (Subst, Int) ->
+translateBlock :: (Autofloat a) => Maybe NamespaceName -> (Block, Int) -> Translation a -> (Subst, Int) -> 
                                                                Either [Error] (Translation a)
-translateBlock blockWithNum trans substNum =
-    let block' = substituteBlock substNum blockWithNum in
+translateBlock name blockWithNum trans substWithNum =
+    let block' = substituteBlock substWithNum blockWithNum name in
     foldM translateLine trans block'
 
 -- Judgment 24. [theta]; D |- |B ~> D'
+-- This is a selector, not a namespace, so we substitute local vars with the subst/block IDs
 translateSubstsBlock :: (Autofloat a) => Translation a -> [(Subst, Int)] ->
                                                      (Block, Int) -> Either [Error] (Translation a)
-translateSubstsBlock trans substsNum blockWithNum = foldM (translateBlock blockWithNum) trans substsNum
+translateSubstsBlock trans substsNum blockWithNum = foldM (translateBlock Nothing blockWithNum) trans substsNum
 
 -- Judgment 23, contd.
 translatePair :: (Autofloat a) => VarEnv -> C.SubEnv -> C.SubProg ->
                                   Translation a -> ((Header, Block), Int) -> Either [Error] (Translation a)
-translatePair varEnv subEnv subProg trans ((Namespace styVar, block), blockNum) =
+translatePair varEnv subEnv subProg trans ((Namespace (StyVar name), block), blockNum) =
     let selEnv = initSelEnv
         bErrs  = checkBlock selEnv block in
     if null (sErrors selEnv) && null bErrs
         then let subst = M.empty in -- is this the correct empty?
-             translateBlock (block, blockNum) trans (subst, 0) -- skip transSubstsBlock; only one subst
+             -- This is a namespace, not selector, so we substitute local vars with the namespace's name
+             translateBlock (Just name) (block, blockNum) trans (subst, 0) -- skip transSubstsBlock; only one subst
         else Left $ sErrors selEnv ++ bErrs
 
 translatePair varEnv subEnv subProg trans ((header@(Select sel), block), blockNum) =
@@ -1456,6 +1654,11 @@ evalPluginAccess valMap trans =
                   evalPluginExpr vmap (List es) = List $ map (evalPluginExpr vmap) es
                   evalPluginExpr vmap (Tuple e1 e2) = Tuple (evalPluginExpr vmap e1) (evalPluginExpr vmap e2)
                   evalPluginExpr vmap (ThenOp e1 e2) = ThenOp (evalPluginExpr vmap e1) (evalPluginExpr vmap e2)
+                  evalPluginExpr vmap (Vector es) = Vector $ map (evalPluginExpr vmap) es
+                  evalPluginExpr vmap (Matrix es) = Matrix $ map (evalPluginExpr vmap) es
+
+                  evalPluginExpr vmap (VectorAccess e1 e2) = VectorAccess e1 (evalPluginExpr vmap e2)
+                  evalPluginExpr vmap (MatrixAccess e1 es) = MatrixAccess e1 (map (evalPluginExpr vmap) es)
 
                   -- Leaves (no strings should be involved)
                   evalPluginExpr _ e@(IntLit _) = e
@@ -1481,7 +1684,7 @@ evalPluginAccess valMap trans =
 -- Judgment 23. G; D |- [P]; |P ~> D'
 -- Fold over the pairs in the Sty program, then the substitutions for a selector, then the lines in a block.
 translateStyProg :: forall a . (Autofloat a) =>
-    VarEnv -> C.SubEnv -> C.SubProg -> StyProg -> C.LabelMap -> [J.StyVal] ->
+    VarEnv -> C.SubEnv -> C.SubProg -> HeaderBlocks -> C.LabelMap -> [J.StyVal] ->
     Either [Error] (Translation a)
 translateStyProg varEnv subEnv subProg styProg labelMap styVals =
     let numberedProg = zip styProg [0..] in -- For creating unique local var names
@@ -1501,18 +1704,17 @@ translateStyProg varEnv subEnv subProg styProg labelMap styVals =
 -- Leave all other statements unchanged
 
 anonKeyword :: String
-anonKeyword = "ANON"
+anonKeyword = "$ANON"
 
-nameAnonStatements :: StyProg -> StyProg
+nameAnonStatements :: HeaderBlocks -> HeaderBlocks
 nameAnonStatements p = map (\(h, b) -> (h, nameAnonBlock b)) p
                    where nameAnonBlock :: Block -> Block
                          nameAnonBlock b = let (count, res) = foldl nameAnonStatement (0, []) b in res
 
                          nameAnonStatement :: (Int, Block) -> Stmt -> (Int, Block)
-                         -- Assign the path "local.ANON_$counter" and increment counter
+                         -- Transform stmt into local variable assignment "ANON_$counter = e" and increment counter
                          nameAnonStatement (i, b) (AnonAssign e) = 
-                                           let path = FieldPath (BStyVar (StyVar localKeyword)) (anonKeyword ++ "_" ++ show i)
-                                               stmt = Assign path e in
+                                           let stmt = PathAssign Nothing (LocalVar $ anonKeyword ++ "_" ++ show i) e in
                                            (i + 1, b ++ [stmt])
                          nameAnonStatement (i, b) s = (i, b ++ [s])
 
@@ -1552,6 +1754,41 @@ lookupField bvar field trans =
               --   else trace ("Recursively looking up field " ++ pathStr (FieldPath bvar field) ++ " -> " ++ pathStr (FieldPath bvarSynonym fieldSynonym)) lookupField bvarSynonym fieldSynonym trans
               -- _ -> fexpr
 
+lookupProperty ::
+     (Autofloat a)
+  => BindingForm
+  -> Field
+  -> Property
+  -> Translation a
+  -> TagExpr a
+lookupProperty bvar field property trans =
+  let name = trName bvar
+  in case lookupField bvar field trans of
+       FExpr e
+        -- to deal with path synonyms, e.g. `y.f = some GPI with property p; z.f = y.f; z.f.p = some value`
+        -- if we're looking for `z.f.p` and we find out that `z.f = y.f`, then look for `y.f.p` instead
+        -- NOTE: this makes a recursive call!
+        ->
+         case e of
+           OptEval (EPath (FieldPath bvarSynonym fieldSynonym)) ->
+             if bvar == bvarSynonym && field == fieldSynonym
+               then error
+                      ("nontermination in lookupProperty with path '" ++
+                       pathStr3 name field property ++ "' set to itself")
+               else lookupProperty bvarSynonym fieldSynonym property trans
+        -- the only thing that might have properties is another field path
+           _ ->
+             error
+               ("path '" ++
+                pathStr3 name field property ++ "' has no properties")
+       FGPI ctor properties ->
+         case M.lookup property properties of
+           Nothing ->
+             error
+               ("path '" ++
+                pathStr3 name field property ++ "'s property does not exist")
+           Just texpr -> texpr
+
 shapeType :: (Autofloat a) => BindingForm -> Field -> Translation a -> ShapeTypeStr
 shapeType bvar field trans =
           case lookupField bvar field trans of
@@ -1573,6 +1810,7 @@ lookupStyVal subName propName vmap =
          Nothing -> error ("plugin accessors in style: for access " ++ toAccess subName propName ++ ", property does not exist")
          Just val -> val
     where toAccess s1 s2 = s1 ++ "." ++ s2
+
 
 --------------------------------------------------------------------------------
 -- Debugging

--- a/test/Shapes/Tests.hs
+++ b/test/Shapes/Tests.hs
@@ -36,4 +36,5 @@ qcProps = testGroup "(checked by QuickCheck)" []
 unitTests =
   testGroup
     "Unit tests"
-    [testCase "one kind of object, get/set identity" circ_get_set_id]
+    []
+    -- [testCase "one kind of object, get/set identity" circ_get_set_id]

--- a/tsdef/README.md
+++ b/tsdef/README.md
@@ -1,0 +1,8 @@
+# How to generate TypeScript types
+
+* Run `stack install` to build the Penrose main library and the `tsdef` module for conversion to TS types.
+* In this directory, run `tsdef > types.d.ts`.
+* If `tsdef` is not found, run `stack install tsdef`.
+* All the exported TS types will be defined in `types.d.ts`.
+
+

--- a/tsdef/types.d.ts
+++ b/tsdef/types.d.ts
@@ -53,7 +53,7 @@ interface IPending<T> {
   contents: Value<T>;
 }
 
-type Expr = IIntLit | IAFloat | IStringLit | IBoolLit | IEPath | ICompApp | IObjFn | IConstrFn | IAvoidFn | IBinOp | IUOp | IList | ITuple | IListAccess | ICtor | ILayering | IPluginAccess | IThenOp;
+type Expr = IIntLit | IAFloat | IStringLit | IBoolLit | IEVar | IEPath | ICompApp | IObjFn | IConstrFn | IAvoidFn | IBinOp | IUOp | IList | ITuple | IVector | IMatrix | IVectorAccess | IMatrixAccess | IListAccess | ICtor | ILayering | IPluginAccess | IThenOp;
 
 interface IIntLit {
   tag: "IntLit";
@@ -73,6 +73,11 @@ interface IStringLit {
 interface IBoolLit {
   tag: "BoolLit";
   contents: boolean;
+}
+
+interface IEVar {
+  tag: "EVar";
+  contents: LocalVar;
 }
 
 interface IEPath {
@@ -120,6 +125,26 @@ interface ITuple {
   contents: [Expr, Expr];
 }
 
+interface IVector {
+  tag: "Vector";
+  contents: Expr[];
+}
+
+interface IMatrix {
+  tag: "Matrix";
+  contents: Expr[];
+}
+
+interface IVectorAccess {
+  tag: "VectorAccess";
+  contents: [Expr, Expr];
+}
+
+interface IMatrixAccess {
+  tag: "MatrixAccess";
+  contents: [Expr, Expr, Expr];
+}
+
 interface IListAccess {
   tag: "ListAccess";
   contents: [Path, number];
@@ -164,7 +189,7 @@ type PropertyDecl = IPropertyDecl;
 
 type IPropertyDecl = [string, Expr];
 
-type Path = IFieldPath | IPropertyPath;
+type Path = IFieldPath | IPropertyPath | ITypePropertyPath;
 
 interface IFieldPath {
   tag: "FieldPath";
@@ -174,6 +199,10 @@ interface IFieldPath {
 interface IPropertyPath {
   tag: "PropertyPath";
   contents: [BindingForm, string, string];
+}
+
+interface ITypePropertyPath {
+  tag: "TypePropertyPath";
 }
 
 type Var = IVarConst;
@@ -195,6 +224,10 @@ interface IBStyVar {
 type StyVar = IStyVar;
 
 type IStyVar = string;
+
+type LocalVar = ILocalVar;
+
+type ILocalVar = string;
 
 type Value<T> = IFloatV<T> | IIntV<T> | IBoolV<T> | IStrV<T> | IPtV<T> | IPathDataV<T> | IPtListV<T> | IPaletteV<T> | IColorV<T> | IFileV<T> | IStyleV<T> | IListV<T> | ITupV<T> | ILListV<T> | IHMatrixV<T> | IPolygonV<T>;
 


### PR DESCRIPTION
# Description

This PR extends Style and the shape definitions to handle local vars and vector/matrix types, and ports existing Style programs to use these features. The motivation is to address the dealbreakers that @keenancrane pointed out when writing graphics code in Style.

Related issues: #375 #372 

Old PR: #398 

# Implementation strategy and design decisions

- Parsing:
  - [x] optional type annotation and import parsing (not used for now)
  - [x] vector & matrix as first class objects in Style
  - [x] new syntax for lists and tuples
  - [x] separate definition of Style identifiers

- Compilation: 
  - Local variables (e.g. `x`) are handled by replacing them, and all references to them, by a field path with a Substance object named uniquely according to the block number and substitution number.
  - Anonymous statements (e.g. `encourage near(x.shape, y.shape)`) are handled by turning them into local variable-named statements with a unique anonymous keyword, using a counter
  - Vector-valued properties are sampled like other properties; to refer to anonymous elements (e.g. `x[0]`) in the list of varying paths, `AccessPath` is used in `findNestedVarying`

# Examples with steps to reproduce them

These include all the currently working Style programs for `penrose-web`. (These are mostly taken from the first sample, though some may not look exactly like the image since they are from old version of the system.)

* Orthogonal vector example from paper: `runpenrose linear-algebra-domain/twoVectorsPerp.sub linear-algebra-domain/linear-algebra-paper-simple.sty linear-algebra-domain/linear-algebra.dsl`

![image](https://user-images.githubusercontent.com/2762356/99040363-028b5400-2557-11eb-9740-a983e689cc3f.png)

* Two sets with labels: `runpenrose set-theory-domain/twosets-simple.sub set-theory-domain/venn-small.sty  set-theory-domain/setTheory.dsl`

![image](https://user-images.githubusercontent.com/2762356/99040395-11720680-2557-11eb-8668-85269064f9e3.png)

* Big set example with circles: `runpenrose set-theory-domain/tree.sub set-theory-domain/venn-opt-test.sty set-theory-domain/setTheory.dsl` 

![image](https://user-images.githubusercontent.com/2762356/99040410-16cf5100-2557-11eb-8fe5-f2635e7813e1.png)

* Big set example with tree:`runpenrose set-theory-domain/tree.sub set-theory-domain/tree.sty set-theory-domain/setTheory.dsl` 

![image](https://user-images.githubusercontent.com/2762356/99040426-1c2c9b80-2557-11eb-90aa-59c6b49738d6.png)

* Continuous map: `runpenrose set-theory-domain/continuousmap.sub set-theory-domain/continuousmap.sty set-theory-domain/setTheory.dsl`

![image](https://user-images.githubusercontent.com/2762356/99040448-251d6d00-2557-11eb-8a39-d11d5e29950d.png)

* Hyperbolic: `runpenrose hyperbolic-domain/hyperbolic-example.sub hyperbolic-domain/PoincareDisk.sty hyperbolic-domain/hyperbolic.dsl`

![image](https://user-images.githubusercontent.com/2762356/93973751-b71cac80-fd42-11ea-9aea-7d65c3277e21.png)

* Geometry (partial): `runpenrose geometry-domain/pythagorean-theorem-sugared.sub geometry-domain/euclidean-simple.sty geometry-domain/geometry.dsl`

![image](https://user-images.githubusercontent.com/2762356/99040478-36667980-2557-11eb-8a76-a1c6edf9511a.png)

* Sets (optimizing thru computation): `runpenrose set-theory-domain/multisets.sub set-theory-domain/venn-comp-test.sty  set-theory-domain/setTheory.dsl`

![image](https://user-images.githubusercontent.com/2762356/94067019-45cd1000-fdbb-11ea-91f4-58772e1df917.png)

* Cross-domain mesh-set example: `runpenrose mesh-set-domain/DomainInterop.sub mesh-set-domain/DomainInterop.sty mesh-set-domain/DomainInterop.dsl`

![image](https://user-images.githubusercontent.com/2762356/99040469-323a5c00-2557-11eb-80ea-ca3226c4b8d1.png)

# Checklist

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I ran [Haddock](https://github.com/penrose/penrose/wiki/Writing-and-generating-documentation#generating-html-documentation-site) and there were no errors when generating the HTML site
- [ ] My changes generate no new warnings
- [ ] New and existing tests pass locally using `stack test`
- [ ] My code follows the style guidelines of this project (e.g.: no HLint warnings)


# Open questions

Questions that require more discussion or to be addressed in future development:

- Ints are not auto-cast to float. (Right now if say `side` refers to a path that's an int, it won't get converted, and won't be VarAD in the autodiff, causing a runtime crash)
- Fully implement `AccessPath` in `Evaluator.ts` (see `TODO`s)
- Look for varying vals in other composite types like matrix, list, tuple in `findNestedVarying` (right now if a matrix contains varying vals, the path won't be found; `AccessPath` needs to include it)
- Dimensionality of vectors/matrices is hardcoded to 2 in some places
- Parametric types in general are handled poorly, with special cases to handle e.g. lists containing floats or vectors