### PR TITLE
Updated mod shapedefs to correspond with new definitions

### DIFF
--- a/penrose-web/src/inspector/README.md
+++ b/penrose-web/src/inspector/README.md
@@ -33,7 +33,7 @@ Create a "mod file" for your shape and place it in `mod/shapedefs/`. This must b
 - `shapeType` should correspond to the name for your shape in `../componentMap.tsx`. 
 - `properties` should be a nested object. Each 'entry' within `properties` must correspond to a property in `YOURSHAPE.tsx` (e.g. `Circle.tsx`).
 - Each property within `properties` should have the following subentries:
-    - An input type property `inputType` corresponding to the appropriate HTML input element you would like to use to customize that property. Currently supported types are `range`, `select`, `text`, `url`, `number`, `color`, `checkbox`. This entry is **required**.
+    - An input type property `inputType` corresponding to the appropriate HTML input element you would like to use to customize that property. Currently supported types are `range`, `select`, `text`, `url`, `number`, `color`, `checkbox`, `mulptrange`, `ptrange`. This entry is **required**.
     - A property `showValue`, set to either `"true"` or `"false"`. If set to `"true"`, the current value of the input element will be displayed next to the input element. For example, on a `range` input element, the user will not see the actual value of the slider in numeric form unless `showValue` is set to true. It is recommended that for `range` specifically, `showValue` is always set to `"true"` and all other input types `showValue` is `"false"`. If left out, this will default to `"false"`.
     - If the input type is `select`, there must be a subentry entitled `options`, which is an array of all possible options for the dropdown menu. This is **required**.
     - Any other [HTML input customization features](https://www.w3schools.com/html/html_form_input_types.asp). For example, the `range` input type takes in a `min` and `max` value respectively. You may provide your own values for these. If you do not choose to, such fields will take their HTML-defined default value. For instance, the `min` and `max` fields for `range` have default values of `0` and `100` respectively. 
@@ -57,5 +57,4 @@ After creating the mod file, add it to `mod/defmap.tsx`.
 
 - The `pathData` attribute is only modifiable if it contains a list of `IPt`. Currently does not work with Bezier curves.
 - If the types in `types.d.ts` change form, `LabeledInput.tsx` will likely need to be modified. For example, if the structure of `IPathData` is changed, attempting to modify the `pathData` attribute will result in a crash.
-- Does not support alpha customization for color attributes.
 - Uses the fact that the canvas is hardcoded. Needs to be updated when that changes.

--- a/penrose-web/src/inspector/views/mod/shapedefs/arrow.json
+++ b/penrose-web/src/inspector/views/mod/shapedefs/arrow.json
@@ -1,28 +1,20 @@
 {
     "shapeType": "Arrow",
     "properties": {
-        "startX": {
-            "inputType": "range",
-            "min": "CANVASL",
-            "max": "CANVASR",
+        "start": {
+            "inputType": "ptrange",
+            "minX": "CANVASL",
+            "maxX": "CANVASR",
+            "minY": "CANVASB",
+            "maxY": "CANVAST",
             "showValue": "true"
         },
-        "startY": {
-            "inputType": "range",
-            "min": "CANVASB",
-            "max": "CANVAST",
-            "showValue": "true"
-        },
-        "endX": {
-            "inputType": "range",
-            "min": "CANVASL",
-            "max": "CANVASR",
-            "showValue": "true"
-        },
-        "endY": {
-            "inputType": "range",
-            "min": "CANVASB",
-            "max": "CANVAST",
+        "end": {
+            "inputType": "ptrange",
+            "minX": "CANVASL",
+            "maxX": "CANVASR",
+            "minY": "CANVASB",
+            "maxY": "CANVAST",
             "showValue": "true"
         },
         "thickness": {
@@ -48,7 +40,7 @@
         },
         "arrowheadStyle": {
             "inputType": "select",
-            "options": ["arrowhead-1", "arrowhead-2"],
+            "options": ["arrowhead-2", "arrowhead-1"],
             "showValue": "false"
         }
     }

--- a/penrose-web/src/inspector/views/mod/shapedefs/circle.json
+++ b/penrose-web/src/inspector/views/mod/shapedefs/circle.json
@@ -1,16 +1,12 @@
 {
     "shapeType": "Circle",
     "properties": {
-        "x": {
-            "inputType": "range",
-            "min": "CANVASL",
-            "max": "CANVASR",
-            "showValue": "true"
-        },
-        "y": {
-            "inputType": "range",
-            "min": "CANVASB",
-            "max": "CANVAST",
+        "center": {
+            "inputType": "ptrange",
+            "minX": "CANVASL",
+            "maxX": "CANVASR",
+            "minY": "CANVASB",
+            "maxY": "CANVAST",
             "showValue": "true"
         },
         "r": {

--- a/penrose-web/src/inspector/views/mod/shapedefs/curve.json
+++ b/penrose-web/src/inspector/views/mod/shapedefs/curve.json
@@ -46,7 +46,7 @@
             "showValue": "false"
         },
         "pathData": {
-            "inputType": "ptrange",
+            "inputType": "mulptrange",
             "showValue": "true",
             "minX": "CANVASL",
             "maxX": "CANVASR",

--- a/penrose-web/src/inspector/views/mod/shapedefs/ellipse.json
+++ b/penrose-web/src/inspector/views/mod/shapedefs/ellipse.json
@@ -1,16 +1,12 @@
 {
     "shapeType": "Ellipse",
     "properties": {
-        "x": {
-            "inputType": "range",
-            "min": "CANVASL",
-            "max": "CANVASR",
-            "showValue": "true"
-        },
-        "y": {
-            "inputType": "range",
-            "min": "CANVASB",
-            "max": "CANVAST",
+        "center": {
+            "inputType": "ptrange",
+            "minX": "CANVASL",
+            "maxX": "CANVASR",
+            "minY": "CANVASB",
+            "maxY": "CANVAST",
             "showValue": "true"
         },
         "rx": {

--- a/penrose-web/src/inspector/views/mod/shapedefs/image.json
+++ b/penrose-web/src/inspector/views/mod/shapedefs/image.json
@@ -1,16 +1,12 @@
 {
     "shapeType": "Image",
     "properties": {
-        "x": {
-            "inputType": "range",
-            "min": "CANVASL",
-            "max": "CANVASR",
-            "showValue": "true"
-        },
-        "y": {
-            "inputType": "range",
-            "min": "CANVASB",
-            "max": "CANVAST",
+        "center": {
+            "inputType": "ptrange",
+            "minX": "CANVASL",
+            "maxX": "CANVASR",
+            "minY": "CANVASB",
+            "maxY": "CANVAST",
             "showValue": "true"
         },
         "w": {

--- a/penrose-web/src/inspector/views/mod/shapedefs/line.json
+++ b/penrose-web/src/inspector/views/mod/shapedefs/line.json
@@ -1,28 +1,20 @@
 {
     "shapeType": "Line",
     "properties": {
-        "startX": {
-            "inputType": "range",
-            "min": "CANVASL",
-            "max": "CANVASR",
+        "start": {
+            "inputType": "ptrange",
+            "minX": "CANVASL",
+            "maxX": "CANVASR",
+            "minY": "CANVASB",
+            "maxY": "CANVAST",
             "showValue": "true"
         },
-        "startY": {
-            "inputType": "range",
-            "min": "CANVASB",
-            "max": "CANVAST",
-            "showValue": "true"
-        },
-        "endX": {
-            "inputType": "range",
-            "min": "CANVASL",
-            "max": "CANVASR",
-            "showValue": "true"
-        },
-        "endY": {
-            "inputType": "range",
-            "min": "CANVASB",
-            "max": "CANVAST",
+        "end": {
+            "inputType": "ptrange",
+            "minX": "CANVASL",
+            "maxX": "CANVASR",
+            "minY": "CANVASB",
+            "maxY": "CANVAST",
             "showValue": "true"
         },
         "thickness": {
@@ -48,7 +40,7 @@
         },
         "arrowheadStyle": {
             "inputType": "select",
-            "options": ["arrowhead-1", "arrowhead-2"],
+            "options": ["arrowhead-2", "arrowhead-1"],
             "showValue": "false"
         },
         "leftArrowhead": {

--- a/penrose-web/src/inspector/views/mod/shapedefs/rectangle.json
+++ b/penrose-web/src/inspector/views/mod/shapedefs/rectangle.json
@@ -1,16 +1,12 @@
 {
     "shapeType": "Rectangle",
     "properties": {
-        "x": {
-            "inputType": "range",
-            "min": "CANVASL",
-            "max": "CANVASR",
-            "showValue": "true"
-        },
-        "y": {
-            "inputType": "range",
-            "min": "CANVASB",
-            "max": "CANVAST",
+        "center": {
+            "inputType": "ptrange",
+            "minX": "CANVASL",
+            "maxX": "CANVASR",
+            "minY": "CANVASB",
+            "maxY": "CANVAST",
             "showValue": "true"
         },
         "w": {

--- a/penrose-web/src/inspector/views/mod/shapedefs/square.json
+++ b/penrose-web/src/inspector/views/mod/shapedefs/square.json
@@ -1,16 +1,12 @@
 {
     "shapeType": "Square",
     "properties": {
-        "x": {
-            "inputType": "range",
-            "min": "CANVASL",
-            "max": "CANVASR",
-            "showValue": "true"
-        },
-        "y": {
-            "inputType": "range",
-            "min": "CANVASB",
-            "max": "CANVAST",
+        "center": {
+            "inputType": "ptrange",
+            "minX": "CANVASL",
+            "maxX": "CANVASR",
+            "minY": "CANVASB",
+            "maxY": "CANVAST",
             "showValue": "true"
         },
         "side": {

--- a/penrose-web/src/inspector/views/mod/shapedefs/text.json
+++ b/penrose-web/src/inspector/views/mod/shapedefs/text.json
@@ -1,16 +1,12 @@
 {
     "shapeType": "Text",
     "properties": {
-        "x": {
-            "inputType": "range",
-            "min": "CANVASL",
-            "max": "CANVASR",
-            "showValue": "true"
-        },
-        "y": {
-            "inputType": "range",
-            "min": "CANVASB",
-            "max": "CANVAST",
+        "center": {
+            "inputType": "ptrange",
+            "minX": "CANVASL",
+            "maxX": "CANVASR",
+            "minY": "CANVASB",
+            "maxY": "CANVAST",
             "showValue": "true"
         },
         "w": {


### PR DESCRIPTION
# Description

Related issues: #409 

Shape definitions were changed in `ShapeDef.ts`, and the JSON shapedef files for the Mod tab no longer worked. I've updated them to match the new definitions and also added necessary support to render them in `LabeledInput.tsx`. 

# Examples with steps to reproduce them

The new changes fixed the original issue (`linear-algebra-domain/twoVectorsPerp.sub linear-algebra-domain/linear-algebra-paper-simple.sty linear-algebra-domain/linear-algebra.dsl`), and I also tested it on the first few example diagrams [here](https://github.com/penrose/penrose/wiki/Example-diagrams). 

# Checklist

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I ran [Haddock](https://github.com/penrose/penrose/wiki/Writing-and-generating-documentation#generating-html-documentation-site) and there were no errors when generating the HTML site
- [x] My changes generate no new warnings
- [x] New and existing tests pass locally using `stack test`
- [x] My code follows the style guidelines of this project (e.g.: no HLint warnings)


