### PR TITLE
fix: add global pseudorandomness

### DIFF
--- a/packages/penrose-core/src/compiler/Domain.test.ts
+++ b/packages/penrose-core/src/compiler/Domain.test.ts
@@ -6,7 +6,7 @@ import * as path from "path";
 import { Result, showError } from "utils/Error";
 
 const outputDir = "/tmp/contexts";
-const saveContexts = true;
+const saveContexts = false;
 const printError = false;
 
 const domainPaths = [

--- a/packages/penrose-core/src/compiler/Domain.test.ts
+++ b/packages/penrose-core/src/compiler/Domain.test.ts
@@ -209,7 +209,7 @@ constructor Cons ['X] : 'X head * List('X) tail -> List('X)
 
 describe("Real Programs", () => {
   // create output folder
-  if (!fs.existsSync(outputDir)) {
+  if (saveContexts && !fs.existsSync(outputDir)) {
     fs.mkdirSync(outputDir);
   }
 

--- a/packages/penrose-core/src/compiler/Style.ts
+++ b/packages/penrose-core/src/compiler/Style.ts
@@ -41,6 +41,7 @@ import {
 import { randFloats } from "utils/Util";
 import { checkTypeConstructor, Env, isDeclaredSubtype } from "./Domain";
 import consola, { LogLevel } from "consola";
+import seedrandom from "seedrandom";
 
 const log = consola
   .create({ level: LogLevel.Warn })
@@ -2495,7 +2496,6 @@ const genOptProblemAndState = (trans: Translation): State => {
   const shapePathList: [string, string][] = findShapeNames(trans);
   const shapePaths = shapePathList.map(mkPath);
 
-  // COMBAK: Use pseudorandomness
   // sample varying fieldsr
   const transInitFields = initFields(varyingPaths, trans);
   // sample varying vals and instantiate all the non - float base properties of every GPI in the translation

--- a/packages/penrose-core/src/compiler/Substance.test.ts
+++ b/packages/penrose-core/src/compiler/Substance.test.ts
@@ -430,7 +430,7 @@ l := Cons(A, nil)
 
 describe("Real Programs", () => {
   // create output folder
-  if (!fs.existsSync(outputDir)) {
+  if (saveContexts && !fs.existsSync(outputDir)) {
     fs.mkdirSync(outputDir);
   }
 

--- a/packages/penrose-core/src/engine/Evaluator.ts
+++ b/packages/penrose-core/src/engine/Evaluator.ts
@@ -1039,7 +1039,7 @@ export const findExpr = (
  * @param json plain object encoding `State` of the diagram
  */
 export const decodeState = (json: any): State => {
-  const rng: prng = seedrandom(json.rng, { global: true });
+  // const rng: prng = seedrandom(json.rng, { global: true });
   const state = {
     ...json,
     varyingValues: json.varyingState,
@@ -1051,7 +1051,7 @@ export const decodeState = (json: any): State => {
     varyingMap: genPathMap(json.varyingPaths, json.varyingState),
     params: json.paramsr,
     pendingMap: new Map(),
-    rng,
+    rng: undefined,
   };
   // cache energy function
   // state.overallObjective = evalEnergyOn(state);

--- a/packages/penrose-core/src/parser/DomainParser.test.ts
+++ b/packages/penrose-core/src/parser/DomainParser.test.ts
@@ -5,7 +5,7 @@ import * as fs from "fs";
 import { result } from "lodash";
 
 const outputDir = "/tmp/asts";
-const saveASTs = true;
+const saveASTs = false;
 
 let parser: nearley.Parser;
 const sameASTs = (results: any[]) => {

--- a/packages/penrose-core/src/parser/DomainParser.test.ts
+++ b/packages/penrose-core/src/parser/DomainParser.test.ts
@@ -214,7 +214,7 @@ List('T) <: List('U)
 
 describe("Real Programs", () => {
   // create output folder
-  if (!fs.existsSync(outputDir)) {
+  if (saveASTs && !fs.existsSync(outputDir)) {
     fs.mkdirSync(outputDir);
   }
 

--- a/packages/penrose-core/src/parser/StyleParser.test.ts
+++ b/packages/penrose-core/src/parser/StyleParser.test.ts
@@ -427,7 +427,7 @@ testing {
 
 describe("Real Programs", () => {
   // create output folder
-  if (!fs.existsSync(outputDir)) {
+  if (saveASTs && !fs.existsSync(outputDir)) {
     fs.mkdirSync(outputDir);
   }
 

--- a/packages/penrose-core/src/parser/StyleParser.test.ts
+++ b/packages/penrose-core/src/parser/StyleParser.test.ts
@@ -6,7 +6,7 @@ import * as fs from "fs";
 import { result } from "lodash";
 
 const outputDir = "/tmp/asts";
-const saveASTs = true;
+const saveASTs = false;
 
 let parser: nearley.Parser;
 const sameASTs = (results: any[]) => {

--- a/packages/penrose-core/src/parser/SubstanceParser.test.ts
+++ b/packages/penrose-core/src/parser/SubstanceParser.test.ts
@@ -5,7 +5,7 @@ import * as fs from "fs";
 import { result } from "lodash";
 
 const outputDir = "/tmp/asts";
-const saveASTs = true;
+const saveASTs = false;
 
 let parser: nearley.Parser;
 const sameASTs = (results: any[]) => {

--- a/packages/penrose-core/src/parser/SubstanceParser.test.ts
+++ b/packages/penrose-core/src/parser/SubstanceParser.test.ts
@@ -171,7 +171,7 @@ CreateSubset(A, B) = CreateSubset(B, C)
 
 describe("Real Programs", () => {
   // create output folder
-  if (!fs.existsSync(outputDir)) {
+  if (saveASTs && !fs.existsSync(outputDir)) {
     fs.mkdirSync(outputDir);
   }
 

--- a/packages/penrose-core/src/utils/Util.tsx
+++ b/packages/penrose-core/src/utils/Util.tsx
@@ -3,6 +3,9 @@ import styled from "styled-components";
 import { staticMap } from "../shapes/componentMap";
 import memoize from "fast-memoize";
 import { times } from "lodash";
+import seedrandom from "seedrandom";
+
+seedrandom("secret-seed", { global: true }); // HACK: constant seed for pseudorandomness
 
 /**
  * Generate a random float. The maximum is exclusive and the minimum is inclusive


### PR DESCRIPTION
# Description

Related issue/PR:  #466

For testing, added a global random seed in `Util.tsx` to enfore global pseudorandomness.

# Implementation strategy and design decisions

Call `seedrandom` with `global` option on.

# Examples with steps to reproduce them

# Checklist

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] New and existing tests pass locally using `yarn test`
- [ ] I ran `yarn docs` and there were no errors when generating the HTML site
- [ ] My code follows the style guidelines of this project (e.g.: no ESLint warnings)

# Open questions

N/A