### PR TITLE
Porting the Domain parser and semantic checker

### DIFF
--- a/penrose-web/package-lock.json
+++ b/penrose-web/package-lock.json
@@ -1789,61 +1789,6 @@
         "slash": "^2.0.0"
       }
     },
-    "@jest/core": {
-      "version": "24.9.0",
-      "resolved": "https://registry.npmjs.org/@jest/core/-/core-24.9.0.tgz",
-      "integrity": "sha512-Fogg3s4wlAr1VX7q+rhV9RVnUv5tD7VuWfYy1+whMiWUrvl7U3QJSJyWcDio9Lq2prqYsZaeTv2Rz24pWGkJ2A==",
-      "requires": {
-        "@jest/console": "^24.7.1",
-        "@jest/reporters": "^24.9.0",
-        "@jest/test-result": "^24.9.0",
-        "@jest/transform": "^24.9.0",
-        "@jest/types": "^24.9.0",
-        "ansi-escapes": "^3.0.0",
-        "chalk": "^2.0.1",
-        "exit": "^0.1.2",
-        "graceful-fs": "^4.1.15",
-        "jest-changed-files": "^24.9.0",
-        "jest-config": "^24.9.0",
-        "jest-haste-map": "^24.9.0",
-        "jest-message-util": "^24.9.0",
-        "jest-regex-util": "^24.3.0",
-        "jest-resolve": "^24.9.0",
-        "jest-resolve-dependencies": "^24.9.0",
-        "jest-runner": "^24.9.0",
-        "jest-runtime": "^24.9.0",
-        "jest-snapshot": "^24.9.0",
-        "jest-util": "^24.9.0",
-        "jest-validate": "^24.9.0",
-        "jest-watcher": "^24.9.0",
-        "micromatch": "^3.1.10",
-        "p-each-series": "^1.0.0",
-        "realpath-native": "^1.1.0",
-        "rimraf": "^2.5.4",
-        "slash": "^2.0.0",
-        "strip-ansi": "^5.0.0"
-      },
-      "dependencies": {
-        "ansi-escapes": {
-          "version": "3.2.0",
-          "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-3.2.0.tgz",
-          "integrity": "sha512-cBhpre4ma+U0T1oM5fXg7Dy1Jw7zzwv7lt/GoCpr+hDQJoYnKVPLL4dCvSEFMmQurOQvSrwT7SL/DAlhBI97RQ=="
-        },
-        "ansi-regex": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
-          "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg=="
-        },
-        "strip-ansi": {
-          "version": "5.2.0",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
-          "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
-          "requires": {
-            "ansi-regex": "^4.1.0"
-          }
-        }
-      }
-    },
     "@jest/environment": {
       "version": "24.9.0",
       "resolved": "https://registry.npmjs.org/@jest/environment/-/environment-24.9.0.tgz",
@@ -1863,41 +1808,6 @@
         "@jest/types": "^24.9.0",
         "jest-message-util": "^24.9.0",
         "jest-mock": "^24.9.0"
-      }
-    },
-    "@jest/reporters": {
-      "version": "24.9.0",
-      "resolved": "https://registry.npmjs.org/@jest/reporters/-/reporters-24.9.0.tgz",
-      "integrity": "sha512-mu4X0yjaHrffOsWmVLzitKmmmWSQ3GGuefgNscUSWNiUNcEOSEQk9k3pERKEQVBb0Cnn88+UESIsZEMH3o88Gw==",
-      "requires": {
-        "@jest/environment": "^24.9.0",
-        "@jest/test-result": "^24.9.0",
-        "@jest/transform": "^24.9.0",
-        "@jest/types": "^24.9.0",
-        "chalk": "^2.0.1",
-        "exit": "^0.1.2",
-        "glob": "^7.1.2",
-        "istanbul-lib-coverage": "^2.0.2",
-        "istanbul-lib-instrument": "^3.0.1",
-        "istanbul-lib-report": "^2.0.4",
-        "istanbul-lib-source-maps": "^3.0.1",
-        "istanbul-reports": "^2.2.6",
-        "jest-haste-map": "^24.9.0",
-        "jest-resolve": "^24.9.0",
-        "jest-runtime": "^24.9.0",
-        "jest-util": "^24.9.0",
-        "jest-worker": "^24.6.0",
-        "node-notifier": "^5.4.2",
-        "slash": "^2.0.0",
-        "source-map": "^0.6.0",
-        "string-length": "^2.0.0"
-      },
-      "dependencies": {
-        "source-map": {
-          "version": "0.6.1",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
-        }
       }
     },
     "@jest/source-map": {
@@ -1930,17 +1840,6 @@
         "@jest/console": "^24.9.0",
         "@jest/types": "^24.9.0",
         "@types/istanbul-lib-coverage": "^2.0.0"
-      }
-    },
-    "@jest/test-sequencer": {
-      "version": "24.9.0",
-      "resolved": "https://registry.npmjs.org/@jest/test-sequencer/-/test-sequencer-24.9.0.tgz",
-      "integrity": "sha512-6qqsU4o0kW1dvA95qfNog8v8gkRN9ph6Lz7r96IvZpHdNipP2cBcb07J1Z45mz/VIS01OHJ3pY8T5fUY38tg4A==",
-      "requires": {
-        "@jest/test-result": "^24.9.0",
-        "jest-haste-map": "^24.9.0",
-        "jest-runner": "^24.9.0",
-        "jest-runtime": "^24.9.0"
       }
     },
     "@jest/transform": {
@@ -2384,7 +2283,6 @@
       "version": "26.0.19",
       "resolved": "https://registry.npmjs.org/@types/jest/-/jest-26.0.19.tgz",
       "integrity": "sha512-jqHoirTG61fee6v6rwbnEuKhpSKih0tuhqeFbCmMmErhtu3BYlOZaXWjffgOstMM4S/3iQD31lI5bGLTrs97yQ==",
-      "dev": true,
       "requires": {
         "jest-diff": "^26.0.0",
         "pretty-format": "^26.0.0"
@@ -2394,7 +2292,6 @@
           "version": "26.6.2",
           "resolved": "https://registry.npmjs.org/@jest/types/-/types-26.6.2.tgz",
           "integrity": "sha512-fC6QCp7Sc5sX6g8Tvbmj4XUTbyrik0akgRy03yjXbQaBWWNWGE7SGtJk98m0N8nzegD/7SggrUlivxo5ax4KWQ==",
-          "dev": true,
           "requires": {
             "@types/istanbul-lib-coverage": "^2.0.0",
             "@types/istanbul-reports": "^3.0.0",
@@ -2407,7 +2304,6 @@
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/@types/istanbul-reports/-/istanbul-reports-3.0.0.tgz",
           "integrity": "sha512-nwKNbvnwJ2/mndE9ItP/zc2TCzw6uuodnF4EHYWD+gCQDVBuRQL5UzbZD0/ezy1iKsFU2ZQiDqg4M9dN4+wZgA==",
-          "dev": true,
           "requires": {
             "@types/istanbul-lib-report": "*"
           }
@@ -2416,7 +2312,6 @@
           "version": "15.0.11",
           "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.11.tgz",
           "integrity": "sha512-jfcNBxHFYJ4nPIacsi3woz1+kvUO6s1CyeEhtnDHBjHUMNj5UlW2GynmnSgiJJEdNg9yW5C8lfoNRZrHGv5EqA==",
-          "dev": true,
           "requires": {
             "@types/yargs-parser": "*"
           }
@@ -2424,14 +2319,12 @@
         "ansi-regex": {
           "version": "5.0.0",
           "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
-          "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
-          "dev": true
+          "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg=="
         },
         "ansi-styles": {
           "version": "4.3.0",
           "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
           "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-          "dev": true,
           "requires": {
             "color-convert": "^2.0.1"
           }
@@ -2440,7 +2333,6 @@
           "version": "4.1.0",
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
           "integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
-          "dev": true,
           "requires": {
             "ansi-styles": "^4.1.0",
             "supports-color": "^7.1.0"
@@ -2450,7 +2342,6 @@
           "version": "2.0.1",
           "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
           "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-          "dev": true,
           "requires": {
             "color-name": "~1.1.4"
           }
@@ -2458,26 +2349,22 @@
         "color-name": {
           "version": "1.1.4",
           "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-          "dev": true
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
         },
         "diff-sequences": {
           "version": "26.6.2",
           "resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-26.6.2.tgz",
-          "integrity": "sha512-Mv/TDa3nZ9sbc5soK+OoA74BsS3mL37yixCvUAQkiuA4Wz6YtwP/K47n2rv2ovzHZvoiQeA5FTQOschKkEwB0Q==",
-          "dev": true
+          "integrity": "sha512-Mv/TDa3nZ9sbc5soK+OoA74BsS3mL37yixCvUAQkiuA4Wz6YtwP/K47n2rv2ovzHZvoiQeA5FTQOschKkEwB0Q=="
         },
         "has-flag": {
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-          "dev": true
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="
         },
         "jest-diff": {
           "version": "26.6.2",
           "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-26.6.2.tgz",
           "integrity": "sha512-6m+9Z3Gv9wN0WFVasqjCL/06+EFCMTqDEUl/b87HYK2rAPTyfz4ZIuSlPhY51PIQRWx5TaxeF1qmXKe9gfN3sA==",
-          "dev": true,
           "requires": {
             "chalk": "^4.0.0",
             "diff-sequences": "^26.6.2",
@@ -2488,14 +2375,12 @@
         "jest-get-type": {
           "version": "26.3.0",
           "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-26.3.0.tgz",
-          "integrity": "sha512-TpfaviN1R2pQWkIihlfEanwOXK0zcxrKEE4MlU6Tn7keoXdN6/3gK/xl0yEh8DOunn5pOVGKf8hB4R9gVh04ig==",
-          "dev": true
+          "integrity": "sha512-TpfaviN1R2pQWkIihlfEanwOXK0zcxrKEE4MlU6Tn7keoXdN6/3gK/xl0yEh8DOunn5pOVGKf8hB4R9gVh04ig=="
         },
         "pretty-format": {
           "version": "26.6.2",
           "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-26.6.2.tgz",
           "integrity": "sha512-7AeGuCYNGmycyQbCqd/3PWH4eOoX/OiCa0uphp57NVTeAGdJGaAliecxwBDHYQCIvrW7aDBZCYeNTP/WX69mkg==",
-          "dev": true,
           "requires": {
             "@jest/types": "^26.6.2",
             "ansi-regex": "^5.0.0",
@@ -2506,14 +2391,12 @@
         "react-is": {
           "version": "17.0.1",
           "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.1.tgz",
-          "integrity": "sha512-NAnt2iGDXohE5LI7uBnLnqvLQMtzhkiAOLXTmv+qnF9Ky7xAPcX8Up/xWIhxvLVGJvuLiNc4xQLtuqDRzb4fSA==",
-          "dev": true
+          "integrity": "sha512-NAnt2iGDXohE5LI7uBnLnqvLQMtzhkiAOLXTmv+qnF9Ky7xAPcX8Up/xWIhxvLVGJvuLiNc4xQLtuqDRzb4fSA=="
         },
         "supports-color": {
           "version": "7.2.0",
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
           "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-          "dev": true,
           "requires": {
             "has-flag": "^4.0.0"
           }
@@ -4546,6 +4429,14 @@
         "node-releases": "^1.1.61"
       }
     },
+    "bs-logger": {
+      "version": "0.2.6",
+      "resolved": "https://registry.npmjs.org/bs-logger/-/bs-logger-0.2.6.tgz",
+      "integrity": "sha512-pd8DCoxmbgc7hyPKOvxtqNcjYoOsABPQdcCUjGp3d42VR2CX1ORhk2A87oqqu5R1kk+76nsxZupkmyd+MVtCog==",
+      "requires": {
+        "fast-json-stable-stringify": "2.x"
+      }
+    },
     "bser": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/bser/-/bser-2.1.1.tgz",
@@ -6187,11 +6078,6 @@
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-1.0.3.tgz",
       "integrity": "sha1-+hN8S9aY7fVc1c0CrFWfkaTEups="
     },
-    "detect-newline": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/detect-newline/-/detect-newline-2.1.0.tgz",
-      "integrity": "sha1-9B8cEL5LAOh7XxPaaAdZ8sW/0+I="
-    },
     "detect-node": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/detect-node/-/detect-node-2.0.4.tgz",
@@ -6225,11 +6111,6 @@
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
       "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A=="
-    },
-    "diff-sequences": {
-      "version": "24.9.0",
-      "resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-24.9.0.tgz",
-      "integrity": "sha512-Dj6Wk3tWyTE+Fo1rW8v0Xhwk80um6yFYKbuAxc9c3EZxIHFDYwbi34Uk42u1CdnIiVorvt4RmlSDjIPyzGC2ew=="
     },
     "diffie-hellman": {
       "version": "5.0.3",
@@ -7780,19 +7661,6 @@
           "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
           "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
         }
-      }
-    },
-    "expect": {
-      "version": "24.9.0",
-      "resolved": "https://registry.npmjs.org/expect/-/expect-24.9.0.tgz",
-      "integrity": "sha512-wvVAx8XIol3Z5m9zvZXiyZOQ+sRJqNTIm6sGjdWlaZIeupQGO3WbYI+15D/AmEwZywL6wtJkbAbJtzkOfBuR0Q==",
-      "requires": {
-        "@jest/types": "^24.9.0",
-        "ansi-styles": "^3.2.0",
-        "jest-get-type": "^24.9.0",
-        "jest-matcher-utils": "^24.9.0",
-        "jest-message-util": "^24.9.0",
-        "jest-regex-util": "^24.9.0"
       }
     },
     "express": {
@@ -9621,162 +9489,6 @@
         }
       }
     },
-    "istanbul-lib-report": {
-      "version": "2.0.8",
-      "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-2.0.8.tgz",
-      "integrity": "sha512-fHBeG573EIihhAblwgxrSenp0Dby6tJMFR/HvlerBsrCTD5bkUuoNtn3gVh29ZCS824cGGBPn7Sg7cNk+2xUsQ==",
-      "requires": {
-        "istanbul-lib-coverage": "^2.0.5",
-        "make-dir": "^2.1.0",
-        "supports-color": "^6.1.0"
-      },
-      "dependencies": {
-        "supports-color": {
-          "version": "6.1.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
-          "integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
-          "requires": {
-            "has-flag": "^3.0.0"
-          }
-        }
-      }
-    },
-    "istanbul-lib-source-maps": {
-      "version": "3.0.6",
-      "resolved": "https://registry.npmjs.org/istanbul-lib-source-maps/-/istanbul-lib-source-maps-3.0.6.tgz",
-      "integrity": "sha512-R47KzMtDJH6X4/YW9XTx+jrLnZnscW4VpNN+1PViSYTejLVPWv7oov+Duf8YQSPyVRUvueQqz1TcsC6mooZTXw==",
-      "requires": {
-        "debug": "^4.1.1",
-        "istanbul-lib-coverage": "^2.0.5",
-        "make-dir": "^2.1.0",
-        "rimraf": "^2.6.3",
-        "source-map": "^0.6.1"
-      },
-      "dependencies": {
-        "source-map": {
-          "version": "0.6.1",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
-        }
-      }
-    },
-    "istanbul-reports": {
-      "version": "2.2.7",
-      "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-2.2.7.tgz",
-      "integrity": "sha512-uu1F/L1o5Y6LzPVSVZXNOoD/KXpJue9aeLRd0sM9uMXfZvzomB0WxVamWb5ue8kA2vVWEmW7EG+A5n3f1kqHKg==",
-      "requires": {
-        "html-escaper": "^2.0.0"
-      }
-    },
-    "jest": {
-      "version": "24.9.0",
-      "resolved": "https://registry.npmjs.org/jest/-/jest-24.9.0.tgz",
-      "integrity": "sha512-YvkBL1Zm7d2B1+h5fHEOdyjCG+sGMz4f8D86/0HiqJ6MB4MnDc8FgP5vdWsGnemOQro7lnYo8UakZ3+5A0jxGw==",
-      "requires": {
-        "import-local": "^2.0.0",
-        "jest-cli": "^24.9.0"
-      },
-      "dependencies": {
-        "jest-cli": {
-          "version": "24.9.0",
-          "resolved": "https://registry.npmjs.org/jest-cli/-/jest-cli-24.9.0.tgz",
-          "integrity": "sha512-+VLRKyitT3BWoMeSUIHRxV/2g8y9gw91Jh5z2UmXZzkZKpbC08CSehVxgHUwTpy+HwGcns/tqafQDJW7imYvGg==",
-          "requires": {
-            "@jest/core": "^24.9.0",
-            "@jest/test-result": "^24.9.0",
-            "@jest/types": "^24.9.0",
-            "chalk": "^2.0.1",
-            "exit": "^0.1.2",
-            "import-local": "^2.0.0",
-            "is-ci": "^2.0.0",
-            "jest-config": "^24.9.0",
-            "jest-util": "^24.9.0",
-            "jest-validate": "^24.9.0",
-            "prompts": "^2.0.1",
-            "realpath-native": "^1.1.0",
-            "yargs": "^13.3.0"
-          }
-        }
-      }
-    },
-    "jest-changed-files": {
-      "version": "24.9.0",
-      "resolved": "https://registry.npmjs.org/jest-changed-files/-/jest-changed-files-24.9.0.tgz",
-      "integrity": "sha512-6aTWpe2mHF0DhL28WjdkO8LyGjs3zItPET4bMSeXU6T3ub4FPMw+mcOcbdGXQOAfmLcxofD23/5Bl9Z4AkFwqg==",
-      "requires": {
-        "@jest/types": "^24.9.0",
-        "execa": "^1.0.0",
-        "throat": "^4.0.0"
-      }
-    },
-    "jest-config": {
-      "version": "24.9.0",
-      "resolved": "https://registry.npmjs.org/jest-config/-/jest-config-24.9.0.tgz",
-      "integrity": "sha512-RATtQJtVYQrp7fvWg6f5y3pEFj9I+H8sWw4aKxnDZ96mob5i5SD6ZEGWgMLXQ4LE8UurrjbdlLWdUeo+28QpfQ==",
-      "requires": {
-        "@babel/core": "^7.1.0",
-        "@jest/test-sequencer": "^24.9.0",
-        "@jest/types": "^24.9.0",
-        "babel-jest": "^24.9.0",
-        "chalk": "^2.0.1",
-        "glob": "^7.1.1",
-        "jest-environment-jsdom": "^24.9.0",
-        "jest-environment-node": "^24.9.0",
-        "jest-get-type": "^24.9.0",
-        "jest-jasmine2": "^24.9.0",
-        "jest-regex-util": "^24.3.0",
-        "jest-resolve": "^24.9.0",
-        "jest-util": "^24.9.0",
-        "jest-validate": "^24.9.0",
-        "micromatch": "^3.1.10",
-        "pretty-format": "^24.9.0",
-        "realpath-native": "^1.1.0"
-      }
-    },
-    "jest-diff": {
-      "version": "24.9.0",
-      "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-24.9.0.tgz",
-      "integrity": "sha512-qMfrTs8AdJE2iqrTp0hzh7kTd2PQWrsFyj9tORoKmu32xjPjeE4NyjVRDz8ybYwqS2ik8N4hsIpiVTyFeo2lBQ==",
-      "requires": {
-        "chalk": "^2.0.1",
-        "diff-sequences": "^24.9.0",
-        "jest-get-type": "^24.9.0",
-        "pretty-format": "^24.9.0"
-      }
-    },
-    "jest-docblock": {
-      "version": "24.9.0",
-      "resolved": "https://registry.npmjs.org/jest-docblock/-/jest-docblock-24.9.0.tgz",
-      "integrity": "sha512-F1DjdpDMJMA1cN6He0FNYNZlo3yYmOtRUnktrT9Q37njYzC5WEaDdmbynIgy0L/IvXvvgsG8OsqhLPXTpfmZAA==",
-      "requires": {
-        "detect-newline": "^2.1.0"
-      }
-    },
-    "jest-each": {
-      "version": "24.9.0",
-      "resolved": "https://registry.npmjs.org/jest-each/-/jest-each-24.9.0.tgz",
-      "integrity": "sha512-ONi0R4BvW45cw8s2Lrx8YgbeXL1oCQ/wIDwmsM3CqM/nlblNCPmnC3IPQlMbRFZu3wKdQ2U8BqM6lh3LJ5Bsog==",
-      "requires": {
-        "@jest/types": "^24.9.0",
-        "chalk": "^2.0.1",
-        "jest-get-type": "^24.9.0",
-        "jest-util": "^24.9.0",
-        "pretty-format": "^24.9.0"
-      }
-    },
-    "jest-environment-jsdom": {
-      "version": "24.9.0",
-      "resolved": "https://registry.npmjs.org/jest-environment-jsdom/-/jest-environment-jsdom-24.9.0.tgz",
-      "integrity": "sha512-Zv9FV9NBRzLuALXjvRijO2351DRQeLYXtpD4xNvfoVFw21IOKNhZAEUKcbiEtjTkm2GsJ3boMVgkaR7rN8qetA==",
-      "requires": {
-        "@jest/environment": "^24.9.0",
-        "@jest/fake-timers": "^24.9.0",
-        "@jest/types": "^24.9.0",
-        "jest-mock": "^24.9.0",
-        "jest-util": "^24.9.0",
-        "jsdom": "^11.5.1"
-      }
-    },
     "jest-environment-jsdom-fourteen": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/jest-environment-jsdom-fourteen/-/jest-environment-jsdom-fourteen-1.0.1.tgz",
@@ -9853,23 +9565,6 @@
         }
       }
     },
-    "jest-environment-node": {
-      "version": "24.9.0",
-      "resolved": "https://registry.npmjs.org/jest-environment-node/-/jest-environment-node-24.9.0.tgz",
-      "integrity": "sha512-6d4V2f4nxzIzwendo27Tr0aFm+IXWa0XEUnaH6nU0FMaozxovt+sfRvh4J47wL1OvF83I3SSTu0XK+i4Bqe7uA==",
-      "requires": {
-        "@jest/environment": "^24.9.0",
-        "@jest/fake-timers": "^24.9.0",
-        "@jest/types": "^24.9.0",
-        "jest-mock": "^24.9.0",
-        "jest-util": "^24.9.0"
-      }
-    },
-    "jest-get-type": {
-      "version": "24.9.0",
-      "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-24.9.0.tgz",
-      "integrity": "sha512-lUseMzAley4LhIcpSP9Jf+fTrQ4a1yHQwLNeeVa2cEmbCGeoZAtYPOIv8JaxLD/sUpKxetKGP+gsHl8f8TSj8Q=="
-    },
     "jest-haste-map": {
       "version": "24.9.0",
       "resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-24.9.0.tgz",
@@ -9899,49 +9594,6 @@
             "nan": "^2.12.1"
           }
         }
-      }
-    },
-    "jest-jasmine2": {
-      "version": "24.9.0",
-      "resolved": "https://registry.npmjs.org/jest-jasmine2/-/jest-jasmine2-24.9.0.tgz",
-      "integrity": "sha512-Cq7vkAgaYKp+PsX+2/JbTarrk0DmNhsEtqBXNwUHkdlbrTBLtMJINADf2mf5FkowNsq8evbPc07/qFO0AdKTzw==",
-      "requires": {
-        "@babel/traverse": "^7.1.0",
-        "@jest/environment": "^24.9.0",
-        "@jest/test-result": "^24.9.0",
-        "@jest/types": "^24.9.0",
-        "chalk": "^2.0.1",
-        "co": "^4.6.0",
-        "expect": "^24.9.0",
-        "is-generator-fn": "^2.0.0",
-        "jest-each": "^24.9.0",
-        "jest-matcher-utils": "^24.9.0",
-        "jest-message-util": "^24.9.0",
-        "jest-runtime": "^24.9.0",
-        "jest-snapshot": "^24.9.0",
-        "jest-util": "^24.9.0",
-        "pretty-format": "^24.9.0",
-        "throat": "^4.0.0"
-      }
-    },
-    "jest-leak-detector": {
-      "version": "24.9.0",
-      "resolved": "https://registry.npmjs.org/jest-leak-detector/-/jest-leak-detector-24.9.0.tgz",
-      "integrity": "sha512-tYkFIDsiKTGwb2FG1w8hX9V0aUb2ot8zY/2nFg087dUageonw1zrLMP4W6zsRO59dPkTSKie+D4rhMuP9nRmrA==",
-      "requires": {
-        "jest-get-type": "^24.9.0",
-        "pretty-format": "^24.9.0"
-      }
-    },
-    "jest-matcher-utils": {
-      "version": "24.9.0",
-      "resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-24.9.0.tgz",
-      "integrity": "sha512-OZz2IXsu6eaiMAwe67c1T+5tUAtQyQx27/EMEkbFAGiw52tB9em+uGbzpcgYVpA8wl0hlxKPZxrly4CXU/GjHA==",
-      "requires": {
-        "chalk": "^2.0.1",
-        "jest-diff": "^24.9.0",
-        "jest-get-type": "^24.9.0",
-        "pretty-format": "^24.9.0"
       }
     },
     "jest-message-util": {
@@ -9989,115 +9641,10 @@
         "realpath-native": "^1.1.0"
       }
     },
-    "jest-resolve-dependencies": {
-      "version": "24.9.0",
-      "resolved": "https://registry.npmjs.org/jest-resolve-dependencies/-/jest-resolve-dependencies-24.9.0.tgz",
-      "integrity": "sha512-Fm7b6AlWnYhT0BXy4hXpactHIqER7erNgIsIozDXWl5dVm+k8XdGVe1oTg1JyaFnOxarMEbax3wyRJqGP2Pq+g==",
-      "requires": {
-        "@jest/types": "^24.9.0",
-        "jest-regex-util": "^24.3.0",
-        "jest-snapshot": "^24.9.0"
-      }
-    },
-    "jest-runner": {
-      "version": "24.9.0",
-      "resolved": "https://registry.npmjs.org/jest-runner/-/jest-runner-24.9.0.tgz",
-      "integrity": "sha512-KksJQyI3/0mhcfspnxxEOBueGrd5E4vV7ADQLT9ESaCzz02WnbdbKWIf5Mkaucoaj7obQckYPVX6JJhgUcoWWg==",
-      "requires": {
-        "@jest/console": "^24.7.1",
-        "@jest/environment": "^24.9.0",
-        "@jest/test-result": "^24.9.0",
-        "@jest/types": "^24.9.0",
-        "chalk": "^2.4.2",
-        "exit": "^0.1.2",
-        "graceful-fs": "^4.1.15",
-        "jest-config": "^24.9.0",
-        "jest-docblock": "^24.3.0",
-        "jest-haste-map": "^24.9.0",
-        "jest-jasmine2": "^24.9.0",
-        "jest-leak-detector": "^24.9.0",
-        "jest-message-util": "^24.9.0",
-        "jest-resolve": "^24.9.0",
-        "jest-runtime": "^24.9.0",
-        "jest-util": "^24.9.0",
-        "jest-worker": "^24.6.0",
-        "source-map-support": "^0.5.6",
-        "throat": "^4.0.0"
-      },
-      "dependencies": {
-        "chalk": {
-          "version": "2.4.2",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
-          "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-          "requires": {
-            "ansi-styles": "^3.2.1",
-            "escape-string-regexp": "^1.0.5",
-            "supports-color": "^5.3.0"
-          }
-        }
-      }
-    },
-    "jest-runtime": {
-      "version": "24.9.0",
-      "resolved": "https://registry.npmjs.org/jest-runtime/-/jest-runtime-24.9.0.tgz",
-      "integrity": "sha512-8oNqgnmF3v2J6PVRM2Jfuj8oX3syKmaynlDMMKQ4iyzbQzIG6th5ub/lM2bCMTmoTKM3ykcUYI2Pw9xwNtjMnw==",
-      "requires": {
-        "@jest/console": "^24.7.1",
-        "@jest/environment": "^24.9.0",
-        "@jest/source-map": "^24.3.0",
-        "@jest/transform": "^24.9.0",
-        "@jest/types": "^24.9.0",
-        "@types/yargs": "^13.0.0",
-        "chalk": "^2.0.1",
-        "exit": "^0.1.2",
-        "glob": "^7.1.3",
-        "graceful-fs": "^4.1.15",
-        "jest-config": "^24.9.0",
-        "jest-haste-map": "^24.9.0",
-        "jest-message-util": "^24.9.0",
-        "jest-mock": "^24.9.0",
-        "jest-regex-util": "^24.3.0",
-        "jest-resolve": "^24.9.0",
-        "jest-snapshot": "^24.9.0",
-        "jest-util": "^24.9.0",
-        "jest-validate": "^24.9.0",
-        "realpath-native": "^1.1.0",
-        "slash": "^2.0.0",
-        "strip-bom": "^3.0.0",
-        "yargs": "^13.3.0"
-      }
-    },
     "jest-serializer": {
       "version": "24.9.0",
       "resolved": "https://registry.npmjs.org/jest-serializer/-/jest-serializer-24.9.0.tgz",
       "integrity": "sha512-DxYipDr8OvfrKH3Kel6NdED3OXxjvxXZ1uIY2I9OFbGg+vUkkg7AGvi65qbhbWNPvDckXmzMPbK3u3HaDO49bQ=="
-    },
-    "jest-snapshot": {
-      "version": "24.9.0",
-      "resolved": "https://registry.npmjs.org/jest-snapshot/-/jest-snapshot-24.9.0.tgz",
-      "integrity": "sha512-uI/rszGSs73xCM0l+up7O7a40o90cnrk429LOiK3aeTvfC0HHmldbd81/B7Ix81KSFe1lwkbl7GnBGG4UfuDew==",
-      "requires": {
-        "@babel/types": "^7.0.0",
-        "@jest/types": "^24.9.0",
-        "chalk": "^2.0.1",
-        "expect": "^24.9.0",
-        "jest-diff": "^24.9.0",
-        "jest-get-type": "^24.9.0",
-        "jest-matcher-utils": "^24.9.0",
-        "jest-message-util": "^24.9.0",
-        "jest-resolve": "^24.9.0",
-        "mkdirp": "^0.5.1",
-        "natural-compare": "^1.4.0",
-        "pretty-format": "^24.9.0",
-        "semver": "^6.2.0"
-      },
-      "dependencies": {
-        "semver": {
-          "version": "6.3.0",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
-        }
-      }
     },
     "jest-util": {
       "version": "24.9.0",
@@ -10128,19 +9675,6 @@
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
           "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
         }
-      }
-    },
-    "jest-validate": {
-      "version": "24.9.0",
-      "resolved": "https://registry.npmjs.org/jest-validate/-/jest-validate-24.9.0.tgz",
-      "integrity": "sha512-HPIt6C5ACwiqSiwi+OfSSHbK8sG7akG8eATl+IPKaeIjtPOeBUd/g3J7DghugzxrGjI93qS/+RPKe1H6PqvhRQ==",
-      "requires": {
-        "@jest/types": "^24.9.0",
-        "camelcase": "^5.3.1",
-        "chalk": "^2.0.1",
-        "jest-get-type": "^24.9.0",
-        "leven": "^3.1.0",
-        "pretty-format": "^24.9.0"
       }
     },
     "jest-watch-typeahead": {
@@ -10250,46 +9784,6 @@
       "resolved": "https://registry.npmjs.org/jsdoctypeparser/-/jsdoctypeparser-9.0.0.tgz",
       "integrity": "sha512-jrTA2jJIL6/DAEILBEh2/w9QxCuwmvNXIry39Ay/HVfhE3o2yVV0U44blYkqdHA/OKloJEqvJy0xU+GSdE2SIw==",
       "dev": true
-    },
-    "jsdom": {
-      "version": "11.12.0",
-      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-11.12.0.tgz",
-      "integrity": "sha512-y8Px43oyiBM13Zc1z780FrfNLJCXTL40EWlty/LXUtcjykRBNgLlCjWXpfSPBl2iv+N7koQN+dvqszHZgT/Fjw==",
-      "requires": {
-        "abab": "^2.0.0",
-        "acorn": "^5.5.3",
-        "acorn-globals": "^4.1.0",
-        "array-equal": "^1.0.0",
-        "cssom": ">= 0.3.2 < 0.4.0",
-        "cssstyle": "^1.0.0",
-        "data-urls": "^1.0.0",
-        "domexception": "^1.0.1",
-        "escodegen": "^1.9.1",
-        "html-encoding-sniffer": "^1.0.2",
-        "left-pad": "^1.3.0",
-        "nwsapi": "^2.0.7",
-        "parse5": "4.0.0",
-        "pn": "^1.1.0",
-        "request": "^2.87.0",
-        "request-promise-native": "^1.0.5",
-        "sax": "^1.2.4",
-        "symbol-tree": "^3.2.2",
-        "tough-cookie": "^2.3.4",
-        "w3c-hr-time": "^1.0.1",
-        "webidl-conversions": "^4.0.2",
-        "whatwg-encoding": "^1.0.3",
-        "whatwg-mimetype": "^2.1.0",
-        "whatwg-url": "^6.4.1",
-        "ws": "^5.2.0",
-        "xml-name-validator": "^3.0.0"
-      },
-      "dependencies": {
-        "acorn": {
-          "version": "5.7.4",
-          "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.7.4.tgz",
-          "integrity": "sha512-1D++VG7BhrtvQpNbBzovKNc1FLGGEE/oGe7b9xJm/RFHMBeUaUGpluV9RLjZa47YFdPcDAenEYuq9pQPcMdLJg=="
-        }
-      }
     },
     "jsesc": {
       "version": "2.5.2",
@@ -11289,18 +10783,6 @@
       "resolved": "https://registry.npmjs.org/node-modules-regexp/-/node-modules-regexp-1.0.0.tgz",
       "integrity": "sha1-jZ2+KJZKSsVxLpExZCEHxx6Q7EA="
     },
-    "node-notifier": {
-      "version": "5.4.3",
-      "resolved": "https://registry.npmjs.org/node-notifier/-/node-notifier-5.4.3.tgz",
-      "integrity": "sha512-M4UBGcs4jeOK9CjTsYwkvH6/MzuUmGCyTW+kCY7uO+1ZVr0+FHGdPdIf5CCLqAaxnRrWidyoQlNkMIIVwbKB8Q==",
-      "requires": {
-        "growly": "^1.3.0",
-        "is-wsl": "^1.1.0",
-        "semver": "^5.5.0",
-        "shellwords": "^0.1.1",
-        "which": "^1.3.0"
-      }
-    },
     "node-pre-gyp": {
       "version": "0.14.0",
       "resolved": "https://registry.npmjs.org/node-pre-gyp/-/node-pre-gyp-0.14.0.tgz",
@@ -11939,14 +11421,6 @@
         "os-tmpdir": "^1.0.0"
       }
     },
-    "p-each-series": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/p-each-series/-/p-each-series-1.0.0.tgz",
-      "integrity": "sha1-kw89Et0fUOdDRFeiLNbwSsatf3E=",
-      "requires": {
-        "p-reduce": "^1.0.0"
-      }
-    },
     "p-finally": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
@@ -12060,11 +11534,6 @@
         "error-ex": "^1.3.1",
         "json-parse-better-errors": "^1.0.1"
       }
-    },
-    "parse5": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/parse5/-/parse5-4.0.0.tgz",
-      "integrity": "sha512-VrZ7eOd3T1Fk4XWNXMgiGBK/z0MG48BWG2uQNU4I72fkQuKUTZpl+u9k+CxEG0twMVzSmXEEz12z5Fnw1jIQFA=="
     },
     "parseurl": {
       "version": "1.3.3",
@@ -13231,24 +12700,6 @@
         "utila": "~0.4"
       }
     },
-    "pretty-format": {
-      "version": "24.9.0",
-      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-24.9.0.tgz",
-      "integrity": "sha512-00ZMZUiHaJrNfk33guavqgvfJS30sLYf0f8+Srklv0AMPodGGHcoHgksZ3OThYnIvOd+8yMCn0YiEOogjlgsnA==",
-      "requires": {
-        "@jest/types": "^24.9.0",
-        "ansi-regex": "^4.0.0",
-        "ansi-styles": "^3.2.0",
-        "react-is": "^16.8.4"
-      },
-      "dependencies": {
-        "ansi-regex": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
-          "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg=="
-        }
-      }
-    },
     "process": {
       "version": "0.11.10",
       "resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
@@ -13278,12 +12729,12 @@
       "integrity": "sha1-mEcocL8igTL8vdhoEputEsPAKeM="
     },
     "prompts": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/prompts/-/prompts-2.3.2.tgz",
-      "integrity": "sha512-Q06uKs2CkNYVID0VqwfAl9mipo99zkBv/n2JtWY89Yxa3ZabWSrs0e2KTudKVa3peLUvYXMefDqIleLPVUBZMA==",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/prompts/-/prompts-2.4.0.tgz",
+      "integrity": "sha512-awZAKrk3vN6CroQukBL+R9051a4R3zCZBlJm/HBfrSZ8iTpYix3VX1vU4mveiLpiwmOJT4wokTF9m6HUk4KqWQ==",
       "requires": {
         "kleur": "^3.0.3",
-        "sisteransi": "^1.0.4"
+        "sisteransi": "^1.0.5"
       }
     },
     "prop-types": {
@@ -13902,6 +13353,80 @@
         "workbox-webpack-plugin": "4.3.1"
       },
       "dependencies": {
+        "@jest/core": {
+          "version": "24.9.0",
+          "resolved": "https://registry.npmjs.org/@jest/core/-/core-24.9.0.tgz",
+          "integrity": "sha512-Fogg3s4wlAr1VX7q+rhV9RVnUv5tD7VuWfYy1+whMiWUrvl7U3QJSJyWcDio9Lq2prqYsZaeTv2Rz24pWGkJ2A==",
+          "requires": {
+            "@jest/console": "^24.7.1",
+            "@jest/reporters": "^24.9.0",
+            "@jest/test-result": "^24.9.0",
+            "@jest/transform": "^24.9.0",
+            "@jest/types": "^24.9.0",
+            "ansi-escapes": "^3.0.0",
+            "chalk": "^2.0.1",
+            "exit": "^0.1.2",
+            "graceful-fs": "^4.1.15",
+            "jest-changed-files": "^24.9.0",
+            "jest-config": "^24.9.0",
+            "jest-haste-map": "^24.9.0",
+            "jest-message-util": "^24.9.0",
+            "jest-regex-util": "^24.3.0",
+            "jest-resolve": "^24.9.0",
+            "jest-resolve-dependencies": "^24.9.0",
+            "jest-runner": "^24.9.0",
+            "jest-runtime": "^24.9.0",
+            "jest-snapshot": "^24.9.0",
+            "jest-util": "^24.9.0",
+            "jest-validate": "^24.9.0",
+            "jest-watcher": "^24.9.0",
+            "micromatch": "^3.1.10",
+            "p-each-series": "^1.0.0",
+            "realpath-native": "^1.1.0",
+            "rimraf": "^2.5.4",
+            "slash": "^2.0.0",
+            "strip-ansi": "^5.0.0"
+          }
+        },
+        "@jest/reporters": {
+          "version": "24.9.0",
+          "resolved": "https://registry.npmjs.org/@jest/reporters/-/reporters-24.9.0.tgz",
+          "integrity": "sha512-mu4X0yjaHrffOsWmVLzitKmmmWSQ3GGuefgNscUSWNiUNcEOSEQk9k3pERKEQVBb0Cnn88+UESIsZEMH3o88Gw==",
+          "requires": {
+            "@jest/environment": "^24.9.0",
+            "@jest/test-result": "^24.9.0",
+            "@jest/transform": "^24.9.0",
+            "@jest/types": "^24.9.0",
+            "chalk": "^2.0.1",
+            "exit": "^0.1.2",
+            "glob": "^7.1.2",
+            "istanbul-lib-coverage": "^2.0.2",
+            "istanbul-lib-instrument": "^3.0.1",
+            "istanbul-lib-report": "^2.0.4",
+            "istanbul-lib-source-maps": "^3.0.1",
+            "istanbul-reports": "^2.2.6",
+            "jest-haste-map": "^24.9.0",
+            "jest-resolve": "^24.9.0",
+            "jest-runtime": "^24.9.0",
+            "jest-util": "^24.9.0",
+            "jest-worker": "^24.6.0",
+            "node-notifier": "^5.4.2",
+            "slash": "^2.0.0",
+            "source-map": "^0.6.0",
+            "string-length": "^2.0.0"
+          }
+        },
+        "@jest/test-sequencer": {
+          "version": "24.9.0",
+          "resolved": "https://registry.npmjs.org/@jest/test-sequencer/-/test-sequencer-24.9.0.tgz",
+          "integrity": "sha512-6qqsU4o0kW1dvA95qfNog8v8gkRN9ph6Lz7r96IvZpHdNipP2cBcb07J1Z45mz/VIS01OHJ3pY8T5fUY38tg4A==",
+          "requires": {
+            "@jest/test-result": "^24.9.0",
+            "jest-haste-map": "^24.9.0",
+            "jest-runner": "^24.9.0",
+            "jest-runtime": "^24.9.0"
+          }
+        },
         "@typescript-eslint/eslint-plugin": {
           "version": "2.34.0",
           "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-2.34.0.tgz",
@@ -13967,10 +13492,25 @@
             "uri-js": "^4.2.2"
           }
         },
+        "ansi-escapes": {
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-3.2.0.tgz",
+          "integrity": "sha512-cBhpre4ma+U0T1oM5fXg7Dy1Jw7zzwv7lt/GoCpr+hDQJoYnKVPLL4dCvSEFMmQurOQvSrwT7SL/DAlhBI97RQ=="
+        },
         "ansi-regex": {
           "version": "4.1.0",
           "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
           "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg=="
+        },
+        "detect-newline": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/detect-newline/-/detect-newline-2.1.0.tgz",
+          "integrity": "sha1-9B8cEL5LAOh7XxPaaAdZ8sW/0+I="
+        },
+        "diff-sequences": {
+          "version": "24.9.0",
+          "resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-24.9.0.tgz",
+          "integrity": "sha512-Dj6Wk3tWyTE+Fo1rW8v0Xhwk80um6yFYKbuAxc9c3EZxIHFDYwbi34Uk42u1CdnIiVorvt4RmlSDjIPyzGC2ew=="
         },
         "eslint": {
           "version": "6.8.0",
@@ -14041,6 +13581,19 @@
             "eslint-visitor-keys": "^1.1.0"
           }
         },
+        "expect": {
+          "version": "24.9.0",
+          "resolved": "https://registry.npmjs.org/expect/-/expect-24.9.0.tgz",
+          "integrity": "sha512-wvVAx8XIol3Z5m9zvZXiyZOQ+sRJqNTIm6sGjdWlaZIeupQGO3WbYI+15D/AmEwZywL6wtJkbAbJtzkOfBuR0Q==",
+          "requires": {
+            "@jest/types": "^24.9.0",
+            "ansi-styles": "^3.2.0",
+            "jest-get-type": "^24.9.0",
+            "jest-matcher-utils": "^24.9.0",
+            "jest-message-util": "^24.9.0",
+            "jest-regex-util": "^24.9.0"
+          }
+        },
         "fast-deep-equal": {
           "version": "3.1.3",
           "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
@@ -14081,6 +13634,383 @@
             "resolve-from": "^4.0.0"
           }
         },
+        "istanbul-lib-report": {
+          "version": "2.0.8",
+          "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-2.0.8.tgz",
+          "integrity": "sha512-fHBeG573EIihhAblwgxrSenp0Dby6tJMFR/HvlerBsrCTD5bkUuoNtn3gVh29ZCS824cGGBPn7Sg7cNk+2xUsQ==",
+          "requires": {
+            "istanbul-lib-coverage": "^2.0.5",
+            "make-dir": "^2.1.0",
+            "supports-color": "^6.1.0"
+          }
+        },
+        "istanbul-lib-source-maps": {
+          "version": "3.0.6",
+          "resolved": "https://registry.npmjs.org/istanbul-lib-source-maps/-/istanbul-lib-source-maps-3.0.6.tgz",
+          "integrity": "sha512-R47KzMtDJH6X4/YW9XTx+jrLnZnscW4VpNN+1PViSYTejLVPWv7oov+Duf8YQSPyVRUvueQqz1TcsC6mooZTXw==",
+          "requires": {
+            "debug": "^4.1.1",
+            "istanbul-lib-coverage": "^2.0.5",
+            "make-dir": "^2.1.0",
+            "rimraf": "^2.6.3",
+            "source-map": "^0.6.1"
+          }
+        },
+        "istanbul-reports": {
+          "version": "2.2.7",
+          "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-2.2.7.tgz",
+          "integrity": "sha512-uu1F/L1o5Y6LzPVSVZXNOoD/KXpJue9aeLRd0sM9uMXfZvzomB0WxVamWb5ue8kA2vVWEmW7EG+A5n3f1kqHKg==",
+          "requires": {
+            "html-escaper": "^2.0.0"
+          }
+        },
+        "jest": {
+          "version": "24.9.0",
+          "resolved": "https://registry.npmjs.org/jest/-/jest-24.9.0.tgz",
+          "integrity": "sha512-YvkBL1Zm7d2B1+h5fHEOdyjCG+sGMz4f8D86/0HiqJ6MB4MnDc8FgP5vdWsGnemOQro7lnYo8UakZ3+5A0jxGw==",
+          "requires": {
+            "import-local": "^2.0.0",
+            "jest-cli": "^24.9.0"
+          },
+          "dependencies": {
+            "jest-cli": {
+              "version": "24.9.0",
+              "resolved": "https://registry.npmjs.org/jest-cli/-/jest-cli-24.9.0.tgz",
+              "integrity": "sha512-+VLRKyitT3BWoMeSUIHRxV/2g8y9gw91Jh5z2UmXZzkZKpbC08CSehVxgHUwTpy+HwGcns/tqafQDJW7imYvGg==",
+              "requires": {
+                "@jest/core": "^24.9.0",
+                "@jest/test-result": "^24.9.0",
+                "@jest/types": "^24.9.0",
+                "chalk": "^2.0.1",
+                "exit": "^0.1.2",
+                "import-local": "^2.0.0",
+                "is-ci": "^2.0.0",
+                "jest-config": "^24.9.0",
+                "jest-util": "^24.9.0",
+                "jest-validate": "^24.9.0",
+                "prompts": "^2.0.1",
+                "realpath-native": "^1.1.0",
+                "yargs": "^13.3.0"
+              }
+            }
+          }
+        },
+        "jest-changed-files": {
+          "version": "24.9.0",
+          "resolved": "https://registry.npmjs.org/jest-changed-files/-/jest-changed-files-24.9.0.tgz",
+          "integrity": "sha512-6aTWpe2mHF0DhL28WjdkO8LyGjs3zItPET4bMSeXU6T3ub4FPMw+mcOcbdGXQOAfmLcxofD23/5Bl9Z4AkFwqg==",
+          "requires": {
+            "@jest/types": "^24.9.0",
+            "execa": "^1.0.0",
+            "throat": "^4.0.0"
+          }
+        },
+        "jest-config": {
+          "version": "24.9.0",
+          "resolved": "https://registry.npmjs.org/jest-config/-/jest-config-24.9.0.tgz",
+          "integrity": "sha512-RATtQJtVYQrp7fvWg6f5y3pEFj9I+H8sWw4aKxnDZ96mob5i5SD6ZEGWgMLXQ4LE8UurrjbdlLWdUeo+28QpfQ==",
+          "requires": {
+            "@babel/core": "^7.1.0",
+            "@jest/test-sequencer": "^24.9.0",
+            "@jest/types": "^24.9.0",
+            "babel-jest": "^24.9.0",
+            "chalk": "^2.0.1",
+            "glob": "^7.1.1",
+            "jest-environment-jsdom": "^24.9.0",
+            "jest-environment-node": "^24.9.0",
+            "jest-get-type": "^24.9.0",
+            "jest-jasmine2": "^24.9.0",
+            "jest-regex-util": "^24.3.0",
+            "jest-resolve": "^24.9.0",
+            "jest-util": "^24.9.0",
+            "jest-validate": "^24.9.0",
+            "micromatch": "^3.1.10",
+            "pretty-format": "^24.9.0",
+            "realpath-native": "^1.1.0"
+          }
+        },
+        "jest-diff": {
+          "version": "24.9.0",
+          "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-24.9.0.tgz",
+          "integrity": "sha512-qMfrTs8AdJE2iqrTp0hzh7kTd2PQWrsFyj9tORoKmu32xjPjeE4NyjVRDz8ybYwqS2ik8N4hsIpiVTyFeo2lBQ==",
+          "requires": {
+            "chalk": "^2.0.1",
+            "diff-sequences": "^24.9.0",
+            "jest-get-type": "^24.9.0",
+            "pretty-format": "^24.9.0"
+          }
+        },
+        "jest-docblock": {
+          "version": "24.9.0",
+          "resolved": "https://registry.npmjs.org/jest-docblock/-/jest-docblock-24.9.0.tgz",
+          "integrity": "sha512-F1DjdpDMJMA1cN6He0FNYNZlo3yYmOtRUnktrT9Q37njYzC5WEaDdmbynIgy0L/IvXvvgsG8OsqhLPXTpfmZAA==",
+          "requires": {
+            "detect-newline": "^2.1.0"
+          }
+        },
+        "jest-each": {
+          "version": "24.9.0",
+          "resolved": "https://registry.npmjs.org/jest-each/-/jest-each-24.9.0.tgz",
+          "integrity": "sha512-ONi0R4BvW45cw8s2Lrx8YgbeXL1oCQ/wIDwmsM3CqM/nlblNCPmnC3IPQlMbRFZu3wKdQ2U8BqM6lh3LJ5Bsog==",
+          "requires": {
+            "@jest/types": "^24.9.0",
+            "chalk": "^2.0.1",
+            "jest-get-type": "^24.9.0",
+            "jest-util": "^24.9.0",
+            "pretty-format": "^24.9.0"
+          }
+        },
+        "jest-environment-jsdom": {
+          "version": "24.9.0",
+          "resolved": "https://registry.npmjs.org/jest-environment-jsdom/-/jest-environment-jsdom-24.9.0.tgz",
+          "integrity": "sha512-Zv9FV9NBRzLuALXjvRijO2351DRQeLYXtpD4xNvfoVFw21IOKNhZAEUKcbiEtjTkm2GsJ3boMVgkaR7rN8qetA==",
+          "requires": {
+            "@jest/environment": "^24.9.0",
+            "@jest/fake-timers": "^24.9.0",
+            "@jest/types": "^24.9.0",
+            "jest-mock": "^24.9.0",
+            "jest-util": "^24.9.0",
+            "jsdom": "^11.5.1"
+          }
+        },
+        "jest-environment-node": {
+          "version": "24.9.0",
+          "resolved": "https://registry.npmjs.org/jest-environment-node/-/jest-environment-node-24.9.0.tgz",
+          "integrity": "sha512-6d4V2f4nxzIzwendo27Tr0aFm+IXWa0XEUnaH6nU0FMaozxovt+sfRvh4J47wL1OvF83I3SSTu0XK+i4Bqe7uA==",
+          "requires": {
+            "@jest/environment": "^24.9.0",
+            "@jest/fake-timers": "^24.9.0",
+            "@jest/types": "^24.9.0",
+            "jest-mock": "^24.9.0",
+            "jest-util": "^24.9.0"
+          }
+        },
+        "jest-get-type": {
+          "version": "24.9.0",
+          "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-24.9.0.tgz",
+          "integrity": "sha512-lUseMzAley4LhIcpSP9Jf+fTrQ4a1yHQwLNeeVa2cEmbCGeoZAtYPOIv8JaxLD/sUpKxetKGP+gsHl8f8TSj8Q=="
+        },
+        "jest-jasmine2": {
+          "version": "24.9.0",
+          "resolved": "https://registry.npmjs.org/jest-jasmine2/-/jest-jasmine2-24.9.0.tgz",
+          "integrity": "sha512-Cq7vkAgaYKp+PsX+2/JbTarrk0DmNhsEtqBXNwUHkdlbrTBLtMJINADf2mf5FkowNsq8evbPc07/qFO0AdKTzw==",
+          "requires": {
+            "@babel/traverse": "^7.1.0",
+            "@jest/environment": "^24.9.0",
+            "@jest/test-result": "^24.9.0",
+            "@jest/types": "^24.9.0",
+            "chalk": "^2.0.1",
+            "co": "^4.6.0",
+            "expect": "^24.9.0",
+            "is-generator-fn": "^2.0.0",
+            "jest-each": "^24.9.0",
+            "jest-matcher-utils": "^24.9.0",
+            "jest-message-util": "^24.9.0",
+            "jest-runtime": "^24.9.0",
+            "jest-snapshot": "^24.9.0",
+            "jest-util": "^24.9.0",
+            "pretty-format": "^24.9.0",
+            "throat": "^4.0.0"
+          }
+        },
+        "jest-leak-detector": {
+          "version": "24.9.0",
+          "resolved": "https://registry.npmjs.org/jest-leak-detector/-/jest-leak-detector-24.9.0.tgz",
+          "integrity": "sha512-tYkFIDsiKTGwb2FG1w8hX9V0aUb2ot8zY/2nFg087dUageonw1zrLMP4W6zsRO59dPkTSKie+D4rhMuP9nRmrA==",
+          "requires": {
+            "jest-get-type": "^24.9.0",
+            "pretty-format": "^24.9.0"
+          }
+        },
+        "jest-matcher-utils": {
+          "version": "24.9.0",
+          "resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-24.9.0.tgz",
+          "integrity": "sha512-OZz2IXsu6eaiMAwe67c1T+5tUAtQyQx27/EMEkbFAGiw52tB9em+uGbzpcgYVpA8wl0hlxKPZxrly4CXU/GjHA==",
+          "requires": {
+            "chalk": "^2.0.1",
+            "jest-diff": "^24.9.0",
+            "jest-get-type": "^24.9.0",
+            "pretty-format": "^24.9.0"
+          }
+        },
+        "jest-resolve-dependencies": {
+          "version": "24.9.0",
+          "resolved": "https://registry.npmjs.org/jest-resolve-dependencies/-/jest-resolve-dependencies-24.9.0.tgz",
+          "integrity": "sha512-Fm7b6AlWnYhT0BXy4hXpactHIqER7erNgIsIozDXWl5dVm+k8XdGVe1oTg1JyaFnOxarMEbax3wyRJqGP2Pq+g==",
+          "requires": {
+            "@jest/types": "^24.9.0",
+            "jest-regex-util": "^24.3.0",
+            "jest-snapshot": "^24.9.0"
+          }
+        },
+        "jest-runner": {
+          "version": "24.9.0",
+          "resolved": "https://registry.npmjs.org/jest-runner/-/jest-runner-24.9.0.tgz",
+          "integrity": "sha512-KksJQyI3/0mhcfspnxxEOBueGrd5E4vV7ADQLT9ESaCzz02WnbdbKWIf5Mkaucoaj7obQckYPVX6JJhgUcoWWg==",
+          "requires": {
+            "@jest/console": "^24.7.1",
+            "@jest/environment": "^24.9.0",
+            "@jest/test-result": "^24.9.0",
+            "@jest/types": "^24.9.0",
+            "chalk": "^2.4.2",
+            "exit": "^0.1.2",
+            "graceful-fs": "^4.1.15",
+            "jest-config": "^24.9.0",
+            "jest-docblock": "^24.3.0",
+            "jest-haste-map": "^24.9.0",
+            "jest-jasmine2": "^24.9.0",
+            "jest-leak-detector": "^24.9.0",
+            "jest-message-util": "^24.9.0",
+            "jest-resolve": "^24.9.0",
+            "jest-runtime": "^24.9.0",
+            "jest-util": "^24.9.0",
+            "jest-worker": "^24.6.0",
+            "source-map-support": "^0.5.6",
+            "throat": "^4.0.0"
+          },
+          "dependencies": {
+            "chalk": {
+              "version": "2.4.2",
+              "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+              "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+              "requires": {
+                "ansi-styles": "^3.2.1",
+                "escape-string-regexp": "^1.0.5",
+                "supports-color": "^5.3.0"
+              }
+            },
+            "supports-color": {
+              "version": "5.5.0",
+              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+              "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+              "requires": {
+                "has-flag": "^3.0.0"
+              }
+            }
+          }
+        },
+        "jest-runtime": {
+          "version": "24.9.0",
+          "resolved": "https://registry.npmjs.org/jest-runtime/-/jest-runtime-24.9.0.tgz",
+          "integrity": "sha512-8oNqgnmF3v2J6PVRM2Jfuj8oX3syKmaynlDMMKQ4iyzbQzIG6th5ub/lM2bCMTmoTKM3ykcUYI2Pw9xwNtjMnw==",
+          "requires": {
+            "@jest/console": "^24.7.1",
+            "@jest/environment": "^24.9.0",
+            "@jest/source-map": "^24.3.0",
+            "@jest/transform": "^24.9.0",
+            "@jest/types": "^24.9.0",
+            "@types/yargs": "^13.0.0",
+            "chalk": "^2.0.1",
+            "exit": "^0.1.2",
+            "glob": "^7.1.3",
+            "graceful-fs": "^4.1.15",
+            "jest-config": "^24.9.0",
+            "jest-haste-map": "^24.9.0",
+            "jest-message-util": "^24.9.0",
+            "jest-mock": "^24.9.0",
+            "jest-regex-util": "^24.3.0",
+            "jest-resolve": "^24.9.0",
+            "jest-snapshot": "^24.9.0",
+            "jest-util": "^24.9.0",
+            "jest-validate": "^24.9.0",
+            "realpath-native": "^1.1.0",
+            "slash": "^2.0.0",
+            "strip-bom": "^3.0.0",
+            "yargs": "^13.3.0"
+          }
+        },
+        "jest-snapshot": {
+          "version": "24.9.0",
+          "resolved": "https://registry.npmjs.org/jest-snapshot/-/jest-snapshot-24.9.0.tgz",
+          "integrity": "sha512-uI/rszGSs73xCM0l+up7O7a40o90cnrk429LOiK3aeTvfC0HHmldbd81/B7Ix81KSFe1lwkbl7GnBGG4UfuDew==",
+          "requires": {
+            "@babel/types": "^7.0.0",
+            "@jest/types": "^24.9.0",
+            "chalk": "^2.0.1",
+            "expect": "^24.9.0",
+            "jest-diff": "^24.9.0",
+            "jest-get-type": "^24.9.0",
+            "jest-matcher-utils": "^24.9.0",
+            "jest-message-util": "^24.9.0",
+            "jest-resolve": "^24.9.0",
+            "mkdirp": "^0.5.1",
+            "natural-compare": "^1.4.0",
+            "pretty-format": "^24.9.0",
+            "semver": "^6.2.0"
+          }
+        },
+        "jest-validate": {
+          "version": "24.9.0",
+          "resolved": "https://registry.npmjs.org/jest-validate/-/jest-validate-24.9.0.tgz",
+          "integrity": "sha512-HPIt6C5ACwiqSiwi+OfSSHbK8sG7akG8eATl+IPKaeIjtPOeBUd/g3J7DghugzxrGjI93qS/+RPKe1H6PqvhRQ==",
+          "requires": {
+            "@jest/types": "^24.9.0",
+            "camelcase": "^5.3.1",
+            "chalk": "^2.0.1",
+            "jest-get-type": "^24.9.0",
+            "leven": "^3.1.0",
+            "pretty-format": "^24.9.0"
+          }
+        },
+        "jsdom": {
+          "version": "11.12.0",
+          "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-11.12.0.tgz",
+          "integrity": "sha512-y8Px43oyiBM13Zc1z780FrfNLJCXTL40EWlty/LXUtcjykRBNgLlCjWXpfSPBl2iv+N7koQN+dvqszHZgT/Fjw==",
+          "requires": {
+            "abab": "^2.0.0",
+            "acorn": "^5.5.3",
+            "acorn-globals": "^4.1.0",
+            "array-equal": "^1.0.0",
+            "cssom": ">= 0.3.2 < 0.4.0",
+            "cssstyle": "^1.0.0",
+            "data-urls": "^1.0.0",
+            "domexception": "^1.0.1",
+            "escodegen": "^1.9.1",
+            "html-encoding-sniffer": "^1.0.2",
+            "left-pad": "^1.3.0",
+            "nwsapi": "^2.0.7",
+            "parse5": "4.0.0",
+            "pn": "^1.1.0",
+            "request": "^2.87.0",
+            "request-promise-native": "^1.0.5",
+            "sax": "^1.2.4",
+            "symbol-tree": "^3.2.2",
+            "tough-cookie": "^2.3.4",
+            "w3c-hr-time": "^1.0.1",
+            "webidl-conversions": "^4.0.2",
+            "whatwg-encoding": "^1.0.3",
+            "whatwg-mimetype": "^2.1.0",
+            "whatwg-url": "^6.4.1",
+            "ws": "^5.2.0",
+            "xml-name-validator": "^3.0.0"
+          },
+          "dependencies": {
+            "acorn": {
+              "version": "5.7.4",
+              "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.7.4.tgz",
+              "integrity": "sha512-1D++VG7BhrtvQpNbBzovKNc1FLGGEE/oGe7b9xJm/RFHMBeUaUGpluV9RLjZa47YFdPcDAenEYuq9pQPcMdLJg=="
+            }
+          }
+        },
+        "node-notifier": {
+          "version": "5.4.3",
+          "resolved": "https://registry.npmjs.org/node-notifier/-/node-notifier-5.4.3.tgz",
+          "integrity": "sha512-M4UBGcs4jeOK9CjTsYwkvH6/MzuUmGCyTW+kCY7uO+1ZVr0+FHGdPdIf5CCLqAaxnRrWidyoQlNkMIIVwbKB8Q==",
+          "requires": {
+            "growly": "^1.3.0",
+            "is-wsl": "^1.1.0",
+            "semver": "^5.5.0",
+            "shellwords": "^0.1.1",
+            "which": "^1.3.0"
+          },
+          "dependencies": {
+            "semver": {
+              "version": "5.7.1",
+              "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+              "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
+            }
+          }
+        },
         "optionator": {
           "version": "0.8.3",
           "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.3.tgz",
@@ -14092,6 +14022,30 @@
             "prelude-ls": "~1.1.2",
             "type-check": "~0.3.2",
             "word-wrap": "~1.2.3"
+          }
+        },
+        "p-each-series": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/p-each-series/-/p-each-series-1.0.0.tgz",
+          "integrity": "sha1-kw89Et0fUOdDRFeiLNbwSsatf3E=",
+          "requires": {
+            "p-reduce": "^1.0.0"
+          }
+        },
+        "parse5": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/parse5/-/parse5-4.0.0.tgz",
+          "integrity": "sha512-VrZ7eOd3T1Fk4XWNXMgiGBK/z0MG48BWG2uQNU4I72fkQuKUTZpl+u9k+CxEG0twMVzSmXEEz12z5Fnw1jIQFA=="
+        },
+        "pretty-format": {
+          "version": "24.9.0",
+          "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-24.9.0.tgz",
+          "integrity": "sha512-00ZMZUiHaJrNfk33guavqgvfJS30sLYf0f8+Srklv0AMPodGGHcoHgksZ3OThYnIvOd+8yMCn0YiEOogjlgsnA==",
+          "requires": {
+            "@jest/types": "^24.9.0",
+            "ansi-regex": "^4.0.0",
+            "ansi-styles": "^3.2.0",
+            "react-is": "^16.8.4"
           }
         },
         "resolve": {
@@ -14112,6 +14066,11 @@
           "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
           "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
         },
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
+        },
         "strip-ansi": {
           "version": "5.2.0",
           "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
@@ -14125,6 +14084,19 @@
           "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
           "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig=="
         },
+        "supports-color": {
+          "version": "6.1.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
+          "integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
+          "requires": {
+            "has-flag": "^3.0.0"
+          }
+        },
+        "throat": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/throat/-/throat-4.1.0.tgz",
+          "integrity": "sha1-iQN8vJLFarGJJua6TLsgDhVnKmo="
+        },
         "tslib": {
           "version": "1.14.1",
           "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
@@ -14136,6 +14108,24 @@
           "integrity": "sha512-kzeQ5B8H3w60nFY2g8cJIuH7JDpsALXySGtwGJ0p2LSjLgay3NdIpqq5SoOBe46bKDW2iq25irHCr8wjomUS2g==",
           "requires": {
             "tslib": "^1.8.1"
+          }
+        },
+        "whatwg-url": {
+          "version": "6.5.0",
+          "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-6.5.0.tgz",
+          "integrity": "sha512-rhRZRqx/TLJQWUpQ6bmrt2UV4f0HCQ463yQuONJqC6fO2VoEb1pTYddbe59SkYq87aoM5A3bdhMZiUiVws+fzQ==",
+          "requires": {
+            "lodash.sortby": "^4.7.0",
+            "tr46": "^1.0.1",
+            "webidl-conversions": "^4.0.2"
+          }
+        },
+        "ws": {
+          "version": "5.2.2",
+          "resolved": "https://registry.npmjs.org/ws/-/ws-5.2.2.tgz",
+          "integrity": "sha512-jaHFD6PFv6UgoIVda6qZllptQsMlDEJkTQcybzzXDYM1XO9Y8em691FGMPmM46WGyLU4z9KMgQN+qrux/nhlHA==",
+          "requires": {
+            "async-limiter": "~1.0.0"
           }
         }
       }
@@ -16524,11 +16514,6 @@
       "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
       "integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ="
     },
-    "throat": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/throat/-/throat-4.1.0.tgz",
-      "integrity": "sha1-iQN8vJLFarGJJua6TLsgDhVnKmo="
-    },
     "through": {
       "version": "2.3.8",
       "resolved": "http://registry.npmjs.org/through/-/through-2.3.8.tgz",
@@ -16640,6 +16625,179 @@
       "integrity": "sha1-qLE/1r/SSJUZZ0zN5VujaTtwbQk=",
       "requires": {
         "punycode": "^2.1.0"
+      }
+    },
+    "true-myth": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/true-myth/-/true-myth-4.1.0.tgz",
+      "integrity": "sha512-X4oBf1WOuLMfXpcKLI94dV4Htknv06vMADss3Whcybr85W1ctjZGZOzMMRYXUUBlhV4bDAGeMojzN/dw7N7qWA=="
+    },
+    "ts-jest": {
+      "version": "26.4.4",
+      "resolved": "https://registry.npmjs.org/ts-jest/-/ts-jest-26.4.4.tgz",
+      "integrity": "sha512-3lFWKbLxJm34QxyVNNCgXX1u4o/RV0myvA2y2Bxm46iGIjKlaY0own9gIckbjZJPn+WaJEnfPPJ20HHGpoq4yg==",
+      "requires": {
+        "@types/jest": "26.x",
+        "bs-logger": "0.x",
+        "buffer-from": "1.x",
+        "fast-json-stable-stringify": "2.x",
+        "jest-util": "^26.1.0",
+        "json5": "2.x",
+        "lodash.memoize": "4.x",
+        "make-error": "1.x",
+        "mkdirp": "1.x",
+        "semver": "7.x",
+        "yargs-parser": "20.x"
+      },
+      "dependencies": {
+        "@jest/types": {
+          "version": "26.6.2",
+          "resolved": "https://registry.npmjs.org/@jest/types/-/types-26.6.2.tgz",
+          "integrity": "sha512-fC6QCp7Sc5sX6g8Tvbmj4XUTbyrik0akgRy03yjXbQaBWWNWGE7SGtJk98m0N8nzegD/7SggrUlivxo5ax4KWQ==",
+          "requires": {
+            "@types/istanbul-lib-coverage": "^2.0.0",
+            "@types/istanbul-reports": "^3.0.0",
+            "@types/node": "*",
+            "@types/yargs": "^15.0.0",
+            "chalk": "^4.0.0"
+          }
+        },
+        "@types/istanbul-reports": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/@types/istanbul-reports/-/istanbul-reports-3.0.0.tgz",
+          "integrity": "sha512-nwKNbvnwJ2/mndE9ItP/zc2TCzw6uuodnF4EHYWD+gCQDVBuRQL5UzbZD0/ezy1iKsFU2ZQiDqg4M9dN4+wZgA==",
+          "requires": {
+            "@types/istanbul-lib-report": "*"
+          }
+        },
+        "@types/yargs": {
+          "version": "15.0.12",
+          "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.12.tgz",
+          "integrity": "sha512-f+fD/fQAo3BCbCDlrUpznF1A5Zp9rB0noS5vnoormHSIPFKL0Z2DcUJ3Gxp5ytH4uLRNxy7AwYUC9exZzqGMAw==",
+          "requires": {
+            "@types/yargs-parser": "*"
+          }
+        },
+        "ansi-styles": {
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+          "requires": {
+            "color-convert": "^2.0.1"
+          }
+        },
+        "braces": {
+          "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
+          "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
+          "requires": {
+            "fill-range": "^7.0.1"
+          }
+        },
+        "chalk": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
+          "integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+        },
+        "fill-range": {
+          "version": "7.0.1",
+          "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
+          "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
+          "requires": {
+            "to-regex-range": "^5.0.1"
+          }
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="
+        },
+        "is-number": {
+          "version": "7.0.0",
+          "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+          "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng=="
+        },
+        "jest-util": {
+          "version": "26.6.2",
+          "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-26.6.2.tgz",
+          "integrity": "sha512-MDW0fKfsn0OI7MS7Euz6h8HNDXVQ0gaM9uW6RjfDmd1DAFcaxX9OqIakHIqhbnmF08Cf2DLDG+ulq8YQQ0Lp0Q==",
+          "requires": {
+            "@jest/types": "^26.6.2",
+            "@types/node": "*",
+            "chalk": "^4.0.0",
+            "graceful-fs": "^4.2.4",
+            "is-ci": "^2.0.0",
+            "micromatch": "^4.0.2"
+          }
+        },
+        "lru-cache": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+          "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+          "requires": {
+            "yallist": "^4.0.0"
+          }
+        },
+        "micromatch": {
+          "version": "4.0.2",
+          "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.2.tgz",
+          "integrity": "sha512-y7FpHSbMUMoyPbYUSzO6PaZ6FyRnQOpHuKwbo1G+Knck95XVU4QAiKdGEnj5wwoS7PlOgthX/09u5iFJ+aYf5Q==",
+          "requires": {
+            "braces": "^3.0.1",
+            "picomatch": "^2.0.5"
+          }
+        },
+        "mkdirp": {
+          "version": "1.0.4",
+          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
+          "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw=="
+        },
+        "semver": {
+          "version": "7.3.4",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.4.tgz",
+          "integrity": "sha512-tCfb2WLjqFAtXn4KEdxIhalnRtoKFN7nAwj0B3ZXCbQloV2tq5eDbcTmT68JJD3nRJq24/XgxtQKFIpQdtvmVw==",
+          "requires": {
+            "lru-cache": "^6.0.0"
+          }
+        },
+        "supports-color": {
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        },
+        "to-regex-range": {
+          "version": "5.0.1",
+          "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+          "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+          "requires": {
+            "is-number": "^7.0.0"
+          }
+        },
+        "yargs-parser": {
+          "version": "20.2.4",
+          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.4.tgz",
+          "integrity": "sha512-WOkpgNhPTlE73h4VFAFsOnomJVaovO8VqLDzy5saChRBFQFBoMYirowyW+Q9HB4HFF4Z7VZTiG3iSzJJA29yRA=="
+        }
       }
     },
     "ts-node": {
@@ -17711,16 +17869,6 @@
       "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-2.3.0.tgz",
       "integrity": "sha512-M4yMwr6mAnQz76TbJm914+gPpB/nCwvZbJU28cUD6dR004SAxDLOOSUaB1JDRqLtaOV/vi0IC5lEAGFgrjGv/g=="
     },
-    "whatwg-url": {
-      "version": "6.5.0",
-      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-6.5.0.tgz",
-      "integrity": "sha512-rhRZRqx/TLJQWUpQ6bmrt2UV4f0HCQ463yQuONJqC6fO2VoEb1pTYddbe59SkYq87aoM5A3bdhMZiUiVws+fzQ==",
-      "requires": {
-        "lodash.sortby": "^4.7.0",
-        "tr46": "^1.0.1",
-        "webidl-conversions": "^4.0.2"
-      }
-    },
     "which": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
@@ -17995,14 +18143,6 @@
         "graceful-fs": "^4.1.11",
         "imurmurhash": "^0.1.4",
         "signal-exit": "^3.0.2"
-      }
-    },
-    "ws": {
-      "version": "5.2.2",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-5.2.2.tgz",
-      "integrity": "sha512-jaHFD6PFv6UgoIVda6qZllptQsMlDEJkTQcybzzXDYM1XO9Y8em691FGMPmM46WGyLU4z9KMgQN+qrux/nhlHA==",
-      "requires": {
-        "async-limiter": "~1.0.0"
       }
     },
     "xml-name-validator": {

--- a/penrose-web/package-lock.json
+++ b/penrose-web/package-lock.json
@@ -8929,6 +8929,11 @@
       "resolved": "https://registry.npmjs.org/immer/-/immer-1.10.0.tgz",
       "integrity": "sha512-O3sR1/opvCDGLEVcvrGTMtLac8GJ5IwZC4puPrLuRj3l7ICKvkmA0vGuU9OW8mV9WIBRnaxp5GJh9IEAaNOoYg=="
     },
+    "immutable": {
+      "version": "4.0.0-rc.12",
+      "resolved": "https://registry.npmjs.org/immutable/-/immutable-4.0.0-rc.12.tgz",
+      "integrity": "sha512-0M2XxkZLx/mi3t8NVwIm1g8nHoEmM9p9UBl/G9k4+hm0kBgOVdMV/B3CY5dQ8qG8qc80NN4gDV4HQv6FTJ5q7A=="
+    },
     "import-cwd": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/import-cwd/-/import-cwd-2.1.0.tgz",

--- a/penrose-web/package-lock.json
+++ b/penrose-web/package-lock.json
@@ -2236,6 +2236,11 @@
         "@types/node": "*"
       }
     },
+    "@types/graphlib": {
+      "version": "2.1.7",
+      "resolved": "https://registry.npmjs.org/@types/graphlib/-/graphlib-2.1.7.tgz",
+      "integrity": "sha512-K7T1n6U2HbTYu+SFHlBjz/RH74OA2D/zF1qlzn8uXbvB4uRg7knOM85ugS2bbXI1TXMh7rLqk4OVRwIwEBaixg=="
+    },
     "@types/hoist-non-react-statics": {
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/@types/hoist-non-react-statics/-/hoist-non-react-statics-3.3.1.tgz",
@@ -8474,6 +8479,14 @@
       "version": "4.2.4",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.4.tgz",
       "integrity": "sha512-WjKPNJF79dtJAVniUlGGWHYGz2jWxT6VhN/4m1NdkbZ2nOsEF+cI1Edgql5zCRhs/VsQYRvrXctxktVXZUkixw=="
+    },
+    "graphlib": {
+      "version": "2.1.8",
+      "resolved": "https://registry.npmjs.org/graphlib/-/graphlib-2.1.8.tgz",
+      "integrity": "sha512-jcLLfkpoVGmH7/InMC/1hIvOPSUh38oJtGhvrOFGzioE1DZ+0YW16RgmOJhHiuWTvGiJQ9Z1Ik43JvkRPRvE+A==",
+      "requires": {
+        "lodash": "^4.17.15"
+      }
     },
     "growly": {
       "version": "1.3.0",

--- a/penrose-web/package.json
+++ b/penrose-web/package.json
@@ -18,6 +18,7 @@
     "eslint": "^6.6.0",
     "eslint-plugin-prefer-arrow": "^1.2.2",
     "fast-memoize": "^2.5.2",
+    "immutable": "^4.0.0-rc.12",
     "lodash": "^4.17.15",
     "mathjax-full": "^3.0.1",
     "node-pre-gyp": "^0.14.0",

--- a/penrose-web/package.json
+++ b/penrose-web/package.json
@@ -36,10 +36,14 @@
     "tslib": "^2.0.3"
   },
   "scripts": {
-    "build:parser": "nearleyc src/parser/Style.ne > src/parser/StyleParser.ts",
-    "start": "npm run build:parser && react-scripts --max_old_space_size=4096 start",
-    "build": "CI=false && npm run build:parser && react-scripts --max_old_space_size=4096 build",
-    "build-lib": "npm run build:parser && ttsc --project tsconfig.lib.json",
+    "build:parsers": "nearleyc src/parser/Domain.ne > src/parser/DomainParser.ts && nearleyc src/parser/Style.ne > src/parser/StyleParser.ts",
+    "prebuild": "npm run build:parsers",
+    "prestart": "npm run build:parsers",
+    "pretest": "npm run build:parsers",
+    "prebuild-lib": "npm run build:parsers",
+    "start": "react-scripts --max_old_space_size=4096 start",
+    "build": "CI=false && react-scripts --max_old_space_size=4096 build",
+    "build-lib": "ttsc --project tsconfig.lib.json",
     "docs": "typedoc --out docs src",
     "test": "react-scripts test",
     "lint": "eslint --ext js,ts,tsx src",

--- a/penrose-web/package.json
+++ b/penrose-web/package.json
@@ -32,6 +32,8 @@
     "seedrandom": "^3.0.5",
     "styled-components": "^5.0.1",
     "svg2pdf.js": "^1.5.0",
+    "true-myth": "^4.1.0",
+    "ts-jest": "^26.4.4",
     "ts-node": "^9.0.0",
     "tslib": "^2.0.3"
   },
@@ -79,6 +81,7 @@
     "ttypescript": "^1.5.12",
     "typedoc": "^0.19.2",
     "typescript": "^3.9.5",
+    "true-myth": "^4.1.0",
     "typescript-transform-paths": "^2.0.1"
   },
   "browserslist": [

--- a/penrose-web/package.json
+++ b/penrose-web/package.json
@@ -8,6 +8,7 @@
   "dependencies": {
     "@penrose/linear-algebra": "^1.0.0",
     "@reach/tabs": "^0.9.0",
+    "@types/graphlib": "^2.1.7",
     "@types/nearley": "^2.11.1",
     "@types/seedrandom": "^2.4.28",
     "@typescript-eslint/eslint-plugin": "^4.5.0",
@@ -18,6 +19,7 @@
     "eslint": "^6.6.0",
     "eslint-plugin-prefer-arrow": "^1.2.2",
     "fast-memoize": "^2.5.2",
+    "graphlib": "^2.1.8",
     "immutable": "^4.0.0-rc.12",
     "lodash": "^4.17.15",
     "mathjax-full": "^3.0.1",

--- a/penrose-web/src/__tests__/env.json
+++ b/penrose-web/src/__tests__/env.json
@@ -1,0 +1,1262 @@
+{
+  "type": "varEnv",
+  "contents": {
+    "typeConstructors": {
+      "Map": {
+        "nametc": "Map",
+        "kindstc": []
+      },
+      "Point": {
+        "nametc": "Point",
+        "kindstc": []
+      },
+      "Set": {
+        "nametc": "Set",
+        "kindstc": []
+      },
+      "String": {
+        "nametc": "String",
+        "kindstc": []
+      }
+    },
+    "valConstructors": {
+      "Singleton": {
+        "namevc": "Singleton",
+        "ylsvc": [],
+        "kindsvc": [],
+        "nsvc": [
+          "p"
+        ],
+        "tlsvc": [
+          {
+            "tag": "TConstr",
+            "contents": {
+              "nameCons": "Point",
+              "argCons": [],
+              "constructorInvokerPos": {
+                "sourceName": "",
+                "sourceLine": 5,
+                "sourceColumn": 31
+              }
+            }
+          }
+        ],
+        "tvc": {
+          "tag": "TConstr",
+          "contents": {
+            "nameCons": "Set",
+            "argCons": [],
+            "constructorInvokerPos": {
+              "sourceName": "",
+              "sourceLine": 5,
+              "sourceColumn": 39
+            }
+          }
+        }
+      }
+    },
+    "operators": {
+      "AddPoint": {
+        "nameop": "AddPoint",
+        "ylsop": [],
+        "kindsop": [],
+        "tlsop": [
+          {
+            "tag": "TConstr",
+            "contents": {
+              "nameCons": "Point",
+              "argCons": [],
+              "constructorInvokerPos": {
+                "sourceName": "",
+                "sourceLine": 13,
+                "sourceColumn": 27
+              }
+            }
+          },
+          {
+            "tag": "TConstr",
+            "contents": {
+              "nameCons": "Set",
+              "argCons": [],
+              "constructorInvokerPos": {
+                "sourceName": "",
+                "sourceLine": 13,
+                "sourceColumn": 35
+              }
+            }
+          }
+        ],
+        "top": {
+          "tag": "TConstr",
+          "contents": {
+            "nameCons": "Set",
+            "argCons": [],
+            "constructorInvokerPos": {
+              "sourceName": "",
+              "sourceLine": 13,
+              "sourceColumn": 44
+            }
+          }
+        }
+      },
+      "CartesianProduct": {
+        "nameop": "CartesianProduct",
+        "ylsop": [],
+        "kindsop": [],
+        "tlsop": [
+          {
+            "tag": "TConstr",
+            "contents": {
+              "nameCons": "Set",
+              "argCons": [],
+              "constructorInvokerPos": {
+                "sourceName": "",
+                "sourceLine": 10,
+                "sourceColumn": 33
+              }
+            }
+          },
+          {
+            "tag": "TConstr",
+            "contents": {
+              "nameCons": "Set",
+              "argCons": [],
+              "constructorInvokerPos": {
+                "sourceName": "",
+                "sourceLine": 10,
+                "sourceColumn": 41
+              }
+            }
+          }
+        ],
+        "top": {
+          "tag": "TConstr",
+          "contents": {
+            "nameCons": "Set",
+            "argCons": [],
+            "constructorInvokerPos": {
+              "sourceName": "",
+              "sourceLine": 10,
+              "sourceColumn": 49
+            }
+          }
+        }
+      },
+      "Difference": {
+        "nameop": "Difference",
+        "ylsop": [],
+        "kindsop": [],
+        "tlsop": [
+          {
+            "tag": "TConstr",
+            "contents": {
+              "nameCons": "Set",
+              "argCons": [],
+              "constructorInvokerPos": {
+                "sourceName": "",
+                "sourceLine": 11,
+                "sourceColumn": 27
+              }
+            }
+          },
+          {
+            "tag": "TConstr",
+            "contents": {
+              "nameCons": "Set",
+              "argCons": [],
+              "constructorInvokerPos": {
+                "sourceName": "",
+                "sourceLine": 11,
+                "sourceColumn": 35
+              }
+            }
+          }
+        ],
+        "top": {
+          "tag": "TConstr",
+          "contents": {
+            "nameCons": "Set",
+            "argCons": [],
+            "constructorInvokerPos": {
+              "sourceName": "",
+              "sourceLine": 11,
+              "sourceColumn": 43
+            }
+          }
+        }
+      },
+      "Intersection": {
+        "nameop": "Intersection",
+        "ylsop": [],
+        "kindsop": [],
+        "tlsop": [
+          {
+            "tag": "TConstr",
+            "contents": {
+              "nameCons": "Set",
+              "argCons": [],
+              "constructorInvokerPos": {
+                "sourceName": "",
+                "sourceLine": 7,
+                "sourceColumn": 29
+              }
+            }
+          },
+          {
+            "tag": "TConstr",
+            "contents": {
+              "nameCons": "Set",
+              "argCons": [],
+              "constructorInvokerPos": {
+                "sourceName": "",
+                "sourceLine": 7,
+                "sourceColumn": 37
+              }
+            }
+          }
+        ],
+        "top": {
+          "tag": "TConstr",
+          "contents": {
+            "nameCons": "Set",
+            "argCons": [],
+            "constructorInvokerPos": {
+              "sourceName": "",
+              "sourceLine": 7,
+              "sourceColumn": 45
+            }
+          }
+        }
+      },
+      "Subset": {
+        "nameop": "Subset",
+        "ylsop": [],
+        "kindsop": [],
+        "tlsop": [
+          {
+            "tag": "TConstr",
+            "contents": {
+              "nameCons": "Set",
+              "argCons": [],
+              "constructorInvokerPos": {
+                "sourceName": "",
+                "sourceLine": 12,
+                "sourceColumn": 23
+              }
+            }
+          },
+          {
+            "tag": "TConstr",
+            "contents": {
+              "nameCons": "Set",
+              "argCons": [],
+              "constructorInvokerPos": {
+                "sourceName": "",
+                "sourceLine": 12,
+                "sourceColumn": 31
+              }
+            }
+          }
+        ],
+        "top": {
+          "tag": "TConstr",
+          "contents": {
+            "nameCons": "Set",
+            "argCons": [],
+            "constructorInvokerPos": {
+              "sourceName": "",
+              "sourceLine": 12,
+              "sourceColumn": 39
+            }
+          }
+        }
+      },
+      "Subtraction": {
+        "nameop": "Subtraction",
+        "ylsop": [],
+        "kindsop": [],
+        "tlsop": [
+          {
+            "tag": "TConstr",
+            "contents": {
+              "nameCons": "Set",
+              "argCons": [],
+              "constructorInvokerPos": {
+                "sourceName": "",
+                "sourceLine": 9,
+                "sourceColumn": 28
+              }
+            }
+          },
+          {
+            "tag": "TConstr",
+            "contents": {
+              "nameCons": "Set",
+              "argCons": [],
+              "constructorInvokerPos": {
+                "sourceName": "",
+                "sourceLine": 9,
+                "sourceColumn": 36
+              }
+            }
+          }
+        ],
+        "top": {
+          "tag": "TConstr",
+          "contents": {
+            "nameCons": "Set",
+            "argCons": [],
+            "constructorInvokerPos": {
+              "sourceName": "",
+              "sourceLine": 9,
+              "sourceColumn": 44
+            }
+          }
+        }
+      },
+      "Union": {
+        "nameop": "Union",
+        "ylsop": [],
+        "kindsop": [],
+        "tlsop": [
+          {
+            "tag": "TConstr",
+            "contents": {
+              "nameCons": "Set",
+              "argCons": [],
+              "constructorInvokerPos": {
+                "sourceName": "",
+                "sourceLine": 8,
+                "sourceColumn": 22
+              }
+            }
+          },
+          {
+            "tag": "TConstr",
+            "contents": {
+              "nameCons": "Set",
+              "argCons": [],
+              "constructorInvokerPos": {
+                "sourceName": "",
+                "sourceLine": 8,
+                "sourceColumn": 30
+              }
+            }
+          }
+        ],
+        "top": {
+          "tag": "TConstr",
+          "contents": {
+            "nameCons": "Set",
+            "argCons": [],
+            "constructorInvokerPos": {
+              "sourceName": "",
+              "sourceLine": 8,
+              "sourceColumn": 38
+            }
+          }
+        }
+      }
+    },
+    "predicates": {
+      "Bijection": {
+        "tag": "Pred1",
+        "contents": {
+          "namepred1": "Bijection",
+          "ylspred1": [],
+          "kindspred1": [],
+          "tlspred1": [
+            {
+              "tag": "TConstr",
+              "contents": {
+                "nameCons": "Map",
+                "argCons": [],
+                "constructorInvokerPos": {
+                  "sourceName": "",
+                  "sourceLine": 24,
+                  "sourceColumn": 27
+                }
+              }
+            }
+          ]
+        }
+      },
+      "Empty": {
+        "tag": "Pred1",
+        "contents": {
+          "namepred1": "Empty",
+          "ylspred1": [],
+          "kindspred1": [],
+          "tlspred1": [
+            {
+              "tag": "TConstr",
+              "contents": {
+                "nameCons": "Set",
+                "argCons": [],
+                "constructorInvokerPos": {
+                  "sourceName": "",
+                  "sourceLine": 17,
+                  "sourceColumn": 23
+                }
+              }
+            }
+          ]
+        }
+      },
+      "From": {
+        "tag": "Pred1",
+        "contents": {
+          "namepred1": "From",
+          "ylspred1": [],
+          "kindspred1": [],
+          "tlspred1": [
+            {
+              "tag": "TConstr",
+              "contents": {
+                "nameCons": "Map",
+                "argCons": [],
+                "constructorInvokerPos": {
+                  "sourceName": "",
+                  "sourceLine": 16,
+                  "sourceColumn": 22
+                }
+              }
+            },
+            {
+              "tag": "TConstr",
+              "contents": {
+                "nameCons": "Set",
+                "argCons": [],
+                "constructorInvokerPos": {
+                  "sourceName": "",
+                  "sourceLine": 16,
+                  "sourceColumn": 30
+                }
+              }
+            },
+            {
+              "tag": "TConstr",
+              "contents": {
+                "nameCons": "Set",
+                "argCons": [],
+                "constructorInvokerPos": {
+                  "sourceName": "",
+                  "sourceLine": 16,
+                  "sourceColumn": 43
+                }
+              }
+            }
+          ]
+        }
+      },
+      "In": {
+        "tag": "Pred1",
+        "contents": {
+          "namepred1": "In",
+          "ylspred1": [],
+          "kindspred1": [],
+          "tlspred1": [
+            {
+              "tag": "TConstr",
+              "contents": {
+                "nameCons": "Point",
+                "argCons": [],
+                "constructorInvokerPos": {
+                  "sourceName": "",
+                  "sourceLine": 21,
+                  "sourceColumn": 22
+                }
+              }
+            },
+            {
+              "tag": "TConstr",
+              "contents": {
+                "nameCons": "Set",
+                "argCons": [],
+                "constructorInvokerPos": {
+                  "sourceName": "",
+                  "sourceLine": 21,
+                  "sourceColumn": 30
+                }
+              }
+            }
+          ]
+        }
+      },
+      "Injection": {
+        "tag": "Pred1",
+        "contents": {
+          "namepred1": "Injection",
+          "ylspred1": [],
+          "kindspred1": [],
+          "tlspred1": [
+            {
+              "tag": "TConstr",
+              "contents": {
+                "nameCons": "Map",
+                "argCons": [],
+                "constructorInvokerPos": {
+                  "sourceName": "",
+                  "sourceLine": 22,
+                  "sourceColumn": 27
+                }
+              }
+            }
+          ]
+        }
+      },
+      "Intersecting": {
+        "tag": "Pred1",
+        "contents": {
+          "namepred1": "Intersecting",
+          "ylspred1": [],
+          "kindspred1": [],
+          "tlspred1": [
+            {
+              "tag": "TConstr",
+              "contents": {
+                "nameCons": "Set",
+                "argCons": [],
+                "constructorInvokerPos": {
+                  "sourceName": "",
+                  "sourceLine": 18,
+                  "sourceColumn": 30
+                }
+              }
+            },
+            {
+              "tag": "TConstr",
+              "contents": {
+                "nameCons": "Set",
+                "argCons": [],
+                "constructorInvokerPos": {
+                  "sourceName": "",
+                  "sourceLine": 18,
+                  "sourceColumn": 39
+                }
+              }
+            }
+          ]
+        }
+      },
+      "IsSubset": {
+        "tag": "Pred1",
+        "contents": {
+          "namepred1": "IsSubset",
+          "ylspred1": [],
+          "kindspred1": [],
+          "tlspred1": [
+            {
+              "tag": "TConstr",
+              "contents": {
+                "nameCons": "Set",
+                "argCons": [],
+                "constructorInvokerPos": {
+                  "sourceName": "",
+                  "sourceLine": 19,
+                  "sourceColumn": 26
+                }
+              }
+            },
+            {
+              "tag": "TConstr",
+              "contents": {
+                "nameCons": "Set",
+                "argCons": [],
+                "constructorInvokerPos": {
+                  "sourceName": "",
+                  "sourceLine": 19,
+                  "sourceColumn": 35
+                }
+              }
+            }
+          ]
+        }
+      },
+      "Not": {
+        "tag": "Pred2",
+        "contents": {
+          "namepred2": "Not",
+          "plspred2": [
+            {
+              "propName": "Prop",
+              "propPos": {
+                "sourceName": "",
+                "sourceLine": 15,
+                "sourceColumn": 22
+              }
+            }
+          ]
+        }
+      },
+      "PairIn": {
+        "tag": "Pred1",
+        "contents": {
+          "namepred1": "PairIn",
+          "ylspred1": [],
+          "kindspred1": [],
+          "tlspred1": [
+            {
+              "tag": "TConstr",
+              "contents": {
+                "nameCons": "Point",
+                "argCons": [],
+                "constructorInvokerPos": {
+                  "sourceName": "",
+                  "sourceLine": 25,
+                  "sourceColumn": 26
+                }
+              }
+            },
+            {
+              "tag": "TConstr",
+              "contents": {
+                "nameCons": "Point",
+                "argCons": [],
+                "constructorInvokerPos": {
+                  "sourceName": "",
+                  "sourceLine": 25,
+                  "sourceColumn": 34
+                }
+              }
+            },
+            {
+              "tag": "TConstr",
+              "contents": {
+                "nameCons": "Map",
+                "argCons": [],
+                "constructorInvokerPos": {
+                  "sourceName": "",
+                  "sourceLine": 25,
+                  "sourceColumn": 39
+                }
+              }
+            }
+          ]
+        }
+      },
+      "PointIn": {
+        "tag": "Pred1",
+        "contents": {
+          "namepred1": "PointIn",
+          "ylspred1": [],
+          "kindspred1": [],
+          "tlspred1": [
+            {
+              "tag": "TConstr",
+              "contents": {
+                "nameCons": "Set",
+                "argCons": [],
+                "constructorInvokerPos": {
+                  "sourceName": "",
+                  "sourceLine": 20,
+                  "sourceColumn": 25
+                }
+              }
+            },
+            {
+              "tag": "TConstr",
+              "contents": {
+                "nameCons": "Point",
+                "argCons": [],
+                "constructorInvokerPos": {
+                  "sourceName": "",
+                  "sourceLine": 20,
+                  "sourceColumn": 35
+                }
+              }
+            }
+          ]
+        }
+      },
+      "Surjection": {
+        "tag": "Pred1",
+        "contents": {
+          "namepred1": "Surjection",
+          "ylspred1": [],
+          "kindspred1": [],
+          "tlspred1": [
+            {
+              "tag": "TConstr",
+              "contents": {
+                "nameCons": "Map",
+                "argCons": [],
+                "constructorInvokerPos": {
+                  "sourceName": "",
+                  "sourceLine": 23,
+                  "sourceColumn": 28
+                }
+              }
+            }
+          ]
+        }
+      }
+    },
+    "typeVarMap": [],
+    "typeValConstructor": [
+      [
+        {
+          "tag": "TConstr",
+          "contents": {
+            "nameCons": "Set",
+            "argCons": [],
+            "constructorInvokerPos": {
+              "sourceName": "",
+              "sourceLine": 5,
+              "sourceColumn": 39
+            }
+          }
+        },
+        {
+          "namevc": "Singleton",
+          "ylsvc": [],
+          "kindsvc": [],
+          "nsvc": [
+            "p"
+          ],
+          "tlsvc": [
+            {
+              "tag": "TConstr",
+              "contents": {
+                "nameCons": "Point",
+                "argCons": [],
+                "constructorInvokerPos": {
+                  "sourceName": "",
+                  "sourceLine": 5,
+                  "sourceColumn": 31
+                }
+              }
+            }
+          ],
+          "tvc": {
+            "tag": "TConstr",
+            "contents": {
+              "nameCons": "Set",
+              "argCons": [],
+              "constructorInvokerPos": {
+                "sourceName": "",
+                "sourceLine": 5,
+                "sourceColumn": 39
+              }
+            }
+          }
+        }
+      ]
+    ],
+    "varMap": [],
+    "preludes": [],
+    "subTypes": [],
+    "typeCtorNames": [
+      "PairIn",
+      "Bijection",
+      "Surjection",
+      "Injection",
+      "In",
+      "PointIn",
+      "IsSubset",
+      "Intersecting",
+      "Empty",
+      "From",
+      "Not",
+      "AddPoint",
+      "Subset",
+      "Difference",
+      "CartesianProduct",
+      "Subtraction",
+      "Union",
+      "Intersection",
+      "Singleton",
+      "Map",
+      "Point",
+      "Set",
+      "String"
+    ],
+    "declaredNames": [],
+    "stmtNotations": [
+      {
+        "fromSnr": [
+          {
+            "tag": "DSLLEntity",
+            "contents": "Map"
+          },
+          {
+            "tag": "Space"
+          },
+          {
+            "tag": "Pattern",
+            "contents": [
+              "f",
+              false
+            ]
+          },
+          {
+            "tag": "NewLine"
+          },
+          {
+            "tag": "Space"
+          },
+          {
+            "tag": "DSLLEntity",
+            "contents": "From"
+          },
+          {
+            "tag": "Lparen"
+          },
+          {
+            "tag": "Pattern",
+            "contents": [
+              "f",
+              false
+            ]
+          },
+          {
+            "tag": "Comma"
+          },
+          {
+            "tag": "Space"
+          },
+          {
+            "tag": "Pattern",
+            "contents": [
+              "A",
+              false
+            ]
+          },
+          {
+            "tag": "Comma"
+          },
+          {
+            "tag": "Space"
+          },
+          {
+            "tag": "Pattern",
+            "contents": [
+              "B",
+              false
+            ]
+          },
+          {
+            "tag": "Rparen"
+          }
+        ],
+        "toSnr": [
+          {
+            "tag": "Pattern",
+            "contents": [
+              "f",
+              false
+            ]
+          },
+          {
+            "tag": "Sym",
+            "contents": ":"
+          },
+          {
+            "tag": "Space"
+          },
+          {
+            "tag": "Pattern",
+            "contents": [
+              "A",
+              false
+            ]
+          },
+          {
+            "tag": "Space"
+          },
+          {
+            "tag": "Sym",
+            "contents": "-"
+          },
+          {
+            "tag": "Sym",
+            "contents": ">"
+          },
+          {
+            "tag": "Space"
+          },
+          {
+            "tag": "Pattern",
+            "contents": [
+              "B",
+              false
+            ]
+          }
+        ],
+        "patternsSnr": [
+          {
+            "tag": "Pattern",
+            "contents": [
+              "f",
+              false
+            ]
+          },
+          {
+            "tag": "Pattern",
+            "contents": [
+              "f",
+              false
+            ]
+          },
+          {
+            "tag": "Pattern",
+            "contents": [
+              "A",
+              false
+            ]
+          },
+          {
+            "tag": "Pattern",
+            "contents": [
+              "B",
+              false
+            ]
+          }
+        ],
+        "entitiesSnr": []
+      },
+      {
+        "fromSnr": [
+          {
+            "tag": "DSLLEntity",
+            "contents": "Not"
+          },
+          {
+            "tag": "Lparen"
+          },
+          {
+            "tag": "DSLLEntity",
+            "contents": "Intersecting"
+          },
+          {
+            "tag": "Lparen"
+          },
+          {
+            "tag": "Pattern",
+            "contents": [
+              "A",
+              false
+            ]
+          },
+          {
+            "tag": "Comma"
+          },
+          {
+            "tag": "Space"
+          },
+          {
+            "tag": "Pattern",
+            "contents": [
+              "B",
+              false
+            ]
+          },
+          {
+            "tag": "Rparen"
+          },
+          {
+            "tag": "Rparen"
+          }
+        ],
+        "toSnr": [
+          {
+            "tag": "Pattern",
+            "contents": [
+              "A",
+              false
+            ]
+          },
+          {
+            "tag": "Space"
+          },
+          {
+            "tag": "Sym",
+            "contents": "∩"
+          },
+          {
+            "tag": "Space"
+          },
+          {
+            "tag": "Pattern",
+            "contents": [
+              "B",
+              false
+            ]
+          },
+          {
+            "tag": "Space"
+          },
+          {
+            "tag": "ExprEq"
+          },
+          {
+            "tag": "Space"
+          },
+          {
+            "tag": "Sym",
+            "contents": "∅"
+          }
+        ],
+        "patternsSnr": [
+          {
+            "tag": "Pattern",
+            "contents": [
+              "A",
+              false
+            ]
+          },
+          {
+            "tag": "Pattern",
+            "contents": [
+              "B",
+              false
+            ]
+          }
+        ],
+        "entitiesSnr": []
+      },
+      {
+        "fromSnr": [
+          {
+            "tag": "Pattern",
+            "contents": [
+              "PointNotIn",
+              false
+            ]
+          },
+          {
+            "tag": "Lparen"
+          },
+          {
+            "tag": "Pattern",
+            "contents": [
+              "A",
+              false
+            ]
+          },
+          {
+            "tag": "Comma"
+          },
+          {
+            "tag": "Space"
+          },
+          {
+            "tag": "Pattern",
+            "contents": [
+              "p",
+              false
+            ]
+          },
+          {
+            "tag": "Rparen"
+          }
+        ],
+        "toSnr": [
+          {
+            "tag": "Pattern",
+            "contents": [
+              "p",
+              false
+            ]
+          },
+          {
+            "tag": "Space"
+          },
+          {
+            "tag": "Sym",
+            "contents": "∉"
+          },
+          {
+            "tag": "Space"
+          },
+          {
+            "tag": "Pattern",
+            "contents": [
+              "A",
+              false
+            ]
+          }
+        ],
+        "patternsSnr": [
+          {
+            "tag": "Pattern",
+            "contents": [
+              "PointNotIn",
+              false
+            ]
+          },
+          {
+            "tag": "Pattern",
+            "contents": [
+              "A",
+              false
+            ]
+          },
+          {
+            "tag": "Pattern",
+            "contents": [
+              "p",
+              false
+            ]
+          }
+        ],
+        "entitiesSnr": []
+      },
+      {
+        "fromSnr": [
+          {
+            "tag": "DSLLEntity",
+            "contents": "PointIn"
+          },
+          {
+            "tag": "Lparen"
+          },
+          {
+            "tag": "Pattern",
+            "contents": [
+              "A",
+              false
+            ]
+          },
+          {
+            "tag": "Comma"
+          },
+          {
+            "tag": "Space"
+          },
+          {
+            "tag": "Pattern",
+            "contents": [
+              "p",
+              false
+            ]
+          },
+          {
+            "tag": "Rparen"
+          }
+        ],
+        "toSnr": [
+          {
+            "tag": "Pattern",
+            "contents": [
+              "p",
+              false
+            ]
+          },
+          {
+            "tag": "Space"
+          },
+          {
+            "tag": "Sym",
+            "contents": "∈"
+          },
+          {
+            "tag": "Space"
+          },
+          {
+            "tag": "Pattern",
+            "contents": [
+              "A",
+              false
+            ]
+          }
+        ],
+        "patternsSnr": [
+          {
+            "tag": "Pattern",
+            "contents": [
+              "A",
+              false
+            ]
+          },
+          {
+            "tag": "Pattern",
+            "contents": [
+              "p",
+              false
+            ]
+          }
+        ],
+        "entitiesSnr": []
+      },
+      {
+        "fromSnr": [
+          {
+            "tag": "DSLLEntity",
+            "contents": "IsSubset"
+          },
+          {
+            "tag": "Lparen"
+          },
+          {
+            "tag": "Pattern",
+            "contents": [
+              "A",
+              false
+            ]
+          },
+          {
+            "tag": "Comma"
+          },
+          {
+            "tag": "Space"
+          },
+          {
+            "tag": "Pattern",
+            "contents": [
+              "B",
+              false
+            ]
+          },
+          {
+            "tag": "Rparen"
+          }
+        ],
+        "toSnr": [
+          {
+            "tag": "Pattern",
+            "contents": [
+              "A",
+              false
+            ]
+          },
+          {
+            "tag": "Space"
+          },
+          {
+            "tag": "Sym",
+            "contents": "⊂"
+          },
+          {
+            "tag": "Space"
+          },
+          {
+            "tag": "Pattern",
+            "contents": [
+              "B",
+              false
+            ]
+          }
+        ],
+        "patternsSnr": [
+          {
+            "tag": "Pattern",
+            "contents": [
+              "A",
+              false
+            ]
+          },
+          {
+            "tag": "Pattern",
+            "contents": [
+              "B",
+              false
+            ]
+          }
+        ],
+        "entitiesSnr": []
+      }
+    ],
+    "errors": ""
+  }
+}

--- a/penrose-web/src/compiler/Domain.test.ts
+++ b/penrose-web/src/compiler/Domain.test.ts
@@ -2,8 +2,12 @@ import * as nearley from "nearley";
 import grammar from "parser/DomainParser";
 import * as path from "path";
 import * as fs from "fs";
-import { result } from "lodash";
-import { checkDomain } from "compiler/Domain";
+import { checkDomain, errorString } from "compiler/Domain";
+
+const compileDomain = (prog: string) => {
+  const { results } = parser.feed(prog);
+  return checkDomain(results[0]);
+};
 
 let parser: nearley.Parser;
 beforeEach(() => {
@@ -21,8 +25,79 @@ type Set
 type Point 
 type Set
     `;
-    const { results } = parser.feed(prog);
-    const res = checkDomain(results[0]);
-    console.log(res);
+  });
+});
+
+describe("Statements", () => {
+  test("constructor decl", () => {
+    const prog = `
+type List ('T)
+type Real
+type Interval
+type OpenInterval
+type ClosedInterval
+constructor Cons ['X] : 'X head * List('X) tail -> List('X)
+constructor Nil['X] -> List('X)
+constructor CreateInterval: Real left * Real right -> Interval
+constructor CreateOpenInterval: Real left * Real right -> OpenInterval
+constructor CreateClosedInterval: Real left * Real right -> ClosedInterval
+    `;
+    const res = compileDomain(prog);
+
+    if (res.isOk()) {
+      const [...typeVars] = res.value.typeVars.keys();
+      expect(typeVars.length).toBe(0);
+      const [...types] = res.value.types.keys();
+      expect(types).toEqual([
+        "String",
+        "List",
+        "Real",
+        "Interval",
+        "OpenInterval",
+        "ClosedInterval",
+      ]);
+      const [...constructors] = res.value.constructors.keys();
+      expect(constructors).toEqual([
+        "Cons",
+        "Nil",
+        "CreateInterval",
+        "CreateOpenInterval",
+        "CreateClosedInterval",
+      ]);
+    } else {
+      fail(errorString(res.error));
+    }
+  });
+});
+
+describe("Errors", () => {
+  const expectErrorOf = (prog: string, errorType: string) => {
+    const result = compileDomain(prog);
+    if (result.isErr()) {
+      expect(compileDomain(prog).unsafelyUnwrapErr().tag).toBe(errorType);
+      console.log(errorString(result.error));
+    } else {
+      fail(`Error ${errorType} was suppoed to occur.`);
+    }
+  };
+  test("Duplicate names", () => {
+    const prog = `
+type Set 
+type Point 
+type Set
+    `;
+    expectErrorOf(prog, "DuplicateName");
+  });
+  test("Type not found", () => {
+    const prog = `
+constructor Cons ['X] : 'X head * List('X) tail -> List('X)
+    `;
+    expectErrorOf(prog, "TypeNotFound");
+  });
+  test("TypeVarNotFound", () => {
+    const prog = `
+constructor Cons ['X] : 'Z head * List('Y) tail -> List('X)
+    `;
+    expectErrorOf(prog, "TypeVarNotFound");
   });
 });

--- a/penrose-web/src/compiler/Domain.test.ts
+++ b/penrose-web/src/compiler/Domain.test.ts
@@ -1,0 +1,28 @@
+import * as nearley from "nearley";
+import grammar from "parser/DomainParser";
+import * as path from "path";
+import * as fs from "fs";
+import { result } from "lodash";
+import { checkDomain } from "compiler/Domain";
+
+let parser: nearley.Parser;
+beforeEach(() => {
+  // NOTE: Neither `feed` nor `finish` will reset the parser state. Therefore recompiling before each unit test
+  parser = new nearley.Parser(nearley.Grammar.fromCompiled(grammar));
+});
+
+describe("Common", () => {
+  test("empty program", () => {
+    const { results } = parser.feed("");
+  });
+  test("comments", () => {
+    const prog = `
+type Set 
+type Point 
+type Set
+    `;
+    const { results } = parser.feed(prog);
+    const res = checkDomain(results[0]);
+    console.log(res);
+  });
+});

--- a/penrose-web/src/compiler/Domain.test.ts
+++ b/penrose-web/src/compiler/Domain.test.ts
@@ -122,8 +122,8 @@ describe("Errors", () => {
   const expectErrorOf = (prog: string, errorType: string) => {
     const result = compileDomain(prog);
     if (result.isErr()) {
-      expect(compileDomain(prog).unsafelyUnwrapErr().tag).toBe(errorType);
       console.log(showDomainErr(result.error));
+      expect(result.error.tag).toBe(errorType);
     } else {
       fail(`Error ${errorType} was suppoed to occur.`);
     }
@@ -142,10 +142,39 @@ constructor Cons ['X] : 'X head * List('X) tail -> List('X)
     `;
     expectErrorOf(prog, "TypeNotFound");
   });
-  test("TypeVarNotFound", () => {
+  test("type var not found", () => {
     const prog = `
-constructor Cons ['X] : 'Z head * List('Y) tail -> List('X)
+  constructor Cons ['X] : 'Z head * List('Y) tail -> List('X)
     `;
     expectErrorOf(prog, "TypeVarNotFound");
+  });
+  test("prop in subtyping relation", () => {
+    const prog = `
+  type Set
+  Prop <: Set
+    `;
+    expectErrorOf(prog, "NotTypeConsInSubtype");
+  });
+  test("type var in subtyping relation", () => {
+    const prog = `
+  'T <: 'V
+    `;
+    expectErrorOf(prog, "NotTypeConsInSubtype");
+  });
+  test("subtype cycle", () => {
+    const prog = `
+  type A
+  type B
+  type C
+  type D
+  type E
+  C <: B
+  B <: A
+  A <: C
+  D <: C
+  E <: D
+  D <: E
+    `;
+    expectErrorOf(prog, "CyclicSubtypes");
   });
 });

--- a/penrose-web/src/compiler/Domain.test.ts
+++ b/penrose-web/src/compiler/Domain.test.ts
@@ -2,12 +2,8 @@ import * as nearley from "nearley";
 import grammar from "parser/DomainParser";
 import * as path from "path";
 import * as fs from "fs";
-import {
-  checkDomain,
-  errorString,
-  DomainEnv,
-  CheckerResult,
-} from "compiler/Domain";
+import { checkDomain, DomainEnv, CheckerResult } from "compiler/Domain";
+import { showDomainErr } from "utils/Error";
 import { compile } from "moo";
 import { type } from "os";
 
@@ -31,7 +27,7 @@ const contextHas = (
     expectedFunctions.map((f) => expect(functions.has(f)).toBe(true));
     expectedPredicates.map((p) => expect(predicates.has(p)).toBe(true));
   } else {
-    fail(errorString(res.error));
+    fail(showDomainErr(res.error));
   }
 };
 
@@ -127,7 +123,7 @@ describe("Errors", () => {
     const result = compileDomain(prog);
     if (result.isErr()) {
       expect(compileDomain(prog).unsafelyUnwrapErr().tag).toBe(errorType);
-      console.log(errorString(result.error));
+      console.log(showDomainErr(result.error));
     } else {
       fail(`Error ${errorType} was suppoed to occur.`);
     }

--- a/penrose-web/src/compiler/Domain.ts
+++ b/penrose-web/src/compiler/Domain.ts
@@ -1,51 +1,16 @@
 import { Map } from "immutable";
 import { keyBy } from "lodash";
-import { Result } from "true-myth";
-const { or, and, ok, err, andThen } = Result;
-
-// TODO: separate out error handling functions to another module
+import {
+  all,
+  and,
+  duplicateName,
+  err,
+  ok,
+  Result,
+  safeChain,
+} from "utils/Error";
 
 export type CheckerResult = Result<DomainEnv, DomainError>;
-
-// TODO: fix template formatting
-export const errorString = (error: DomainError): string => {
-  switch (error.tag) {
-    case "TypeDeclared": {
-      return `Type ${error.typeName.value} already exists`;
-    }
-    case "TypeNotFound": {
-      return `Type ${error.typeName.value} (at ${loc(
-        error.typeName
-      )}) does not exist`;
-    }
-    case "TypeVarNotFound": {
-      return `Type variable ${error.typeVar.name.value} (at ${loc(
-        error.typeVar
-      )}) does not exist`;
-    }
-    case "DuplicateName": {
-      const { firstDefined, name, location } = error;
-      return `Name ${name.value} (at ${loc(
-        location
-      )}) already exists, first declared at ${loc(firstDefined)}`;
-    }
-  }
-};
-
-// action constructors for error
-const duplicateName = (
-  name: Identifier,
-  location: ASTNode,
-  firstDefined: ASTNode
-): DuplicateName => ({
-  tag: "DuplicateName",
-  name,
-  location,
-  firstDefined,
-});
-
-// const loc = (node: ASTNode) => `${node.start.line}:${node.start.col}`;
-const loc = (node: ASTNode) => `line ${node.start.line}`;
 
 export interface DomainEnv {
   types: Map<string, TypeDecl>;
@@ -58,6 +23,29 @@ export interface DomainEnv {
   subTypes: [Type, Type][];
 }
 
+// HACK: locations for dummy AST nodes. Revisit if this pattern becomes widespread.
+// TODO: move this function to a util module
+const idOf = (value: string) => ({
+  start: { line: 1, col: 1 },
+  end: { line: 1, col: 1 },
+  tag: "Identifier",
+  type: "identifier",
+  value: value,
+});
+
+/* Built in types for all Domain programs */
+const builtinTypes: [string, TypeDecl][] = [
+  [
+    "String",
+    {
+      start: { line: 1, col: 1 },
+      end: { line: 1, col: 1 },
+      tag: "TypeDecl",
+      name: idOf("String"),
+      params: [],
+    },
+  ],
+];
 const initEnv = (): DomainEnv => ({
   types: Map(builtinTypes),
   typeVars: Map(),
@@ -69,24 +57,10 @@ const initEnv = (): DomainEnv => ({
   subTypes: [],
 });
 
-const all = <Ok, Error>(...results: Result<Ok, Error>[]): Result<Ok, Error> =>
-  results.reduce(
-    (currentResult: Result<Ok, Error>, nextResult: Result<Ok, Error>) =>
-      and(nextResult, currentResult),
-    results[0] // TODO: separate out this element in argument
-  );
-
-const safeChain = <Item, Ok, Error>(
-  itemList: Item[],
-  func: (nextItem: Item, currentResult: Ok) => Result<Ok, Error>,
-  initialResult: Result<Ok, Error>
-): Result<Ok, Error> =>
-  itemList.reduce(
-    (currentResult: Result<Ok, Error>, nextItem: Item) =>
-      andThen((res: Ok) => func(nextItem, res), currentResult),
-    initialResult
-  );
-
+/**
+ * Top-level function for the Domain semantic checker. Given a Domain AST, it output either a `DomainError` or a `DomainEnv` context.
+ * @param prog compiled AST of a Domain program
+ */
 export const checkDomain = (prog: DomainProg): CheckerResult => {
   const { statements } = prog;
   // load built-in types
@@ -229,25 +203,3 @@ const checkTypeConstructor = (
 
 const checkArg = (arg: Arg, env: DomainEnv): CheckerResult =>
   checkType(arg.type, env);
-
-// HACK: locations for dummy AST nodes. Revisit if this pattern becomes widespread.
-const idOf = (value: string) => ({
-  start: { line: 1, col: 1 },
-  end: { line: 1, col: 1 },
-  tag: "Identifier",
-  type: "identifier",
-  value: value,
-});
-
-const builtinTypes: [string, TypeDecl][] = [
-  [
-    "String",
-    {
-      start: { line: 1, col: 1 },
-      end: { line: 1, col: 1 },
-      tag: "TypeDecl",
-      name: idOf("String"),
-      params: [],
-    },
-  ],
-];

--- a/penrose-web/src/compiler/Domain.ts
+++ b/penrose-web/src/compiler/Domain.ts
@@ -1,0 +1,70 @@
+import { Result } from "true-myth";
+const { ok, err, andThen } = Result;
+type CheckerResult = Result<DomainEnv, DomainError>;
+
+const toString = (error: DomainError): string => {
+  switch (error.tag) {
+    case "TypeDeclaredError": {
+      return `Name ${error.typeName} already exists in the context`;
+    }
+  }
+};
+
+interface DomainEnv {
+  types: Map<string, TypeDecl>;
+}
+
+export const checkDomain = (prog: DomainProg): CheckerResult => {
+  const { statements } = prog;
+  // load built-in types
+  const env: DomainEnv = initEnv();
+  // check all statements
+  const res: CheckerResult = statements.reduce(
+    (envOrError: CheckerResult, stmt: DomainStmt) =>
+      andThen((env) => checkStmt(stmt, env), envOrError),
+    ok(env)
+  );
+  return res;
+};
+
+const checkStmt = (stmt: DomainStmt, env: DomainEnv): CheckerResult => {
+  switch (stmt.tag) {
+    case "TypeDecl": {
+      const { name, params } = stmt;
+      if (env.types.has(name.value)) {
+        return err({ tag: "TypeDeclaredError", typeName: name });
+      }
+      // TODO: remove side effect?
+      env.types.set(name.value, stmt);
+      return ok(env);
+    }
+  }
+  // COMBAK: remove
+  return ok(env);
+};
+
+const initEnv = (): DomainEnv => ({
+  types: new Map(builtinTypes),
+});
+
+// HACK: locations for dummy AST nodes. Revisit if this pattern becomes widespread.
+const idOf = (value: string) => ({
+  start: { line: 1, col: 1 },
+  end: { line: 1, col: 1 },
+  tag: "Identifier",
+  type: "identifier",
+  value: value,
+});
+
+const builtinTypes: [string, TypeDecl][] = [
+  [
+    "String",
+    {
+      start: { line: 1, col: 1 },
+      end: { line: 1, col: 1 },
+      tag: "TypeDecl",
+      name: idOf("String"),
+      params: [],
+    },
+  ],
+];

--- a/penrose-web/src/parser/Domain.ne
+++ b/penrose-web/src/parser/Domain.ne
@@ -201,7 +201,7 @@ subtype -> type _ "<:" _ type {%
 
 # Basic types
   
-var -> identifier {% ([name]): VarConst => ({ ...rangeOf(name), tag: "VarConst", name }) %}
+var -> identifier {% id %}
 
 # TODO: without `'`, type_var will look the same as 0-arg type_constructor
 type_var -> "'" identifier {% 

--- a/penrose-web/src/parser/Domain.ne
+++ b/penrose-web/src/parser/Domain.ne
@@ -252,8 +252,7 @@ named_arg -> type __ var {%
   })
 %}
 
-prop -> "Prop" _ var {% nth(2) %}
-prop_list -> sepBy1[prop, "*"] {% ([d]) => d %}
+prop -> "Prop" {% ([kw]): Prop => ({ ...rangeOf(kw), tag: "Prop" })  %}
 
 # Common 
 

--- a/penrose-web/src/parser/Domain.ne
+++ b/penrose-web/src/parser/Domain.ne
@@ -1,0 +1,87 @@
+
+@preprocessor typescript
+
+# Lexer
+@{%
+
+import * as moo from "moo";
+import { concat, compact, flatten, last } from 'lodash'
+import { rangeOf, rangeBetween, rangeFrom, nth, convertTokenId } from 'parser/ParserUtil'
+
+// NOTE: ordering matters here. Top patterns get matched __first__
+const lexer = moo.compile({
+  ws: /[ \t]+/,
+  nl: { match: "\n", lineBreaks: true },
+  lte: "<=",
+  lt: "<",
+  gte: ">=",
+  gt: ">",
+  eq: "==",
+  lparen: "(",
+  rparen: ")",
+  comma: ",",
+  string_literal: /"(?:[^\n\\"]|\\["\\ntbfr])*"/,
+  float_literal: /[+-]?(?:\d+(?:[.]\d*)?(?:[eE][+-]?\d+)?|[.]\d+(?:[eE][+-]?\d+)?)/,
+  comment: /--.*?$/,
+  multiline_comment: { 
+    match: /\/\*(?:[\s\S]*?)\*\//,
+    lineBreaks: true 
+  },
+  dot: ".",
+  brackets: "[]",
+  lbracket: "[",
+  rbracket: "]",
+  lbrace: "{",
+  rbrace: "}",
+  assignment: "=",
+  def: ":=",
+  plus: "+",
+  exp: "^",
+  minus: "-",
+  multiply: "*",
+  divide: "/",
+  modulo: "%",
+  colon: ":",
+  semi: ";",
+  question: "?",
+  dollar: "$",
+  tick: "\`",
+  identifier: {
+    match: /[A-z_][A-Za-z_0-9]*/,
+    type: moo.keywords({
+      // NOTE: the next line add type annotation keywords into the keyword set and thereby forbidding users to use keywords like `shape`
+      // "type-keyword": styleTypes, 
+      type: "type",
+      value: "value",
+      constructor: "constructor",
+      function: "function",
+      predicate: "predicate",
+      notation: "notation"
+    })
+  }
+});
+
+%} # end of lexer
+
+@lexer lexer
+
+input -> _ml 
+
+# white space definitions 
+
+comment 
+  -> %comment {% convertTokenId %}
+  |  %multiline_comment {% ([d]) => rangeOf(d) %}
+
+_c_ -> (%ws | comment):* 
+
+_ml -> multi_line_ws_char:* 
+
+multi_line_ws_char
+    -> %ws
+    |  "\n"
+    | comment # skip comments
+
+__ -> %ws:+ 
+
+_ -> %ws:*

--- a/penrose-web/src/parser/Domain.ne
+++ b/penrose-web/src/parser/Domain.ne
@@ -65,10 +65,50 @@ const lexer = moo.compile({
 
 @lexer lexer
 
-input -> _ml 
+input -> statements 
+
+statements
+    # base case
+    -> _ {% () => [] %} 
+    # whitespaces at the beginning (NOTE: comments are allowed)
+    |  _c_ "\n" statements {% nth(2) %} # 
+    # spaces around each statement (NOTE: still wrap in list to spread later)
+    |  _ statement _ {% d => [d[1]] %}
+    # whitespaces in between and at the end (NOTE: comments are allowed)
+    |  _ statement _c_ "\n" statements {% d => [d[1], ...d[4]] %}
+
+statement 
+  -> type        {% id %}
+  |  predicate   {% id %}
+  |  function    {% id %}
+  |  constructor {% id %}
+  |  prelude     {% id %}
+  |  notation    {% id %}
+  |  subtype     {% id %}
+
+# TODO: parse the y with kind case as well, or is it obsolete?
+type -> "type" __ identifier 
+
+# TODO: finish below
+predicate -> "predicate" __ identifier
+function -> "function" __ identifier
+constructor -> "constructor" __ identifier
+prelude -> "prelude" __ identifier
+notation -> "notation" __ identifier
+subtype -> "subtype" __ identifier
+
+# Common 
+
+identifier -> %identifier {% 
+  ([d]) => ({
+    ...rangeOf(d),
+    tag: 'Identifier',
+    value: d.text,
+    type: "identifier"
+  })
+%}
 
 # white space definitions 
-
 comment 
   -> %comment {% convertTokenId %}
   |  %multiline_comment {% ([d]) => rangeOf(d) %}

--- a/penrose-web/src/parser/DomainParser.test.ts
+++ b/penrose-web/src/parser/DomainParser.test.ts
@@ -130,6 +130,32 @@ function Empty -> Scalar
       `;
     const { results } = parser.feed(prog);
     sameASTs(results);
-    printAST(results[0]);
+  });
+  test("notation decls", () => {
+    const prog = `
+notation "A ⊂ B" ~ "IsSubset(A, B)"
+notation "p ∈ A" ~ "PointIn(A, p)"
+notation "p ∉ A" ~ "PointNotIn(A, p)"
+notation "A ∩ B = ∅" ~ "Not(Intersecting(A, B))"
+notation "f: A -> B" ~ "Map f; From(f, A, B)"
+      `;
+    const { results } = parser.feed(prog);
+    sameASTs(results);
+  });
+  test("notation decls", () => {
+    const prog = `
+Reals <: Set
+Interval <: Set
+Reals <: Interval
+OpenInterval <: Interval
+ClosedInterval <: Interval
+LeftClopenInterval <: Interval
+RightClopenInterval <: Interval
+-- edge cases
+List(Vector) <: List(Matrix)
+List('T) <: List('U)
+      `;
+    const { results } = parser.feed(prog);
+    sameASTs(results);
   });
 });

--- a/penrose-web/src/parser/DomainParser.test.ts
+++ b/penrose-web/src/parser/DomainParser.test.ts
@@ -1,0 +1,36 @@
+import * as nearley from "nearley";
+import grammar from "./DomainParser";
+import * as path from "path";
+import * as fs from "fs";
+
+// const outputDir = "/tmp/asts";
+// const saveASTs = true;
+
+let parser: nearley.Parser;
+const sameASTs = (results: any[]) => {
+  for (const p of results) expect(results[0]).toEqual(p);
+  expect(results.length).toEqual(1);
+};
+
+// USAGE:
+// printAST(results[0])
+const printAST = (ast: any) => {
+  console.log(JSON.stringify(ast));
+};
+
+const domainPaths = [
+  "linear-algebra-domain/linear-algebra.dsl",
+  "set-theory-domain/setTheory.dsl",
+];
+
+beforeEach(() => {
+  // NOTE: Neither `feed` nor `finish` will reset the parser state. Therefore recompiling before each unit test
+  parser = new nearley.Parser(nearley.Grammar.fromCompiled(grammar));
+});
+
+describe("Common", () => {
+  test("empty program", () => {
+    const { results } = parser.feed("");
+    sameASTs(results);
+  });
+});

--- a/penrose-web/src/parser/DomainParser.test.ts
+++ b/penrose-web/src/parser/DomainParser.test.ts
@@ -4,8 +4,8 @@ import * as path from "path";
 import * as fs from "fs";
 import { result } from "lodash";
 
-// const outputDir = "/tmp/asts";
-// const saveASTs = true;
+const outputDir = "/tmp/asts";
+const saveASTs = true;
 
 let parser: nearley.Parser;
 const sameASTs = (results: any[]) => {
@@ -157,5 +157,27 @@ List('T) <: List('U)
       `;
     const { results } = parser.feed(prog);
     sameASTs(results);
+  });
+});
+
+describe("Real Programs", () => {
+  // create output folder
+  if (!fs.existsSync(outputDir)) {
+    fs.mkdirSync(outputDir);
+  }
+
+  domainPaths.map((examplePath) => {
+    const file = path.join("../examples/", examplePath);
+    const prog = fs.readFileSync(file, "utf8");
+    test(examplePath, () => {
+      const { results } = parser.feed(prog);
+      sameASTs(results);
+      // write to output folder
+      if (saveASTs) {
+        const exampleName = path.basename(examplePath, ".dsl");
+        const astPath = path.join(outputDir, exampleName + ".ast.json");
+        fs.writeFileSync(astPath, JSON.stringify(results[0]), "utf8");
+      }
+    });
   });
 });

--- a/penrose-web/src/parser/DomainParser.test.ts
+++ b/penrose-web/src/parser/DomainParser.test.ts
@@ -25,12 +25,12 @@ const domainPaths = [
 
 beforeEach(() => {
   // NOTE: Neither `feed` nor `finish` will reset the parser state. Therefore recompiling before each unit test
-  parser = new nearley.Parser(nearley.Grammar.fromCompiled(grammar));
+  // parser = new nearley.Parser(nearley.Grammar.fromCompiled(grammar));
 });
 
 describe("Common", () => {
   test("empty program", () => {
-    const { results } = parser.feed("");
-    sameASTs(results);
+    // const { results } = parser.feed("");
+    // sameASTs(results);
   });
 });

--- a/penrose-web/src/parser/DomainParser.test.ts
+++ b/penrose-web/src/parser/DomainParser.test.ts
@@ -2,6 +2,7 @@ import * as nearley from "nearley";
 import grammar from "./DomainParser";
 import * as path from "path";
 import * as fs from "fs";
+import { result } from "lodash";
 
 // const outputDir = "/tmp/asts";
 // const saveASTs = true;
@@ -25,12 +26,49 @@ const domainPaths = [
 
 beforeEach(() => {
   // NOTE: Neither `feed` nor `finish` will reset the parser state. Therefore recompiling before each unit test
-  // parser = new nearley.Parser(nearley.Grammar.fromCompiled(grammar));
+  parser = new nearley.Parser(nearley.Grammar.fromCompiled(grammar));
 });
 
 describe("Common", () => {
   test("empty program", () => {
-    // const { results } = parser.feed("");
-    // sameASTs(results);
+    const { results } = parser.feed("");
+    sameASTs(results);
+  });
+  test("comments", () => {
+    const { results } = parser.feed("");
+    sameASTs(results);
+  });
+});
+
+describe("Statement types", () => {
+  test("type decls", () => {
+    const prog = `
+-- comments
+type Set 
+type Point 
+type ParametrizedSet (s1: Set, s2: Set)
+    `;
+    const { results } = parser.feed(prog);
+    sameASTs(results);
+    printAST(results[0]);
+  });
+  test("predicate decls", () => {
+    const prog = `
+-- comments
+predicate Not : Prop p1
+predicate From : Map f * Set domain * Set codomain
+predicate Empty : Set s
+predicate Intersecting : Set s1 * Set s2
+predicate IsSubset : Set s1 * Set s2
+predicate PointIn : Set s * Point p
+predicate In : Point p * Set s
+predicate Injection : Map m
+predicate Surjection : Map m
+predicate Bijection : Map m
+predicate PairIn : Point * Point * Map
+    `;
+    const { results } = parser.feed(prog);
+    sameASTs(results);
+    printAST(results[0]);
   });
 });

--- a/penrose-web/src/parser/DomainParser.test.ts
+++ b/penrose-web/src/parser/DomainParser.test.ts
@@ -50,7 +50,6 @@ type ParametrizedSet (s1: Set, s2: Set)
     `;
     const { results } = parser.feed(prog);
     sameASTs(results);
-    printAST(results[0]);
   });
   test("predicate decls", () => {
     const prog = `
@@ -66,6 +65,20 @@ predicate Injection : Map m
 predicate Surjection : Map m
 predicate Bijection : Map m
 predicate PairIn : Point * Point * Map
+    `;
+    const { results } = parser.feed(prog);
+    sameASTs(results);
+  });
+  test("function decls", () => {
+    const prog = `
+-- comments
+function Intersection : Set a * Set b -> Set
+function Union : Set a * Set b -> Set
+function Subtraction : Set a * Set b -> Set
+function CartesianProduct : Set a * Set b -> Set
+function Difference : Set a * Set b -> Set
+function Subset : Set a * Set b -> Set
+function AddPoint : Point p * Set s1 -> Set
     `;
     const { results } = parser.feed(prog);
     sameASTs(results);

--- a/penrose-web/src/parser/DomainParser.ts
+++ b/penrose-web/src/parser/DomainParser.ts
@@ -3,6 +3,7 @@
 // Bypasses TS6133. Allow declared but unused functions.
 // @ts-ignore
 function id(d: any[]): any { return d[0]; }
+declare var identifier: any;
 declare var comment: any;
 declare var multiline_comment: any;
 declare var ws: any;
@@ -96,7 +97,33 @@ interface Grammar {
 const grammar: Grammar = {
   Lexer: lexer,
   ParserRules: [
-    {"name": "input", "symbols": ["_ml"]},
+    {"name": "input", "symbols": ["statements"]},
+    {"name": "statements", "symbols": ["_"], "postprocess": () => []},
+    {"name": "statements", "symbols": ["_c_", {"literal":"\n"}, "statements"], "postprocess": nth(2)},
+    {"name": "statements", "symbols": ["_", "statement", "_"], "postprocess": d => [d[1]]},
+    {"name": "statements", "symbols": ["_", "statement", "_c_", {"literal":"\n"}, "statements"], "postprocess": d => [d[1], ...d[4]]},
+    {"name": "statement", "symbols": ["type"], "postprocess": id},
+    {"name": "statement", "symbols": ["predicate"], "postprocess": id},
+    {"name": "statement", "symbols": ["function"], "postprocess": id},
+    {"name": "statement", "symbols": ["constructor"], "postprocess": id},
+    {"name": "statement", "symbols": ["prelude"], "postprocess": id},
+    {"name": "statement", "symbols": ["notation"], "postprocess": id},
+    {"name": "statement", "symbols": ["subtype"], "postprocess": id},
+    {"name": "type", "symbols": [{"literal":"type"}, "__", "identifier"]},
+    {"name": "predicate", "symbols": [{"literal":"predicate"}, "__", "identifier"]},
+    {"name": "function", "symbols": [{"literal":"function"}, "__", "identifier"]},
+    {"name": "constructor", "symbols": [{"literal":"constructor"}, "__", "identifier"]},
+    {"name": "prelude", "symbols": [{"literal":"prelude"}, "__", "identifier"]},
+    {"name": "notation", "symbols": [{"literal":"notation"}, "__", "identifier"]},
+    {"name": "subtype", "symbols": [{"literal":"subtype"}, "__", "identifier"]},
+    {"name": "identifier", "symbols": [(lexer.has("identifier") ? {type: "identifier"} : identifier)], "postprocess":  
+        ([d]) => ({
+          ...rangeOf(d),
+          tag: 'Identifier',
+          value: d.text,
+          type: "identifier"
+        })
+        },
     {"name": "comment", "symbols": [(lexer.has("comment") ? {type: "comment"} : comment)], "postprocess": convertTokenId},
     {"name": "comment", "symbols": [(lexer.has("multiline_comment") ? {type: "multiline_comment"} : multiline_comment)], "postprocess": ([d]) => rangeOf(d)},
     {"name": "_c_$ebnf$1", "symbols": []},

--- a/penrose-web/src/parser/DomainParser.ts
+++ b/penrose-web/src/parser/DomainParser.ts
@@ -1,0 +1,123 @@
+// Generated automatically by nearley, version 2.20.1
+// http://github.com/Hardmath123/nearley
+// Bypasses TS6133. Allow declared but unused functions.
+// @ts-ignore
+function id(d: any[]): any { return d[0]; }
+declare var comment: any;
+declare var multiline_comment: any;
+declare var ws: any;
+
+
+import * as moo from "moo";
+import { concat, compact, flatten, last } from 'lodash'
+import { rangeOf, rangeBetween, rangeFrom, nth, convertTokenId } from 'parser/ParserUtil'
+
+// NOTE: ordering matters here. Top patterns get matched __first__
+const lexer = moo.compile({
+  ws: /[ \t]+/,
+  nl: { match: "\n", lineBreaks: true },
+  lte: "<=",
+  lt: "<",
+  gte: ">=",
+  gt: ">",
+  eq: "==",
+  lparen: "(",
+  rparen: ")",
+  comma: ",",
+  string_literal: /"(?:[^\n\\"]|\\["\\ntbfr])*"/,
+  float_literal: /[+-]?(?:\d+(?:[.]\d*)?(?:[eE][+-]?\d+)?|[.]\d+(?:[eE][+-]?\d+)?)/,
+  comment: /--.*?$/,
+  multiline_comment: { 
+    match: /\/\*(?:[\s\S]*?)\*\//,
+    lineBreaks: true 
+  },
+  dot: ".",
+  brackets: "[]",
+  lbracket: "[",
+  rbracket: "]",
+  lbrace: "{",
+  rbrace: "}",
+  assignment: "=",
+  def: ":=",
+  plus: "+",
+  exp: "^",
+  minus: "-",
+  multiply: "*",
+  divide: "/",
+  modulo: "%",
+  colon: ":",
+  semi: ";",
+  question: "?",
+  dollar: "$",
+  tick: "\`",
+  identifier: {
+    match: /[A-z_][A-Za-z_0-9]*/,
+    type: moo.keywords({
+      // NOTE: the next line add type annotation keywords into the keyword set and thereby forbidding users to use keywords like `shape`
+      // "type-keyword": styleTypes, 
+      type: "type",
+      value: "value",
+      constructor: "constructor",
+      function: "function",
+      predicate: "predicate",
+      notation: "notation"
+    })
+  }
+});
+
+
+interface NearleyToken {
+  value: any;
+  [key: string]: any;
+};
+
+interface NearleyLexer {
+  reset: (chunk: string, info: any) => void;
+  next: () => NearleyToken | undefined;
+  save: () => any;
+  formatError: (token: never) => string;
+  has: (tokenType: string) => boolean;
+};
+
+interface NearleyRule {
+  name: string;
+  symbols: NearleySymbol[];
+  postprocess?: (d: any[], loc?: number, reject?: {}) => any;
+};
+
+type NearleySymbol = string | { literal: any } | { test: (token: any) => boolean };
+
+interface Grammar {
+  Lexer: NearleyLexer | undefined;
+  ParserRules: NearleyRule[];
+  ParserStart: string;
+};
+
+const grammar: Grammar = {
+  Lexer: lexer,
+  ParserRules: [
+    {"name": "input", "symbols": ["_ml"]},
+    {"name": "comment", "symbols": [(lexer.has("comment") ? {type: "comment"} : comment)], "postprocess": convertTokenId},
+    {"name": "comment", "symbols": [(lexer.has("multiline_comment") ? {type: "multiline_comment"} : multiline_comment)], "postprocess": ([d]) => rangeOf(d)},
+    {"name": "_c_$ebnf$1", "symbols": []},
+    {"name": "_c_$ebnf$1$subexpression$1", "symbols": [(lexer.has("ws") ? {type: "ws"} : ws)]},
+    {"name": "_c_$ebnf$1$subexpression$1", "symbols": ["comment"]},
+    {"name": "_c_$ebnf$1", "symbols": ["_c_$ebnf$1", "_c_$ebnf$1$subexpression$1"], "postprocess": (d) => d[0].concat([d[1]])},
+    {"name": "_c_", "symbols": ["_c_$ebnf$1"]},
+    {"name": "_ml$ebnf$1", "symbols": []},
+    {"name": "_ml$ebnf$1", "symbols": ["_ml$ebnf$1", "multi_line_ws_char"], "postprocess": (d) => d[0].concat([d[1]])},
+    {"name": "_ml", "symbols": ["_ml$ebnf$1"]},
+    {"name": "multi_line_ws_char", "symbols": [(lexer.has("ws") ? {type: "ws"} : ws)]},
+    {"name": "multi_line_ws_char", "symbols": [{"literal":"\n"}]},
+    {"name": "multi_line_ws_char", "symbols": ["comment"]},
+    {"name": "__$ebnf$1", "symbols": [(lexer.has("ws") ? {type: "ws"} : ws)]},
+    {"name": "__$ebnf$1", "symbols": ["__$ebnf$1", (lexer.has("ws") ? {type: "ws"} : ws)], "postprocess": (d) => d[0].concat([d[1]])},
+    {"name": "__", "symbols": ["__$ebnf$1"]},
+    {"name": "_$ebnf$1", "symbols": []},
+    {"name": "_$ebnf$1", "symbols": ["_$ebnf$1", (lexer.has("ws") ? {type: "ws"} : ws)], "postprocess": (d) => d[0].concat([d[1]])},
+    {"name": "_", "symbols": ["_$ebnf$1"]}
+  ],
+  ParserStart: "input",
+};
+
+export default grammar;

--- a/penrose-web/src/parser/DomainParser.ts
+++ b/penrose-web/src/parser/DomainParser.ts
@@ -180,7 +180,7 @@ const grammar: Grammar = {
           tag: "SubTypeDecl", subType, superType
         })
         },
-    {"name": "var", "symbols": ["identifier"], "postprocess": ([name]): VarConst => ({ ...rangeOf(name), tag: "VarConst", name })},
+    {"name": "var", "symbols": ["identifier"], "postprocess": id},
     {"name": "type_var", "symbols": [{"literal":"'"}, "identifier"], "postprocess":  
         ([a, name]) => ({ ...rangeBetween(a, name), tag: "TypeVar", name }) 
         },

--- a/penrose-web/src/parser/DomainParser.ts
+++ b/penrose-web/src/parser/DomainParser.ts
@@ -286,24 +286,7 @@ const grammar: Grammar = {
            tag: "Arg", variable, type 
         })
         },
-    {"name": "prop", "symbols": [{"literal":"Prop"}, "_", "var"], "postprocess": nth(2)},
-    {"name": "prop_list$macrocall$2", "symbols": ["prop"]},
-    {"name": "prop_list$macrocall$3", "symbols": [{"literal":"*"}]},
-    {"name": "prop_list$macrocall$1$ebnf$1", "symbols": []},
-    {"name": "prop_list$macrocall$1$ebnf$1$subexpression$1", "symbols": ["_", "prop_list$macrocall$3", "_", "prop_list$macrocall$2"]},
-    {"name": "prop_list$macrocall$1$ebnf$1", "symbols": ["prop_list$macrocall$1$ebnf$1", "prop_list$macrocall$1$ebnf$1$subexpression$1"], "postprocess": (d) => d[0].concat([d[1]])},
-    {"name": "prop_list$macrocall$1$ebnf$2", "symbols": ["prop_list$macrocall$3"], "postprocess": id},
-    {"name": "prop_list$macrocall$1$ebnf$2", "symbols": [], "postprocess": () => null},
-    {"name": "prop_list$macrocall$1", "symbols": ["prop_list$macrocall$2", "prop_list$macrocall$1$ebnf$1", "prop_list$macrocall$1$ebnf$2"], "postprocess":  
-        d => { 
-          const [first, rest] = [d[0], d[1]];
-          if(rest.length > 0) {
-            const restNodes = rest.map((ts: any[]) => ts[3]);
-            return concat(first, ...restNodes);
-          } else return first;
-        }
-        },
-    {"name": "prop_list", "symbols": ["prop_list$macrocall$1"], "postprocess": ([d]) => d},
+    {"name": "prop", "symbols": [{"literal":"Prop"}], "postprocess": ([kw]): Prop => ({ ...rangeOf(kw), tag: "Prop" })},
     {"name": "identifier", "symbols": [(lexer.has("identifier") ? {type: "identifier"} : identifier)], "postprocess":  
         ([d]) => ({
           ...rangeOf(d),

--- a/penrose-web/src/parser/ParserUtil.ts
+++ b/penrose-web/src/parser/ParserUtil.ts
@@ -1,0 +1,103 @@
+const tokenStart = (token: any) => {
+  return {
+    line: token.line,
+    col: token.col - 1,
+  };
+};
+
+// TODO: test multiline range
+const tokenEnd = (token: any) => {
+  const { text } = token;
+  const nl = /\r\n|\r|\n/;
+  var newlines = 0;
+  var textLength = text.length;
+  if (token.lineBreaks) {
+    newlines = text.split(nl).length;
+    textLength = text.substring(text.lastIndexOf(nl) + 1);
+  }
+  return {
+    line: token.line + newlines,
+    col: token.col + textLength - 1,
+  };
+};
+
+export const rangeOf = (token: any) => {
+  // if it's already converted, assume it's an AST Node
+  if (token.start && token.end) {
+    return { start: token.start, end: token.end };
+  }
+  return {
+    start: tokenStart(token),
+    end: tokenEnd(token),
+  };
+};
+
+const before = (loc1: SourceLoc, loc2: SourceLoc) => {
+  if (loc1.line < loc2.line) {
+    return true;
+  }
+  if (loc1.line > loc2.line) {
+    return false;
+  }
+  return loc1.col < loc2.col;
+};
+
+const minLoc = (...locs: SourceLoc[]) => {
+  if (locs.length === 0) throw new TypeError();
+  let minLoc = locs[0];
+  for (const l of locs) if (before(l, minLoc)) minLoc = l;
+  return minLoc;
+};
+
+const maxLoc = (...locs: SourceLoc[]) => {
+  if (locs.length === 0) throw new TypeError();
+  let maxLoc = locs[0];
+  for (const l of locs) if (before(maxLoc, l)) maxLoc = l;
+  return maxLoc;
+};
+
+/** Given a list of tokens, find the range of tokens */
+export const rangeFrom = (children: ASTNode[]) => {
+  // NOTE: this function is called in intermediate steps with empty lists, so will need to guard against empty lists.
+  if (children.length === 0) {
+    // console.trace(`No children ${JSON.stringify(children)}`);
+    return { start: { line: 1, col: 1 }, end: { line: 1, col: 1 } };
+  }
+
+  if (children.length === 1) {
+    const child = children[0];
+    return { start: child.start, end: child.end };
+  }
+
+  return {
+    start: minLoc(...children.map((n) => n.start)),
+    end: maxLoc(...children.map((n) => n.end)),
+    // children TODO: decide if want children/parent pointers in the tree
+  };
+};
+
+export const rangeBetween = (beginToken: any, endToken: any) => {
+  const [beginRange, endRange] = [beginToken, endToken].map(rangeOf);
+  return {
+    start: beginRange.start,
+    end: endRange.end,
+  };
+};
+
+// const walkTree = <T>(root: ASTNode, f: (ASTNode): T) => {
+// TODO: implement
+// }
+
+export const convertTokenId = ([token]: any) => {
+  return {
+    ...rangeOf(token),
+    value: token.text,
+    type: token.type,
+  };
+};
+
+export const nth = (n: number) => {
+  return function(d: any[]) {
+    return d[n];
+  };
+};

--- a/penrose-web/src/parser/ParserUtil.ts
+++ b/penrose-web/src/parser/ParserUtil.ts
@@ -1,3 +1,5 @@
+import { compact } from "lodash";
+
 const tokenStart = (token: any) => {
   return {
     line: token.line,
@@ -69,14 +71,18 @@ export const rangeFrom = (children: ASTNode[]) => {
     return { start: child.start, end: child.end };
   }
 
+  // NOTE: use of compact to remove optional nodes
   return {
-    start: minLoc(...children.map((n) => n.start)),
-    end: maxLoc(...children.map((n) => n.end)),
+    start: minLoc(...compact(children).map((n) => n.start)),
+    end: maxLoc(...compact(children).map((n) => n.end)),
     // children TODO: decide if want children/parent pointers in the tree
   };
 };
 
 export const rangeBetween = (beginToken: any, endToken: any) => {
+  // handle null cases for easier use in postprocessors
+  if (!endToken) return rangeOf(beginToken);
+  if (!beginToken) return rangeOf(endToken);
   const [beginRange, endRange] = [beginToken, endToken].map(rangeOf);
   return {
     start: beginRange.start,

--- a/penrose-web/src/parser/Style.ne
+++ b/penrose-web/src/parser/Style.ne
@@ -5,6 +5,7 @@
 
 import * as moo from "moo";
 import { concat, compact, flatten, last } from 'lodash'
+import { rangeOf, rangeBetween, rangeFrom, nth, convertTokenId } from 'parser/ParserUtil'
 
 const styleTypes: string[] =
   [ "scalar"
@@ -83,108 +84,6 @@ const lexer = moo.compile({
     })
   }
 });
-
-
-function tokenStart(token: any) {
-  return {
-      line: token.line,
-      col: token.col - 1
-  };
-}
-
-// TODO: test multiline range
-const tokenEnd = (token: any) => {
-  const { text } = token;
-  const nl = /\r\n|\r|\n/;
-  var newlines = 0;
-  var textLength = text.length;
-  if (token.lineBreaks) {
-    newlines = text.split(nl).length;
-    textLength = text.substring(text.lastIndexOf(nl) + 1);
-  }
-  return {
-      line: token.line + newlines,
-      col: token.col + textLength - 1
-  };
-}
-
-const rangeOf = (token: any) => {
-  // if it's already converted, assume it's an AST Node
-  if(token.start && token.end) {
-    return { start: token.start, end: token.end };
-  }
-  return {
-    start: tokenStart(token),
-    end: tokenEnd(token)
-  };
-}
-
-const before = (loc1: SourceLoc, loc2: SourceLoc) => {
-  if (loc1.line < loc2.line) { return true; }
-  if (loc1.line > loc2.line) { return false; }
-  return loc1.col < loc2.col;
-}
-
-const minLoc = (...locs: SourceLoc[]) => {
-  if(locs.length === 0) throw new TypeError();
-  let minLoc = locs[0];
-  for(const l of locs)
-    if(before(l, minLoc)) minLoc = l;
-  return minLoc;
-}
-const maxLoc = (...locs: SourceLoc[]) => {
-  if(locs.length === 0) throw new TypeError();
-  let maxLoc = locs[0];
-  for(const l of locs)
-    if(before(maxLoc, l)) maxLoc = l;
-  return maxLoc;
-}
-
-/** Given a list of tokens, find the range of tokens */
-const rangeFrom = (children: ASTNode[]) => {
-  // NOTE: this function is called in intermediate steps with empty lists, so will need to guard against empty lists.
-  if(children.length === 0) {
-    // console.trace(`No children ${JSON.stringify(children)}`);
-    return { start: {line: 1, col: 1}, end: {line: 1, col: 1} };
-  }
-
-  if(children.length === 1) {
-    const child = children[0];
-    return { start: child.start, end: child.end };
-  }
-
-  return {
-    start: minLoc(...children.map(n => n.start)),
-    end: maxLoc(...children.map(n => n.end)),
-    // children TODO: decide if want children/parent pointers in the tree
-  }
-}
-
-const rangeBetween = (beginToken: any, endToken: any) => {
-  const [beginRange, endRange] = [beginToken, endToken].map(rangeOf);
-  return {
-    start: beginRange.start,
-    end: endRange.end
-  }
-}
-
-// const walkTree = <T>(root: ASTNode, f: (ASTNode): T) => {
-  // TODO: implement
-// }
-
-const convertTokenId = ([token]: any) => {
-  return {
-    ...rangeOf(token),
-    value: token.text,
-    type: token.type,
-  };
-}
-
-const nth = (n: number) => {
-  return function(d: any[]) {
-      return d[n];
-  };
-}
 
 // Node constructors
 

--- a/penrose-web/src/parser/StyleParser.ts
+++ b/penrose-web/src/parser/StyleParser.ts
@@ -13,6 +13,7 @@ declare var ws: any;
 
 import * as moo from "moo";
 import { concat, compact, flatten, last } from 'lodash'
+import { rangeOf, rangeBetween, rangeFrom, nth, convertTokenId } from 'parser/ParserUtil'
 
 const styleTypes: string[] =
   [ "scalar"
@@ -91,108 +92,6 @@ const lexer = moo.compile({
     })
   }
 });
-
-
-function tokenStart(token: any) {
-  return {
-      line: token.line,
-      col: token.col - 1
-  };
-}
-
-// TODO: test multiline range
-const tokenEnd = (token: any) => {
-  const { text } = token;
-  const nl = /\r\n|\r|\n/;
-  var newlines = 0;
-  var textLength = text.length;
-  if (token.lineBreaks) {
-    newlines = text.split(nl).length;
-    textLength = text.substring(text.lastIndexOf(nl) + 1);
-  }
-  return {
-      line: token.line + newlines,
-      col: token.col + textLength - 1
-  };
-}
-
-const rangeOf = (token: any) => {
-  // if it's already converted, assume it's an AST Node
-  if(token.start && token.end) {
-    return { start: token.start, end: token.end };
-  }
-  return {
-    start: tokenStart(token),
-    end: tokenEnd(token)
-  };
-}
-
-const before = (loc1: SourceLoc, loc2: SourceLoc) => {
-  if (loc1.line < loc2.line) { return true; }
-  if (loc1.line > loc2.line) { return false; }
-  return loc1.col < loc2.col;
-}
-
-const minLoc = (...locs: SourceLoc[]) => {
-  if(locs.length === 0) throw new TypeError();
-  let minLoc = locs[0];
-  for(const l of locs)
-    if(before(l, minLoc)) minLoc = l;
-  return minLoc;
-}
-const maxLoc = (...locs: SourceLoc[]) => {
-  if(locs.length === 0) throw new TypeError();
-  let maxLoc = locs[0];
-  for(const l of locs)
-    if(before(maxLoc, l)) maxLoc = l;
-  return maxLoc;
-}
-
-/** Given a list of tokens, find the range of tokens */
-const rangeFrom = (children: ASTNode[]) => {
-  // NOTE: this function is called in intermediate steps with empty lists, so will need to guard against empty lists.
-  if(children.length === 0) {
-    // console.trace(`No children ${JSON.stringify(children)}`);
-    return { start: {line: 1, col: 1}, end: {line: 1, col: 1} };
-  }
-
-  if(children.length === 1) {
-    const child = children[0];
-    return { start: child.start, end: child.end };
-  }
-
-  return {
-    start: minLoc(...children.map(n => n.start)),
-    end: maxLoc(...children.map(n => n.end)),
-    // children TODO: decide if want children/parent pointers in the tree
-  }
-}
-
-const rangeBetween = (beginToken: any, endToken: any) => {
-  const [beginRange, endRange] = [beginToken, endToken].map(rangeOf);
-  return {
-    start: beginRange.start,
-    end: endRange.end
-  }
-}
-
-// const walkTree = <T>(root: ASTNode, f: (ASTNode): T) => {
-  // TODO: implement
-// }
-
-const convertTokenId = ([token]: any) => {
-  return {
-    ...rangeOf(token),
-    value: token.text,
-    type: token.type,
-  };
-}
-
-const nth = (n: number) => {
-  return function(d: any[]) {
-      return d[n];
-  };
-}
 
 // Node constructors
 

--- a/penrose-web/src/types/errors.d.ts
+++ b/penrose-web/src/types/errors.d.ts
@@ -12,11 +12,16 @@ type DomainError =
   | TypeNotFound
   | DuplicateName
   | CyclicSubtypes
-  | NotTypeConsInSubtype;
+  | NotTypeConsInSubtype
+  | NotTypeConsInPrelude;
 
 interface CyclicSubtypes {
   tag: "CyclicSubtypes";
   cycles: string[][];
+}
+interface NotTypeConsInPrelude {
+  tag: "NotTypeConsInPrelude";
+  type: Prop | TypeVar;
 }
 
 interface NotTypeConsInSubtype {

--- a/penrose-web/src/types/errors.d.ts
+++ b/penrose-web/src/types/errors.d.ts
@@ -10,7 +10,19 @@ type DomainError =
   | TypeDeclared
   | TypeVarNotFound
   | TypeNotFound
-  | DuplicateName;
+  | DuplicateName
+  | CyclicSubtypes
+  | NotTypeConsInSubtype;
+
+interface CyclicSubtypes {
+  tag: "CyclicSubtypes";
+  cycles: string[][];
+}
+
+interface NotTypeConsInSubtype {
+  tag: "NotTypeConsInSubtype";
+  type: Prop | TypeVar;
+}
 interface TypeDeclared {
   tag: "TypeDeclared";
   typeName: Identifier;

--- a/penrose-web/src/types/errors.d.ts
+++ b/penrose-web/src/types/errors.d.ts
@@ -1,0 +1,40 @@
+//#region ErrorTypes
+
+// type PenroseError = LanguageError | RuntimeError;
+// type LanguageError = DomainError | SubstanceError | StyleError | PluginError;
+// type RuntimeError = OptimizerError | EvaluatorError;
+// type StyleError = StyleParseError | StyleCheckError | TranslationError;
+type PenroseError = DomainError & { type: "DomainError" };
+
+type DomainError =
+  | TypeDeclared
+  | TypeVarNotFound
+  | TypeNotFound
+  | DuplicateName;
+interface TypeDeclared {
+  tag: "TypeDeclared";
+  typeName: Identifier;
+}
+interface DuplicateName {
+  tag: "DuplicateName";
+  name: Identifier;
+  location: ASTNode;
+  firstDefined: ASTNode;
+}
+interface TypeVarNotFound {
+  tag: "TypeVarNotFound";
+  typeVar: TypeVar;
+}
+interface TypeNotFound {
+  tag: "TypeNotFound";
+  typeName: Identifier;
+}
+interface StyleError {
+  sources: ErrorSource[];
+  message: FormatString; // Style matched failed with Substance object $1 and select in Style $2
+}
+
+// NOTE: aliased to ASTNode for now, can include more types for different errors
+type ErrorSource = ASTNode;
+
+//#endregion

--- a/penrose-web/src/types/types.d.ts
+++ b/penrose-web/src/types/types.d.ts
@@ -758,7 +758,7 @@ interface DomainProg extends ASTNode {
 type Type = TypeVar | TypeConstructor | Prop;
 interface Arg extends ASTNode {
   tag: "Arg";
-  variable: Var | undefined;
+  variable: Identifier | undefined;
   type: Type;
 }
 interface TypeVar extends ASTNode {
@@ -781,11 +781,6 @@ type DomainStmt =
   | PreludeDecl
   | NotationDecl
   | SubTypeDecl;
-
-interface VarConst extends ASTNode {
-  tag: "VarConst";
-  name: Identifier;
-}
 
 interface TypeDecl extends ASTNode {
   tag: "TypeDecl";
@@ -1489,10 +1484,14 @@ type LanguageError = DomainError | SubstanceError | StyleError | PluginError;
 type RuntimeError = OptimizerError | EvaluatorError;
 type StyleError = StyleParseError | StyleCheckError | TranslationError;
 
-type DomainError = TypeDeclaredError;
-interface TypeDeclaredError {
-  tag: "TypeDeclaredError";
+type DomainError = TypeDeclared | TypeVarNotFound;
+interface TypeDeclared {
+  tag: "TypeDeclared";
   typeName: Identifier;
+}
+interface TypeVarNotFound {
+  tag: "TypeVarNotFound";
+  typeVar: TypeVar;
 }
 interface StyleError {
   sources: ErrorSource[];

--- a/penrose-web/src/types/types.d.ts
+++ b/penrose-web/src/types/types.d.ts
@@ -761,9 +761,17 @@ interface Arg extends ASTNode {
   variable: Var | undefined;
   type: Type;
 }
+interface TypeVar extends ASTNode {
+  tag: "TypeVar";
+  name: Identifier;
+}
+interface TypeConstructor {
+  tag: "TypeConstructor";
+  name: Identifier;
+  args: Type[];
+}
 interface Prop extends ASTNode {
   tag: "Prop";
-  contents: "Prop";
 }
 type DomainStmt =
   | TypeDecl
@@ -778,15 +786,6 @@ type DomainStmt =
 interface VarConst extends ASTNode {
   tag: "VarConst";
   name: Identifier;
-}
-interface TypeVar extends ASTNode {
-  tag: "TypeVar";
-  name: Identifier;
-}
-interface TypeConstructor {
-  tag: "TypeConstructor";
-  name: Identifier;
-  args: Type[];
 }
 
 interface TypeDecl extends ASTNode {

--- a/penrose-web/src/types/types.d.ts
+++ b/penrose-web/src/types/types.d.ts
@@ -826,6 +826,7 @@ interface FunctionDecl extends ASTNode {
   name: Identifier;
   params: TypeParam[];
   args: Arg[];
+  output: Type;
 }
 interface ConstructorDecl extends ASTNode {
   tag: "ConstructorDecl";

--- a/penrose-web/src/types/types.d.ts
+++ b/penrose-web/src/types/types.d.ts
@@ -750,15 +750,34 @@ interface IOptDebugInfo {
 
 //#region Domain AST
 
-type DomainProg = DomainStmt[];
+interface DomainProg extends ASTNode {
+  tag: "DomainProg";
+  statements: DomainStmt[];
+}
 
 type Type = TypeVar | TypeConstructor;
 type TypeArg = VarConst | Type;
 type Variable = VarConst | TypeVar;
 type Kind = ConstType | Type;
-type ConstType = "type"; // TODO: locational info?
-type Prop = "Prop";
 
+interface TypeParam extends ASTNode {
+  tag: "TypeParam";
+  variable: Variable;
+  kind: Kind;
+}
+interface Arg extends ASTNode {
+  tag: "Arg";
+  variable: Var | undefined;
+  type: Type;
+}
+interface ConstType extends ASTNode {
+  tag: "ConstType";
+  contents: "type";
+}
+interface Prop extends ASTNode {
+  tag: "Prop";
+  contents: "Prop";
+}
 type DomainStmt =
   | TypeDecl
   | PredicateDecl
@@ -786,36 +805,35 @@ interface TypeConstructor {
 interface TypeDecl extends ASTNode {
   tag: "TypeDecl";
   name: Identifier;
-  params: [Variable, Kind][]; // TODO: is this still supported?
+  params: TypeParam[]; // TODO: is this still supported?
 }
 
 interface PredicateDecl extends ASTNode {
   tag: "PredicateDecl";
   name: Identifier;
-  params: [Variable, Kind][];
-  args: [Var, Type][];
+  params: TypeParam[];
+  args: Arg[];
 }
 
 interface NestedPredicateDecl extends ASTNode {
   tag: "NestedPredicateDecl";
   name: Identifier;
-  args: [Var, Prop][];
+  args: Var[]; // TODO: check if `Prop` is really needed. We do only parse `Prop` as a type, so including it in the AST seems redundant.
 }
 
 interface FunctionDecl extends ASTNode {
   tag: "FunctionDecl";
   name: Identifier;
-  params: [Variable, Kind][];
-  args: [Var, Type][];
+  params: TypeParam[];
+  args: Arg[];
 }
 interface ConstructorDecl extends ASTNode {
   tag: "ConstructorDecl";
   name: Identifier;
-  params: [Variable, Kind][];
-  args: [Var, Type][];
+  params: TypeParam[];
+  args: Arg[];
   output: Type;
 }
-// TODO: finish
 interface PreludeDecl extends ASTNode {
   name: Var;
   type: Type;
@@ -825,7 +843,6 @@ interface NotationDecl extends ASTNode {
   from: string;
   to: string;
 }
-// TODO: finish
 interface SubTypeDecl extends ASTNode {
   tag: "SubTypeDecl";
   subType: Type;

--- a/penrose-web/src/types/types.d.ts
+++ b/penrose-web/src/types/types.d.ts
@@ -755,24 +755,11 @@ interface DomainProg extends ASTNode {
   statements: DomainStmt[];
 }
 
-type Type = TypeVar | TypeConstructor;
-type TypeArg = VarConst | Type;
-type Variable = VarConst | TypeVar;
-type Kind = ConstType | Type;
-
-interface TypeParam extends ASTNode {
-  tag: "TypeParam";
-  variable: Variable;
-  kind: Kind;
-}
+type Type = TypeVar | TypeConstructor | Prop;
 interface Arg extends ASTNode {
   tag: "Arg";
   variable: Var | undefined;
   type: Type;
-}
-interface ConstType extends ASTNode {
-  tag: "ConstType";
-  contents: "type";
 }
 interface Prop extends ASTNode {
   tag: "Prop";
@@ -799,39 +786,33 @@ interface TypeVar extends ASTNode {
 interface TypeConstructor {
   tag: "TypeConstructor";
   name: Identifier;
-  args: TypeArg[];
+  args: Type[];
 }
 
 interface TypeDecl extends ASTNode {
   tag: "TypeDecl";
   name: Identifier;
-  params: TypeParam[]; // TODO: is this still supported?
+  params: Type[];
 }
 
 interface PredicateDecl extends ASTNode {
   tag: "PredicateDecl";
   name: Identifier;
-  params: TypeParam[];
+  params: Type[];
   args: Arg[];
-}
-
-interface NestedPredicateDecl extends ASTNode {
-  tag: "NestedPredicateDecl";
-  name: Identifier;
-  args: Var[]; // TODO: check if `Prop` is really needed. We do only parse `Prop` as a type, so including it in the AST seems redundant.
 }
 
 interface FunctionDecl extends ASTNode {
   tag: "FunctionDecl";
   name: Identifier;
-  params: TypeParam[];
+  params: Type[];
   args: Arg[];
   output: Type;
 }
 interface ConstructorDecl extends ASTNode {
   tag: "ConstructorDecl";
   name: Identifier;
-  params: TypeParam[];
+  params: Type[];
   args: Arg[];
   output: Type;
 }

--- a/penrose-web/src/types/types.d.ts
+++ b/penrose-web/src/types/types.d.ts
@@ -773,6 +773,7 @@ interface TypeConstructor {
 interface Prop extends ASTNode {
   tag: "Prop";
 }
+
 type DomainStmt =
   | TypeDecl
   | PredicateDecl
@@ -1474,47 +1475,5 @@ interface Identifier extends ASTNode {
   type: string;
   value: string;
 }
-
-//#endregion
-
-//#region Errors
-
-type PenroseError = LanguageError | RuntimeError;
-type LanguageError = DomainError | SubstanceError | StyleError | PluginError;
-type RuntimeError = OptimizerError | EvaluatorError;
-type StyleError = StyleParseError | StyleCheckError | TranslationError;
-
-type TaggedDomainError = DomainError & { type: "DomainError " };
-
-type DomainError =
-  | TypeDeclared
-  | TypeVarNotFound
-  | TypeNotFound
-  | DuplicateName;
-interface TypeDeclared {
-  tag: "TypeDeclared";
-  typeName: Identifier;
-}
-interface DuplicateName {
-  tag: "DuplicateName";
-  name: Identifier;
-  location: ASTNode;
-  firstDefined: ASTNode;
-}
-interface TypeVarNotFound {
-  tag: "TypeVarNotFound";
-  typeVar: TypeVar;
-}
-interface TypeNotFound {
-  tag: "TypeNotFound";
-  typeName: Identifier;
-}
-interface StyleError {
-  sources: ErrorSource[];
-  message: FormatString; // Style matched failed with Substance object $1 and select in Style $2
-}
-
-// NOTE: aliased to ASTNode for now, can include more types for different errors
-type ErrorSource = ASTNode;
 
 //#endregion

--- a/penrose-web/src/types/types.d.ts
+++ b/penrose-web/src/types/types.d.ts
@@ -791,23 +791,23 @@ interface TypeDecl extends ASTNode {
 interface PredicateDecl extends ASTNode {
   tag: "PredicateDecl";
   name: Identifier;
-  params: Type[];
+  params: TypeVar[];
   args: Arg[];
 }
 
 interface FunctionDecl extends ASTNode {
   tag: "FunctionDecl";
   name: Identifier;
-  params: Type[];
+  params: TypeVar[];
   args: Arg[];
-  output: Type;
+  output: Arg;
 }
 interface ConstructorDecl extends ASTNode {
   tag: "ConstructorDecl";
   name: Identifier;
-  params: Type[];
+  params: TypeVar[];
   args: Arg[];
-  output: Type;
+  output: Arg;
 }
 interface PreludeDecl extends ASTNode {
   tag: "PreludeDecl";
@@ -1484,14 +1484,28 @@ type LanguageError = DomainError | SubstanceError | StyleError | PluginError;
 type RuntimeError = OptimizerError | EvaluatorError;
 type StyleError = StyleParseError | StyleCheckError | TranslationError;
 
-type DomainError = TypeDeclared | TypeVarNotFound;
+type DomainError =
+  | TypeDeclared
+  | TypeVarNotFound
+  | TypeNotFound
+  | DuplicateName;
 interface TypeDeclared {
   tag: "TypeDeclared";
   typeName: Identifier;
 }
+interface DuplicateName {
+  tag: "DuplicateName";
+  name: Identifier;
+  location: ASTNode;
+  firstDefined: ASTNode;
+}
 interface TypeVarNotFound {
   tag: "TypeVarNotFound";
   typeVar: TypeVar;
+}
+interface TypeNotFound {
+  tag: "TypeNotFound";
+  typeName: Identifier;
 }
 interface StyleError {
   sources: ErrorSource[];

--- a/penrose-web/src/types/types.d.ts
+++ b/penrose-web/src/types/types.d.ts
@@ -776,7 +776,6 @@ interface Prop extends ASTNode {
 type DomainStmt =
   | TypeDecl
   | PredicateDecl
-  | NestedPredicateDecl
   | FunctionDecl
   | ConstructorDecl
   | PreludeDecl
@@ -816,11 +815,13 @@ interface ConstructorDecl extends ASTNode {
   output: Type;
 }
 interface PreludeDecl extends ASTNode {
+  tag: "PreludeDecl";
   name: Var;
   type: Type;
 }
 // TODO: check if string type is enough
 interface NotationDecl extends ASTNode {
+  tag: "NotationDecl";
   from: string;
   to: string;
 }
@@ -1037,7 +1038,7 @@ interface ISubEnv {
 type VarEnv = IVarEnv;
 
 interface IVarEnv {
-  typeConstructors: { [k: string]: TypeConstructor };
+  typeConstructors: { [k: string]: ITypeConstructor };
   valConstructors: { [k: string]: ValConstructor };
   operators: { [k: string]: Operator };
   predicates: { [k: string]: PredicateEnv };
@@ -1051,7 +1052,7 @@ interface IVarEnv {
   stmtNotations: StmtNotationRule[];
   errors: string;
 }
-type TypeConstructor = ITypeConstructor;
+// type TypeConstructor = ITypeConstructor;
 
 interface ITypeConstructor {
   nametc: string;
@@ -1482,19 +1483,23 @@ interface Identifier extends ASTNode {
 //#endregion
 
 //#region Errors
+
 type PenroseError = LanguageError | RuntimeError;
 type LanguageError = DomainError | SubstanceError | StyleError | PluginError;
 type RuntimeError = OptimizerError | EvaluatorError;
 type StyleError = StyleParseError | StyleCheckError | TranslationError;
-interface LanguageError {
-  message: string;
-  sources: ErrorSource[];
+
+type DomainError = TypeDeclaredError;
+interface TypeDeclaredError {
+  tag: "TypeDeclaredError";
+  typeName: Identifier;
 }
 interface StyleError {
   sources: ErrorSource[];
   message: FormatString; // Style matched failed with Substance object $1 and select in Style $2
 }
-interface ErrorSource {
-  node: ASTNode;
-}
+
+// NOTE: aliased to ASTNode for now, can include more types for different errors
+type ErrorSource = ASTNode;
+
 //#endregion

--- a/penrose-web/src/types/types.d.ts
+++ b/penrose-web/src/types/types.d.ts
@@ -1484,6 +1484,8 @@ type LanguageError = DomainError | SubstanceError | StyleError | PluginError;
 type RuntimeError = OptimizerError | EvaluatorError;
 type StyleError = StyleParseError | StyleCheckError | TranslationError;
 
+type TaggedDomainError = DomainError & { type: "DomainError " };
+
 type DomainError =
   | TypeDeclared
   | TypeVarNotFound

--- a/penrose-web/src/types/types.d.ts
+++ b/penrose-web/src/types/types.d.ts
@@ -748,6 +748,92 @@ interface IOptDebugInfo {
 
 //#endregion
 
+//#region Domain AST
+
+type DomainProg = DomainStmt[];
+
+type Type = TypeVar | TypeConstructor;
+type TypeArg = VarConst | Type;
+type Variable = VarConst | TypeVar;
+type Kind = ConstType | Type;
+type ConstType = "type"; // TODO: locational info?
+type Prop = "Prop";
+
+type DomainStmt =
+  | TypeDecl
+  | PredicateDecl
+  | NestedPredicateDecl
+  | FunctionDecl
+  | ConstructorDecl
+  | PreludeDecl
+  | NotationDecl
+  | SubTypeDecl;
+
+interface VarConst extends ASTNode {
+  tag: "VarConst";
+  name: Identifier;
+}
+interface TypeVar extends ASTNode {
+  tag: "TypeVar";
+  name: Identifier;
+}
+interface TypeConstructor {
+  tag: "TypeConstructor";
+  name: Identifier;
+  args: TypeArg[];
+}
+
+interface TypeDecl extends ASTNode {
+  tag: "TypeDecl";
+  name: Identifier;
+  params: [Variable, Kind][]; // TODO: is this still supported?
+}
+
+interface PredicateDecl extends ASTNode {
+  tag: "PredicateDecl";
+  name: Identifier;
+  params: [Variable, Kind][];
+  args: [Var, Type][];
+}
+
+interface NestedPredicateDecl extends ASTNode {
+  tag: "NestedPredicateDecl";
+  name: Identifier;
+  args: [Var, Prop][];
+}
+
+interface FunctionDecl extends ASTNode {
+  tag: "FunctionDecl";
+  name: Identifier;
+  params: [Variable, Kind][];
+  args: [Var, Type][];
+}
+interface ConstructorDecl extends ASTNode {
+  tag: "ConstructorDecl";
+  name: Identifier;
+  params: [Variable, Kind][];
+  args: [Var, Type][];
+  output: Type;
+}
+// TODO: finish
+interface PreludeDecl extends ASTNode {
+  name: Var;
+  type: Type;
+}
+// TODO: check if string type is enough
+interface NotationDecl extends ASTNode {
+  from: string;
+  to: string;
+}
+// TODO: finish
+interface SubTypeDecl extends ASTNode {
+  tag: "SubTypeDecl";
+  subType: Type;
+  superType: Type;
+}
+
+//#endregion
+
 //#region Style AST
 
 /** Top level type for Style AST */
@@ -1397,7 +1483,7 @@ interface Identifier extends ASTNode {
 
 //#endregion
 
-//#region
+//#region Errors
 type PenroseError = LanguageError | RuntimeError;
 type LanguageError = DomainError | SubstanceError | StyleError | PluginError;
 type RuntimeError = OptimizerError | EvaluatorError;

--- a/penrose-web/src/utils/Error.ts
+++ b/penrose-web/src/utils/Error.ts
@@ -39,6 +39,17 @@ export const showDomainErr = (error: DomainError): string => {
         error.cycles
       )}`;
     }
+    case "NotTypeConsInPrelude": {
+      if (error.type.tag === "Prop")
+        return `Prop (at ${loc(
+          error.type
+        )}) is not a type constructor. Only type constructors are allowed for prelude values.`;
+      else {
+        return `${error.type.name.value} (at ${loc(
+          error.type
+        )}) is not a type constructor. Only type constructors are allowed in prelude values.`;
+      }
+    }
   }
 };
 
@@ -50,6 +61,13 @@ const showCycles = (cycles: string[][]) => {
 export const cyclicSubtypes = (cycles: string[][]): CyclicSubtypes => ({
   tag: "CyclicSubtypes",
   cycles,
+});
+
+export const notTypeConsInPrelude = (
+  type: Prop | TypeVar
+): NotTypeConsInPrelude => ({
+  tag: "NotTypeConsInPrelude",
+  type,
 });
 
 export const notTypeConsInSubtype = (

--- a/penrose-web/src/utils/Error.ts
+++ b/penrose-web/src/utils/Error.ts
@@ -23,8 +23,41 @@ export const showDomainErr = (error: DomainError): string => {
         location
       )}) already exists, first declared at ${loc(firstDefined)}`;
     }
+    case "NotTypeConsInSubtype": {
+      if (error.type.tag === "Prop")
+        return `Prop (at ${loc(
+          error.type
+        )}) is not a type constructor. Only type constructors are allowed in subtyping relations.`;
+      else {
+        return `${error.type.name.value} (at ${loc(
+          error.type
+        )}) is not a type constructor. Only type constructors are allowed in subtyping relations.`;
+      }
+    }
+    case "CyclicSubtypes": {
+      return `Subtyping relations in this program form a cycle. Cycles of types are:\n${showCycles(
+        error.cycles
+      )}`;
+    }
   }
 };
+
+const showCycles = (cycles: string[][]) => {
+  const pathString = (path: string[]) => path.join(" -> ");
+  return cycles.map(pathString).join("\n");
+};
+
+export const cyclicSubtypes = (cycles: string[][]): CyclicSubtypes => ({
+  tag: "CyclicSubtypes",
+  cycles,
+});
+
+export const notTypeConsInSubtype = (
+  type: Prop | TypeVar
+): NotTypeConsInSubtype => ({
+  tag: "NotTypeConsInSubtype",
+  type,
+});
 
 // action constructors for error
 export const duplicateName = (

--- a/penrose-web/src/utils/Error.ts
+++ b/penrose-web/src/utils/Error.ts
@@ -1,0 +1,65 @@
+import { Result } from "true-myth";
+const { or, and, ok, err, andThen } = Result;
+
+// TODO: fix template formatting
+export const showDomainErr = (error: DomainError): string => {
+  switch (error.tag) {
+    case "TypeDeclared": {
+      return `Type ${error.typeName.value} already exists`;
+    }
+    case "TypeNotFound": {
+      return `Type ${error.typeName.value} (at ${loc(
+        error.typeName
+      )}) does not exist`;
+    }
+    case "TypeVarNotFound": {
+      return `Type variable ${error.typeVar.name.value} (at ${loc(
+        error.typeVar
+      )}) does not exist`;
+    }
+    case "DuplicateName": {
+      const { firstDefined, name, location } = error;
+      return `Name ${name.value} (at ${loc(
+        location
+      )}) already exists, first declared at ${loc(firstDefined)}`;
+    }
+  }
+};
+
+// action constructors for error
+export const duplicateName = (
+  name: Identifier,
+  location: ASTNode,
+  firstDefined: ASTNode
+): DuplicateName => ({
+  tag: "DuplicateName",
+  name,
+  location,
+  firstDefined,
+});
+
+// const loc = (node: ASTNode) => `${node.start.line}:${node.start.col}`;
+const loc = (node: ASTNode) => `line ${node.start.line}`;
+
+export const all = <Ok, Error>(
+  ...results: Result<Ok, Error>[]
+): Result<Ok, Error> =>
+  results.reduce(
+    (currentResult: Result<Ok, Error>, nextResult: Result<Ok, Error>) =>
+      and(nextResult, currentResult),
+    results[0] // TODO: separate out this element in argument
+  );
+
+export const safeChain = <Item, Ok, Error>(
+  itemList: Item[],
+  func: (nextItem: Item, currentResult: Ok) => Result<Ok, Error>,
+  initialResult: Result<Ok, Error>
+): Result<Ok, Error> =>
+  itemList.reduce(
+    (currentResult: Result<Ok, Error>, nextItem: Item) =>
+      andThen((res: Ok) => func(nextItem, res), currentResult),
+    initialResult
+  );
+
+// NOTE: re-export all true-myth types to reduce boilerplate
+export { Result, and, or, ok, err, andThen };

--- a/src/Penrose/Element.hs
+++ b/src/Penrose/Element.hs
@@ -40,15 +40,16 @@ data ElementStmt
   | OdStmt Od
   | PdStmt Pd
   | SnStmt Sn -- Statement notation
-  | PreludeDeclStmt Var
-                    T
+  | PreludeDeclStmt Var T
   deriving (Show, Eq, Typeable)
 
 -- | tconstructor
-data Cd = Cd
-  { nameCd  :: String
-  , inputCd :: [(Y, K)]
-  } deriving (Eq, Typeable)
+data Cd =
+  Cd
+    { nameCd  :: String
+    , inputCd :: [(Y, K)]
+    }
+  deriving (Eq, Typeable)
 
 instance Show Cd where
   show (Cd nameCd inputCd) =
@@ -58,12 +59,14 @@ instance Show Cd where
       iString = show inputCd
 
 -- | vconstructor
-data Vd = Vd
-  { nameVd  :: String
-  , varsVd  :: [(Y, K)]
-  , typesVd :: [(Var, T)]
-  , toVd    :: T
-  } deriving (Eq, Typeable)
+data Vd =
+  Vd
+    { nameVd  :: String
+    , varsVd  :: [(Y, K)]
+    , typesVd :: [(Var, T)]
+    , toVd    :: T
+    }
+  deriving (Eq, Typeable)
 
 instance Show Vd where
   show (Vd nameVd varsVd typesVd toVd) =
@@ -78,10 +81,12 @@ instance Show Vd where
       dString = show toVd
 
 -- | Subtype declarations
-data SubtypeDecl = SubtypeDecl
-  { subType   :: T
-  , superType :: T
-  } deriving (Eq, Typeable)
+data SubtypeDecl =
+  SubtypeDecl
+    { subType   :: T
+    , superType :: T
+    }
+  deriving (Eq, Typeable)
 
 instance Show SubtypeDecl where
   show (SubtypeDecl subType superType) = aString ++ "Subtype of" ++ bString
@@ -90,12 +95,14 @@ instance Show SubtypeDecl where
       bString = show superType
 
 -- | predicates
-data Od = Od
-  { nameOd  :: String
-  , varsOd  :: [(Y, K)]
-  , typesOd :: [(Var, T)]
-  , toOd    :: T
-  } deriving (Eq, Typeable)
+data Od =
+  Od
+    { nameOd  :: String
+    , varsOd  :: [(Y, K)]
+    , typesOd :: [(Var, T)]
+    , toOd    :: T
+    }
+  deriving (Eq, Typeable)
 
 instance Show Od where
   show (Od nameOd varsOd typesOd toOd) =
@@ -115,11 +122,13 @@ data Pd
   | Pd2Const Pd2
   deriving (Show, Eq, Typeable)
 
-data Pd1 = Pd1
-  { namePd1  :: String
-  , varsPd1  :: [(Y, K)]
-  , typesPd1 :: [(Var, T)]
-  } deriving (Eq, Typeable)
+data Pd1 =
+  Pd1
+    { namePd1  :: String
+    , varsPd1  :: [(Y, K)]
+    , typesPd1 :: [(Var, T)]
+    }
+  deriving (Eq, Typeable)
 
 instance Show Pd1 where
   show (Pd1 namePd1 varsPd1 typesPd1) =
@@ -131,10 +140,12 @@ instance Show Pd1 where
       bString = show varsPd1
       cString = show typesPd1
 
-data Pd2 = Pd2
-  { namePd2  :: String
-  , propsPd2 :: [(Var, Prop)]
-  } deriving (Eq, Typeable)
+data Pd2 =
+  Pd2
+    { namePd2  :: String
+    , propsPd2 :: [(Var, Prop)]
+    }
+  deriving (Eq, Typeable)
 
 instance Show Pd2 where
   show (Pd2 namePd2 propsPd2) =
@@ -144,10 +155,12 @@ instance Show Pd2 where
       bString = show propsPd2
 
 -- | Statement notation (for syntactic sugar)
-data Sn = Sn
-  { fromSn :: String
-  , toSn   :: String
-  } deriving (Eq, Typeable)
+data Sn =
+  Sn
+    { fromSn :: String
+    , toSn   :: String
+    }
+  deriving (Eq, Typeable)
 
 instance Show Sn where
   show (Sn fromSn toSn) = "(notation: from: " ++ a ++ " to: " ++ b
@@ -320,28 +333,28 @@ check :: ElementProg -> VarEnv
 check p =
   let loadedEnv = loadBuiltInTypes initE
       env = foldl checkElementStmt loadedEnv p
-  in if null (errors env)
-       then env
-       else error $
-            "Element type checking failed with the following problems: \n" ++
-            ppShow (errors env) ++ ppShow env
+   in if null (errors env)
+        then env
+        else error $
+             "Element type checking failed with the following problems: \n" ++
+             ppShow (errors env) ++ ppShow env
   where
     initE =
       VarEnv
-      { typeConstructors = M.empty
-      , valConstructors = M.empty
-      , operators = M.empty
-      , predicates = M.empty
-      , typeVarMap = M.empty
-      , typeValConstructor = M.empty
-      , varMap = M.empty
-      , subTypes = []
-      , stmtNotations = []
-      , typeCtorNames = []
-      , preludes = []
-      , declaredNames = []
-      , errors = ""
-      }
+        { typeConstructors = M.empty
+        , valConstructors = M.empty
+        , operators = M.empty
+        , predicates = M.empty
+        , typeVarMap = M.empty
+        , typeValConstructor = M.empty
+        , varMap = M.empty
+        , subTypes = []
+        , stmtNotations = []
+        , typeCtorNames = []
+        , preludes = []
+        , declaredNames = []
+        , errors = ""
+        }
 
 -- | Load the initial environemt with built in types and predicates
 loadBuiltInTypes :: VarEnv -> VarEnv
@@ -350,8 +363,10 @@ loadBuiltInTypes initEnv = foldl go initEnv builtInTypes
     go env typeCons =
       let typeName = nametc typeCons
           env' = addName typeName initEnv
-      in env'
-         {typeConstructors = M.insert typeName typeCons $ typeConstructors env'}
+       in env'
+            { typeConstructors =
+                M.insert typeName typeCons $ typeConstructors env'
+            }
 
 -- | all the built-in types supported by all Element programs
 builtInTypes :: [TypeConstructor]
@@ -366,15 +381,15 @@ checkElementStmt e (CdStmt c) =
       env1 = foldl checkK e kinds
       tc = TypeConstructor {nametc = nameCd c, kindstc = kinds}
       ef = addName (nameCd c) env1
-  in ef {typeConstructors = M.insert (nameCd c) tc $ typeConstructors ef}
+   in ef {typeConstructors = M.insert (nameCd c) tc $ typeConstructors ef}
 checkElementStmt e (SubtypeDeclStmt s) =
   let env1 = checkDeclaredType e (subType s)
       env2 = checkDeclaredType env1 (superType s)
       env3 = env2 {subTypes = (subType s, superType s) : subTypes env2}
-  in env3
+   in env3
 checkElementStmt e (PreludeDeclStmt (VarConst pvar) ptype) =
   let env = checkT e ptype
-  in env {preludes = ((VarConst pvar), ptype) : preludes env}
+   in env {preludes = ((VarConst pvar), ptype) : preludes env}
 checkElementStmt e (VdStmt v) =
   let kinds = seconds (varsVd v)
       env1 = foldl checkK e kinds
@@ -385,18 +400,18 @@ checkElementStmt e (VdStmt v) =
       env3 = checkT env2 res
       vc =
         ValConstructor
-        { namevc = nameVd v
-        , ylsvc = firsts (varsVd v)
-        , kindsvc = seconds (varsVd v)
-        , nsvc = firsts (typesVd v)
-        , tlsvc = seconds (typesVd v)
-        , tvc = toVd v
-        }
+          { namevc = nameVd v
+          , ylsvc = firsts (varsVd v)
+          , kindsvc = seconds (varsVd v)
+          , nsvc = firsts (typesVd v)
+          , tlsvc = seconds (typesVd v)
+          , tvc = toVd v
+          }
       e1 = addName (nameVd v) env3
       ef = addValConstructor vc e1
-  in if env2 == e || env2 /= e && env3 == e || env3 /= e && e1 == e || e1 /= e
-       then ef {valConstructors = M.insert (nameVd v) vc $ valConstructors ef}
-       else error "Error!" -- Does not suppose to reach here
+   in if env2 == e || env2 /= e && env3 == e || env3 /= e && e1 == e || e1 /= e
+        then ef {valConstructors = M.insert (nameVd v) vc $ valConstructors ef}
+        else error "Error!" -- Does not suppose to reach here
 checkElementStmt e (OdStmt v) =
   let kinds = seconds (varsOd v)
       env1 = foldl checkK e kinds
@@ -407,16 +422,16 @@ checkElementStmt e (OdStmt v) =
       env3 = checkT env2 res
       op =
         Operator
-        { nameop = nameOd v
-        , ylsop = firsts (varsOd v)
-        , kindsop = seconds (varsOd v)
-        , tlsop = seconds (typesOd v)
-        , top = toOd v
-        }
+          { nameop = nameOd v
+          , ylsop = firsts (varsOd v)
+          , kindsop = seconds (varsOd v)
+          , tlsop = seconds (typesOd v)
+          , top = toOd v
+          }
       ef = addName (nameOd v) env3
-  in if env2 == e || env2 /= e && env3 == e || env3 /= e
-       then ef {operators = M.insert (nameOd v) op $ operators ef}
-       else error "Error!" -- Does not suppose to reach here
+   in if env2 == e || env2 /= e && env3 == e || env3 /= e
+        then ef {operators = M.insert (nameOd v) op $ operators ef}
+        else error "Error!" -- Does not suppose to reach here
 checkElementStmt e (PdStmt (Pd1Const v)) =
   let kinds = seconds (varsPd1 v)
       env1 = foldl checkK e kinds
@@ -426,36 +441,36 @@ checkElementStmt e (PdStmt (Pd1Const v)) =
       pd1 =
         Pred1 $
         Prd1
-        { namepred1 = namePd1 v
-        , ylspred1 = firsts (varsPd1 v)
-        , kindspred1 = seconds (varsPd1 v)
-        , tlspred1 = seconds (typesPd1 v)
-        }
+          { namepred1 = namePd1 v
+          , ylspred1 = firsts (varsPd1 v)
+          , kindspred1 = seconds (varsPd1 v)
+          , tlspred1 = seconds (typesPd1 v)
+          }
       ef = addName (namePd1 v) e
-  in if env2 == e || env2 /= e
-       then ef {predicates = M.insert (namePd1 v) pd1 $ predicates ef}
-       else error "Error!" -- Does not suppose to reach here
+   in if env2 == e || env2 /= e
+        then ef {predicates = M.insert (namePd1 v) pd1 $ predicates ef}
+        else error "Error!" -- Does not suppose to reach here
 checkElementStmt e (PdStmt (Pd2Const v)) =
   let pd = Pred2 $ Prd2 {namepred2 = namePd2 v, plspred2 = seconds (propsPd2 v)}
       ef = addName (namePd2 v) e
-  in ef {predicates = M.insert (namePd2 v) pd $ predicates ef}
+   in ef {predicates = M.insert (namePd2 v) pd $ predicates ef}
 checkElementStmt e (SnStmt s) =
   let (from, to, patterns, entities) = T.translatePatterns (fromSn s, toSn s) e
       newSnr =
         StmtNotationRule
-        { fromSnr = from
-        , toSnr = to
-        , patternsSnr = patterns
-        , entitiesSnr = entities
-        }
-  in e {stmtNotations = newSnr : stmtNotations e}
+          { fromSnr = from
+          , toSnr = to
+          , patternsSnr = patterns
+          , entitiesSnr = entities
+          }
+   in e {stmtNotations = newSnr : stmtNotations e}
 
 computeSubTypes :: VarEnv -> VarEnv
 computeSubTypes e =
   let env1 = e {subTypes = transitiveClosure (subTypes e)}
-  in if isClosureNotCyclic (subTypes env1)
-       then env1
-       else env1 {errors = errors env1 ++ "Cyclic Subtyping Relation! \n"}
+   in if isClosureNotCyclic (subTypes env1)
+        then env1
+        else env1 {errors = errors env1 ++ "Cyclic Subtyping Relation! \n"}
 
 -- | 'parseElement' runs the actual parser function: 'elementParser', taking in a
 --   program String, parses it and semantically checks it. It outputs the
@@ -467,7 +482,7 @@ parseElement elementFile elementIn =
     Right prog ->
       let env = check prog
           env1 = computeSubTypes env
-      in Right env1
+       in Right env1
 
 ----------------------------- Test Driver --------------------------------------
 -- | For testing: first uncomment the module definition to make this module the

--- a/src/Penrose/Substance.hs
+++ b/src/Penrose/Substance.hs
@@ -272,11 +272,7 @@ predicate = do
   args <- parens (predicateArg `sepBy1` comma)
   pos <- getSourcePos
   return
-    SubPredicate
-      { predicateName = n
-      , predicateArgs = args
-      , predicatePos = pos
-      }
+    SubPredicate {predicateName = n, predicateArgs = args, predicatePos = pos}
 
 -- NOTE: ordering matters here because expr might succeed first by parsing the predicate name as a var. In general, it's not a good idea to start any parser with an id that's not unique to a type. Fix this later when rewriting the whole thing.
 predicateArg :: Parser SubPredArg

--- a/src/Penrose/Substance.hs
+++ b/src/Penrose/Substance.hs
@@ -588,6 +588,7 @@ compareTypes varEnv (k1, k2) = (k1 == k2 || isSubtypeK k1 k2 varEnv) -- TODO: re
 -- In places where they do not need to match exactly (where type and regular variables exist in the formal type)
 -- a substitution entry is generated. substitutionHelper2 helps in generating these entries for type constructor arguments and
 -- substitutionInsert does the insertion of the entry into the substitution map “sigma”.
+substHelper :: VarEnv -> M.Map Y Arg -> (K, K) -> M.Map Y Arg
 substHelper varEnv sigma (KT (TConstr (TypeCtorApp atc argsAT pos1)), KT (TConstr (TypeCtorApp ftc argsFT pos2)))
   | atc `elem` declaredNames varEnv || ftc `elem` declaredNames varEnv =
     substHelper2 varEnv sigma (AVar (VarConst atc), AVar (VarConst ftc))


### PR DESCRIPTION
# Description

Related issue/PR: #419 

This PR contains the parser for the Domain language written in TypeScript.

# Implementation strategy and design decisions

* Revise the Domain AST to include source locations and simplify overly nested types
* Remove dependent types from the grammar
* Add a test suite for the parser
* Automatic parser generation upon `npm run/build/build-lib/start`

# Examples with steps to reproduce them

* Run `npm test`, which will trigger a `pretest` script that builds all parsers (see below)
* To manually build all parsers, run `npm run build:parsers`
* Example: AST for `set-theory-domain/setTheory.dsl`: https://gist.github.com/wodeni/c135c2e67da0397db3d11a8b945791e7

# Checklist

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] New and existing tests pass locally using `npm test`
- [x] I ran `npm run docs` and there were no errors when generating the HTML site
- [x] My code follows the style guidelines of this project (e.g.: no ESLint warnings)

# Open questions

Questions that require more discussion or to be addressed in future development:
