### PR TITLE
fix: allow trailing comments without newline at the end

### DIFF
--- a/packages/penrose-core/src/compiler/Domain.ts
+++ b/packages/penrose-core/src/compiler/Domain.ts
@@ -25,7 +25,7 @@ export const parseDomain = (prog: string): Result<DomainProg, ParseError> => {
     nearley.Grammar.fromCompiled(domainGrammar)
   );
   try {
-    const { results } = parser.feed(prog);
+    const { results } = parser.feed(prog).feed("\n"); // NOTE: extra newline to avoid trailing comments
     const ast: DomainProg = results[0] as DomainProg;
     return ok(ast);
   } catch (e) {

--- a/packages/penrose-core/src/compiler/Style.ts
+++ b/packages/penrose-core/src/compiler/Style.ts
@@ -2557,7 +2557,7 @@ const genOptProblemAndState = (trans: Translation): State => {
 export const parseStyle = (p: string): Result<StyProg, ParseError> => {
   const parser = new nearley.Parser(nearley.Grammar.fromCompiled(styleGrammar));
   try {
-    const { results } = parser.feed(p);
+    const { results } = parser.feed(p).feed("\n");
     const ast: StyProg = results[0] as StyProg;
     return ok(ast);
   } catch (e) {

--- a/packages/penrose-core/src/compiler/Substance.test.ts
+++ b/packages/penrose-core/src/compiler/Substance.test.ts
@@ -77,8 +77,7 @@ Set A
 Set B
 Set C
 Set D
--- Set E
-    `;
+-- Set E`;
     const env = envOrError(domainProg);
     const res = compileSubstance(prog, env);
     expect(res.isOk()).toBe(true);

--- a/packages/penrose-core/src/compiler/Substance.test.ts
+++ b/packages/penrose-core/src/compiler/Substance.test.ts
@@ -71,6 +71,18 @@ describe("Common", () => {
     const res = compileSubstance(prog, env);
     expect(res.isOk()).toBe(true);
   });
+  test("trailing comment", () => {
+    const prog = `
+Set A
+Set B
+Set C
+Set D
+-- Set E
+    `;
+    const env = envOrError(domainProg);
+    const res = compileSubstance(prog, env);
+    expect(res.isOk()).toBe(true);
+  });
 });
 
 describe("Postprocess", () => {

--- a/packages/penrose-core/src/compiler/Substance.ts
+++ b/packages/penrose-core/src/compiler/Substance.ts
@@ -33,7 +33,7 @@ export const parseSubstance = (prog: string): Result<SubProg, ParseError> => {
     nearley.Grammar.fromCompiled(substanceGrammar)
   );
   try {
-    const { results } = parser.feed(prog);
+    const { results } = parser.feed(prog).feed("\n"); // NOTE: extra newline to avoid trailing comments
     const ast: SubProg = results[0] as SubProg;
     return ok(ast);
   } catch (e) {

--- a/packages/penrose-core/src/parser/SubstanceParser.test.ts
+++ b/packages/penrose-core/src/parser/SubstanceParser.test.ts
@@ -78,6 +78,26 @@ AutoLabel All
     const { results } = parser.feed(prog);
     sameASTs(results);
   });
+  test("no trailing newline", () => {
+    const prog = `
+Set A
+Set B
+Set C
+Set D
+Set E`;
+    const { results } = parser.feed(prog);
+    sameASTs(results);
+  });
+  test("trailing comment", () => {
+    const prog = `
+Set A
+Set B
+Set C
+Set D
+-- Set E`;
+    const { results } = parser.feed(prog).feed("\n");
+    sameASTs(results);
+  });
 });
 
 describe("statements", () => {


### PR DESCRIPTION
# Description

Related issue/PR: #470 

As described in the issue.

# Implementation strategy and design decisions

* Call `feed('\n')` after parsing every program in all 3 parsers.
* Add tests

# Examples with steps to reproduce them

# Checklist

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] New and existing tests pass locally using `yarn test`
- [x] I ran `yarn docs` and there were no errors when generating the HTML site
- [x] My code follows the style guidelines of this project (e.g.: no ESLint warnings)

# Open questions

