### PR TITLE
Improve Style compiler error-handling

### DIFF
--- a/examples/geometry-domain/euclidean-simple.sty
+++ b/examples/geometry-domain/euclidean-simple.sty
@@ -339,7 +339,7 @@ Point `C` {
 Angle theta
 where theta := InteriorAngle(q, p, r); Right(theta)
 with Point p; Point q; Point r {
-      theta.perpSize = 13.0
+      override theta.perpSize = 13.0
 
       -- override theta.shape = Path {
       -- 		 pathData : perpPath(q.vec, p.vec, r.vec, theta.perpSize)

--- a/examples/mesh-set-domain/DomainInterop.sty
+++ b/examples/mesh-set-domain/DomainInterop.sty
@@ -200,10 +200,10 @@ SimplicialComplex K {
        K.padding = 25.0
 
        K.text = Text {
-	 center : (K.icon.center[0] - K.icon.w / 2.0 + K.padding, K.icon.center[1] - K.icon.h / 2.0 + K.padding)
-	 string : K.label
-	 rotation : 0.0
-	 color : Colors.black
+         center : (K.icon.center[0] - K.icon.w / 2.0 + K.padding, K.icon.center[1] - K.icon.h / 2.0 + K.padding)
+         string : K.label
+         rotation : 0.0
+         color : Colors.black
        }
 
      encourage centerLabel(K.icon, K.text)
@@ -215,7 +215,7 @@ SimplicialComplex K {
 
        K.const_text = Text {
        	 center : (K.icon.center[0], K.icon.center[1] - (K.size_y / 2.0) - K.expr_padding)
-       	 string : "\\text{ }"
+       	 string : "\text{ }"
        	 rotation : 0.0
        	 color : global.starColor
        }

--- a/examples/set-theory-domain/venn.sty
+++ b/examples/set-theory-domain/venn.sty
@@ -1,3 +1,13 @@
+-- SelectorDeclTypeError
+-- forall Setfhjh x { }
+
+-- SelectorVarMultipleDecl
+-- forall Set x; Set x { }
+
+-- SelectorRelTypeMismatch
+-- forall Point x; Set y; Set z
+-- where x := Union(y, z) { }
+
 forall Set x {
     x.icon = Circle {
         strokeWidth : 0.0

--- a/examples/set-theory-domain/venn.sty
+++ b/examples/set-theory-domain/venn.sty
@@ -7,16 +7,6 @@ forall Set x {
         string : x.label
     }
 
-    -- DeletedPropWithNoGPIError
-    -- x.z = 0.0
-    -- delete x.z.p
-
-    x.icon2 = x.icon
-    -- this works
-    x.icon2.strokeWidth = 5.0
-    -- COMBAK: This does not appear to have worked
-    delete x.icon2.strokeWidth
-
     ensure contains(x.icon, x.text)
     ensure minSize(x.icon)
     ensure maxSize(x.icon)

--- a/examples/set-theory-domain/venn.sty
+++ b/examples/set-theory-domain/venn.sty
@@ -1,48 +1,11 @@
--- SelectorDeclTypeError
--- forall Setfhjh x { }
-
--- SelectorVarMultipleDecl
--- forall Set x; Set x { }
-
--- SelectorRelTypeMismatch
--- forall Point x; Set y; Set z
--- where x := Union(y, z) { }
-
--- forall Point p {
---        delete p.f
--- }
-
 forall Set x {
-   -- DeletedNonexistentFieldError
-   -- delete x.z
-
     x.icon = Circle {
         strokeWidth : 0.0
-        -- center: (0.0, 0.0)
     }
-
-    -- DeletedVectorElemError
-    -- delete x.icon[0]
-
-   -- DeletedNonexistentFieldError
-   -- delete x.z
 
     x.text = Text {
         string : x.label
     }
-
-    -- COMBAK: Should this have a warning? Currently doesn't
-    -- delete x.icon.z 
-
-    -- DeletedPropWithNoSubObjError
-    -- delete y.z
-
-    -- DeletedPropWithNoFieldError
-    -- delete x.z.p
-
-    -- These both cause a weird crash that's not caught
-    -- override x.icon = x.icon
-    -- ensure contains(x.icon, x.text2)
 
     -- DeletedPropWithNoGPIError
     -- x.z = 0.0

--- a/examples/set-theory-domain/venn.sty
+++ b/examples/set-theory-domain/venn.sty
@@ -8,14 +8,51 @@
 -- forall Point x; Set y; Set z
 -- where x := Union(y, z) { }
 
+-- forall Point p {
+--        delete p.f
+-- }
+
 forall Set x {
+   -- DeletedNonexistentFieldError
+   -- delete x.z
+
     x.icon = Circle {
         strokeWidth : 0.0
+        -- center: (0.0, 0.0)
     }
+
+    -- DeletedVectorElemError
+    -- delete x.icon[0]
+
+   -- DeletedNonexistentFieldError
+   -- delete x.z
 
     x.text = Text {
         string : x.label
     }
+
+    -- COMBAK: Should this have a warning? Currently doesn't
+    -- delete x.icon.z 
+
+    -- DeletedPropWithNoSubObjError
+    -- delete y.z
+
+    -- DeletedPropWithNoFieldError
+    -- delete x.z.p
+
+    -- These both cause a weird crash that's not caught
+    -- override x.icon = x.icon
+    -- ensure contains(x.icon, x.text2)
+
+    -- DeletedPropWithNoGPIError
+    -- x.z = 0.0
+    -- delete x.z.p
+
+    x.icon2 = x.icon
+    -- this works
+    x.icon2.strokeWidth = 5.0
+    -- COMBAK: This does not appear to have worked
+    delete x.icon2.strokeWidth
 
     ensure contains(x.icon, x.text)
     ensure minSize(x.icon)

--- a/packages/penrose-core/src/App.tsx
+++ b/packages/penrose-core/src/App.tsx
@@ -123,7 +123,7 @@ class App extends React.Component<any, ICanvasState> {
           this.setState({ data: initState });
           void this.onCanvasState(initState);
         } else {
-          void console.error(compileRes.error);
+          void console.error("Failed to compile with errors:", compileRes.error);
         }
       },
       () => {

--- a/packages/penrose-core/src/compiler/Style.test.ts
+++ b/packages/penrose-core/src/compiler/Style.test.ts
@@ -264,40 +264,83 @@ describe("Compiler", () => {
 
     const errorStyProgs = {
       // ------ Selector errors (from Substance)
-      SelectorDeclTypeError: `forall Setfhjh x { }`,
-      SelectorVarMultipleDecl: `forall Set x; Set x { }`,
+      SelectorDeclTypeError: [`forall Setfhjh x { }`],
+      SelectorVarMultipleDecl: [`forall Set x; Set x { }`],
 
       // COMBAK: Style doesn't throw parse error if the program is just "forall Point `A`"... instead it fails inside compileStyle with an undefined selector environment
-      SelectorDeclTypeMismatch: "forall Point `A` { }",
+      SelectorDeclTypeMismatch: [`forall Point \`A\` { }`],
 
-      SelectorRelTypeMismatch: `forall Point x; Set y; Set z
-      where x := Union(y, z) { } `,
+      SelectorRelTypeMismatch: [`forall Point x; Set y; Set z
+      where x := Union(y, z) { } `],
 
-      TaggedSubstanceError: `forall Set x; Point y
-where IsSubset(y, x) { }`,
+      TaggedSubstanceError: [`forall Set x; Point y
+where IsSubset(y, x) { }`],
 
-      // ------- Block errors (deletion)
-      DeletedPropWithNoSubObjError: `forall Set x { delete y.z.p }`,
-      DeletedPropWithNoFieldError: `forall Set x { x.icon = Circle { }
-delete x.z.p }`,
+      // ------- Translation errors (deletion)
+      DeletedPropWithNoSubObjError: [`forall Set x { delete y.z.p }`],
+      DeletedPropWithNoFieldError: [`forall Set x { x.icon = Circle { }
+delete x.z.p }`],
 
-      DeletedPropWithNoGPIError: `forall Set x { x.z = 0.0
-delete x.z.p }`,
+      DeletedPropWithNoGPIError: [`forall Set x { x.z = 0.0
+delete x.z.p }`],
 
       // COMBAK: This doesn't catch the error
       // COMBAK: Style appears to throw parse error if line ends with a trailing space
       // COMBAK: Why is this a parse error??
-      //       CircularPathAlias: `forall Set x { x.icon = Circle { }
-      // x.icon.center = x.icon.center }`,
+      // COMBAK: Test the instance in `insertExpr` as well as in `compileStyle`
+      //       CircularPathAlias: [`forall Set x { x.icon = Circle { }
+      // x.icon.center = x.icon.center }`],
 
-      DeletedNonexistentFieldError: `forall Set x { delete x.z }`,
+      DeletedNonexistentFieldError: [`forall Set x { delete x.z }`],
       DeletedVectorElemError:
-        `forall Set x {  
+        [`forall Set x {  
          x.icon = Circle { 
            center: (0.0, 0.0) 
          }
-         delete x.icon[0] }`,
+         delete x.icon[0] }`],
+
+      // ---------- Translation errors (insertion)
+
+      InsertedPathWithoutOverrideError:
+        [`forall Set x { 
+           x.z = 1.0 
+           x.z = 2.0
+}`,
+          `forall Set x { 
+         x.icon = Circle { 
+           center: (0.0, 0.0) 
+         }
+           x.icon.center = 2.0
+}`],
+
+      InsertedPropWithNoFieldError:
+        [`forall Set x {
+    x.icon.r = 0.0
+}`],
+
+      InsertedPropWithNoGPIError:
+        [`forall Set x {
+    x.icon = "hello"
+    x.icon.r = 0.0
+}`],
+
+      // ---------- Runtime errors (insertExpr)
+
+      // COMBAK / TODO(errors): Test this more thoroughly
+      // COMBAK / NOTE: runtime errors aren't caught if an expr isn't evaluated, since we don't have statics. Test these separately.
+
+      //       RuntimeValueTypeError: [
+      //         `forall Set x { 
+      //          x.icon = Circle { 
+      //            center: (0.0, 0.0) 
+      //          }
+      //            x.icon.center[0] = "hello"
+      //            x.icon.center[1] = x.icon.center[0]
+      // }`]
+
     };
+
+    // ---------- Errors that should maybe be modeled + tested
 
     // COMBAK: Should this have a warning/error? Currently doesn't
     // `forall Set x { x.icon = Circle { }; delete x.icon.z }
@@ -314,8 +357,10 @@ delete x.z.p }`,
     // }
 
     // Test that each program yields its error type
-    for (const [errorType, styProg] of Object.entries(errorStyProgs)) {
-      testStyProgForError(styProg, errorType);
+    for (const [errorType, styProgs] of Object.entries(errorStyProgs)) {
+      for (const styProg of styProgs) {
+        testStyProgForError(styProg, errorType);
+      }
     }
   });
 

--- a/packages/penrose-core/src/compiler/Style.test.ts
+++ b/packages/penrose-core/src/compiler/Style.test.ts
@@ -10,9 +10,8 @@ import {
 import * as fs from "fs";
 import _ from "lodash";
 import * as path from "path";
-import { unsafelyUnwrap, Result } from "utils/Error";
+import { andThen, unsafelyUnwrap, Result, showError, showStyErr } from "utils/Error";
 import { compileDomain, Env } from "./Domain";
-
 // TODO: Reorganize and name tests by compiler stage
 
 // Load file in format "domain-dir/file.extension"
@@ -28,6 +27,7 @@ const loadFiles = (paths: string[]): string[] => {
 
 // Run the Domain + Substance parsers and checkers to yield the Style compiler's input
 // files must follow schema: { domain, substance, style }
+// Disambiguates functions as well
 export const loadProgs = ([domainStr, subStr, styStr]: [
   string,
   string,
@@ -52,6 +52,8 @@ export const loadProgs = ([domainStr, subStr, styStr]: [
     subProg,
     styProg,
   ];
+
+  S.disambiguateFunctions(varEnv, subProg);
   return res;
 };
 
@@ -134,7 +136,6 @@ describe("Compiler", () => {
       StyProg
     ] = loadProgs(loadFiles(triple) as [string, string, string]);
 
-    S.disambiguateFunctions(varEnv, subProg);
     const selEnvs = S.checkSelsAndMakeEnv(varEnv, styProgInit.blocks);
 
     const selErrs: StyErrors = _.flatMap(selEnvs, (e) =>
@@ -178,7 +179,7 @@ describe("Compiler", () => {
       SubProg,
       StyProg
     ] = loadProgs(loadFiles(triple) as [string, string, string]);
-    S.disambiguateFunctions(varEnv, subProg);
+
     const selEnvs = S.checkSelsAndMakeEnv(varEnv, styProgInit.blocks);
     const selErrs: StyErrors = _.flatMap(selEnvs, (e) =>
       e.warnings.concat(e.errors)
@@ -225,5 +226,97 @@ describe("Compiler", () => {
 
   // TODO: There are no tests directly for the substitution application part of the compiler, though I guess you could walk the AST (making the substitution-application code more generic to do so) and check that there are no Style variables anywhere? Except for, I guess, namespace names?
 
-  //
+  // Test errors
+  const PRINT_ERRORS = false;
+
+  const expectErrorOf = (result: Result<State, PenroseError>, errorType: string) => {
+    if (result.isErr()) {
+      // NOTE: Can't call showError as Style returns a composite result in firstStyleError
+      // if (printError) console.log(showError(result.error));
+      if (PRINT_ERRORS) console.log(result.error.messages);
+      expect(result.error.tag).toBe(errorType);
+    } else {
+      fail(`Error ${errorType} was supposed to occur.`);
+    }
+  };
+
+  describe("Errors", () => {
+
+    const subProg = loadFile("set-theory-domain/twosets-simple.sub");
+    const domainProg = loadFile("set-theory-domain/setTheory.dsl");
+    // We test variations on this Style program
+    // const styPath = "set-theory-domain/venn.sty"; 
+
+    const domainRes: Result<Env, PenroseError> = compileDomain(domainProg);
+
+    const subRes: Result<[SubstanceEnv, Env], PenroseError> = andThen(
+      (env) => compileSubstance(subProg, env),
+      domainRes
+    );
+
+    const testStyProgForError = (styProg: string, errorType: string) => {
+      const styRes: Result<State, PenroseError> = andThen(
+        (res) => S.compileStyle(styProg, ...res),
+        subRes
+      );
+      expectErrorOf(styRes, errorType);
+    };
+
+    const errorStyProgs = {
+      // ------ Selector errors (from Substance)
+      SelectorDeclTypeError: `forall Setfhjh x { }`,
+      SelectorVarMultipleDecl: `forall Set x; Set x { }`,
+
+      // COMBAK: Style doesn't throw parse error if the program is just "forall Point `A`"... instead it fails inside compileStyle with an undefined selector environment
+      SelectorDeclTypeMismatch: "forall Point `A` { }",
+
+      SelectorRelTypeMismatch: `forall Point x; Set y; Set z
+      where x := Union(y, z) { } `,
+
+      TaggedSubstanceError: `forall Set x; Point y
+where IsSubset(y, x) { }`,
+
+      // ------- Block errors (deletion)
+      DeletedPropWithNoSubObjError: `forall Set x { delete y.z.p }`,
+      DeletedPropWithNoFieldError: `forall Set x { x.icon = Circle { }
+delete x.z.p }`,
+
+      DeletedPropWithNoGPIError: `forall Set x { x.z = 0.0
+delete x.z.p }`,
+
+      // COMBAK: This doesn't catch the error
+      // COMBAK: Style appears to throw parse error if line ends with a trailing space
+      // COMBAK: Why is this a parse error??
+      //       CircularPathAlias: `forall Set x { x.icon = Circle { }
+      // x.icon.center = x.icon.center }`,
+
+      DeletedNonexistentFieldError: `forall Set x { delete x.z }`,
+      DeletedVectorElemError:
+        `forall Set x {  
+         x.icon = Circle { 
+           center: (0.0, 0.0) 
+         }
+         delete x.icon[0] }`,
+    };
+
+    // COMBAK: Should this have a warning/error? Currently doesn't
+    // `forall Set x { x.icon = Circle { }; delete x.icon.z }
+
+    // COMBAK: These both cause a weird crash that's not caught
+    // override x.icon = x.icon
+    // ensure contains(x.icon, x.text2)
+
+    // forall Set x { x.icon = Circle { }
+    // x.icon2 = x.icon
+    // x.icon2.strokeWidth = 5.0
+    // -- COMBAK: This line does not appear to have worked
+    // delete x.icon2.strokeWidth
+    // }
+
+    // Test that each program yields its error type
+    for (const [errorType, styProg] of Object.entries(errorStyProgs)) {
+      testStyProgForError(styProg, errorType);
+    }
+  });
+
 });

--- a/packages/penrose-core/src/compiler/Style.test.ts
+++ b/packages/penrose-core/src/compiler/Style.test.ts
@@ -231,10 +231,18 @@ describe("Compiler", () => {
 
   const expectErrorOf = (result: Result<State, PenroseError>, errorType: string) => {
     if (result.isErr()) {
-      // NOTE: Can't call showError as Style returns a composite result in firstStyleError
-      // if (printError) console.log(showError(result.error));
-      if (PRINT_ERRORS) console.log(result.error.messages);
-      expect(result.error.tag).toBe(errorType);
+      const res: PenroseError = result.error;
+      if (res.errorType !== "StyleError") {
+        fail(`Error ${errorType} was supposed to occur. Got a non-Style error '${res.errorType}'.`);
+      }
+
+      if (res.tag !== "StyleErrorList") {
+        fail(`Error ${errorType} was supposed to occur. Did not receive a Style list. Got ${res.tag}.`);
+      }
+
+      if (PRINT_ERRORS) { console.log(result.error); }
+
+      expect(res.errors[0].tag).toBe(errorType);
     } else {
       fail(`Error ${errorType} was supposed to occur.`);
     }

--- a/packages/penrose-core/src/engine/EngineUtils.ts
+++ b/packages/penrose-core/src/engine/EngineUtils.ts
@@ -15,6 +15,16 @@ export const wrapErr = (s: string): StyleError => {
   };
 };
 
+// TODO(errors): should these kinds of errors be caught by block statics rather than failing at runtime?
+export const runtimeValueTypeError = (path: Path, expectedType: string, actualType: string): StyleError => {
+  return {
+    tag: "RuntimeValueTypeError",
+    path,
+    expectedType,
+    actualType
+  };
+};
+
 // Generic utils for mapping over values
 
 export function mapTup2<T, S>(f: (arg: T) => S, t: [T, T]): [S, S] {
@@ -435,7 +445,7 @@ export const insertExpr = (
       ) {
         trans = addWarn(
           trans,
-          wrapErr("warning: overriding field expression without override flag set")
+          { tag: "InsertedPathWithoutOverrideError", path }
         ); // TODO(error): Should this be an error?
       }
 
@@ -455,6 +465,12 @@ export const insertExpr = (
       const fieldRes: FieldExpr<IVarAD> =
         trans.trMap[name.contents.value][field.value];
 
+      // TODO(errors): Catch error if SubObj, etc don't exist -- but should these kinds of errors be caught by block statics rather than failing at runtime?
+      if (!fieldRes) {
+        // TODO(errors): Catch error if field doesn't exist
+        return addWarn(trans, { tag: "InsertedPropWithNoFieldError", subObj: name, field, property: prop, path });
+      }
+
       if (fieldRes.tag === "FExpr") {
         // Deal with GPI aliasing (i.e. only happens if a GPI is aliased to another, and some operation is performed on the aliased GPI's property, it happens to the original)
         // TODO: Test this
@@ -465,10 +481,11 @@ export const insertExpr = (
               p.name.contents.value === name.contents.value &&
               p.field.value === field.value
             ) {
-              const err = `path was aliased to itself`;
               if (compiling) {
-                return addWarn(trans, wrapErr(err));
+                return addWarn(trans, { tag: "CircularPathAlias", path });
               }
+              // TODO(errors): Use "showErrors" not these ad-hoc errors
+              const err = `path was aliased to itself`;
               throw Error(err);
             }
             const newPath = clone(path);
@@ -486,10 +503,11 @@ export const insertExpr = (
           }
         }
 
-        const err = `Err: Sub obj '${name.contents.value}' does not have GPI '${field.value}'; cannot add property '${prop.value}'`;
+        // TODO(error)
         if (compiling) {
-          return addWarn(trans, wrapErr(err));
+          return addWarn(trans, { tag: "InsertedPropWithNoGPIError", subObj: name, field, property: prop, path });
         }
+        const err = `Err: Sub obj '${name.contents.value}' does not have GPI '${field.value}'; cannot add property '${prop.value}'`;
         throw Error(err);
       } else if (fieldRes.tag === "FGPI") {
         const [, properties] = fieldRes.contents;
@@ -499,7 +517,7 @@ export const insertExpr = (
         if (compiling && !override && properties.hasOwnProperty(prop.value)) {
           trans = addWarn(
             trans,
-            wrapErr("warning: overriding property expression without override flag set")
+            { tag: "InsertedPathWithoutOverrideError", path }
           );
         }
 
@@ -520,10 +538,10 @@ export const insertExpr = (
           [name, field] = [innerPath.name, innerPath.field];
           const res = trans.trMap[name.contents.value][field.value];
           if (res.tag !== "FExpr") {
-            const err = "did not expect GPI in vector access";
             if (compiling) {
-              return addWarn(trans, wrapErr(err));
+              return addWarn(trans, runtimeValueTypeError(path, "Float", "GPI"));
             }
+            const err = "did not expect GPI in vector access";
             throw Error(err);
           }
           const res2: TagExpr<IVarAD> = res.contents;
@@ -531,10 +549,10 @@ export const insertExpr = (
           if (res2.tag === "OptEval") {
             const res3: Expr = res2.contents;
             if (res3.tag !== "Vector") {
-              const err = "expected Vector";
               if (compiling) {
-                return addWarn(trans, wrapErr(err));
+                return addWarn(trans, runtimeValueTypeError(path, "Vector", res3.tag));
               }
+              const err = "expected Vector";
               throw Error(err);
             }
             const res4: Expr[] = res3.contents;
@@ -544,10 +562,10 @@ export const insertExpr = (
             } else if (expr.tag === "Done") {
               res4[exprToNumber(indices[0])] = floatValToExpr(expr.contents);
             } else {
-              const err = "unexpected pending val";
               if (compiling) {
-                return addWarn(trans, wrapErr(err));
+                return addWarn(trans, runtimeValueTypeError(path, "Float", "Pending float"));
               }
+              const err = "unexpected pending val";
               throw Error(err);
             }
 
@@ -558,7 +576,7 @@ export const insertExpr = (
             if (res3.tag !== "VectorV") {
               const err = "expected Vector";
               if (compiling) {
-                return addWarn(trans, wrapErr(err));
+                return addWarn(trans, runtimeValueTypeError(path, "Vector", "res3.tag"));
               }
               throw Error(err);
             }
@@ -567,19 +585,20 @@ export const insertExpr = (
             if (expr.tag === "Done" && expr.contents.tag === "FloatV") {
               res4[exprToNumber(indices[0])] = expr.contents.contents;
             } else {
-              const err = "unexpected val";
               if (compiling) {
-                return addWarn(trans, wrapErr(err));
+                return addWarn(trans, runtimeValueTypeError(path, "Float", expr.tag));
               }
+              const err = "unexpected val";
               throw Error(err);
             }
 
             return trans;
           } else {
-            const err = "unexpected tag";
             if (compiling) {
-              return addWarn(trans, wrapErr(err));
+              // TODO(errors): expected type?
+              return addWarn(trans, runtimeValueTypeError(path, "Float", res2.tag));
             }
+            const err = "unexpected tag";
             throw Error(err);
           }
         }
@@ -598,10 +617,10 @@ export const insertExpr = (
             // Deal with vector expresions
             const res2 = res.contents;
             if (res2.tag !== "Vector") {
-              const err = "expected Vector";
               if (compiling) {
-                return addWarn(trans, wrapErr(err));
+                return addWarn(trans, runtimeValueTypeError(path, "Vector", res2.tag));
               }
+              const err = "expected Vector";
               throw Error(err);
             }
             const res3 = res2.contents;
@@ -611,10 +630,10 @@ export const insertExpr = (
             } else if (expr.tag === "Done") {
               res3[exprToNumber(indices[0])] = floatValToExpr(expr.contents);
             } else {
-              const err = "unexpected pending val";
               if (compiling) {
-                return addWarn(trans, wrapErr(err));
+                return addWarn(trans, runtimeValueTypeError(path, "Float", expr.tag));
               }
+              const err = "unexpected pending val";
               throw Error(err);
             }
 
@@ -623,10 +642,10 @@ export const insertExpr = (
             // Deal with vector values
             const res2 = res.contents;
             if (res2.tag !== "VectorV") {
-              const err = "expected Vector";
               if (compiling) {
-                return addWarn(trans, wrapErr(err));
+                return addWarn(trans, runtimeValueTypeError(path, "Vector", res2.tag));
               }
+              const err = "expected Vector";
               throw Error(err);
             }
             const res3 = res2.contents;
@@ -634,21 +653,21 @@ export const insertExpr = (
             if (expr.tag === "Done" && expr.contents.tag === "FloatV") {
               res3[exprToNumber(indices[0])] = expr.contents.contents;
             } else {
-              const err = "unexpected val";
               if (compiling) {
-                return addWarn(trans, wrapErr(err));
+                return addWarn(trans, runtimeValueTypeError(path, "Float", expr.tag));
               }
+              const err = "unexpected val";
               throw Error(err);
             }
 
             return trans;
           } else {
-            throw Error("unexpected tag");
+            throw Error("internal error: unexpected tag");
           }
         }
 
         default:
-          throw Error("should not have nested AccessPath in AccessPath");
+          throw Error("internal error: should not have nested AccessPath in AccessPath");
       }
     }
   }

--- a/packages/penrose-core/src/engine/EngineUtils.ts
+++ b/packages/penrose-core/src/engine/EngineUtils.ts
@@ -7,6 +7,14 @@ const clone = require("rfdc")({ proto: false, circles: false });
 
 // TODO: Is there a way to write these mapping/conversion functions with less boilerplate?
 
+// For wrapping temp Style errors until figuring out how they should be categorized
+export const wrapErr = (s: string): StyleError => {
+  return {
+    tag: "GenericStyleError",
+    messages: [s]
+  };
+};
+
 // Generic utils for mapping over values
 
 export function mapTup2<T, S>(f: (arg: T) => S, t: [T, T]): [S, S] {
@@ -427,7 +435,7 @@ export const insertExpr = (
       ) {
         trans = addWarn(
           trans,
-          "warning: overriding field expression without override flag set"
+          wrapErr("warning: overriding field expression without override flag set")
         ); // TODO(error): Should this be an error?
       }
 
@@ -459,7 +467,7 @@ export const insertExpr = (
             ) {
               const err = `path was aliased to itself`;
               if (compiling) {
-                return addWarn(trans, err);
+                return addWarn(trans, wrapErr(err));
               }
               throw Error(err);
             }
@@ -480,7 +488,7 @@ export const insertExpr = (
 
         const err = `Err: Sub obj '${name.contents.value}' does not have GPI '${field.value}'; cannot add property '${prop.value}'`;
         if (compiling) {
-          return addWarn(trans, err);
+          return addWarn(trans, wrapErr(err));
         }
         throw Error(err);
       } else if (fieldRes.tag === "FGPI") {
@@ -491,7 +499,7 @@ export const insertExpr = (
         if (compiling && !override && properties.hasOwnProperty(prop.value)) {
           trans = addWarn(
             trans,
-            "warning: overriding property expression without override flag set"
+            wrapErr("warning: overriding property expression without override flag set")
           );
         }
 
@@ -514,7 +522,7 @@ export const insertExpr = (
           if (res.tag !== "FExpr") {
             const err = "did not expect GPI in vector access";
             if (compiling) {
-              return addWarn(trans, err);
+              return addWarn(trans, wrapErr(err));
             }
             throw Error(err);
           }
@@ -525,7 +533,7 @@ export const insertExpr = (
             if (res3.tag !== "Vector") {
               const err = "expected Vector";
               if (compiling) {
-                return addWarn(trans, err);
+                return addWarn(trans, wrapErr(err));
               }
               throw Error(err);
             }
@@ -538,7 +546,7 @@ export const insertExpr = (
             } else {
               const err = "unexpected pending val";
               if (compiling) {
-                return addWarn(trans, err);
+                return addWarn(trans, wrapErr(err));
               }
               throw Error(err);
             }
@@ -550,7 +558,7 @@ export const insertExpr = (
             if (res3.tag !== "VectorV") {
               const err = "expected Vector";
               if (compiling) {
-                return addWarn(trans, err);
+                return addWarn(trans, wrapErr(err));
               }
               throw Error(err);
             }
@@ -561,7 +569,7 @@ export const insertExpr = (
             } else {
               const err = "unexpected val";
               if (compiling) {
-                return addWarn(trans, err);
+                return addWarn(trans, wrapErr(err));
               }
               throw Error(err);
             }
@@ -570,7 +578,7 @@ export const insertExpr = (
           } else {
             const err = "unexpected tag";
             if (compiling) {
-              return addWarn(trans, err);
+              return addWarn(trans, wrapErr(err));
             }
             throw Error(err);
           }
@@ -592,7 +600,7 @@ export const insertExpr = (
             if (res2.tag !== "Vector") {
               const err = "expected Vector";
               if (compiling) {
-                return addWarn(trans, err);
+                return addWarn(trans, wrapErr(err));
               }
               throw Error(err);
             }
@@ -605,7 +613,7 @@ export const insertExpr = (
             } else {
               const err = "unexpected pending val";
               if (compiling) {
-                return addWarn(trans, err);
+                return addWarn(trans, wrapErr(err));
               }
               throw Error(err);
             }
@@ -617,7 +625,7 @@ export const insertExpr = (
             if (res2.tag !== "VectorV") {
               const err = "expected Vector";
               if (compiling) {
-                return addWarn(trans, err);
+                return addWarn(trans, wrapErr(err));
               }
               throw Error(err);
             }
@@ -628,7 +636,7 @@ export const insertExpr = (
             } else {
               const err = "unexpected val";
               if (compiling) {
-                return addWarn(trans, err);
+                return addWarn(trans, wrapErr(err));
               }
               throw Error(err);
             }

--- a/packages/penrose-core/src/parser/DomainParser.ts
+++ b/packages/penrose-core/src/parser/DomainParser.ts
@@ -2,9 +2,7 @@
 // http://github.com/Hardmath123/nearley
 // Bypasses TS6133. Allow declared but unused functions.
 // @ts-ignore
-function id(d: any[]): any {
-  return d[0];
-}
+function id(d: any[]): any { return d[0]; }
 declare var string_literal: any;
 declare var identifier: any;
 declare var comment: any;
@@ -13,17 +11,8 @@ declare var ws: any;
 
 /* eslint-disable */
 import * as moo from "moo";
-import { concat, compact, flatten, last } from "lodash";
-import {
-  optional,
-  tokensIn,
-  basicSymbols,
-  rangeOf,
-  rangeBetween,
-  rangeFrom,
-  nth,
-  convertTokenId,
-} from "parser/ParserUtil";
+import { concat, compact, flatten, last } from 'lodash'
+import { optional, tokensIn, basicSymbols, rangeOf, rangeBetween, rangeFrom, nth, convertTokenId } from 'parser/ParserUtil'
 
 // NOTE: ordering matters here. Top patterns get matched __first__
 const lexer = moo.compile({
@@ -32,27 +21,28 @@ const lexer = moo.compile({
     match: /[A-z_][A-Za-z_0-9]*/,
     type: moo.keywords({
       // NOTE: the next line add type annotation keywords into the keyword set and thereby forbidding users to use keywords like `shape`
-      // "type-keyword": styleTypes,
+      // "type-keyword": styleTypes, 
       type: "type",
       value: "value",
       constructor: "constructor",
       function: "function",
       predicate: "predicate",
       notation: "notation",
-      prop: "Prop",
-    }),
-  },
+      prop: "Prop"
+    })
+  }
 });
 
 const nodeData = (children: ASTNode[]) => ({
   nodeType: "Domain",
-  children,
+  children
 });
+
 
 interface NearleyToken {
   value: any;
   [key: string]: any;
-}
+};
 
 interface NearleyLexer {
   reset: (chunk: string, info: any) => void;
@@ -60,579 +50,266 @@ interface NearleyLexer {
   save: () => any;
   formatError: (token: never) => string;
   has: (tokenType: string) => boolean;
-}
+};
 
 interface NearleyRule {
   name: string;
   symbols: NearleySymbol[];
   postprocess?: (d: any[], loc?: number, reject?: {}) => any;
-}
+};
 
-type NearleySymbol =
-  | string
-  | { literal: any }
-  | { test: (token: any) => boolean };
+type NearleySymbol = string | { literal: any } | { test: (token: any) => boolean };
 
 interface Grammar {
   Lexer: NearleyLexer | undefined;
   ParserRules: NearleyRule[];
   ParserStart: string;
-}
+};
 
 const grammar: Grammar = {
   Lexer: lexer,
   ParserRules: [
-    {
-      name: "input",
-      symbols: ["statements"],
-      postprocess: ([statements]): DomainProg => ({
-        ...nodeData(statements),
-        ...rangeFrom(statements),
-        tag: "DomainProg",
-        statements,
-      }),
-    },
-    { name: "statements", symbols: ["_"], postprocess: () => [] },
-    {
-      name: "statements",
-      symbols: ["_c_", { literal: "\n" }, "statements"],
-      postprocess: nth(2),
-    },
-    {
-      name: "statements",
-      symbols: ["_", "statement", "_c_"],
-      postprocess: (d) => [d[1]],
-    },
-    {
-      name: "statements",
-      symbols: ["_", "statement", "_c_", { literal: "\n" }, "statements"],
-      postprocess: (d) => [d[1], ...d[4]],
-    },
-    { name: "statement", symbols: ["type"], postprocess: id },
-    { name: "statement", symbols: ["predicate"], postprocess: id },
-    { name: "statement", symbols: ["function"], postprocess: id },
-    { name: "statement", symbols: ["constructor_decl"], postprocess: id },
-    { name: "statement", symbols: ["prelude"], postprocess: id },
-    { name: "statement", symbols: ["notation"], postprocess: id },
-    { name: "statement", symbols: ["subtype"], postprocess: id },
-    {
-      name: "type$ebnf$1$subexpression$1",
-      symbols: [
-        "_",
-        { literal: "(" },
-        "_",
-        "type_params",
-        "_",
-        { literal: ")" },
-      ],
-    },
-    {
-      name: "type$ebnf$1",
-      symbols: ["type$ebnf$1$subexpression$1"],
-      postprocess: id,
-    },
-    { name: "type$ebnf$1", symbols: [], postprocess: () => null },
-    {
-      name: "type",
-      symbols: [{ literal: "type" }, "__", "identifier", "type$ebnf$1"],
-      postprocess: ([typ, , name, ps]): TypeDecl => {
-        const params = ps ? ps[3] : [];
-        return {
-          ...nodeData([name, ...params]),
-          ...rangeBetween(typ, name),
-          tag: "TypeDecl",
-          name,
-          params,
-        };
-      },
-    },
-    {
-      name: "predicate",
-      symbols: [
-        { literal: "predicate" },
-        "__",
-        "identifier",
-        "type_params_list",
-        "args_list",
-      ],
-      postprocess: ([kw, , name, params, args]): PredicateDecl => ({
-        ...nodeData([name, ...params, ...args]),
-        ...rangeFrom([rangeOf(kw), ...args, ...params]),
-        tag: "PredicateDecl",
-        name,
-        params,
-        args,
-      }),
-    },
-    {
-      name: "function",
-      symbols: [
-        { literal: "function" },
-        "__",
-        "identifier",
-        "type_params_list",
-        "args_list",
-        "_",
-        { literal: "->" },
-        "_",
-        "arg",
-      ],
-      postprocess: ([kw, , name, ps, as, , , , output]): FunctionDecl => {
-        const params = optional(ps, []);
-        const args = optional(as, []);
-        return {
-          ...nodeData([name, output, ...params, ...args]),
-          ...rangeBetween(rangeOf(kw), output),
-          tag: "FunctionDecl",
-          name,
-          output,
-          params,
-          args,
-        };
-      },
-    },
-    {
-      name: "constructor_decl",
-      symbols: [
-        { literal: "constructor" },
-        "__",
-        "identifier",
-        "type_params_list",
-        "named_args_list",
-        "_",
-        { literal: "->" },
-        "_",
-        "arg",
-      ],
-      postprocess: ([kw, , name, ps, as, , , , output]): ConstructorDecl => {
-        const params = optional(ps, []);
-        const args = optional(as, []);
-        return {
-          ...nodeData([name, output, ...params, ...args]),
-          ...rangeBetween(rangeOf(kw), output),
-          tag: "ConstructorDecl",
-          name,
-          output,
-          params,
-          args,
-        };
-      },
-    },
-    {
-      name: "prelude",
-      symbols: [
-        { literal: "value" },
-        "__",
-        "var",
-        "_",
-        { literal: ":" },
-        "_",
-        "type",
-      ],
-      postprocess: ([kw, , name, , , , type]): PreludeDecl => ({
-        ...nodeData([name, type]),
-        ...rangeBetween(rangeOf(kw), type),
-        tag: "PreludeDecl",
-        name,
-        type,
-      }),
-    },
-    {
-      name: "notation",
-      symbols: [
-        { literal: "notation" },
-        "_",
-        "string_lit",
-        "_",
-        { literal: "~" },
-        "_",
-        "string_lit",
-      ],
-      postprocess: ([kw, , from, , , , to]): NotationDecl => ({
-        ...nodeData([from, to]),
-        ...rangeBetween(rangeOf(kw), to),
-        tag: "NotationDecl",
-        from,
-        to,
-      }),
-    },
-    {
-      name: "subtype",
-      symbols: ["type", "_", { literal: "<:" }, "_", "type"],
-      postprocess: ([subType, , , , superType]): SubTypeDecl => ({
-        ...nodeData([subType, superType]),
-        ...rangeBetween(subType, superType),
-        tag: "SubTypeDecl",
-        subType,
-        superType,
-      }),
-    },
-    { name: "var", symbols: ["identifier"], postprocess: id },
-    {
-      name: "type_var",
-      symbols: [{ literal: "'" }, "identifier"],
-      postprocess: ([a, name]) => ({
-        ...nodeData([name]),
-        ...rangeBetween(a, name),
-        tag: "TypeVar",
-        name,
-      }),
-    },
-    { name: "type", symbols: ["type_var"], postprocess: id },
-    { name: "type", symbols: ["type_constructor"], postprocess: id },
-    { name: "type", symbols: ["prop"], postprocess: id },
-    {
-      name: "type_constructor$ebnf$1",
-      symbols: ["type_arg_list"],
-      postprocess: id,
-    },
-    { name: "type_constructor$ebnf$1", symbols: [], postprocess: () => null },
-    {
-      name: "type_constructor",
-      symbols: ["identifier", "type_constructor$ebnf$1"],
-      postprocess: ([name, a]): TypeConstructor => {
-        const args = optional(a, []);
-        return {
-          ...nodeData([name, ...args]),
-          ...rangeFrom([name, ...args]),
-          tag: "TypeConstructor",
-          name,
-          args,
-        };
-      },
-    },
-    { name: "type_arg_list$macrocall$2", symbols: ["type"] },
-    { name: "type_arg_list$macrocall$3", symbols: [{ literal: "," }] },
-    { name: "type_arg_list$macrocall$1$ebnf$1", symbols: [] },
-    {
-      name: "type_arg_list$macrocall$1$ebnf$1$subexpression$1",
-      symbols: [
-        "_",
-        "type_arg_list$macrocall$3",
-        "_",
-        "type_arg_list$macrocall$2",
-      ],
-    },
-    {
-      name: "type_arg_list$macrocall$1$ebnf$1",
-      symbols: [
-        "type_arg_list$macrocall$1$ebnf$1",
-        "type_arg_list$macrocall$1$ebnf$1$subexpression$1",
-      ],
-      postprocess: (d) => d[0].concat([d[1]]),
-    },
-    {
-      name: "type_arg_list$macrocall$1$ebnf$2",
-      symbols: ["type_arg_list$macrocall$3"],
-      postprocess: id,
-    },
-    {
-      name: "type_arg_list$macrocall$1$ebnf$2",
-      symbols: [],
-      postprocess: () => null,
-    },
-    {
-      name: "type_arg_list$macrocall$1",
-      symbols: [
-        "type_arg_list$macrocall$2",
-        "type_arg_list$macrocall$1$ebnf$1",
-        "type_arg_list$macrocall$1$ebnf$2",
-      ],
-      postprocess: (d) => {
-        const [first, rest] = [d[0], d[1]];
-        if (rest.length > 0) {
-          const restNodes = rest.map((ts: any[]) => ts[3]);
-          return concat(first, ...restNodes);
-        } else return first;
-      },
-    },
-    {
-      name: "type_arg_list",
-      symbols: [
-        "_",
-        { literal: "(" },
-        "_",
-        "type_arg_list$macrocall$1",
-        "_",
-        { literal: ")" },
-      ],
-      postprocess: ([, , , d]): Type[] => flatten(d),
-    },
-    { name: "type_params_list", symbols: [], postprocess: (d) => [] },
-    {
-      name: "type_params_list",
-      symbols: [
-        "_",
-        { literal: "[" },
-        "_",
-        "type_params",
-        "_",
-        { literal: "]" },
-      ],
-      postprocess: nth(3),
-    },
-    { name: "type_params$macrocall$2", symbols: ["type_var"] },
-    { name: "type_params$macrocall$3", symbols: [{ literal: "," }] },
-    { name: "type_params$macrocall$1$ebnf$1", symbols: [] },
-    {
-      name: "type_params$macrocall$1$ebnf$1$subexpression$1",
-      symbols: ["_", "type_params$macrocall$3", "_", "type_params$macrocall$2"],
-    },
-    {
-      name: "type_params$macrocall$1$ebnf$1",
-      symbols: [
-        "type_params$macrocall$1$ebnf$1",
-        "type_params$macrocall$1$ebnf$1$subexpression$1",
-      ],
-      postprocess: (d) => d[0].concat([d[1]]),
-    },
-    {
-      name: "type_params$macrocall$1$ebnf$2",
-      symbols: ["type_params$macrocall$3"],
-      postprocess: id,
-    },
-    {
-      name: "type_params$macrocall$1$ebnf$2",
-      symbols: [],
-      postprocess: () => null,
-    },
-    {
-      name: "type_params$macrocall$1",
-      symbols: [
-        "type_params$macrocall$2",
-        "type_params$macrocall$1$ebnf$1",
-        "type_params$macrocall$1$ebnf$2",
-      ],
-      postprocess: (d) => {
-        const [first, rest] = [d[0], d[1]];
-        if (rest.length > 0) {
-          const restNodes = rest.map((ts: any[]) => ts[3]);
-          return concat(first, ...restNodes);
-        } else return first;
-      },
-    },
-    {
-      name: "type_params",
-      symbols: ["type_params$macrocall$1"],
-      postprocess: ([d]) => d,
-    },
-    { name: "args_list", symbols: [], postprocess: (d) => [] },
-    { name: "args_list$macrocall$2", symbols: ["arg"] },
-    { name: "args_list$macrocall$3", symbols: [{ literal: "*" }] },
-    { name: "args_list$macrocall$1$ebnf$1", symbols: [] },
-    {
-      name: "args_list$macrocall$1$ebnf$1$subexpression$1",
-      symbols: ["_", "args_list$macrocall$3", "_", "args_list$macrocall$2"],
-    },
-    {
-      name: "args_list$macrocall$1$ebnf$1",
-      symbols: [
-        "args_list$macrocall$1$ebnf$1",
-        "args_list$macrocall$1$ebnf$1$subexpression$1",
-      ],
-      postprocess: (d) => d[0].concat([d[1]]),
-    },
-    {
-      name: "args_list$macrocall$1$ebnf$2",
-      symbols: ["args_list$macrocall$3"],
-      postprocess: id,
-    },
-    {
-      name: "args_list$macrocall$1$ebnf$2",
-      symbols: [],
-      postprocess: () => null,
-    },
-    {
-      name: "args_list$macrocall$1",
-      symbols: [
-        "args_list$macrocall$2",
-        "args_list$macrocall$1$ebnf$1",
-        "args_list$macrocall$1$ebnf$2",
-      ],
-      postprocess: (d) => {
-        const [first, rest] = [d[0], d[1]];
-        if (rest.length > 0) {
-          const restNodes = rest.map((ts: any[]) => ts[3]);
-          return concat(first, ...restNodes);
-        } else return first;
-      },
-    },
-    {
-      name: "args_list",
-      symbols: ["_", { literal: ":" }, "_", "args_list$macrocall$1"],
-      postprocess: ([, , , d]): Arg[] => flatten(d),
-    },
-    { name: "arg$ebnf$1$subexpression$1", symbols: ["__", "var"] },
-    {
-      name: "arg$ebnf$1",
-      symbols: ["arg$ebnf$1$subexpression$1"],
-      postprocess: id,
-    },
-    { name: "arg$ebnf$1", symbols: [], postprocess: () => null },
-    {
-      name: "arg",
-      symbols: ["type", "arg$ebnf$1"],
-      postprocess: ([type, v]): Arg => {
-        const variable = v ? v[1] : undefined;
-        const range = variable ? rangeBetween(variable, type) : rangeOf(type);
-        return {
-          ...nodeData(variable ? [variable, type] : [type]),
-          ...range,
-          tag: "Arg",
-          variable,
-          type,
-        };
-      },
-    },
-    { name: "named_args_list", symbols: [], postprocess: (d) => [] },
-    { name: "named_args_list$macrocall$2", symbols: ["named_arg"] },
-    { name: "named_args_list$macrocall$3", symbols: [{ literal: "*" }] },
-    { name: "named_args_list$macrocall$1$ebnf$1", symbols: [] },
-    {
-      name: "named_args_list$macrocall$1$ebnf$1$subexpression$1",
-      symbols: [
-        "_",
-        "named_args_list$macrocall$3",
-        "_",
-        "named_args_list$macrocall$2",
-      ],
-    },
-    {
-      name: "named_args_list$macrocall$1$ebnf$1",
-      symbols: [
-        "named_args_list$macrocall$1$ebnf$1",
-        "named_args_list$macrocall$1$ebnf$1$subexpression$1",
-      ],
-      postprocess: (d) => d[0].concat([d[1]]),
-    },
-    {
-      name: "named_args_list$macrocall$1$ebnf$2",
-      symbols: ["named_args_list$macrocall$3"],
-      postprocess: id,
-    },
-    {
-      name: "named_args_list$macrocall$1$ebnf$2",
-      symbols: [],
-      postprocess: () => null,
-    },
-    {
-      name: "named_args_list$macrocall$1",
-      symbols: [
-        "named_args_list$macrocall$2",
-        "named_args_list$macrocall$1$ebnf$1",
-        "named_args_list$macrocall$1$ebnf$2",
-      ],
-      postprocess: (d) => {
-        const [first, rest] = [d[0], d[1]];
-        if (rest.length > 0) {
-          const restNodes = rest.map((ts: any[]) => ts[3]);
-          return concat(first, ...restNodes);
-        } else return first;
-      },
-    },
-    {
-      name: "named_args_list",
-      symbols: ["_", { literal: ":" }, "_", "named_args_list$macrocall$1"],
-      postprocess: ([, , , d]): Arg[] => flatten(d),
-    },
-    {
-      name: "named_arg",
-      symbols: ["type", "__", "var"],
-      postprocess: ([type, , variable]): Arg => ({
-        ...nodeData([type, variable]),
-        ...rangeBetween(type, variable),
-        tag: "Arg",
-        variable,
-        type,
-      }),
-    },
-    {
-      name: "prop",
-      symbols: [{ literal: "Prop" }],
-      postprocess: ([kw]): Prop => ({
-        ...nodeData([]),
-        ...rangeOf(kw),
-        tag: "Prop",
-      }),
-    },
-    {
-      name: "string_lit",
-      symbols: [
-        lexer.has("string_literal")
-          ? { type: "string_literal" }
-          : string_literal,
-      ],
-      postprocess: ([d]): IStringLit => ({
-        ...nodeData([]),
-        ...rangeOf(d),
-        tag: "StringLit",
-        contents: d.value,
-      }),
-    },
-    {
-      name: "identifier",
-      symbols: [lexer.has("identifier") ? { type: "identifier" } : identifier],
-      postprocess: ([d]) => ({
-        ...nodeData([]),
-        ...rangeOf(d),
-        tag: "Identifier",
-        value: d.text,
-        type: "identifier",
-      }),
-    },
-    {
-      name: "comment",
-      symbols: [lexer.has("comment") ? { type: "comment" } : comment],
-      postprocess: convertTokenId,
-    },
-    {
-      name: "comment",
-      symbols: [
-        lexer.has("multiline_comment")
-          ? { type: "multiline_comment" }
-          : multiline_comment,
-      ],
-      postprocess: ([d]) => rangeOf(d),
-    },
-    { name: "_c_$ebnf$1", symbols: [] },
-    {
-      name: "_c_$ebnf$1$subexpression$1",
-      symbols: [lexer.has("ws") ? { type: "ws" } : ws],
-    },
-    { name: "_c_$ebnf$1$subexpression$1", symbols: ["comment"] },
-    {
-      name: "_c_$ebnf$1",
-      symbols: ["_c_$ebnf$1", "_c_$ebnf$1$subexpression$1"],
-      postprocess: (d) => d[0].concat([d[1]]),
-    },
-    { name: "_c_", symbols: ["_c_$ebnf$1"] },
-    { name: "_ml$ebnf$1", symbols: [] },
-    {
-      name: "_ml$ebnf$1",
-      symbols: ["_ml$ebnf$1", "multi_line_ws_char"],
-      postprocess: (d) => d[0].concat([d[1]]),
-    },
-    { name: "_ml", symbols: ["_ml$ebnf$1"] },
-    {
-      name: "multi_line_ws_char",
-      symbols: [lexer.has("ws") ? { type: "ws" } : ws],
-    },
-    { name: "multi_line_ws_char", symbols: [{ literal: "\n" }] },
-    { name: "multi_line_ws_char", symbols: ["comment"] },
-    { name: "__$ebnf$1", symbols: [lexer.has("ws") ? { type: "ws" } : ws] },
-    {
-      name: "__$ebnf$1",
-      symbols: ["__$ebnf$1", lexer.has("ws") ? { type: "ws" } : ws],
-      postprocess: (d) => d[0].concat([d[1]]),
-    },
-    { name: "__", symbols: ["__$ebnf$1"] },
-    { name: "_$ebnf$1", symbols: [] },
-    {
-      name: "_$ebnf$1",
-      symbols: ["_$ebnf$1", lexer.has("ws") ? { type: "ws" } : ws],
-      postprocess: (d) => d[0].concat([d[1]]),
-    },
-    { name: "_", symbols: ["_$ebnf$1"] },
+    {"name": "input", "symbols": ["statements"], "postprocess":  
+        ([statements]): DomainProg => ({
+          ...nodeData(statements),
+          ...rangeFrom(statements),
+          tag: "DomainProg",
+          statements
+        })
+        },
+    {"name": "statements", "symbols": ["_"], "postprocess": () => []},
+    {"name": "statements", "symbols": ["_c_", {"literal":"\n"}, "statements"], "postprocess": nth(2)},
+    {"name": "statements", "symbols": ["_", "statement", "_c_"], "postprocess": d => [d[1]]},
+    {"name": "statements", "symbols": ["_", "statement", "_c_", {"literal":"\n"}, "statements"], "postprocess": d => [d[1], ...d[4]]},
+    {"name": "statement", "symbols": ["type"], "postprocess": id},
+    {"name": "statement", "symbols": ["predicate"], "postprocess": id},
+    {"name": "statement", "symbols": ["function"], "postprocess": id},
+    {"name": "statement", "symbols": ["constructor_decl"], "postprocess": id},
+    {"name": "statement", "symbols": ["prelude"], "postprocess": id},
+    {"name": "statement", "symbols": ["notation"], "postprocess": id},
+    {"name": "statement", "symbols": ["subtype"], "postprocess": id},
+    {"name": "type$ebnf$1$subexpression$1", "symbols": ["_", {"literal":"("}, "_", "type_params", "_", {"literal":")"}]},
+    {"name": "type$ebnf$1", "symbols": ["type$ebnf$1$subexpression$1"], "postprocess": id},
+    {"name": "type$ebnf$1", "symbols": [], "postprocess": () => null},
+    {"name": "type", "symbols": [{"literal":"type"}, "__", "identifier", "type$ebnf$1"], "postprocess": 
+        ([typ, , name, ps]): TypeDecl => {
+          const params = ps ? ps[3] : [];
+          return { 
+            ...nodeData([name, ...params]),
+            ...rangeBetween(typ, name),
+            tag: "TypeDecl", name, params
+          };
+        }
+        },
+    {"name": "predicate", "symbols": [{"literal":"predicate"}, "__", "identifier", "type_params_list", "args_list"], "postprocess": 
+        ([kw, , name, params, args]): PredicateDecl => ({
+          ...nodeData([name, ...params, ...args]),
+          ...rangeFrom([rangeOf(kw), ...args, ...params]),
+          tag: "PredicateDecl", name, params, args
+        })
+        },
+    {"name": "function", "symbols": [{"literal":"function"}, "__", "identifier", "type_params_list", "args_list", "_", {"literal":"->"}, "_", "arg"], "postprocess": 
+        ([kw, , name, ps, as, , , , output]): FunctionDecl => {
+          const params = optional(ps, []);
+          const args   = optional(as, []);
+          return {
+            ...nodeData([name, output, ...params, ...args]),
+            ...rangeBetween(rangeOf(kw), output),
+            tag: "FunctionDecl", name, output, params, args
+          };
+        }
+          },
+    {"name": "constructor_decl", "symbols": [{"literal":"constructor"}, "__", "identifier", "type_params_list", "named_args_list", "_", {"literal":"->"}, "_", "arg"], "postprocess": 
+        ([kw, , name, ps, as, , , , output]): ConstructorDecl => {
+          const params = optional(ps, []);
+          const args   = optional(as, []);
+          return {
+            ...nodeData([name, output, ...params, ...args]),
+            ...rangeBetween(rangeOf(kw), output),
+            tag: "ConstructorDecl", name, output, params, args
+          }
+        }
+          },
+    {"name": "prelude", "symbols": [{"literal":"value"}, "__", "var", "_", {"literal":":"}, "_", "type"], "postprocess": 
+        ([kw, , name, , , , type]): PreludeDecl => ({
+          ...nodeData([name, type]),
+          ...rangeBetween(rangeOf(kw), type),
+          tag: "PreludeDecl", name, type
+        })
+        },
+    {"name": "notation", "symbols": [{"literal":"notation"}, "_", "string_lit", "_", {"literal":"~"}, "_", "string_lit"], "postprocess": 
+        ([kw, , from, , , , to]): NotationDecl => ({
+          ...nodeData([from, to]),
+          ...rangeBetween(rangeOf(kw), to),
+          tag: "NotationDecl", from, to
+        })
+        },
+    {"name": "subtype", "symbols": ["type", "_", {"literal":"<:"}, "_", "type"], "postprocess": 
+        ([subType, , , , superType]): SubTypeDecl => ({
+          ...nodeData([subType, superType]),
+          ...rangeBetween(subType, superType),
+          tag: "SubTypeDecl", subType, superType
+        })
+        },
+    {"name": "var", "symbols": ["identifier"], "postprocess": id},
+    {"name": "type_var", "symbols": [{"literal":"'"}, "identifier"], "postprocess":  
+        ([a, name]) => ({ 
+          ...nodeData([name]),
+          ...rangeBetween(a, name), 
+          tag: "TypeVar", name 
+        }) 
+        },
+    {"name": "type", "symbols": ["type_var"], "postprocess": id},
+    {"name": "type", "symbols": ["type_constructor"], "postprocess": id},
+    {"name": "type", "symbols": ["prop"], "postprocess": id},
+    {"name": "type_constructor$ebnf$1", "symbols": ["type_arg_list"], "postprocess": id},
+    {"name": "type_constructor$ebnf$1", "symbols": [], "postprocess": () => null},
+    {"name": "type_constructor", "symbols": ["identifier", "type_constructor$ebnf$1"], "postprocess":  
+        ([name, a]): TypeConstructor => {
+          const args = optional(a, []);
+          return {
+            ...nodeData([name, ...args]),
+            ...rangeFrom([name, ...args]),
+            tag: "TypeConstructor", name, args 
+          };
+        }
+         },
+    {"name": "type_arg_list$macrocall$2", "symbols": ["type"]},
+    {"name": "type_arg_list$macrocall$3", "symbols": [{"literal":","}]},
+    {"name": "type_arg_list$macrocall$1$ebnf$1", "symbols": []},
+    {"name": "type_arg_list$macrocall$1$ebnf$1$subexpression$1", "symbols": ["_", "type_arg_list$macrocall$3", "_", "type_arg_list$macrocall$2"]},
+    {"name": "type_arg_list$macrocall$1$ebnf$1", "symbols": ["type_arg_list$macrocall$1$ebnf$1", "type_arg_list$macrocall$1$ebnf$1$subexpression$1"], "postprocess": (d) => d[0].concat([d[1]])},
+    {"name": "type_arg_list$macrocall$1$ebnf$2", "symbols": ["type_arg_list$macrocall$3"], "postprocess": id},
+    {"name": "type_arg_list$macrocall$1$ebnf$2", "symbols": [], "postprocess": () => null},
+    {"name": "type_arg_list$macrocall$1", "symbols": ["type_arg_list$macrocall$2", "type_arg_list$macrocall$1$ebnf$1", "type_arg_list$macrocall$1$ebnf$2"], "postprocess":  
+        d => { 
+          const [first, rest] = [d[0], d[1]];
+          if(rest.length > 0) {
+            const restNodes = rest.map((ts: any[]) => ts[3]);
+            return concat(first, ...restNodes);
+          } else return first;
+        }
+        },
+    {"name": "type_arg_list", "symbols": ["_", {"literal":"("}, "_", "type_arg_list$macrocall$1", "_", {"literal":")"}], "postprocess": ([, , , d]): Type[] => flatten(d)},
+    {"name": "type_params_list", "symbols": [], "postprocess": d => []},
+    {"name": "type_params_list", "symbols": ["_", {"literal":"["}, "_", "type_params", "_", {"literal":"]"}], "postprocess": nth(3)},
+    {"name": "type_params$macrocall$2", "symbols": ["type_var"]},
+    {"name": "type_params$macrocall$3", "symbols": [{"literal":","}]},
+    {"name": "type_params$macrocall$1$ebnf$1", "symbols": []},
+    {"name": "type_params$macrocall$1$ebnf$1$subexpression$1", "symbols": ["_", "type_params$macrocall$3", "_", "type_params$macrocall$2"]},
+    {"name": "type_params$macrocall$1$ebnf$1", "symbols": ["type_params$macrocall$1$ebnf$1", "type_params$macrocall$1$ebnf$1$subexpression$1"], "postprocess": (d) => d[0].concat([d[1]])},
+    {"name": "type_params$macrocall$1$ebnf$2", "symbols": ["type_params$macrocall$3"], "postprocess": id},
+    {"name": "type_params$macrocall$1$ebnf$2", "symbols": [], "postprocess": () => null},
+    {"name": "type_params$macrocall$1", "symbols": ["type_params$macrocall$2", "type_params$macrocall$1$ebnf$1", "type_params$macrocall$1$ebnf$2"], "postprocess":  
+        d => { 
+          const [first, rest] = [d[0], d[1]];
+          if(rest.length > 0) {
+            const restNodes = rest.map((ts: any[]) => ts[3]);
+            return concat(first, ...restNodes);
+          } else return first;
+        }
+        },
+    {"name": "type_params", "symbols": ["type_params$macrocall$1"], "postprocess": ([d]) => d},
+    {"name": "args_list", "symbols": [], "postprocess": d => []},
+    {"name": "args_list$macrocall$2", "symbols": ["arg"]},
+    {"name": "args_list$macrocall$3", "symbols": [{"literal":"*"}]},
+    {"name": "args_list$macrocall$1$ebnf$1", "symbols": []},
+    {"name": "args_list$macrocall$1$ebnf$1$subexpression$1", "symbols": ["_", "args_list$macrocall$3", "_", "args_list$macrocall$2"]},
+    {"name": "args_list$macrocall$1$ebnf$1", "symbols": ["args_list$macrocall$1$ebnf$1", "args_list$macrocall$1$ebnf$1$subexpression$1"], "postprocess": (d) => d[0].concat([d[1]])},
+    {"name": "args_list$macrocall$1$ebnf$2", "symbols": ["args_list$macrocall$3"], "postprocess": id},
+    {"name": "args_list$macrocall$1$ebnf$2", "symbols": [], "postprocess": () => null},
+    {"name": "args_list$macrocall$1", "symbols": ["args_list$macrocall$2", "args_list$macrocall$1$ebnf$1", "args_list$macrocall$1$ebnf$2"], "postprocess":  
+        d => { 
+          const [first, rest] = [d[0], d[1]];
+          if(rest.length > 0) {
+            const restNodes = rest.map((ts: any[]) => ts[3]);
+            return concat(first, ...restNodes);
+          } else return first;
+        }
+        },
+    {"name": "args_list", "symbols": ["_", {"literal":":"}, "_", "args_list$macrocall$1"], "postprocess": ([, , , d]): Arg[] => flatten(d)},
+    {"name": "arg$ebnf$1$subexpression$1", "symbols": ["__", "var"]},
+    {"name": "arg$ebnf$1", "symbols": ["arg$ebnf$1$subexpression$1"], "postprocess": id},
+    {"name": "arg$ebnf$1", "symbols": [], "postprocess": () => null},
+    {"name": "arg", "symbols": ["type", "arg$ebnf$1"], "postprocess":  
+        ([type, v]): Arg => {
+          const variable = v ? v[1] : undefined;
+          const range = variable ? rangeBetween(variable, type) : rangeOf(type);
+          return { 
+            ...nodeData(variable ? [variable, type] : [type]),
+            ...range, 
+            tag: "Arg", variable, type 
+          };
+        }
+        },
+    {"name": "named_args_list", "symbols": [], "postprocess": d => []},
+    {"name": "named_args_list$macrocall$2", "symbols": ["named_arg"]},
+    {"name": "named_args_list$macrocall$3", "symbols": [{"literal":"*"}]},
+    {"name": "named_args_list$macrocall$1$ebnf$1", "symbols": []},
+    {"name": "named_args_list$macrocall$1$ebnf$1$subexpression$1", "symbols": ["_", "named_args_list$macrocall$3", "_", "named_args_list$macrocall$2"]},
+    {"name": "named_args_list$macrocall$1$ebnf$1", "symbols": ["named_args_list$macrocall$1$ebnf$1", "named_args_list$macrocall$1$ebnf$1$subexpression$1"], "postprocess": (d) => d[0].concat([d[1]])},
+    {"name": "named_args_list$macrocall$1$ebnf$2", "symbols": ["named_args_list$macrocall$3"], "postprocess": id},
+    {"name": "named_args_list$macrocall$1$ebnf$2", "symbols": [], "postprocess": () => null},
+    {"name": "named_args_list$macrocall$1", "symbols": ["named_args_list$macrocall$2", "named_args_list$macrocall$1$ebnf$1", "named_args_list$macrocall$1$ebnf$2"], "postprocess":  
+        d => { 
+          const [first, rest] = [d[0], d[1]];
+          if(rest.length > 0) {
+            const restNodes = rest.map((ts: any[]) => ts[3]);
+            return concat(first, ...restNodes);
+          } else return first;
+        }
+        },
+    {"name": "named_args_list", "symbols": ["_", {"literal":":"}, "_", "named_args_list$macrocall$1"], "postprocess": ([, , , d]): Arg[] => flatten(d)},
+    {"name": "named_arg", "symbols": ["type", "__", "var"], "postprocess":  
+        ([type, , variable]): Arg => ({
+           ...nodeData([type, variable]),
+           ...rangeBetween(type, variable), 
+           tag: "Arg", variable, type 
+        })
+        },
+    {"name": "prop", "symbols": [{"literal":"Prop"}], "postprocess":  
+        ([kw]): Prop => ({
+           ...nodeData([]),
+           ...rangeOf(kw), 
+           tag: "Prop" 
+        })  
+        },
+    {"name": "string_lit", "symbols": [(lexer.has("string_literal") ? {type: "string_literal"} : string_literal)], "postprocess": 
+        ([d]): IStringLit => ({
+          ...nodeData([]),
+          ...rangeOf(d),
+          tag: 'StringLit',
+          contents: d.value
+        })
+        },
+    {"name": "identifier", "symbols": [(lexer.has("identifier") ? {type: "identifier"} : identifier)], "postprocess":  
+        ([d]) => ({
+          ...nodeData([]),
+          ...rangeOf(d),
+          tag: 'Identifier',
+          value: d.text,
+          type: "identifier"
+        })
+        },
+    {"name": "comment", "symbols": [(lexer.has("comment") ? {type: "comment"} : comment)], "postprocess": convertTokenId},
+    {"name": "comment", "symbols": [(lexer.has("multiline_comment") ? {type: "multiline_comment"} : multiline_comment)], "postprocess": ([d]) => rangeOf(d)},
+    {"name": "_c_$ebnf$1", "symbols": []},
+    {"name": "_c_$ebnf$1$subexpression$1", "symbols": [(lexer.has("ws") ? {type: "ws"} : ws)]},
+    {"name": "_c_$ebnf$1$subexpression$1", "symbols": ["comment"]},
+    {"name": "_c_$ebnf$1", "symbols": ["_c_$ebnf$1", "_c_$ebnf$1$subexpression$1"], "postprocess": (d) => d[0].concat([d[1]])},
+    {"name": "_c_", "symbols": ["_c_$ebnf$1"]},
+    {"name": "_ml$ebnf$1", "symbols": []},
+    {"name": "_ml$ebnf$1", "symbols": ["_ml$ebnf$1", "multi_line_ws_char"], "postprocess": (d) => d[0].concat([d[1]])},
+    {"name": "_ml", "symbols": ["_ml$ebnf$1"]},
+    {"name": "multi_line_ws_char", "symbols": [(lexer.has("ws") ? {type: "ws"} : ws)]},
+    {"name": "multi_line_ws_char", "symbols": [{"literal":"\n"}]},
+    {"name": "multi_line_ws_char", "symbols": ["comment"]},
+    {"name": "__$ebnf$1", "symbols": [(lexer.has("ws") ? {type: "ws"} : ws)]},
+    {"name": "__$ebnf$1", "symbols": ["__$ebnf$1", (lexer.has("ws") ? {type: "ws"} : ws)], "postprocess": (d) => d[0].concat([d[1]])},
+    {"name": "__", "symbols": ["__$ebnf$1"]},
+    {"name": "_$ebnf$1", "symbols": []},
+    {"name": "_$ebnf$1", "symbols": ["_$ebnf$1", (lexer.has("ws") ? {type: "ws"} : ws)], "postprocess": (d) => d[0].concat([d[1]])},
+    {"name": "_", "symbols": ["_$ebnf$1"]}
   ],
   ParserStart: "input",
 };

--- a/packages/penrose-core/src/parser/StyleParser.ts
+++ b/packages/penrose-core/src/parser/StyleParser.ts
@@ -2,9 +2,7 @@
 // http://github.com/Hardmath123/nearley
 // Bypasses TS6133. Allow declared but unused functions.
 // @ts-ignore
-function id(d: any[]): any {
-  return d[0];
-}
+function id(d: any[]): any { return d[0]; }
 declare var string_literal: any;
 declare var float_literal: any;
 declare var identifier: any;
@@ -12,38 +10,32 @@ declare var comment: any;
 declare var multiline_comment: any;
 declare var ws: any;
 
+
 /* eslint-disable */
 import * as moo from "moo";
-import { concat, compact, flatten, last } from "lodash";
-import {
-  basicSymbols,
-  rangeOf,
-  rangeBetween,
-  rangeFrom,
-  nth,
-  convertTokenId,
-} from "parser/ParserUtil";
+import { concat, compact, flatten, last } from 'lodash'
+import { basicSymbols, rangeOf, rangeBetween, rangeFrom, nth, convertTokenId } from 'parser/ParserUtil'
 
-const styleTypes: string[] = [
-  "scalar",
-  "int",
-  "bool",
-  "string",
-  "path",
-  "color",
-  "file",
-  "style",
-  "shape", // TODO: make sure this is the intended keyword
-  "vec2",
-  "vec3",
-  "vec4",
-  "mat2x2",
-  "mat3x3",
-  "mat4x4",
-  "function",
-  "objective",
-  "constraint",
-];
+const styleTypes: string[] =
+  [ "scalar"
+  , "int"
+  , "bool"
+  , "string"
+  , "path"
+  , "color"
+  , "file"
+  , "style"
+  , "shape" // TODO: make sure this is the intended keyword
+  , "vec2"
+  , "vec3"
+  , "vec4"
+  , "mat2x2"
+  , "mat3x3"
+  , "mat4x4"
+  , "function"
+  , "objective"
+  , "constraint"
+  ];
 
 // NOTE: ordering matters here. Top patterns get matched __first__
 const lexer = moo.compile({
@@ -52,7 +44,7 @@ const lexer = moo.compile({
     match: /[A-z_][A-Za-z_0-9]*/,
     type: moo.keywords({
       // NOTE: the next line add type annotation keywords into the keyword set and thereby forbidding users to use keywords like `shape`
-      // "type-keyword": styleTypes,
+      // "type-keyword": styleTypes, 
       forall: "forall",
       where: "where",
       with: "with",
@@ -64,13 +56,13 @@ const lexer = moo.compile({
       encourage: "encourage",
       ensure: "ensure",
       override: "override",
-    }),
-  },
+    })
+  }
 });
 
 const nodeData = (children: ASTNode[]) => ({
   nodeType: "Style",
-  children,
+  children
 });
 
 // Node constructors
@@ -81,10 +73,11 @@ const declList = (type: StyT, ids: BindingForm[]): DeclPattern[] => {
     ...rangeFrom([t, i]),
     tag: "DeclPattern",
     type: t,
-    id: i,
+    id: i 
   });
   return ids.map((i: BindingForm) => decl(type, i));
-};
+}
+
 
 const selector = (
   hd: DeclPatterns,
@@ -101,29 +94,25 @@ const selector = (
     where: whr,
     namespace,
   };
-};
+}
 
 const layering = (kw: any, below: Path, above: Path): ILayering => ({
   ...nodeData([above, below]),
   ...rangeFrom(kw ? [rangeOf(kw), above, below] : [above, below]),
-  tag: "Layering",
-  above,
-  below,
-});
+  tag: 'Layering', above, below
+})
 
 const binop = (op: BinaryOp, left: Expr, right: Expr): IBinOp => ({
   ...nodeData([left, right]),
   ...rangeBetween(left, right),
-  tag: "BinOp",
-  op,
-  left,
-  right,
-});
+  tag: 'BinOp', op, left, right
+})
+
 
 interface NearleyToken {
   value: any;
   [key: string]: any;
-}
+};
 
 interface NearleyLexer {
   reset: (chunk: string, info: any) => void;
@@ -131,1106 +120,517 @@ interface NearleyLexer {
   save: () => any;
   formatError: (token: never) => string;
   has: (tokenType: string) => boolean;
-}
+};
 
 interface NearleyRule {
   name: string;
   symbols: NearleySymbol[];
   postprocess?: (d: any[], loc?: number, reject?: {}) => any;
-}
+};
 
-type NearleySymbol =
-  | string
-  | { literal: any }
-  | { test: (token: any) => boolean };
+type NearleySymbol = string | { literal: any } | { test: (token: any) => boolean };
 
 interface Grammar {
   Lexer: NearleyLexer | undefined;
   ParserRules: NearleyRule[];
   ParserStart: string;
-}
+};
 
 const grammar: Grammar = {
   Lexer: lexer,
   ParserRules: [
-    {
-      name: "input",
-      symbols: ["_ml", "header_blocks"],
-      postprocess: ([, blocks]): StyProg => ({
-        ...nodeData(blocks),
-        ...rangeFrom(blocks),
-        tag: "StyProg",
-        blocks,
-      }),
-    },
-    { name: "header_blocks$ebnf$1", symbols: [] },
-    {
-      name: "header_blocks$ebnf$1",
-      symbols: ["header_blocks$ebnf$1", "header_block"],
-      postprocess: (d) => d[0].concat([d[1]]),
-    },
-    {
-      name: "header_blocks",
-      symbols: ["header_blocks$ebnf$1"],
-      postprocess: id,
-    },
-    {
-      name: "header_block",
-      symbols: ["header", "block", "_ml"],
-      postprocess: ([header, block]): HeaderBlock => ({
-        ...nodeData([header, block]),
-        ...rangeFrom([header, block]),
-        tag: "HeaderBlock",
-        header,
-        block,
-      }),
-    },
-    { name: "header", symbols: ["selector"], postprocess: id },
-    { name: "header", symbols: ["namespace"], postprocess: id },
-    { name: "selector$ebnf$1", symbols: ["forall"], postprocess: id },
-    { name: "selector$ebnf$1", symbols: [], postprocess: () => null },
-    { name: "selector$ebnf$2", symbols: ["select_as"], postprocess: id },
-    { name: "selector$ebnf$2", symbols: [], postprocess: () => null },
-    {
-      name: "selector",
-      symbols: ["selector$ebnf$1", "decl_patterns", "_ml", "selector$ebnf$2"],
-      postprocess: (d) => selector(d[1], undefined, undefined, d[3]),
-    },
-    { name: "selector$ebnf$3", symbols: ["forall"], postprocess: id },
-    { name: "selector$ebnf$3", symbols: [], postprocess: () => null },
-    { name: "selector$ebnf$4", symbols: ["select_as"], postprocess: id },
-    { name: "selector$ebnf$4", symbols: [], postprocess: () => null },
-    {
-      name: "selector",
-      symbols: [
-        "selector$ebnf$3",
-        "decl_patterns",
-        "_ml",
-        "select_where",
-        "selector$ebnf$4",
-      ],
-      postprocess: (d) => selector(d[1], undefined, d[3], d[4]),
-    },
-    { name: "selector$ebnf$5", symbols: ["forall"], postprocess: id },
-    { name: "selector$ebnf$5", symbols: [], postprocess: () => null },
-    { name: "selector$ebnf$6", symbols: ["select_as"], postprocess: id },
-    { name: "selector$ebnf$6", symbols: [], postprocess: () => null },
-    {
-      name: "selector",
-      symbols: [
-        "selector$ebnf$5",
-        "decl_patterns",
-        "_ml",
-        "select_with",
-        "selector$ebnf$6",
-      ],
-      postprocess: (d) => selector(d[1], d[3], undefined, d[4]),
-    },
-    { name: "selector$ebnf$7", symbols: ["forall"], postprocess: id },
-    { name: "selector$ebnf$7", symbols: [], postprocess: () => null },
-    { name: "selector$ebnf$8", symbols: ["select_as"], postprocess: id },
-    { name: "selector$ebnf$8", symbols: [], postprocess: () => null },
-    {
-      name: "selector",
-      symbols: [
-        "selector$ebnf$7",
-        "decl_patterns",
-        "_ml",
-        "select_where",
-        "select_with",
-        "selector$ebnf$8",
-      ],
-      postprocess: (d) => selector(d[1], d[4], d[3], d[5]),
-    },
-    { name: "selector$ebnf$9", symbols: ["forall"], postprocess: id },
-    { name: "selector$ebnf$9", symbols: [], postprocess: () => null },
-    { name: "selector$ebnf$10", symbols: ["select_as"], postprocess: id },
-    { name: "selector$ebnf$10", symbols: [], postprocess: () => null },
-    {
-      name: "selector",
-      symbols: [
-        "selector$ebnf$9",
-        "decl_patterns",
-        "_ml",
-        "select_with",
-        "select_where",
-        "selector$ebnf$10",
-      ],
-      postprocess: (d) => selector(d[1], d[3], d[4], d[5]),
-    },
-    {
-      name: "forall",
-      symbols: [{ literal: "forall" }, "__"],
-      postprocess: nth(0),
-    },
-    {
-      name: "select_with",
-      symbols: [{ literal: "with" }, "__", "decl_patterns", "_ml"],
-      postprocess: (d) => d[2],
-    },
-    { name: "decl_patterns$macrocall$2", symbols: ["decl_list"] },
-    { name: "decl_patterns$macrocall$3", symbols: [{ literal: ";" }] },
-    { name: "decl_patterns$macrocall$1$ebnf$1", symbols: [] },
-    {
-      name: "decl_patterns$macrocall$1$ebnf$1$subexpression$1",
-      symbols: [
-        "_",
-        "decl_patterns$macrocall$3",
-        "_",
-        "decl_patterns$macrocall$2",
-      ],
-    },
-    {
-      name: "decl_patterns$macrocall$1$ebnf$1",
-      symbols: [
-        "decl_patterns$macrocall$1$ebnf$1",
-        "decl_patterns$macrocall$1$ebnf$1$subexpression$1",
-      ],
-      postprocess: (d) => d[0].concat([d[1]]),
-    },
-    {
-      name: "decl_patterns$macrocall$1$ebnf$2",
-      symbols: ["decl_patterns$macrocall$3"],
-      postprocess: id,
-    },
-    {
-      name: "decl_patterns$macrocall$1$ebnf$2",
-      symbols: [],
-      postprocess: () => null,
-    },
-    {
-      name: "decl_patterns$macrocall$1",
-      symbols: [
-        "decl_patterns$macrocall$2",
-        "decl_patterns$macrocall$1$ebnf$1",
-        "decl_patterns$macrocall$1$ebnf$2",
-      ],
-      postprocess: (d) => {
-        const [first, rest] = [d[0], d[1]];
-        if (rest.length > 0) {
-          const restNodes = rest.map((ts: any[]) => ts[3]);
-          return concat(first, ...restNodes);
-        } else return first;
-      },
-    },
-    {
-      name: "decl_patterns",
-      symbols: ["decl_patterns$macrocall$1"],
-      postprocess: ([d]): DeclPatterns => {
-        const contents = flatten(d) as DeclPattern[];
-        return {
-          ...nodeData([...contents]),
-          ...rangeFrom(contents),
-          tag: "DeclPatterns",
-          contents,
-        };
-      },
-    },
-    { name: "decl_list$macrocall$2", symbols: ["binding_form"] },
-    { name: "decl_list$macrocall$3", symbols: [{ literal: "," }] },
-    { name: "decl_list$macrocall$1$ebnf$1", symbols: [] },
-    {
-      name: "decl_list$macrocall$1$ebnf$1$subexpression$1",
-      symbols: ["_", "decl_list$macrocall$3", "_", "decl_list$macrocall$2"],
-    },
-    {
-      name: "decl_list$macrocall$1$ebnf$1",
-      symbols: [
-        "decl_list$macrocall$1$ebnf$1",
-        "decl_list$macrocall$1$ebnf$1$subexpression$1",
-      ],
-      postprocess: (d) => d[0].concat([d[1]]),
-    },
-    {
-      name: "decl_list$macrocall$1$ebnf$2",
-      symbols: ["decl_list$macrocall$3"],
-      postprocess: id,
-    },
-    {
-      name: "decl_list$macrocall$1$ebnf$2",
-      symbols: [],
-      postprocess: () => null,
-    },
-    {
-      name: "decl_list$macrocall$1",
-      symbols: [
-        "decl_list$macrocall$2",
-        "decl_list$macrocall$1$ebnf$1",
-        "decl_list$macrocall$1$ebnf$2",
-      ],
-      postprocess: (d) => {
-        const [first, rest] = [d[0], d[1]];
-        if (rest.length > 0) {
-          const restNodes = rest.map((ts: any[]) => ts[3]);
-          return concat(first, ...restNodes);
-        } else return first;
-      },
-    },
-    {
-      name: "decl_list",
-      symbols: ["identifier", "__", "decl_list$macrocall$1"],
-      postprocess: ([type, , ids]): DeclPattern[] => {
-        return declList(type, ids);
-      },
-    },
-    {
-      name: "select_where",
-      symbols: [{ literal: "where" }, "__", "relation_list", "_ml"],
-      postprocess: (d) => d[2],
-    },
-    { name: "relation_list$macrocall$2", symbols: ["relation"] },
-    { name: "relation_list$macrocall$3", symbols: [{ literal: ";" }] },
-    { name: "relation_list$macrocall$1$ebnf$1", symbols: [] },
-    {
-      name: "relation_list$macrocall$1$ebnf$1$subexpression$1",
-      symbols: [
-        "_",
-        "relation_list$macrocall$3",
-        "_",
-        "relation_list$macrocall$2",
-      ],
-    },
-    {
-      name: "relation_list$macrocall$1$ebnf$1",
-      symbols: [
-        "relation_list$macrocall$1$ebnf$1",
-        "relation_list$macrocall$1$ebnf$1$subexpression$1",
-      ],
-      postprocess: (d) => d[0].concat([d[1]]),
-    },
-    {
-      name: "relation_list$macrocall$1$ebnf$2",
-      symbols: ["relation_list$macrocall$3"],
-      postprocess: id,
-    },
-    {
-      name: "relation_list$macrocall$1$ebnf$2",
-      symbols: [],
-      postprocess: () => null,
-    },
-    {
-      name: "relation_list$macrocall$1",
-      symbols: [
-        "relation_list$macrocall$2",
-        "relation_list$macrocall$1$ebnf$1",
-        "relation_list$macrocall$1$ebnf$2",
-      ],
-      postprocess: (d) => {
-        const [first, rest] = [d[0], d[1]];
-        if (rest.length > 0) {
-          const restNodes = rest.map((ts: any[]) => ts[3]);
-          return concat(first, ...restNodes);
-        } else return first;
-      },
-    },
-    {
-      name: "relation_list",
-      symbols: ["relation_list$macrocall$1"],
-      postprocess: ([d]): RelationPatterns => ({
-        ...nodeData([...d]),
-        ...rangeFrom(d),
-        tag: "RelationPatterns",
-        contents: d,
-      }),
-    },
-    { name: "relation", symbols: ["rel_bind"], postprocess: id },
-    { name: "relation", symbols: ["rel_pred"], postprocess: id },
-    {
-      name: "rel_bind",
-      symbols: ["binding_form", "_", { literal: ":=" }, "_", "sel_expr"],
-      postprocess: ([id, , , , expr]): RelBind => ({
-        ...nodeData([id, expr]),
-        ...rangeFrom([id, expr]),
-        tag: "RelBind",
-        id,
-        expr,
-      }),
-    },
-    {
-      name: "rel_pred",
-      symbols: [
-        "identifier",
-        "_",
-        { literal: "(" },
-        "pred_arg_list",
-        { literal: ")" },
-      ],
-      postprocess: ([name, , , args]): RelPred => ({
-        ...nodeData([name, ...args]),
-        ...rangeFrom([name, ...args]),
-        tag: "RelPred",
-        name,
-        args,
-      }),
-    },
-    { name: "sel_expr_list", symbols: ["_"], postprocess: (d) => [] },
-    { name: "sel_expr_list$macrocall$2", symbols: ["sel_expr"] },
-    { name: "sel_expr_list$macrocall$3", symbols: [{ literal: "," }] },
-    { name: "sel_expr_list$macrocall$1$ebnf$1", symbols: [] },
-    {
-      name: "sel_expr_list$macrocall$1$ebnf$1$subexpression$1",
-      symbols: [
-        "_",
-        "sel_expr_list$macrocall$3",
-        "_",
-        "sel_expr_list$macrocall$2",
-      ],
-    },
-    {
-      name: "sel_expr_list$macrocall$1$ebnf$1",
-      symbols: [
-        "sel_expr_list$macrocall$1$ebnf$1",
-        "sel_expr_list$macrocall$1$ebnf$1$subexpression$1",
-      ],
-      postprocess: (d) => d[0].concat([d[1]]),
-    },
-    {
-      name: "sel_expr_list$macrocall$1$ebnf$2",
-      symbols: ["sel_expr_list$macrocall$3"],
-      postprocess: id,
-    },
-    {
-      name: "sel_expr_list$macrocall$1$ebnf$2",
-      symbols: [],
-      postprocess: () => null,
-    },
-    {
-      name: "sel_expr_list$macrocall$1",
-      symbols: [
-        "sel_expr_list$macrocall$2",
-        "sel_expr_list$macrocall$1$ebnf$1",
-        "sel_expr_list$macrocall$1$ebnf$2",
-      ],
-      postprocess: (d) => {
-        const [first, rest] = [d[0], d[1]];
-        if (rest.length > 0) {
-          const restNodes = rest.map((ts: any[]) => ts[3]);
-          return concat(first, ...restNodes);
-        } else return first;
-      },
-    },
-    {
-      name: "sel_expr_list",
-      symbols: ["_", "sel_expr_list$macrocall$1", "_"],
-      postprocess: nth(1),
-    },
-    {
-      name: "sel_expr",
-      symbols: [
-        "identifier",
-        "_",
-        { literal: "(" },
-        "sel_expr_list",
-        { literal: ")" },
-      ],
-      postprocess: ([name, , , args]): SEFuncOrValCons => ({
-        ...nodeData([name, ...args]),
-        ...rangeFrom([name, ...args]),
-        tag: "SEFuncOrValCons",
-        name,
-        args,
-      }),
-    },
-    {
-      name: "sel_expr",
-      symbols: ["binding_form"],
-      postprocess: ([d]): SEBind => ({
-        ...nodeData([d]),
-        ...rangeFrom([d]),
-        tag: "SEBind",
-        contents: d,
-      }),
-    },
-    { name: "pred_arg_list", symbols: ["_"], postprocess: (d) => [] },
-    { name: "pred_arg_list$macrocall$2", symbols: ["pred_arg"] },
-    { name: "pred_arg_list$macrocall$3", symbols: [{ literal: "," }] },
-    { name: "pred_arg_list$macrocall$1$ebnf$1", symbols: [] },
-    {
-      name: "pred_arg_list$macrocall$1$ebnf$1$subexpression$1",
-      symbols: [
-        "_",
-        "pred_arg_list$macrocall$3",
-        "_",
-        "pred_arg_list$macrocall$2",
-      ],
-    },
-    {
-      name: "pred_arg_list$macrocall$1$ebnf$1",
-      symbols: [
-        "pred_arg_list$macrocall$1$ebnf$1",
-        "pred_arg_list$macrocall$1$ebnf$1$subexpression$1",
-      ],
-      postprocess: (d) => d[0].concat([d[1]]),
-    },
-    {
-      name: "pred_arg_list$macrocall$1$ebnf$2",
-      symbols: ["pred_arg_list$macrocall$3"],
-      postprocess: id,
-    },
-    {
-      name: "pred_arg_list$macrocall$1$ebnf$2",
-      symbols: [],
-      postprocess: () => null,
-    },
-    {
-      name: "pred_arg_list$macrocall$1",
-      symbols: [
-        "pred_arg_list$macrocall$2",
-        "pred_arg_list$macrocall$1$ebnf$1",
-        "pred_arg_list$macrocall$1$ebnf$2",
-      ],
-      postprocess: (d) => {
-        const [first, rest] = [d[0], d[1]];
-        if (rest.length > 0) {
-          const restNodes = rest.map((ts: any[]) => ts[3]);
-          return concat(first, ...restNodes);
-        } else return first;
-      },
-    },
-    {
-      name: "pred_arg_list",
-      symbols: ["_", "pred_arg_list$macrocall$1", "_"],
-      postprocess: nth(1),
-    },
-    { name: "pred_arg", symbols: ["rel_pred"], postprocess: id },
-    {
-      name: "pred_arg",
-      symbols: ["binding_form"],
-      postprocess: ([d]): SEBind => ({
-        ...nodeData([d]),
-        ...rangeFrom([d]),
-        tag: "SEBind",
-        contents: d,
-      }),
-    },
-    { name: "binding_form", symbols: ["subVar"], postprocess: id },
-    { name: "binding_form", symbols: ["styVar"], postprocess: id },
-    {
-      name: "subVar",
-      symbols: [{ literal: "`" }, "identifier", { literal: "`" }],
-      postprocess: ([ltick, contents, rtick]): SubVar => ({
-        ...nodeData([contents]),
-        ...rangeBetween(rangeOf(ltick), rangeOf(rtick)),
-        tag: "SubVar",
-        contents,
-      }),
-    },
-    {
-      name: "styVar",
-      symbols: ["identifier"],
-      postprocess: ([contents]): StyVar => ({
-        ...nodeData([contents]),
-        ...rangeOf(contents),
-        tag: "StyVar",
-        contents,
-      }),
-    },
-    {
-      name: "select_as",
-      symbols: [{ literal: "as" }, "__", "namespace"],
-      postprocess: nth(2),
-    },
-    {
-      name: "namespace",
-      symbols: ["styVar", "_ml"],
-      postprocess: ([contents]): Namespace => ({
-        ...nodeData([contents]),
-        ...rangeOf(contents),
-        tag: "Namespace",
-        contents,
-      }),
-    },
-    {
-      name: "block",
-      symbols: [{ literal: "{" }, "statements", { literal: "}" }],
-      postprocess: ([lbrace, stmts, rbrace]): Block => ({
-        ...nodeData(stmts),
-        ...rangeBetween(lbrace, rbrace),
-        tag: "Block",
-        statements: stmts,
-      }),
-    },
-    { name: "statements", symbols: ["_"], postprocess: () => [] },
-    {
-      name: "statements",
-      symbols: ["_c_", { literal: "\n" }, "statements"],
-      postprocess: nth(2),
-    },
-    {
-      name: "statements",
-      symbols: ["_", "statement", "_"],
-      postprocess: (d) => [d[1]],
-    },
-    {
-      name: "statements",
-      symbols: ["_", "statement", "_c_", { literal: "\n" }, "statements"],
-      postprocess: (d) => [d[1], ...d[4]],
-    },
-    { name: "statement", symbols: ["delete"], postprocess: id },
-    { name: "statement", symbols: ["override"], postprocess: id },
-    { name: "statement", symbols: ["path_assign"], postprocess: id },
-    {
-      name: "statement",
-      symbols: ["anonymous_expr"],
-      postprocess: ([contents]): IAnonAssign => ({
-        ...nodeData([contents]),
-        ...rangeOf(contents),
-        tag: "AnonAssign",
-        contents,
-      }),
-    },
-    {
-      name: "delete",
-      symbols: [{ literal: "delete" }, "__", "path"],
-      postprocess: ([kw, , contents]): Delete => {
-        return {
+    {"name": "input", "symbols": ["_ml", "header_blocks"], "postprocess": 
+        ([, blocks]): StyProg => ({
+          ...nodeData(blocks),
+          ...rangeFrom(blocks),
+          tag: "StyProg", blocks
+        })
+        },
+    {"name": "header_blocks$ebnf$1", "symbols": []},
+    {"name": "header_blocks$ebnf$1", "symbols": ["header_blocks$ebnf$1", "header_block"], "postprocess": (d) => d[0].concat([d[1]])},
+    {"name": "header_blocks", "symbols": ["header_blocks$ebnf$1"], "postprocess": id},
+    {"name": "header_block", "symbols": ["header", "block", "_ml"], "postprocess": 
+        ([header, block]): HeaderBlock => ({
+          ...nodeData([header, block]), 
+          ...rangeFrom([header, block]), 
+          tag:"HeaderBlock", header, block 
+        })
+        },
+    {"name": "header", "symbols": ["selector"], "postprocess": id},
+    {"name": "header", "symbols": ["namespace"], "postprocess": id},
+    {"name": "selector$ebnf$1", "symbols": ["forall"], "postprocess": id},
+    {"name": "selector$ebnf$1", "symbols": [], "postprocess": () => null},
+    {"name": "selector$ebnf$2", "symbols": ["select_as"], "postprocess": id},
+    {"name": "selector$ebnf$2", "symbols": [], "postprocess": () => null},
+    {"name": "selector", "symbols": ["selector$ebnf$1", "decl_patterns", "_ml", "selector$ebnf$2"], "postprocess": (d) => selector(d[1], undefined, undefined, d[3])},
+    {"name": "selector$ebnf$3", "symbols": ["forall"], "postprocess": id},
+    {"name": "selector$ebnf$3", "symbols": [], "postprocess": () => null},
+    {"name": "selector$ebnf$4", "symbols": ["select_as"], "postprocess": id},
+    {"name": "selector$ebnf$4", "symbols": [], "postprocess": () => null},
+    {"name": "selector", "symbols": ["selector$ebnf$3", "decl_patterns", "_ml", "select_where", "selector$ebnf$4"], "postprocess": (d) => selector(d[1], undefined, d[3], d[4])},
+    {"name": "selector$ebnf$5", "symbols": ["forall"], "postprocess": id},
+    {"name": "selector$ebnf$5", "symbols": [], "postprocess": () => null},
+    {"name": "selector$ebnf$6", "symbols": ["select_as"], "postprocess": id},
+    {"name": "selector$ebnf$6", "symbols": [], "postprocess": () => null},
+    {"name": "selector", "symbols": ["selector$ebnf$5", "decl_patterns", "_ml", "select_with", "selector$ebnf$6"], "postprocess": (d) => selector(d[1], d[3], undefined, d[4])},
+    {"name": "selector$ebnf$7", "symbols": ["forall"], "postprocess": id},
+    {"name": "selector$ebnf$7", "symbols": [], "postprocess": () => null},
+    {"name": "selector$ebnf$8", "symbols": ["select_as"], "postprocess": id},
+    {"name": "selector$ebnf$8", "symbols": [], "postprocess": () => null},
+    {"name": "selector", "symbols": ["selector$ebnf$7", "decl_patterns", "_ml", "select_where", "select_with", "selector$ebnf$8"], "postprocess": (d) => selector(d[1], d[4], d[3], d[5])},
+    {"name": "selector$ebnf$9", "symbols": ["forall"], "postprocess": id},
+    {"name": "selector$ebnf$9", "symbols": [], "postprocess": () => null},
+    {"name": "selector$ebnf$10", "symbols": ["select_as"], "postprocess": id},
+    {"name": "selector$ebnf$10", "symbols": [], "postprocess": () => null},
+    {"name": "selector", "symbols": ["selector$ebnf$9", "decl_patterns", "_ml", "select_with", "select_where", "selector$ebnf$10"], "postprocess": (d) => selector(d[1], d[3], d[4], d[5])},
+    {"name": "forall", "symbols": [{"literal":"forall"}, "__"], "postprocess": nth(0)},
+    {"name": "select_with", "symbols": [{"literal":"with"}, "__", "decl_patterns", "_ml"], "postprocess": d => d[2]},
+    {"name": "decl_patterns$macrocall$2", "symbols": ["decl_list"]},
+    {"name": "decl_patterns$macrocall$3", "symbols": [{"literal":";"}]},
+    {"name": "decl_patterns$macrocall$1$ebnf$1", "symbols": []},
+    {"name": "decl_patterns$macrocall$1$ebnf$1$subexpression$1", "symbols": ["_", "decl_patterns$macrocall$3", "_", "decl_patterns$macrocall$2"]},
+    {"name": "decl_patterns$macrocall$1$ebnf$1", "symbols": ["decl_patterns$macrocall$1$ebnf$1", "decl_patterns$macrocall$1$ebnf$1$subexpression$1"], "postprocess": (d) => d[0].concat([d[1]])},
+    {"name": "decl_patterns$macrocall$1$ebnf$2", "symbols": ["decl_patterns$macrocall$3"], "postprocess": id},
+    {"name": "decl_patterns$macrocall$1$ebnf$2", "symbols": [], "postprocess": () => null},
+    {"name": "decl_patterns$macrocall$1", "symbols": ["decl_patterns$macrocall$2", "decl_patterns$macrocall$1$ebnf$1", "decl_patterns$macrocall$1$ebnf$2"], "postprocess":  
+        d => { 
+          const [first, rest] = [d[0], d[1]];
+          if(rest.length > 0) {
+            const restNodes = rest.map((ts: any[]) => ts[3]);
+            return concat(first, ...restNodes);
+          } else return first;
+        }
+        },
+    {"name": "decl_patterns", "symbols": ["decl_patterns$macrocall$1"], "postprocess":  
+        ([d]): DeclPatterns => {
+          const contents = flatten(d) as DeclPattern[];
+          return {
+            ...nodeData([...contents]), 
+            ...rangeFrom(contents),
+            tag: "DeclPatterns", contents
+          };
+        }
+        },
+    {"name": "decl_list$macrocall$2", "symbols": ["binding_form"]},
+    {"name": "decl_list$macrocall$3", "symbols": [{"literal":","}]},
+    {"name": "decl_list$macrocall$1$ebnf$1", "symbols": []},
+    {"name": "decl_list$macrocall$1$ebnf$1$subexpression$1", "symbols": ["_", "decl_list$macrocall$3", "_", "decl_list$macrocall$2"]},
+    {"name": "decl_list$macrocall$1$ebnf$1", "symbols": ["decl_list$macrocall$1$ebnf$1", "decl_list$macrocall$1$ebnf$1$subexpression$1"], "postprocess": (d) => d[0].concat([d[1]])},
+    {"name": "decl_list$macrocall$1$ebnf$2", "symbols": ["decl_list$macrocall$3"], "postprocess": id},
+    {"name": "decl_list$macrocall$1$ebnf$2", "symbols": [], "postprocess": () => null},
+    {"name": "decl_list$macrocall$1", "symbols": ["decl_list$macrocall$2", "decl_list$macrocall$1$ebnf$1", "decl_list$macrocall$1$ebnf$2"], "postprocess":  
+        d => { 
+          const [first, rest] = [d[0], d[1]];
+          if(rest.length > 0) {
+            const restNodes = rest.map((ts: any[]) => ts[3]);
+            return concat(first, ...restNodes);
+          } else return first;
+        }
+        },
+    {"name": "decl_list", "symbols": ["identifier", "__", "decl_list$macrocall$1"], "postprocess":  
+        ([type, , ids]): DeclPattern[] => {
+          return declList(type, ids);
+        }
+        },
+    {"name": "select_where", "symbols": [{"literal":"where"}, "__", "relation_list", "_ml"], "postprocess": d => d[2]},
+    {"name": "relation_list$macrocall$2", "symbols": ["relation"]},
+    {"name": "relation_list$macrocall$3", "symbols": [{"literal":";"}]},
+    {"name": "relation_list$macrocall$1$ebnf$1", "symbols": []},
+    {"name": "relation_list$macrocall$1$ebnf$1$subexpression$1", "symbols": ["_", "relation_list$macrocall$3", "_", "relation_list$macrocall$2"]},
+    {"name": "relation_list$macrocall$1$ebnf$1", "symbols": ["relation_list$macrocall$1$ebnf$1", "relation_list$macrocall$1$ebnf$1$subexpression$1"], "postprocess": (d) => d[0].concat([d[1]])},
+    {"name": "relation_list$macrocall$1$ebnf$2", "symbols": ["relation_list$macrocall$3"], "postprocess": id},
+    {"name": "relation_list$macrocall$1$ebnf$2", "symbols": [], "postprocess": () => null},
+    {"name": "relation_list$macrocall$1", "symbols": ["relation_list$macrocall$2", "relation_list$macrocall$1$ebnf$1", "relation_list$macrocall$1$ebnf$2"], "postprocess":  
+        d => { 
+          const [first, rest] = [d[0], d[1]];
+          if(rest.length > 0) {
+            const restNodes = rest.map((ts: any[]) => ts[3]);
+            return concat(first, ...restNodes);
+          } else return first;
+        }
+        },
+    {"name": "relation_list", "symbols": ["relation_list$macrocall$1"], "postprocess":  
+        ([d]): RelationPatterns => ({
+          ...nodeData([...d]), 
+          ...rangeFrom(d),
+          tag: "RelationPatterns",
+          contents: d
+        })
+        },
+    {"name": "relation", "symbols": ["rel_bind"], "postprocess": id},
+    {"name": "relation", "symbols": ["rel_pred"], "postprocess": id},
+    {"name": "rel_bind", "symbols": ["binding_form", "_", {"literal":":="}, "_", "sel_expr"], "postprocess": 
+        ([id, , , , expr]): RelBind => ({
+          ...nodeData([id, expr]), 
+          ...rangeFrom([id, expr]),
+          tag: "RelBind", id, expr
+        })
+        },
+    {"name": "rel_pred", "symbols": ["identifier", "_", {"literal":"("}, "pred_arg_list", {"literal":")"}], "postprocess":  
+        ([name, , , args, ]): RelPred => ({
+          ...nodeData([name, ...args]), 
+          ...rangeFrom([name, ...args]),
+          tag: "RelPred", name, args
+        }) 
+        },
+    {"name": "sel_expr_list", "symbols": ["_"], "postprocess": d => []},
+    {"name": "sel_expr_list$macrocall$2", "symbols": ["sel_expr"]},
+    {"name": "sel_expr_list$macrocall$3", "symbols": [{"literal":","}]},
+    {"name": "sel_expr_list$macrocall$1$ebnf$1", "symbols": []},
+    {"name": "sel_expr_list$macrocall$1$ebnf$1$subexpression$1", "symbols": ["_", "sel_expr_list$macrocall$3", "_", "sel_expr_list$macrocall$2"]},
+    {"name": "sel_expr_list$macrocall$1$ebnf$1", "symbols": ["sel_expr_list$macrocall$1$ebnf$1", "sel_expr_list$macrocall$1$ebnf$1$subexpression$1"], "postprocess": (d) => d[0].concat([d[1]])},
+    {"name": "sel_expr_list$macrocall$1$ebnf$2", "symbols": ["sel_expr_list$macrocall$3"], "postprocess": id},
+    {"name": "sel_expr_list$macrocall$1$ebnf$2", "symbols": [], "postprocess": () => null},
+    {"name": "sel_expr_list$macrocall$1", "symbols": ["sel_expr_list$macrocall$2", "sel_expr_list$macrocall$1$ebnf$1", "sel_expr_list$macrocall$1$ebnf$2"], "postprocess":  
+        d => { 
+          const [first, rest] = [d[0], d[1]];
+          if(rest.length > 0) {
+            const restNodes = rest.map((ts: any[]) => ts[3]);
+            return concat(first, ...restNodes);
+          } else return first;
+        }
+        },
+    {"name": "sel_expr_list", "symbols": ["_", "sel_expr_list$macrocall$1", "_"], "postprocess": nth(1)},
+    {"name": "sel_expr", "symbols": ["identifier", "_", {"literal":"("}, "sel_expr_list", {"literal":")"}], "postprocess":  
+        ([name, , , args, ]): SEFuncOrValCons => ({
+          ...nodeData([name, ...args]), 
+          ...rangeFrom([name, ...args]),
+          tag: "SEFuncOrValCons",
+          name, args
+        }) 
+          },
+    {"name": "sel_expr", "symbols": ["binding_form"], "postprocess":  ([d]): SEBind => ({
+          ...nodeData([d]),
+          ...rangeFrom([d]), 
+          tag: "SEBind", contents: d
+        }) 
+          },
+    {"name": "pred_arg_list", "symbols": ["_"], "postprocess": d => []},
+    {"name": "pred_arg_list$macrocall$2", "symbols": ["pred_arg"]},
+    {"name": "pred_arg_list$macrocall$3", "symbols": [{"literal":","}]},
+    {"name": "pred_arg_list$macrocall$1$ebnf$1", "symbols": []},
+    {"name": "pred_arg_list$macrocall$1$ebnf$1$subexpression$1", "symbols": ["_", "pred_arg_list$macrocall$3", "_", "pred_arg_list$macrocall$2"]},
+    {"name": "pred_arg_list$macrocall$1$ebnf$1", "symbols": ["pred_arg_list$macrocall$1$ebnf$1", "pred_arg_list$macrocall$1$ebnf$1$subexpression$1"], "postprocess": (d) => d[0].concat([d[1]])},
+    {"name": "pred_arg_list$macrocall$1$ebnf$2", "symbols": ["pred_arg_list$macrocall$3"], "postprocess": id},
+    {"name": "pred_arg_list$macrocall$1$ebnf$2", "symbols": [], "postprocess": () => null},
+    {"name": "pred_arg_list$macrocall$1", "symbols": ["pred_arg_list$macrocall$2", "pred_arg_list$macrocall$1$ebnf$1", "pred_arg_list$macrocall$1$ebnf$2"], "postprocess":  
+        d => { 
+          const [first, rest] = [d[0], d[1]];
+          if(rest.length > 0) {
+            const restNodes = rest.map((ts: any[]) => ts[3]);
+            return concat(first, ...restNodes);
+          } else return first;
+        }
+        },
+    {"name": "pred_arg_list", "symbols": ["_", "pred_arg_list$macrocall$1", "_"], "postprocess": nth(1)},
+    {"name": "pred_arg", "symbols": ["rel_pred"], "postprocess": id},
+    {"name": "pred_arg", "symbols": ["binding_form"], "postprocess":  ([d]): SEBind => ({
+          ...nodeData([d]),
+          ...rangeFrom([d]), 
+          tag: "SEBind", contents: d
+        }) 
+          },
+    {"name": "binding_form", "symbols": ["subVar"], "postprocess": id},
+    {"name": "binding_form", "symbols": ["styVar"], "postprocess": id},
+    {"name": "subVar", "symbols": [{"literal":"`"}, "identifier", {"literal":"`"}], "postprocess": 
+        ([ltick, contents, rtick]): SubVar => ({ 
+          ...nodeData([contents]), 
+          ...rangeBetween(rangeOf(ltick), rangeOf(rtick)),
+          tag: "SubVar", contents
+        })
+        },
+    {"name": "styVar", "symbols": ["identifier"], "postprocess": 
+        ([contents]): StyVar => ({ 
+          ...nodeData([contents]),
+          ...rangeOf(contents), 
+          tag: "StyVar", contents
+        })
+        },
+    {"name": "select_as", "symbols": [{"literal":"as"}, "__", "namespace"], "postprocess": nth(2)},
+    {"name": "namespace", "symbols": ["styVar", "_ml"], "postprocess": 
+        ([contents]): Namespace => ({
+          ...nodeData([contents]),
+          ...rangeOf(contents),
+          tag: "Namespace",
+          contents
+        })
+        },
+    {"name": "block", "symbols": [{"literal":"{"}, "statements", {"literal":"}"}], "postprocess":  
+        ([lbrace, stmts, rbrace]): Block => ({
+          ...nodeData(stmts),
+          ...rangeBetween(lbrace, rbrace),
+          tag: "Block",
+          statements: stmts
+        })
+        },
+    {"name": "statements", "symbols": ["_"], "postprocess": () => []},
+    {"name": "statements", "symbols": ["_c_", {"literal":"\n"}, "statements"], "postprocess": nth(2)},
+    {"name": "statements", "symbols": ["_", "statement", "_"], "postprocess": d => [d[1]]},
+    {"name": "statements", "symbols": ["_", "statement", "_c_", {"literal":"\n"}, "statements"], "postprocess": d => [d[1], ...d[4]]},
+    {"name": "statement", "symbols": ["delete"], "postprocess": id},
+    {"name": "statement", "symbols": ["override"], "postprocess": id},
+    {"name": "statement", "symbols": ["path_assign"], "postprocess": id},
+    {"name": "statement", "symbols": ["anonymous_expr"], "postprocess":  ([contents]): IAnonAssign => 
+        ({
+          ...nodeData([contents]), 
+          ...rangeOf(contents), 
+          tag: "AnonAssign", contents
+        }) 
+          },
+    {"name": "delete", "symbols": [{"literal":"delete"}, "__", "path"], "postprocess": 
+        ([kw, , contents]): Delete => {
+         return {
           ...nodeData([contents]),
           ...rangeBetween(rangeOf(kw), contents),
-          tag: "Delete",
-          contents,
-        };
-      },
-    },
-    {
-      name: "override",
-      symbols: [
-        { literal: "override" },
-        "__",
-        "path",
-        "_",
-        { literal: "=" },
-        "_",
-        "assign_expr",
-      ],
-      postprocess: ([kw, , path, , , , value]): IOverride => ({
-        ...nodeData([path, value]),
-        ...rangeBetween(kw, value),
-        tag: "Override",
-        path,
-        value,
-      }),
-    },
-    { name: "path_assign$ebnf$1", symbols: ["type"], postprocess: id },
-    { name: "path_assign$ebnf$1", symbols: [], postprocess: () => null },
-    {
-      name: "path_assign",
-      symbols: [
-        "path_assign$ebnf$1",
-        "__",
-        "path",
-        "_",
-        { literal: "=" },
-        "_",
-        "assign_expr",
-      ],
-      postprocess: ([type, , path, , , , value]): PathAssign => ({
-        ...nodeData(type ? [type, path, value] : [path, value]),
-        ...rangeBetween(type ? type : path, value),
-        tag: "PathAssign",
-        type,
-        path,
-        value,
-      }),
-    },
-    {
-      name: "type",
-      symbols: ["identifier"],
-      postprocess: ([contents]): StyType => ({
-        ...nodeData([contents]),
-        ...rangeOf(contents),
-        tag: "TypeOf",
-        contents,
-      }),
-    },
-    {
-      name: "type",
-      symbols: ["identifier", { literal: "[]" }],
-      postprocess: ([contents]): StyType => ({
-        ...nodeData([contents]),
-        ...rangeOf(contents),
-        tag: "ListOf",
-        contents,
-      }),
-    },
-    { name: "path", symbols: ["entity_path"], postprocess: id },
-    { name: "path", symbols: ["access_path"], postprocess: id },
-    { name: "entity_path", symbols: ["propertyPath"], postprocess: id },
-    { name: "entity_path", symbols: ["fieldPath"], postprocess: id },
-    { name: "entity_path", symbols: ["localVar"], postprocess: id },
-    {
-      name: "propertyPath",
-      symbols: [
-        "binding_form",
-        { literal: "." },
-        "identifier",
-        { literal: "." },
-        "identifier",
-      ],
-      postprocess: ([name, , field, , property]): IPropertyPath => ({
-        ...nodeData([name, field, property]),
-        ...rangeFrom([name, field, property]),
-        tag: "PropertyPath",
-        name,
-        field,
-        property,
-      }),
-    },
-    {
-      name: "fieldPath",
-      symbols: ["binding_form", { literal: "." }, "identifier"],
-      postprocess: ([name, , field]): IFieldPath => ({
-        ...nodeData([name, field]),
-        ...rangeFrom([name, field]),
-        tag: "FieldPath",
-        name,
-        field,
-      }),
-    },
-    {
-      name: "localVar",
-      symbols: ["identifier"],
-      postprocess: ([contents]): LocalVar => ({
-        ...nodeData([contents]),
-        ...rangeOf(contents),
-        tag: "LocalVar",
-        contents,
-      }),
-    },
-    {
-      name: "access_path",
-      symbols: ["entity_path", "_", "access_ops"],
-      postprocess: ([path, , indices]): IAccessPath => {
-        const lastIndex = last(indices);
-        return {
-          ...nodeData([path]), // TODO: model access op as an AST node to solve the range and child node issue
-          ...rangeBetween(path, lastIndex),
-          tag: "AccessPath",
-          path,
-          indices,
-        };
-      },
-    },
-    { name: "access_ops", symbols: ["access_op"] },
-    {
-      name: "access_ops",
-      symbols: ["access_op", "_", "access_ops"],
-      postprocess: (d: any[]) => [d[0], ...d[2]],
-    },
-    {
-      name: "access_op",
-      symbols: [{ literal: "[" }, "_", "expr", "_", { literal: "]" }],
-      postprocess: nth(2),
-    },
-    { name: "assign_expr", symbols: ["expr"], postprocess: id },
-    { name: "assign_expr", symbols: ["layering"], postprocess: id },
-    { name: "assign_expr", symbols: ["objective"], postprocess: id },
-    { name: "assign_expr", symbols: ["constraint"], postprocess: id },
-    { name: "assign_expr", symbols: ["gpi_decl"], postprocess: id },
-    { name: "anonymous_expr", symbols: ["layering"], postprocess: id },
-    { name: "anonymous_expr", symbols: ["objective"], postprocess: id },
-    { name: "anonymous_expr", symbols: ["constraint"], postprocess: id },
-    { name: "expr", symbols: ["arithmeticExpr"], postprocess: id },
-    {
-      name: "parenthesized",
-      symbols: [{ literal: "(" }, "_", "arithmeticExpr", "_", { literal: ")" }],
-      postprocess: nth(2),
-    },
-    { name: "parenthesized", symbols: ["expr_literal"], postprocess: id },
-    {
-      name: "unary",
-      symbols: [{ literal: "-" }, "_", "parenthesized"],
-      postprocess: (d): IUOp => ({
-        ...nodeData([d[2]]),
-        ...rangeBetween(d[0], d[2]),
-        tag: "UOp",
-        op: "UMinus",
-        arg: d[2],
-      }),
-    },
-    { name: "unary", symbols: ["parenthesized"], postprocess: id },
-    {
-      name: "factor",
-      symbols: ["unary", "_", { literal: "^" }, "_", "factor"],
-      postprocess: (d): IBinOp => binop("Exp", d[0], d[4]),
-    },
-    { name: "factor", symbols: ["unary"], postprocess: id },
-    {
-      name: "term",
-      symbols: ["term", "_", { literal: "*" }, "_", "factor"],
-      postprocess: (d): IBinOp => binop("Multiply", d[0], d[4]),
-    },
-    {
-      name: "term",
-      symbols: ["term", "_", { literal: "/" }, "_", "factor"],
-      postprocess: (d): IBinOp => binop("Divide", d[0], d[4]),
-    },
-    { name: "term", symbols: ["factor"], postprocess: id },
-    {
-      name: "arithmeticExpr",
-      symbols: ["arithmeticExpr", "_", { literal: "+" }, "_", "term"],
-      postprocess: (d): IBinOp => binop("BPlus", d[0], d[4]),
-    },
-    {
-      name: "arithmeticExpr",
-      symbols: ["arithmeticExpr", "_", { literal: "-" }, "_", "term"],
-      postprocess: (d): IBinOp => binop("BMinus", d[0], d[4]),
-    },
-    { name: "arithmeticExpr", symbols: ["term"], postprocess: id },
-    { name: "expr_literal", symbols: ["bool_lit"], postprocess: id },
-    { name: "expr_literal", symbols: ["string_lit"], postprocess: id },
-    { name: "expr_literal", symbols: ["annotated_float"], postprocess: id },
-    {
-      name: "expr_literal",
-      symbols: ["computation_function"],
-      postprocess: id,
-    },
-    { name: "expr_literal", symbols: ["path"], postprocess: id },
-    { name: "expr_literal", symbols: ["list"], postprocess: id },
-    { name: "expr_literal", symbols: ["tuple"], postprocess: id },
-    { name: "expr_literal", symbols: ["vector"], postprocess: id },
-    {
-      name: "list",
-      symbols: [{ literal: "[" }, "_", "expr_list", "_", { literal: "]" }],
-      postprocess: ([lbracket, , exprs, , rbracket]): IList => ({
-        ...nodeData(exprs),
-        ...rangeBetween(lbracket, rbracket),
-        tag: "List",
-        contents: exprs,
-      }),
-    },
-    {
-      name: "tuple",
-      symbols: [
-        { literal: "{" },
-        "_",
-        "expr",
-        "_",
-        { literal: "," },
-        "_",
-        "expr",
-        "_",
-        { literal: "}" },
-      ],
-      postprocess: ([lbrace, , e1, , , , e2, , rbrace]): ITuple => ({
-        ...nodeData([e1, e2]),
-        ...rangeBetween(lbrace, rbrace),
-        tag: "Tuple",
-        contents: [e1, e2],
-      }),
-    },
-    {
-      name: "vector",
-      symbols: [
-        { literal: "(" },
-        "_",
-        "expr",
-        "_",
-        { literal: "," },
-        "expr_list",
-        { literal: ")" },
-      ],
-      postprocess: ([lparen, , first, , , rest, rparen]): IVector => ({
-        ...nodeData([first, ...rest]),
-        ...rangeBetween(lparen, rparen),
-        tag: "Vector",
-        contents: [first, ...rest],
-      }),
-    },
-    { name: "bool_lit$subexpression$1", symbols: [{ literal: "true" }] },
-    { name: "bool_lit$subexpression$1", symbols: [{ literal: "false" }] },
-    {
-      name: "bool_lit",
-      symbols: ["bool_lit$subexpression$1"],
-      postprocess: ([[d]]): IBoolLit => ({
-        ...nodeData([]),
-        ...rangeOf(d),
-        tag: "BoolLit",
-        contents: d.text === "true", // https://stackoverflow.com/questions/263965/how-can-i-convert-a-string-to-boolean-in-javascript
-      }),
-    },
-    {
-      name: "string_lit",
-      symbols: [
-        lexer.has("string_literal")
-          ? { type: "string_literal" }
-          : string_literal,
-      ],
-      postprocess: ([d]): IStringLit => ({
-        ...nodeData([]),
-        ...rangeOf(d),
-        tag: "StringLit",
-        contents: d.value,
-      }),
-    },
-    {
-      name: "annotated_float",
-      symbols: [{ literal: "?" }],
-      postprocess: ([d]): IVary => ({
-        ...nodeData([]),
-        ...rangeOf(d),
-        tag: "Vary",
-      }),
-    },
-    {
-      name: "annotated_float",
-      symbols: [
-        lexer.has("float_literal") ? { type: "float_literal" } : float_literal,
-      ],
-      postprocess: ([d]): IFix => ({
-        ...nodeData([]),
-        ...rangeOf(d),
-        tag: "Fix",
-        contents: parseFloat(d),
-      }),
-    },
-    { name: "layering$ebnf$1", symbols: ["layer_keyword"], postprocess: id },
-    { name: "layering$ebnf$1", symbols: [], postprocess: () => null },
-    {
-      name: "layering",
-      symbols: [
-        "layering$ebnf$1",
-        "path",
-        "__",
-        { literal: "below" },
-        "__",
-        "path",
-      ],
-      postprocess: (d): ILayering => layering(d[0], d[1], d[5]),
-    },
-    { name: "layering$ebnf$2", symbols: ["layer_keyword"], postprocess: id },
-    { name: "layering$ebnf$2", symbols: [], postprocess: () => null },
-    {
-      name: "layering",
-      symbols: [
-        "layering$ebnf$2",
-        "path",
-        "__",
-        { literal: "above" },
-        "__",
-        "path",
-      ],
-      postprocess: (d): ILayering => layering(d[0], d[5], d[1]),
-    },
-    {
-      name: "layer_keyword",
-      symbols: [{ literal: "layer" }, "__"],
-      postprocess: nth(0),
-    },
-    {
-      name: "computation_function",
-      symbols: [
-        "identifier",
-        "_",
-        { literal: "(" },
-        "expr_list",
-        { literal: ")" },
-      ],
-      postprocess: ([name, , , args, rparen]): ICompApp => ({
-        ...nodeData([name, ...args]),
-        ...rangeBetween(name, rparen),
-        tag: "CompApp",
-        name,
-        args,
-      }),
-    },
-    {
-      name: "objective",
-      symbols: [
-        { literal: "encourage" },
-        "__",
-        "identifier",
-        "_",
-        { literal: "(" },
-        "expr_list",
-        { literal: ")" },
-      ],
-      postprocess: ([kw, , name, , , args, rparen]): IObjFn => ({
-        ...nodeData([name, ...args]),
-        ...rangeBetween(kw, rparen),
-        tag: "ObjFn",
-        name,
-        args,
-      }),
-    },
-    {
-      name: "constraint",
-      symbols: [
-        { literal: "ensure" },
-        "__",
-        "identifier",
-        "_",
-        { literal: "(" },
-        "expr_list",
-        { literal: ")" },
-      ],
-      postprocess: ([kw, , name, , , args, rparen]): IConstrFn => ({
-        ...nodeData([name, ...args]),
-        ...rangeBetween(kw, rparen),
-        tag: "ConstrFn",
-        name,
-        args,
-      }),
-    },
-    { name: "expr_list", symbols: ["_"], postprocess: (d) => [] },
-    { name: "expr_list$macrocall$2", symbols: ["expr"] },
-    { name: "expr_list$macrocall$3", symbols: [{ literal: "," }] },
-    { name: "expr_list$macrocall$1$ebnf$1", symbols: [] },
-    {
-      name: "expr_list$macrocall$1$ebnf$1$subexpression$1",
-      symbols: ["_", "expr_list$macrocall$3", "_", "expr_list$macrocall$2"],
-    },
-    {
-      name: "expr_list$macrocall$1$ebnf$1",
-      symbols: [
-        "expr_list$macrocall$1$ebnf$1",
-        "expr_list$macrocall$1$ebnf$1$subexpression$1",
-      ],
-      postprocess: (d) => d[0].concat([d[1]]),
-    },
-    {
-      name: "expr_list$macrocall$1$ebnf$2",
-      symbols: ["expr_list$macrocall$3"],
-      postprocess: id,
-    },
-    {
-      name: "expr_list$macrocall$1$ebnf$2",
-      symbols: [],
-      postprocess: () => null,
-    },
-    {
-      name: "expr_list$macrocall$1",
-      symbols: [
-        "expr_list$macrocall$2",
-        "expr_list$macrocall$1$ebnf$1",
-        "expr_list$macrocall$1$ebnf$2",
-      ],
-      postprocess: (d) => {
-        const [first, rest] = [d[0], d[1]];
-        if (rest.length > 0) {
-          const restNodes = rest.map((ts: any[]) => ts[3]);
-          return concat(first, ...restNodes);
-        } else return first;
-      },
-    },
-    {
-      name: "expr_list",
-      symbols: ["_", "expr_list$macrocall$1", "_"],
-      postprocess: nth(1),
-    },
-    {
-      name: "gpi_decl",
-      symbols: [
-        "identifier",
-        "_",
-        { literal: "{" },
-        "property_decl_list",
-        { literal: "}" },
-      ],
-      postprocess: ([shapeName, , , properties, rbrace]): GPIDecl => ({
-        ...nodeData([shapeName, ...properties]),
-        ...rangeBetween(shapeName, rbrace),
-        tag: "GPIDecl",
-        shapeName,
-        properties,
-      }),
-    },
-    { name: "property_decl_list", symbols: ["_"], postprocess: () => [] },
-    {
-      name: "property_decl_list",
-      symbols: ["_c_", { literal: "\n" }, "property_decl_list"],
-      postprocess: nth(2),
-    },
-    {
-      name: "property_decl_list",
-      symbols: ["_", "property_decl", "_"],
-      postprocess: (d) => [d[1]],
-    },
-    {
-      name: "property_decl_list",
-      symbols: [
-        "_",
-        "property_decl",
-        "_c_",
-        { literal: "\n" },
-        "property_decl_list",
-      ],
-      postprocess: (d) => [d[1], ...d[4]],
-    },
-    {
-      name: "property_decl",
-      symbols: ["identifier", "_", { literal: ":" }, "_", "expr"],
-      postprocess: ([name, , , , value]): PropertyDecl => ({
-        ...nodeData([name, value]),
-        ...rangeBetween(name, value),
-        tag: "PropertyDecl",
-        name,
-        value,
-      }),
-    },
-    {
-      name: "identifier",
-      symbols: [lexer.has("identifier") ? { type: "identifier" } : identifier],
-      postprocess: ([d]): Identifier => ({
-        ...nodeData([]),
-        ...rangeOf(d),
-        tag: "Identifier",
-        value: d.text,
-        type: styleTypes.includes(d.text) ? "type-keyword" : "identifier",
-      }),
-    },
-    {
-      name: "comment",
-      symbols: [lexer.has("comment") ? { type: "comment" } : comment],
-      postprocess: convertTokenId,
-    },
-    {
-      name: "comment",
-      symbols: [
-        lexer.has("multiline_comment")
-          ? { type: "multiline_comment" }
-          : multiline_comment,
-      ],
-      postprocess: ([d]) => rangeOf(d),
-    },
-    { name: "_c_$ebnf$1", symbols: [] },
-    {
-      name: "_c_$ebnf$1$subexpression$1",
-      symbols: [lexer.has("ws") ? { type: "ws" } : ws],
-    },
-    { name: "_c_$ebnf$1$subexpression$1", symbols: ["comment"] },
-    {
-      name: "_c_$ebnf$1",
-      symbols: ["_c_$ebnf$1", "_c_$ebnf$1$subexpression$1"],
-      postprocess: (d) => d[0].concat([d[1]]),
-    },
-    { name: "_c_", symbols: ["_c_$ebnf$1"] },
-    { name: "_ml$ebnf$1", symbols: [] },
-    {
-      name: "_ml$ebnf$1",
-      symbols: ["_ml$ebnf$1", "multi_line_ws_char"],
-      postprocess: (d) => d[0].concat([d[1]]),
-    },
-    { name: "_ml", symbols: ["_ml$ebnf$1"] },
-    {
-      name: "multi_line_ws_char",
-      symbols: [lexer.has("ws") ? { type: "ws" } : ws],
-    },
-    { name: "multi_line_ws_char", symbols: [{ literal: "\n" }] },
-    { name: "multi_line_ws_char", symbols: ["comment"] },
-    { name: "__$ebnf$1", symbols: [lexer.has("ws") ? { type: "ws" } : ws] },
-    {
-      name: "__$ebnf$1",
-      symbols: ["__$ebnf$1", lexer.has("ws") ? { type: "ws" } : ws],
-      postprocess: (d) => d[0].concat([d[1]]),
-    },
-    { name: "__", symbols: ["__$ebnf$1"] },
-    { name: "_$ebnf$1", symbols: [] },
-    {
-      name: "_$ebnf$1",
-      symbols: ["_$ebnf$1", lexer.has("ws") ? { type: "ws" } : ws],
-      postprocess: (d) => d[0].concat([d[1]]),
-    },
-    { name: "_", symbols: ["_$ebnf$1"] },
+          tag: "Delete", contents
+        }}
+        },
+    {"name": "override", "symbols": [{"literal":"override"}, "__", "path", "_", {"literal":"="}, "_", "assign_expr"], "postprocess": 
+        ([kw, , path, , , , value]): IOverride => ({ 
+          ...nodeData([path, value]),
+          ...rangeBetween(kw, value),
+          tag: "Override", path, value
+        })
+        },
+    {"name": "path_assign$ebnf$1", "symbols": ["type"], "postprocess": id},
+    {"name": "path_assign$ebnf$1", "symbols": [], "postprocess": () => null},
+    {"name": "path_assign", "symbols": ["path_assign$ebnf$1", "__", "path", "_", {"literal":"="}, "_", "assign_expr"], "postprocess": 
+        ([type, , path, , , , value]): PathAssign => ({ 
+          ...nodeData(type ? [type, path, value] : [path, value]),
+          ...rangeBetween(type ? type : path, value),
+          tag: "PathAssign",
+          type, path, value
+        })
+        },
+    {"name": "type", "symbols": ["identifier"], "postprocess":  ([contents]): StyType => ({
+          ...nodeData([contents]),
+          ...rangeOf(contents),
+          tag: 'TypeOf', contents
+        }) 
+          },
+    {"name": "type", "symbols": ["identifier", {"literal":"[]"}], "postprocess":  ([contents]): StyType => ({
+          ...nodeData([contents]),
+          ...rangeOf(contents), 
+          tag: 'ListOf', contents
+        }) 
+          },
+    {"name": "path", "symbols": ["entity_path"], "postprocess": id},
+    {"name": "path", "symbols": ["access_path"], "postprocess": id},
+    {"name": "entity_path", "symbols": ["propertyPath"], "postprocess": id},
+    {"name": "entity_path", "symbols": ["fieldPath"], "postprocess": id},
+    {"name": "entity_path", "symbols": ["localVar"], "postprocess": id},
+    {"name": "propertyPath", "symbols": ["binding_form", {"literal":"."}, "identifier", {"literal":"."}, "identifier"], "postprocess": 
+        ([name, , field, , property]): IPropertyPath => ({
+          ...nodeData([name, field, property]),
+          ...rangeFrom([name, field, property]),
+          tag: "PropertyPath", name, field, property
+        })
+        },
+    {"name": "fieldPath", "symbols": ["binding_form", {"literal":"."}, "identifier"], "postprocess": 
+        ([name, , field]): IFieldPath => ({
+          ...nodeData([name, field]),
+          ...rangeFrom([name, field]),
+          tag: "FieldPath", name, field
+        })
+        },
+    {"name": "localVar", "symbols": ["identifier"], "postprocess": 
+        ([contents]): LocalVar => ({
+          ...nodeData([contents]),
+          ...rangeOf(contents),
+          tag: "LocalVar", contents
+        })
+        },
+    {"name": "access_path", "symbols": ["entity_path", "_", "access_ops"], "postprocess": 
+        ([path, , indices]): IAccessPath => {
+          const lastIndex = last(indices);
+          return {
+            ...nodeData([path]), // TODO: model access op as an AST node to solve the range and child node issue
+            ...rangeBetween(path, lastIndex),
+            tag: "AccessPath", path, indices
+          }
+        }
+        },
+    {"name": "access_ops", "symbols": ["access_op"]},
+    {"name": "access_ops", "symbols": ["access_op", "_", "access_ops"], "postprocess": (d: any[]) => [d[0], ...d[2]]},
+    {"name": "access_op", "symbols": [{"literal":"["}, "_", "expr", "_", {"literal":"]"}], "postprocess": nth(2)},
+    {"name": "assign_expr", "symbols": ["expr"], "postprocess": id},
+    {"name": "assign_expr", "symbols": ["layering"], "postprocess": id},
+    {"name": "assign_expr", "symbols": ["objective"], "postprocess": id},
+    {"name": "assign_expr", "symbols": ["constraint"], "postprocess": id},
+    {"name": "assign_expr", "symbols": ["gpi_decl"], "postprocess": id},
+    {"name": "anonymous_expr", "symbols": ["layering"], "postprocess": id},
+    {"name": "anonymous_expr", "symbols": ["objective"], "postprocess": id},
+    {"name": "anonymous_expr", "symbols": ["constraint"], "postprocess": id},
+    {"name": "expr", "symbols": ["arithmeticExpr"], "postprocess": id},
+    {"name": "parenthesized", "symbols": [{"literal":"("}, "_", "arithmeticExpr", "_", {"literal":")"}], "postprocess": nth(2)},
+    {"name": "parenthesized", "symbols": ["expr_literal"], "postprocess": id},
+    {"name": "unary", "symbols": [{"literal":"-"}, "_", "parenthesized"], "postprocess":  (d): IUOp => 
+        ({
+          ...nodeData([d[2]]),
+          ...rangeBetween(d[0], d[2]),
+          tag: 'UOp', op: "UMinus", arg: d[2]
+        }) 
+          },
+    {"name": "unary", "symbols": ["parenthesized"], "postprocess": id},
+    {"name": "factor", "symbols": ["unary", "_", {"literal":"^"}, "_", "factor"], "postprocess": (d): IBinOp => binop('Exp', d[0], d[4])},
+    {"name": "factor", "symbols": ["unary"], "postprocess": id},
+    {"name": "term", "symbols": ["term", "_", {"literal":"*"}, "_", "factor"], "postprocess": (d): IBinOp => binop('Multiply', d[0], d[4])},
+    {"name": "term", "symbols": ["term", "_", {"literal":"/"}, "_", "factor"], "postprocess": (d): IBinOp => binop('Divide', d[0], d[4])},
+    {"name": "term", "symbols": ["factor"], "postprocess": id},
+    {"name": "arithmeticExpr", "symbols": ["arithmeticExpr", "_", {"literal":"+"}, "_", "term"], "postprocess": (d): IBinOp => binop('BPlus', d[0], d[4])},
+    {"name": "arithmeticExpr", "symbols": ["arithmeticExpr", "_", {"literal":"-"}, "_", "term"], "postprocess": (d): IBinOp => binop('BMinus', d[0], d[4])},
+    {"name": "arithmeticExpr", "symbols": ["term"], "postprocess": id},
+    {"name": "expr_literal", "symbols": ["bool_lit"], "postprocess": id},
+    {"name": "expr_literal", "symbols": ["string_lit"], "postprocess": id},
+    {"name": "expr_literal", "symbols": ["annotated_float"], "postprocess": id},
+    {"name": "expr_literal", "symbols": ["computation_function"], "postprocess": id},
+    {"name": "expr_literal", "symbols": ["path"], "postprocess": id},
+    {"name": "expr_literal", "symbols": ["list"], "postprocess": id},
+    {"name": "expr_literal", "symbols": ["tuple"], "postprocess": id},
+    {"name": "expr_literal", "symbols": ["vector"], "postprocess": id},
+    {"name": "list", "symbols": [{"literal":"["}, "_", "expr_list", "_", {"literal":"]"}], "postprocess":  
+        ([lbracket, , exprs, , rbracket]): IList => ({
+          ...nodeData(exprs),
+          ...rangeBetween(lbracket, rbracket),
+          tag: 'List',
+          contents: exprs
+        })
+        },
+    {"name": "tuple", "symbols": [{"literal":"{"}, "_", "expr", "_", {"literal":","}, "_", "expr", "_", {"literal":"}"}], "postprocess":  
+        ([lbrace, , e1, , , , e2, , rbrace]): ITuple => ({
+          ...nodeData([e1, e2]),
+          ...rangeBetween(lbrace, rbrace),
+          tag: 'Tuple',
+          contents: [e1, e2]
+        })
+        },
+    {"name": "vector", "symbols": [{"literal":"("}, "_", "expr", "_", {"literal":","}, "expr_list", {"literal":")"}], "postprocess":  
+        ([lparen, , first, , , rest, rparen]): IVector => ({
+          ...nodeData([first, ...rest]),
+          ...rangeBetween(lparen, rparen),
+          tag: 'Vector',
+          contents: [first, ...rest]
+        })
+        },
+    {"name": "bool_lit$subexpression$1", "symbols": [{"literal":"true"}]},
+    {"name": "bool_lit$subexpression$1", "symbols": [{"literal":"false"}]},
+    {"name": "bool_lit", "symbols": ["bool_lit$subexpression$1"], "postprocess": 
+        ([[d]]): IBoolLit => ({
+          ...nodeData([]),
+          ...rangeOf(d),
+          tag: 'BoolLit',
+          contents: d.text === 'true' // https://stackoverflow.com/questions/263965/how-can-i-convert-a-string-to-boolean-in-javascript
+        })
+        },
+    {"name": "string_lit", "symbols": [(lexer.has("string_literal") ? {type: "string_literal"} : string_literal)], "postprocess": 
+        ([d]): IStringLit => ({
+          ...nodeData([]),
+          ...rangeOf(d),
+          tag: 'StringLit',
+          contents: d.value
+        })
+        },
+    {"name": "annotated_float", "symbols": [{"literal":"?"}], "postprocess": ([d]): IVary => ({ ...nodeData([]), ...rangeOf(d), tag: 'Vary' })},
+    {"name": "annotated_float", "symbols": [(lexer.has("float_literal") ? {type: "float_literal"} : float_literal)], "postprocess":  
+        ([d]): IFix => ({ ...nodeData([]), ...rangeOf(d), tag: 'Fix', contents: parseFloat(d) }) 
+          },
+    {"name": "layering$ebnf$1", "symbols": ["layer_keyword"], "postprocess": id},
+    {"name": "layering$ebnf$1", "symbols": [], "postprocess": () => null},
+    {"name": "layering", "symbols": ["layering$ebnf$1", "path", "__", {"literal":"below"}, "__", "path"], "postprocess": (d): ILayering => layering(d[0], d[1], d[5])},
+    {"name": "layering$ebnf$2", "symbols": ["layer_keyword"], "postprocess": id},
+    {"name": "layering$ebnf$2", "symbols": [], "postprocess": () => null},
+    {"name": "layering", "symbols": ["layering$ebnf$2", "path", "__", {"literal":"above"}, "__", "path"], "postprocess": (d): ILayering => layering(d[0], d[5], d[1])},
+    {"name": "layer_keyword", "symbols": [{"literal":"layer"}, "__"], "postprocess": nth(0)},
+    {"name": "computation_function", "symbols": ["identifier", "_", {"literal":"("}, "expr_list", {"literal":")"}], "postprocess":  
+        ([name, , , args, rparen]): ICompApp => ({
+          ...nodeData([name, ...args]),
+          ...rangeBetween(name, rparen),
+          tag: "CompApp",
+          name, args
+        }) 
+        },
+    {"name": "objective", "symbols": [{"literal":"encourage"}, "__", "identifier", "_", {"literal":"("}, "expr_list", {"literal":")"}], "postprocess":  
+        ([kw, , name, , , args, rparen]): IObjFn => ({
+          ...nodeData([name, ...args]),
+          ...rangeBetween(kw, rparen),
+          tag: "ObjFn",
+          name, args
+        }) 
+        },
+    {"name": "constraint", "symbols": [{"literal":"ensure"}, "__", "identifier", "_", {"literal":"("}, "expr_list", {"literal":")"}], "postprocess":  
+        ([kw, , name, , , args, rparen]): IConstrFn => ({
+          ...nodeData([name, ...args]),
+          ...rangeBetween(kw, rparen),
+          tag: "ConstrFn",
+          name, args
+        }) 
+        },
+    {"name": "expr_list", "symbols": ["_"], "postprocess": d => []},
+    {"name": "expr_list$macrocall$2", "symbols": ["expr"]},
+    {"name": "expr_list$macrocall$3", "symbols": [{"literal":","}]},
+    {"name": "expr_list$macrocall$1$ebnf$1", "symbols": []},
+    {"name": "expr_list$macrocall$1$ebnf$1$subexpression$1", "symbols": ["_", "expr_list$macrocall$3", "_", "expr_list$macrocall$2"]},
+    {"name": "expr_list$macrocall$1$ebnf$1", "symbols": ["expr_list$macrocall$1$ebnf$1", "expr_list$macrocall$1$ebnf$1$subexpression$1"], "postprocess": (d) => d[0].concat([d[1]])},
+    {"name": "expr_list$macrocall$1$ebnf$2", "symbols": ["expr_list$macrocall$3"], "postprocess": id},
+    {"name": "expr_list$macrocall$1$ebnf$2", "symbols": [], "postprocess": () => null},
+    {"name": "expr_list$macrocall$1", "symbols": ["expr_list$macrocall$2", "expr_list$macrocall$1$ebnf$1", "expr_list$macrocall$1$ebnf$2"], "postprocess":  
+        d => { 
+          const [first, rest] = [d[0], d[1]];
+          if(rest.length > 0) {
+            const restNodes = rest.map((ts: any[]) => ts[3]);
+            return concat(first, ...restNodes);
+          } else return first;
+        }
+        },
+    {"name": "expr_list", "symbols": ["_", "expr_list$macrocall$1", "_"], "postprocess": nth(1)},
+    {"name": "gpi_decl", "symbols": ["identifier", "_", {"literal":"{"}, "property_decl_list", {"literal":"}"}], "postprocess": 
+        ([shapeName, , , properties, rbrace]): GPIDecl => ({
+          ...nodeData([shapeName, ...properties]),
+          ...rangeBetween(shapeName, rbrace),
+          tag: "GPIDecl",
+          shapeName, properties
+        })
+        },
+    {"name": "property_decl_list", "symbols": ["_"], "postprocess": () => []},
+    {"name": "property_decl_list", "symbols": ["_c_", {"literal":"\n"}, "property_decl_list"], "postprocess": nth(2)},
+    {"name": "property_decl_list", "symbols": ["_", "property_decl", "_"], "postprocess": d => [d[1]]},
+    {"name": "property_decl_list", "symbols": ["_", "property_decl", "_c_", {"literal":"\n"}, "property_decl_list"], "postprocess": d => [d[1], ...d[4]]},
+    {"name": "property_decl", "symbols": ["identifier", "_", {"literal":":"}, "_", "expr"], "postprocess": 
+        ([name, , , , value]): PropertyDecl => ({
+          ...nodeData([name, value]),
+          ...rangeBetween(name, value),
+          tag: "PropertyDecl",
+          name, value
+        })
+        },
+    {"name": "identifier", "symbols": [(lexer.has("identifier") ? {type: "identifier"} : identifier)], "postprocess":  
+        ([d]): Identifier => ({
+          ...nodeData([]),
+          ...rangeOf(d),
+          tag: 'Identifier',
+          value: d.text,
+          type: styleTypes.includes(d.text) ? "type-keyword" : "identifier"
+        })
+        },
+    {"name": "comment", "symbols": [(lexer.has("comment") ? {type: "comment"} : comment)], "postprocess": convertTokenId},
+    {"name": "comment", "symbols": [(lexer.has("multiline_comment") ? {type: "multiline_comment"} : multiline_comment)], "postprocess": ([d]) => rangeOf(d)},
+    {"name": "_c_$ebnf$1", "symbols": []},
+    {"name": "_c_$ebnf$1$subexpression$1", "symbols": [(lexer.has("ws") ? {type: "ws"} : ws)]},
+    {"name": "_c_$ebnf$1$subexpression$1", "symbols": ["comment"]},
+    {"name": "_c_$ebnf$1", "symbols": ["_c_$ebnf$1", "_c_$ebnf$1$subexpression$1"], "postprocess": (d) => d[0].concat([d[1]])},
+    {"name": "_c_", "symbols": ["_c_$ebnf$1"]},
+    {"name": "_ml$ebnf$1", "symbols": []},
+    {"name": "_ml$ebnf$1", "symbols": ["_ml$ebnf$1", "multi_line_ws_char"], "postprocess": (d) => d[0].concat([d[1]])},
+    {"name": "_ml", "symbols": ["_ml$ebnf$1"]},
+    {"name": "multi_line_ws_char", "symbols": [(lexer.has("ws") ? {type: "ws"} : ws)]},
+    {"name": "multi_line_ws_char", "symbols": [{"literal":"\n"}]},
+    {"name": "multi_line_ws_char", "symbols": ["comment"]},
+    {"name": "__$ebnf$1", "symbols": [(lexer.has("ws") ? {type: "ws"} : ws)]},
+    {"name": "__$ebnf$1", "symbols": ["__$ebnf$1", (lexer.has("ws") ? {type: "ws"} : ws)], "postprocess": (d) => d[0].concat([d[1]])},
+    {"name": "__", "symbols": ["__$ebnf$1"]},
+    {"name": "_$ebnf$1", "symbols": []},
+    {"name": "_$ebnf$1", "symbols": ["_$ebnf$1", (lexer.has("ws") ? {type: "ws"} : ws)], "postprocess": (d) => d[0].concat([d[1]])},
+    {"name": "_", "symbols": ["_$ebnf$1"]}
   ],
   ParserStart: "input",
 };

--- a/packages/penrose-core/src/parser/SubstanceParser.ts
+++ b/packages/penrose-core/src/parser/SubstanceParser.ts
@@ -2,9 +2,7 @@
 // http://github.com/Hardmath123/nearley
 // Bypasses TS6133. Allow declared but unused functions.
 // @ts-ignore
-function id(d: any[]): any {
-  return d[0];
-}
+function id(d: any[]): any { return d[0]; }
 declare var string_literal: any;
 declare var tex_literal: any;
 declare var identifier: any;
@@ -12,18 +10,11 @@ declare var comment: any;
 declare var multiline_comment: any;
 declare var ws: any;
 
+
 /* eslint-disable */
 import * as moo from "moo";
-import { concat, compact, flatten, last } from "lodash";
-import {
-  optional,
-  basicSymbols,
-  rangeOf,
-  rangeBetween,
-  rangeFrom,
-  nth,
-  convertTokenId,
-} from "parser/ParserUtil";
+import { concat, compact, flatten, last } from 'lodash'
+import { optional, basicSymbols, rangeOf, rangeBetween, rangeFrom, nth, convertTokenId } from 'parser/ParserUtil'
 
 // NOTE: ordering matters here. Top patterns get matched __first__
 const lexer = moo.compile({
@@ -35,24 +26,25 @@ const lexer = moo.compile({
     match: /[A-z_][A-Za-z_0-9]*/,
     type: moo.keywords({
       // NOTE: the next line add type annotation keywords into the keyword set and thereby forbidding users to use keywords like `shape`
-      // "type-keyword": styleTypes,
+      // "type-keyword": styleTypes, 
       all: "All",
       label: "Label",
       noLabel: "NoLabel",
-      autoLabel: "AutoLabel",
-    }),
-  },
+      autoLabel: "AutoLabel"
+    })
+  }
 });
 
 const nodeData = (children: ASTNode[]) => ({
   nodeType: "Substance",
-  children,
+  children
 });
+
 
 interface NearleyToken {
   value: any;
   [key: string]: any;
-}
+};
 
 interface NearleyLexer {
   reset: (chunk: string, info: any) => void;
@@ -60,619 +52,295 @@ interface NearleyLexer {
   save: () => any;
   formatError: (token: never) => string;
   has: (tokenType: string) => boolean;
-}
+};
 
 interface NearleyRule {
   name: string;
   symbols: NearleySymbol[];
   postprocess?: (d: any[], loc?: number, reject?: {}) => any;
-}
+};
 
-type NearleySymbol =
-  | string
-  | { literal: any }
-  | { test: (token: any) => boolean };
+type NearleySymbol = string | { literal: any } | { test: (token: any) => boolean };
 
 interface Grammar {
   Lexer: NearleyLexer | undefined;
   ParserRules: NearleyRule[];
   ParserStart: string;
-}
+};
 
 const grammar: Grammar = {
   Lexer: lexer,
   ParserRules: [
-    {
-      name: "input",
-      symbols: ["statements"],
-      postprocess: ([d]): SubProg => {
-        const statements = flatten(d) as SubStmt[];
-        return {
-          ...nodeData(statements),
-          ...rangeFrom(statements),
-          tag: "SubProg",
-          statements,
-        };
-      },
-    },
-    { name: "statements", symbols: ["_"], postprocess: () => [] },
-    {
-      name: "statements",
-      symbols: ["_c_", { literal: "\n" }, "statements"],
-      postprocess: nth(2),
-    },
-    {
-      name: "statements",
-      symbols: ["_", "statement", "_c_"],
-      postprocess: (d) => [d[1]],
-    },
-    {
-      name: "statements",
-      symbols: ["_", "statement", "_c_", { literal: "\n" }, "statements"],
-      postprocess: (d) => [d[1], ...d[4]],
-    },
-    { name: "statement", symbols: ["decl"], postprocess: id },
-    { name: "statement", symbols: ["bind"], postprocess: id },
-    { name: "statement", symbols: ["decl_bind"], postprocess: id },
-    { name: "statement", symbols: ["apply_predicate"], postprocess: id },
-    { name: "statement", symbols: ["label_stmt"], postprocess: id },
-    { name: "statement", symbols: ["equal_exprs"], postprocess: id },
-    { name: "statement", symbols: ["equal_predicates"], postprocess: id },
-    { name: "decl$macrocall$2", symbols: ["identifier"] },
-    { name: "decl$macrocall$3", symbols: [{ literal: "," }] },
-    { name: "decl$macrocall$1$ebnf$1", symbols: [] },
-    {
-      name: "decl$macrocall$1$ebnf$1$subexpression$1",
-      symbols: ["_", "decl$macrocall$3", "_", "decl$macrocall$2"],
-    },
-    {
-      name: "decl$macrocall$1$ebnf$1",
-      symbols: [
-        "decl$macrocall$1$ebnf$1",
-        "decl$macrocall$1$ebnf$1$subexpression$1",
-      ],
-      postprocess: (d) => d[0].concat([d[1]]),
-    },
-    {
-      name: "decl$macrocall$1$ebnf$2",
-      symbols: ["decl$macrocall$3"],
-      postprocess: id,
-    },
-    { name: "decl$macrocall$1$ebnf$2", symbols: [], postprocess: () => null },
-    {
-      name: "decl$macrocall$1",
-      symbols: [
-        "decl$macrocall$2",
-        "decl$macrocall$1$ebnf$1",
-        "decl$macrocall$1$ebnf$2",
-      ],
-      postprocess: (d) => {
-        const [first, rest] = [d[0], d[1]];
-        if (rest.length > 0) {
-          const restNodes = rest.map((ts: any[]) => ts[3]);
-          return concat(first, ...restNodes);
-        } else return first;
-      },
-    },
-    {
-      name: "decl",
-      symbols: ["type_constructor", "__", "decl$macrocall$1"],
-      postprocess: ([type, , ids]): Decl[] =>
-        ids.map(
-          (name: Identifier): Decl => ({
-            ...nodeData([type, name]),
-            ...rangeBetween(type, name),
-            tag: "Decl",
-            type,
-            name,
-          })
-        ),
-    },
-    {
-      name: "bind",
-      symbols: ["identifier", "_", { literal: ":=" }, "_", "sub_expr"],
-      postprocess: ([variable, , , , expr]): Bind => ({
-        ...nodeData([variable, expr]),
-        ...rangeBetween(variable, expr),
-        tag: "Bind",
-        variable,
-        expr,
-      }),
-    },
-    {
-      name: "decl_bind",
-      symbols: [
-        "type_constructor",
-        "__",
-        "identifier",
-        "_",
-        { literal: ":=" },
-        "_",
-        "sub_expr",
-      ],
-      postprocess: ([type, , variable, , , , expr]): [Decl, Bind] => {
-        const decl: Decl = {
-          ...nodeData([type, variable]),
-          ...rangeBetween(type, variable),
-          tag: "Decl",
-          type,
-          name: variable,
-        };
-        const bind: Bind = {
+    {"name": "input", "symbols": ["statements"], "postprocess":  
+        ([d]): SubProg => {
+          const statements = flatten(d) as SubStmt[];
+          return { ...nodeData(statements), ...rangeFrom(statements), tag: "SubProg", statements };
+        }
+        },
+    {"name": "statements", "symbols": ["_"], "postprocess": () => []},
+    {"name": "statements", "symbols": ["_c_", {"literal":"\n"}, "statements"], "postprocess": nth(2)},
+    {"name": "statements", "symbols": ["_", "statement", "_c_"], "postprocess": d => [d[1]]},
+    {"name": "statements", "symbols": ["_", "statement", "_c_", {"literal":"\n"}, "statements"], "postprocess": d => [d[1], ...d[4]]},
+    {"name": "statement", "symbols": ["decl"], "postprocess": id},
+    {"name": "statement", "symbols": ["bind"], "postprocess": id},
+    {"name": "statement", "symbols": ["decl_bind"], "postprocess": id},
+    {"name": "statement", "symbols": ["apply_predicate"], "postprocess": id},
+    {"name": "statement", "symbols": ["label_stmt"], "postprocess": id},
+    {"name": "statement", "symbols": ["equal_exprs"], "postprocess": id},
+    {"name": "statement", "symbols": ["equal_predicates"], "postprocess": id},
+    {"name": "decl$macrocall$2", "symbols": ["identifier"]},
+    {"name": "decl$macrocall$3", "symbols": [{"literal":","}]},
+    {"name": "decl$macrocall$1$ebnf$1", "symbols": []},
+    {"name": "decl$macrocall$1$ebnf$1$subexpression$1", "symbols": ["_", "decl$macrocall$3", "_", "decl$macrocall$2"]},
+    {"name": "decl$macrocall$1$ebnf$1", "symbols": ["decl$macrocall$1$ebnf$1", "decl$macrocall$1$ebnf$1$subexpression$1"], "postprocess": (d) => d[0].concat([d[1]])},
+    {"name": "decl$macrocall$1$ebnf$2", "symbols": ["decl$macrocall$3"], "postprocess": id},
+    {"name": "decl$macrocall$1$ebnf$2", "symbols": [], "postprocess": () => null},
+    {"name": "decl$macrocall$1", "symbols": ["decl$macrocall$2", "decl$macrocall$1$ebnf$1", "decl$macrocall$1$ebnf$2"], "postprocess":  
+        d => { 
+          const [first, rest] = [d[0], d[1]];
+          if(rest.length > 0) {
+            const restNodes = rest.map((ts: any[]) => ts[3]);
+            return concat(first, ...restNodes);
+          } else return first;
+        }
+        },
+    {"name": "decl", "symbols": ["type_constructor", "__", "decl$macrocall$1"], "postprocess": 
+        ([type, , ids]): Decl[] => ids.map((name: Identifier): Decl => ({
+          ...nodeData([type, name]),
+          ...rangeBetween(type, name),
+          tag: "Decl", type, name
+        }))
+        },
+    {"name": "bind", "symbols": ["identifier", "_", {"literal":":="}, "_", "sub_expr"], "postprocess": 
+        ([variable, , , , expr]): Bind => ({
           ...nodeData([variable, expr]),
           ...rangeBetween(variable, expr),
-          tag: "Bind",
-          variable,
-          expr,
-        };
-        return [decl, bind];
-      },
-    },
-    { name: "apply_predicate$macrocall$2", symbols: ["pred_arg"] },
-    { name: "apply_predicate$macrocall$3", symbols: [{ literal: "," }] },
-    { name: "apply_predicate$macrocall$1$ebnf$1", symbols: [] },
-    {
-      name: "apply_predicate$macrocall$1$ebnf$1$subexpression$1",
-      symbols: [
-        "_",
-        "apply_predicate$macrocall$3",
-        "_",
-        "apply_predicate$macrocall$2",
-      ],
-    },
-    {
-      name: "apply_predicate$macrocall$1$ebnf$1",
-      symbols: [
-        "apply_predicate$macrocall$1$ebnf$1",
-        "apply_predicate$macrocall$1$ebnf$1$subexpression$1",
-      ],
-      postprocess: (d) => d[0].concat([d[1]]),
-    },
-    {
-      name: "apply_predicate$macrocall$1$ebnf$2",
-      symbols: ["apply_predicate$macrocall$3"],
-      postprocess: id,
-    },
-    {
-      name: "apply_predicate$macrocall$1$ebnf$2",
-      symbols: [],
-      postprocess: () => null,
-    },
-    {
-      name: "apply_predicate$macrocall$1",
-      symbols: [
-        "apply_predicate$macrocall$2",
-        "apply_predicate$macrocall$1$ebnf$1",
-        "apply_predicate$macrocall$1$ebnf$2",
-      ],
-      postprocess: (d) => {
-        const [first, rest] = [d[0], d[1]];
-        if (rest.length > 0) {
-          const restNodes = rest.map((ts: any[]) => ts[3]);
-          return concat(first, ...restNodes);
-        } else return first;
-      },
-    },
-    {
-      name: "apply_predicate",
-      symbols: [
-        "identifier",
-        "_",
-        { literal: "(" },
-        "_",
-        "apply_predicate$macrocall$1",
-        "_",
-        { literal: ")" },
-      ],
-      postprocess: ([name, , , , args]): ApplyPredicate => ({
-        ...nodeData([name, ...args]),
-        ...rangeFrom([name, ...args]),
-        tag: "ApplyPredicate",
-        name,
-        args,
-      }),
-    },
-    { name: "pred_arg", symbols: ["sub_expr"], postprocess: id },
-    { name: "sub_expr", symbols: ["identifier"], postprocess: id },
-    { name: "sub_expr", symbols: ["deconstructor"], postprocess: id },
-    { name: "sub_expr", symbols: ["func"], postprocess: id },
-    { name: "sub_expr", symbols: ["string_lit"], postprocess: id },
-    {
-      name: "deconstructor",
-      symbols: ["identifier", "_", { literal: "." }, "_", "identifier"],
-      postprocess: ([variable, , , , field]): Deconstructor => ({
-        ...nodeData([variable, field]),
-        ...rangeBetween(variable, field),
-        tag: "Deconstructor",
-        variable,
-        field,
-      }),
-    },
-    { name: "func$macrocall$2", symbols: ["sub_expr"] },
-    { name: "func$macrocall$3", symbols: [{ literal: "," }] },
-    {
-      name: "func$macrocall$1$ebnf$1",
-      symbols: ["func$macrocall$2"],
-      postprocess: id,
-    },
-    { name: "func$macrocall$1$ebnf$1", symbols: [], postprocess: () => null },
-    { name: "func$macrocall$1$ebnf$2", symbols: [] },
-    {
-      name: "func$macrocall$1$ebnf$2$subexpression$1",
-      symbols: ["_", "func$macrocall$3", "_", "func$macrocall$2"],
-    },
-    {
-      name: "func$macrocall$1$ebnf$2",
-      symbols: [
-        "func$macrocall$1$ebnf$2",
-        "func$macrocall$1$ebnf$2$subexpression$1",
-      ],
-      postprocess: (d) => d[0].concat([d[1]]),
-    },
-    {
-      name: "func$macrocall$1",
-      symbols: ["func$macrocall$1$ebnf$1", "func$macrocall$1$ebnf$2"],
-      postprocess: (d) => {
-        const [first, rest] = [d[0], d[1]];
-        if (!first) return [];
-        if (rest.length > 0) {
-          const restNodes = rest.map((ts: any[]) => ts[3]);
-          return concat(first, ...restNodes);
-        } else return first;
-      },
-    },
-    {
-      name: "func",
-      symbols: [
-        "identifier",
-        "_",
-        { literal: "(" },
-        "_",
-        "func$macrocall$1",
-        "_",
-        { literal: ")" },
-      ],
-      postprocess: ([name, , , , args]): Func => ({
-        ...nodeData([name, ...args]),
-        ...rangeFrom([name, ...args]),
-        tag: "Func",
-        name,
-        args,
-      }),
-    },
-    {
-      name: "equal_exprs",
-      symbols: ["sub_expr", "_", { literal: "=" }, "_", "sub_expr"],
-      postprocess: ([left, , , , right]): EqualExprs => ({
-        ...nodeData([left, right]),
-        ...rangeBetween(left, right),
-        tag: "EqualExprs",
-        left,
-        right,
-      }),
-    },
-    {
-      name: "equal_predicates",
-      symbols: [
-        "apply_predicate",
-        "_",
-        { literal: "<->" },
-        "_",
-        "apply_predicate",
-      ],
-      postprocess: ([left, , , , right]): EqualPredicates => ({
-        ...nodeData([left, right]),
-        ...rangeBetween(left, right),
-        tag: "EqualPredicates",
-        left,
-        right,
-      }),
-    },
-    { name: "label_stmt", symbols: ["label_decl"], postprocess: id },
-    { name: "label_stmt", symbols: ["no_label"], postprocess: id },
-    { name: "label_stmt", symbols: ["auto_label"], postprocess: id },
-    {
-      name: "label_decl",
-      symbols: [{ literal: "Label" }, "__", "identifier", "__", "tex_literal"],
-      postprocess: ([kw, , variable, , label]): LabelDecl => ({
-        ...nodeData([variable, label]),
-        ...rangeBetween(rangeOf(kw), label),
-        tag: "LabelDecl",
-        variable,
-        label,
-      }),
-    },
-    { name: "no_label$macrocall$2", symbols: ["identifier"] },
-    { name: "no_label$macrocall$3", symbols: [{ literal: "," }] },
-    { name: "no_label$macrocall$1$ebnf$1", symbols: [] },
-    {
-      name: "no_label$macrocall$1$ebnf$1$subexpression$1",
-      symbols: ["_", "no_label$macrocall$3", "_", "no_label$macrocall$2"],
-    },
-    {
-      name: "no_label$macrocall$1$ebnf$1",
-      symbols: [
-        "no_label$macrocall$1$ebnf$1",
-        "no_label$macrocall$1$ebnf$1$subexpression$1",
-      ],
-      postprocess: (d) => d[0].concat([d[1]]),
-    },
-    {
-      name: "no_label$macrocall$1$ebnf$2",
-      symbols: ["no_label$macrocall$3"],
-      postprocess: id,
-    },
-    {
-      name: "no_label$macrocall$1$ebnf$2",
-      symbols: [],
-      postprocess: () => null,
-    },
-    {
-      name: "no_label$macrocall$1",
-      symbols: [
-        "no_label$macrocall$2",
-        "no_label$macrocall$1$ebnf$1",
-        "no_label$macrocall$1$ebnf$2",
-      ],
-      postprocess: (d) => {
-        const [first, rest] = [d[0], d[1]];
-        if (rest.length > 0) {
-          const restNodes = rest.map((ts: any[]) => ts[3]);
-          return concat(first, ...restNodes);
-        } else return first;
-      },
-    },
-    {
-      name: "no_label",
-      symbols: [{ literal: "NoLabel" }, "__", "no_label$macrocall$1"],
-      postprocess: ([kw, , args]): NoLabel => ({
-        ...nodeData([...args]),
-        ...rangeFrom([rangeOf(kw), ...args]),
-        tag: "NoLabel",
-        args,
-      }),
-    },
-    {
-      name: "auto_label",
-      symbols: [{ literal: "AutoLabel" }, "__", "label_option"],
-      postprocess: ([kw, , option]): AutoLabel => ({
-        ...nodeData([option]),
-        ...rangeBetween(kw, option),
-        tag: "AutoLabel",
-        option,
-      }),
-    },
-    {
-      name: "label_option",
-      symbols: [{ literal: "All" }],
-      postprocess: ([kw]): LabelOption => ({
-        ...nodeData([]),
-        ...rangeOf(kw),
-        tag: "DefaultLabels",
-      }),
-    },
-    { name: "label_option$macrocall$2", symbols: ["identifier"] },
-    { name: "label_option$macrocall$3", symbols: [{ literal: "," }] },
-    { name: "label_option$macrocall$1$ebnf$1", symbols: [] },
-    {
-      name: "label_option$macrocall$1$ebnf$1$subexpression$1",
-      symbols: [
-        "_",
-        "label_option$macrocall$3",
-        "_",
-        "label_option$macrocall$2",
-      ],
-    },
-    {
-      name: "label_option$macrocall$1$ebnf$1",
-      symbols: [
-        "label_option$macrocall$1$ebnf$1",
-        "label_option$macrocall$1$ebnf$1$subexpression$1",
-      ],
-      postprocess: (d) => d[0].concat([d[1]]),
-    },
-    {
-      name: "label_option$macrocall$1$ebnf$2",
-      symbols: ["label_option$macrocall$3"],
-      postprocess: id,
-    },
-    {
-      name: "label_option$macrocall$1$ebnf$2",
-      symbols: [],
-      postprocess: () => null,
-    },
-    {
-      name: "label_option$macrocall$1",
-      symbols: [
-        "label_option$macrocall$2",
-        "label_option$macrocall$1$ebnf$1",
-        "label_option$macrocall$1$ebnf$2",
-      ],
-      postprocess: (d) => {
-        const [first, rest] = [d[0], d[1]];
-        if (rest.length > 0) {
-          const restNodes = rest.map((ts: any[]) => ts[3]);
-          return concat(first, ...restNodes);
-        } else return first;
-      },
-    },
-    {
-      name: "label_option",
-      symbols: ["label_option$macrocall$1"],
-      postprocess: ([variables]): LabelOption => ({
-        ...nodeData([]),
-        ...rangeFrom(variables),
-        tag: "LabelIDs",
-        variables,
-      }),
-    },
-    {
-      name: "type_constructor$ebnf$1",
-      symbols: ["type_arg_list"],
-      postprocess: id,
-    },
-    { name: "type_constructor$ebnf$1", symbols: [], postprocess: () => null },
-    {
-      name: "type_constructor",
-      symbols: ["identifier", "type_constructor$ebnf$1"],
-      postprocess: ([name, a]): TypeConsApp => {
-        const args = optional(a, []);
-        return {
+          tag: "Bind", variable, expr
+        })
+        },
+    {"name": "decl_bind", "symbols": ["type_constructor", "__", "identifier", "_", {"literal":":="}, "_", "sub_expr"], "postprocess": 
+        ([type, , variable, , , , expr]): [Decl, Bind] => {
+          const decl: Decl = {
+            ...nodeData([type, variable]),
+            ...rangeBetween(type, variable),
+            tag: "Decl", type, name: variable
+          };
+          const bind: Bind = {
+            ...nodeData([variable, expr]),
+            ...rangeBetween(variable, expr),
+            tag: "Bind", variable, expr
+          };
+          return [decl, bind];
+        }
+        },
+    {"name": "apply_predicate$macrocall$2", "symbols": ["pred_arg"]},
+    {"name": "apply_predicate$macrocall$3", "symbols": [{"literal":","}]},
+    {"name": "apply_predicate$macrocall$1$ebnf$1", "symbols": []},
+    {"name": "apply_predicate$macrocall$1$ebnf$1$subexpression$1", "symbols": ["_", "apply_predicate$macrocall$3", "_", "apply_predicate$macrocall$2"]},
+    {"name": "apply_predicate$macrocall$1$ebnf$1", "symbols": ["apply_predicate$macrocall$1$ebnf$1", "apply_predicate$macrocall$1$ebnf$1$subexpression$1"], "postprocess": (d) => d[0].concat([d[1]])},
+    {"name": "apply_predicate$macrocall$1$ebnf$2", "symbols": ["apply_predicate$macrocall$3"], "postprocess": id},
+    {"name": "apply_predicate$macrocall$1$ebnf$2", "symbols": [], "postprocess": () => null},
+    {"name": "apply_predicate$macrocall$1", "symbols": ["apply_predicate$macrocall$2", "apply_predicate$macrocall$1$ebnf$1", "apply_predicate$macrocall$1$ebnf$2"], "postprocess":  
+        d => { 
+          const [first, rest] = [d[0], d[1]];
+          if(rest.length > 0) {
+            const restNodes = rest.map((ts: any[]) => ts[3]);
+            return concat(first, ...restNodes);
+          } else return first;
+        }
+        },
+    {"name": "apply_predicate", "symbols": ["identifier", "_", {"literal":"("}, "_", "apply_predicate$macrocall$1", "_", {"literal":")"}], "postprocess": 
+        ([name, , , , args]): ApplyPredicate => ({
           ...nodeData([name, ...args]),
           ...rangeFrom([name, ...args]),
-          tag: "TypeConstructor",
-          name,
-          args,
-        };
-      },
-    },
-    { name: "type_arg_list$macrocall$2", symbols: ["type_constructor"] },
-    { name: "type_arg_list$macrocall$3", symbols: [{ literal: "," }] },
-    { name: "type_arg_list$macrocall$1$ebnf$1", symbols: [] },
-    {
-      name: "type_arg_list$macrocall$1$ebnf$1$subexpression$1",
-      symbols: [
-        "_",
-        "type_arg_list$macrocall$3",
-        "_",
-        "type_arg_list$macrocall$2",
-      ],
-    },
-    {
-      name: "type_arg_list$macrocall$1$ebnf$1",
-      symbols: [
-        "type_arg_list$macrocall$1$ebnf$1",
-        "type_arg_list$macrocall$1$ebnf$1$subexpression$1",
-      ],
-      postprocess: (d) => d[0].concat([d[1]]),
-    },
-    {
-      name: "type_arg_list$macrocall$1$ebnf$2",
-      symbols: ["type_arg_list$macrocall$3"],
-      postprocess: id,
-    },
-    {
-      name: "type_arg_list$macrocall$1$ebnf$2",
-      symbols: [],
-      postprocess: () => null,
-    },
-    {
-      name: "type_arg_list$macrocall$1",
-      symbols: [
-        "type_arg_list$macrocall$2",
-        "type_arg_list$macrocall$1$ebnf$1",
-        "type_arg_list$macrocall$1$ebnf$2",
-      ],
-      postprocess: (d) => {
-        const [first, rest] = [d[0], d[1]];
-        if (rest.length > 0) {
-          const restNodes = rest.map((ts: any[]) => ts[3]);
-          return concat(first, ...restNodes);
-        } else return first;
-      },
-    },
-    {
-      name: "type_arg_list",
-      symbols: [
-        "_",
-        { literal: "(" },
-        "_",
-        "type_arg_list$macrocall$1",
-        "_",
-        { literal: ")" },
-      ],
-      postprocess: ([, , , d]): TypeConsApp[] => flatten(d),
-    },
-    {
-      name: "string_lit",
-      symbols: [
-        lexer.has("string_literal")
-          ? { type: "string_literal" }
-          : string_literal,
-      ],
-      postprocess: ([d]): IStringLit => ({
-        ...nodeData([]),
-        ...rangeOf(d),
-        tag: "StringLit",
-        contents: d.value,
-      }),
-    },
-    {
-      name: "tex_literal",
-      symbols: [
-        lexer.has("tex_literal") ? { type: "tex_literal" } : tex_literal,
-      ],
-      postprocess: ([d]): IStringLit => ({
-        ...nodeData([]),
-        ...rangeOf(d),
-        tag: "StringLit",
-        contents: d.text.substring(1, d.text.length - 1), // NOTE: remove dollars
-      }),
-    },
-    {
-      name: "identifier",
-      symbols: [lexer.has("identifier") ? { type: "identifier" } : identifier],
-      postprocess: ([d]) => ({
-        ...nodeData([]),
-        ...rangeOf(d),
-        tag: "Identifier",
-        value: d.text,
-        type: "identifier",
-      }),
-    },
-    {
-      name: "comment",
-      symbols: [lexer.has("comment") ? { type: "comment" } : comment],
-      postprocess: convertTokenId,
-    },
-    {
-      name: "comment",
-      symbols: [
-        lexer.has("multiline_comment")
-          ? { type: "multiline_comment" }
-          : multiline_comment,
-      ],
-      postprocess: ([d]) => rangeOf(d),
-    },
-    { name: "_c_$ebnf$1", symbols: [] },
-    {
-      name: "_c_$ebnf$1$subexpression$1",
-      symbols: [lexer.has("ws") ? { type: "ws" } : ws],
-    },
-    { name: "_c_$ebnf$1$subexpression$1", symbols: ["comment"] },
-    {
-      name: "_c_$ebnf$1",
-      symbols: ["_c_$ebnf$1", "_c_$ebnf$1$subexpression$1"],
-      postprocess: (d) => d[0].concat([d[1]]),
-    },
-    { name: "_c_", symbols: ["_c_$ebnf$1"] },
-    { name: "_ml$ebnf$1", symbols: [] },
-    {
-      name: "_ml$ebnf$1",
-      symbols: ["_ml$ebnf$1", "multi_line_ws_char"],
-      postprocess: (d) => d[0].concat([d[1]]),
-    },
-    { name: "_ml", symbols: ["_ml$ebnf$1"] },
-    {
-      name: "multi_line_ws_char",
-      symbols: [lexer.has("ws") ? { type: "ws" } : ws],
-    },
-    { name: "multi_line_ws_char", symbols: [{ literal: "\n" }] },
-    { name: "multi_line_ws_char", symbols: ["comment"] },
-    { name: "__$ebnf$1", symbols: [lexer.has("ws") ? { type: "ws" } : ws] },
-    {
-      name: "__$ebnf$1",
-      symbols: ["__$ebnf$1", lexer.has("ws") ? { type: "ws" } : ws],
-      postprocess: (d) => d[0].concat([d[1]]),
-    },
-    { name: "__", symbols: ["__$ebnf$1"] },
-    { name: "_$ebnf$1", symbols: [] },
-    {
-      name: "_$ebnf$1",
-      symbols: ["_$ebnf$1", lexer.has("ws") ? { type: "ws" } : ws],
-      postprocess: (d) => d[0].concat([d[1]]),
-    },
-    { name: "_", symbols: ["_$ebnf$1"] },
+          tag: "ApplyPredicate", name, args
+        })
+        },
+    {"name": "pred_arg", "symbols": ["sub_expr"], "postprocess": id},
+    {"name": "sub_expr", "symbols": ["identifier"], "postprocess": id},
+    {"name": "sub_expr", "symbols": ["deconstructor"], "postprocess": id},
+    {"name": "sub_expr", "symbols": ["func"], "postprocess": id},
+    {"name": "sub_expr", "symbols": ["string_lit"], "postprocess": id},
+    {"name": "deconstructor", "symbols": ["identifier", "_", {"literal":"."}, "_", "identifier"], "postprocess": 
+        ([variable, , , , field]): Deconstructor => ({
+          ...nodeData([variable, field]),
+          ...rangeBetween(variable, field),
+          tag: "Deconstructor", variable, field
+        })
+        },
+    {"name": "func$macrocall$2", "symbols": ["sub_expr"]},
+    {"name": "func$macrocall$3", "symbols": [{"literal":","}]},
+    {"name": "func$macrocall$1$ebnf$1", "symbols": ["func$macrocall$2"], "postprocess": id},
+    {"name": "func$macrocall$1$ebnf$1", "symbols": [], "postprocess": () => null},
+    {"name": "func$macrocall$1$ebnf$2", "symbols": []},
+    {"name": "func$macrocall$1$ebnf$2$subexpression$1", "symbols": ["_", "func$macrocall$3", "_", "func$macrocall$2"]},
+    {"name": "func$macrocall$1$ebnf$2", "symbols": ["func$macrocall$1$ebnf$2", "func$macrocall$1$ebnf$2$subexpression$1"], "postprocess": (d) => d[0].concat([d[1]])},
+    {"name": "func$macrocall$1", "symbols": ["func$macrocall$1$ebnf$1", "func$macrocall$1$ebnf$2"], "postprocess":  
+        d => { 
+          const [first, rest] = [d[0], d[1]];
+          if(!first) return [];
+          if(rest.length > 0) {
+            const restNodes = rest.map((ts: any[]) => ts[3]);
+            return concat(first, ...restNodes);
+          } else return first;
+        }
+        },
+    {"name": "func", "symbols": ["identifier", "_", {"literal":"("}, "_", "func$macrocall$1", "_", {"literal":")"}], "postprocess": 
+        ([name, , , , args]): Func => ({
+          ...nodeData([name, ...args]),
+          ...rangeFrom([name, ...args]),
+          tag: "Func", name, args
+        })
+        },
+    {"name": "equal_exprs", "symbols": ["sub_expr", "_", {"literal":"="}, "_", "sub_expr"], "postprocess": 
+        ([left, , , , right]): EqualExprs => ({
+          ...nodeData([left, right]),
+          ...rangeBetween(left, right),
+          tag: "EqualExprs", left, right
+        })
+        },
+    {"name": "equal_predicates", "symbols": ["apply_predicate", "_", {"literal":"<->"}, "_", "apply_predicate"], "postprocess": 
+        ([left, , , , right]): EqualPredicates => ({
+          ...nodeData([left, right]),
+          ...rangeBetween(left, right),
+          tag: "EqualPredicates", left, right
+        })
+        },
+    {"name": "label_stmt", "symbols": ["label_decl"], "postprocess": id},
+    {"name": "label_stmt", "symbols": ["no_label"], "postprocess": id},
+    {"name": "label_stmt", "symbols": ["auto_label"], "postprocess": id},
+    {"name": "label_decl", "symbols": [{"literal":"Label"}, "__", "identifier", "__", "tex_literal"], "postprocess": 
+        ([kw, , variable, , label]): LabelDecl => ({
+          ...nodeData([variable, label]),
+          ...rangeBetween(rangeOf(kw), label),
+          tag: "LabelDecl", variable, label
+        })
+        },
+    {"name": "no_label$macrocall$2", "symbols": ["identifier"]},
+    {"name": "no_label$macrocall$3", "symbols": [{"literal":","}]},
+    {"name": "no_label$macrocall$1$ebnf$1", "symbols": []},
+    {"name": "no_label$macrocall$1$ebnf$1$subexpression$1", "symbols": ["_", "no_label$macrocall$3", "_", "no_label$macrocall$2"]},
+    {"name": "no_label$macrocall$1$ebnf$1", "symbols": ["no_label$macrocall$1$ebnf$1", "no_label$macrocall$1$ebnf$1$subexpression$1"], "postprocess": (d) => d[0].concat([d[1]])},
+    {"name": "no_label$macrocall$1$ebnf$2", "symbols": ["no_label$macrocall$3"], "postprocess": id},
+    {"name": "no_label$macrocall$1$ebnf$2", "symbols": [], "postprocess": () => null},
+    {"name": "no_label$macrocall$1", "symbols": ["no_label$macrocall$2", "no_label$macrocall$1$ebnf$1", "no_label$macrocall$1$ebnf$2"], "postprocess":  
+        d => { 
+          const [first, rest] = [d[0], d[1]];
+          if(rest.length > 0) {
+            const restNodes = rest.map((ts: any[]) => ts[3]);
+            return concat(first, ...restNodes);
+          } else return first;
+        }
+        },
+    {"name": "no_label", "symbols": [{"literal":"NoLabel"}, "__", "no_label$macrocall$1"], "postprocess": 
+        ([kw, , args]): NoLabel => ({
+          ...nodeData([...args]),
+          ...rangeFrom([rangeOf(kw), ...args]),
+          tag: "NoLabel", args
+        })
+        },
+    {"name": "auto_label", "symbols": [{"literal":"AutoLabel"}, "__", "label_option"], "postprocess": 
+        ([kw, , option]): AutoLabel => ({
+          ...nodeData([option]),
+          ...rangeBetween(kw, option),
+          tag: "AutoLabel", option 
+        })
+        },
+    {"name": "label_option", "symbols": [{"literal":"All"}], "postprocess": ([kw]): LabelOption => ({ ...nodeData([]), ...rangeOf(kw), tag: "DefaultLabels" })},
+    {"name": "label_option$macrocall$2", "symbols": ["identifier"]},
+    {"name": "label_option$macrocall$3", "symbols": [{"literal":","}]},
+    {"name": "label_option$macrocall$1$ebnf$1", "symbols": []},
+    {"name": "label_option$macrocall$1$ebnf$1$subexpression$1", "symbols": ["_", "label_option$macrocall$3", "_", "label_option$macrocall$2"]},
+    {"name": "label_option$macrocall$1$ebnf$1", "symbols": ["label_option$macrocall$1$ebnf$1", "label_option$macrocall$1$ebnf$1$subexpression$1"], "postprocess": (d) => d[0].concat([d[1]])},
+    {"name": "label_option$macrocall$1$ebnf$2", "symbols": ["label_option$macrocall$3"], "postprocess": id},
+    {"name": "label_option$macrocall$1$ebnf$2", "symbols": [], "postprocess": () => null},
+    {"name": "label_option$macrocall$1", "symbols": ["label_option$macrocall$2", "label_option$macrocall$1$ebnf$1", "label_option$macrocall$1$ebnf$2"], "postprocess":  
+        d => { 
+          const [first, rest] = [d[0], d[1]];
+          if(rest.length > 0) {
+            const restNodes = rest.map((ts: any[]) => ts[3]);
+            return concat(first, ...restNodes);
+          } else return first;
+        }
+        },
+    {"name": "label_option", "symbols": ["label_option$macrocall$1"], "postprocess":  
+        ([variables]): LabelOption => ({ ...nodeData([]), ...rangeFrom(variables), tag: "LabelIDs", variables }) 
+             },
+    {"name": "type_constructor$ebnf$1", "symbols": ["type_arg_list"], "postprocess": id},
+    {"name": "type_constructor$ebnf$1", "symbols": [], "postprocess": () => null},
+    {"name": "type_constructor", "symbols": ["identifier", "type_constructor$ebnf$1"], "postprocess":  
+        ([name, a]): TypeConsApp => {
+          const args = optional(a, []);
+          return {
+            ...nodeData([name, ...args]),
+            ...rangeFrom([name, ...args]),
+            tag: "TypeConstructor", name, args 
+          };
+        }
+        },
+    {"name": "type_arg_list$macrocall$2", "symbols": ["type_constructor"]},
+    {"name": "type_arg_list$macrocall$3", "symbols": [{"literal":","}]},
+    {"name": "type_arg_list$macrocall$1$ebnf$1", "symbols": []},
+    {"name": "type_arg_list$macrocall$1$ebnf$1$subexpression$1", "symbols": ["_", "type_arg_list$macrocall$3", "_", "type_arg_list$macrocall$2"]},
+    {"name": "type_arg_list$macrocall$1$ebnf$1", "symbols": ["type_arg_list$macrocall$1$ebnf$1", "type_arg_list$macrocall$1$ebnf$1$subexpression$1"], "postprocess": (d) => d[0].concat([d[1]])},
+    {"name": "type_arg_list$macrocall$1$ebnf$2", "symbols": ["type_arg_list$macrocall$3"], "postprocess": id},
+    {"name": "type_arg_list$macrocall$1$ebnf$2", "symbols": [], "postprocess": () => null},
+    {"name": "type_arg_list$macrocall$1", "symbols": ["type_arg_list$macrocall$2", "type_arg_list$macrocall$1$ebnf$1", "type_arg_list$macrocall$1$ebnf$2"], "postprocess":  
+        d => { 
+          const [first, rest] = [d[0], d[1]];
+          if(rest.length > 0) {
+            const restNodes = rest.map((ts: any[]) => ts[3]);
+            return concat(first, ...restNodes);
+          } else return first;
+        }
+        },
+    {"name": "type_arg_list", "symbols": ["_", {"literal":"("}, "_", "type_arg_list$macrocall$1", "_", {"literal":")"}], "postprocess":  
+        ([, , , d]): TypeConsApp[] => flatten(d) 
+        },
+    {"name": "string_lit", "symbols": [(lexer.has("string_literal") ? {type: "string_literal"} : string_literal)], "postprocess": 
+        ([d]): IStringLit => ({
+          ...nodeData([]),
+          ...rangeOf(d),
+          tag: 'StringLit',
+          contents: d.value
+        })
+        },
+    {"name": "tex_literal", "symbols": [(lexer.has("tex_literal") ? {type: "tex_literal"} : tex_literal)], "postprocess":  
+        ([d]): IStringLit => ({
+          ...nodeData([]),
+          ...rangeOf(d),
+          tag: 'StringLit',
+          contents: d.text.substring(1, d.text.length - 1), // NOTE: remove dollars
+        })
+        },
+    {"name": "identifier", "symbols": [(lexer.has("identifier") ? {type: "identifier"} : identifier)], "postprocess":  
+        ([d]) => ({
+          ...nodeData([]),
+          ...rangeOf(d),
+          tag: 'Identifier',
+          value: d.text,
+          type: "identifier"
+        })
+        },
+    {"name": "comment", "symbols": [(lexer.has("comment") ? {type: "comment"} : comment)], "postprocess": convertTokenId},
+    {"name": "comment", "symbols": [(lexer.has("multiline_comment") ? {type: "multiline_comment"} : multiline_comment)], "postprocess": ([d]) => rangeOf(d)},
+    {"name": "_c_$ebnf$1", "symbols": []},
+    {"name": "_c_$ebnf$1$subexpression$1", "symbols": [(lexer.has("ws") ? {type: "ws"} : ws)]},
+    {"name": "_c_$ebnf$1$subexpression$1", "symbols": ["comment"]},
+    {"name": "_c_$ebnf$1", "symbols": ["_c_$ebnf$1", "_c_$ebnf$1$subexpression$1"], "postprocess": (d) => d[0].concat([d[1]])},
+    {"name": "_c_", "symbols": ["_c_$ebnf$1"]},
+    {"name": "_ml$ebnf$1", "symbols": []},
+    {"name": "_ml$ebnf$1", "symbols": ["_ml$ebnf$1", "multi_line_ws_char"], "postprocess": (d) => d[0].concat([d[1]])},
+    {"name": "_ml", "symbols": ["_ml$ebnf$1"]},
+    {"name": "multi_line_ws_char", "symbols": [(lexer.has("ws") ? {type: "ws"} : ws)]},
+    {"name": "multi_line_ws_char", "symbols": [{"literal":"\n"}]},
+    {"name": "multi_line_ws_char", "symbols": ["comment"]},
+    {"name": "__$ebnf$1", "symbols": [(lexer.has("ws") ? {type: "ws"} : ws)]},
+    {"name": "__$ebnf$1", "symbols": ["__$ebnf$1", (lexer.has("ws") ? {type: "ws"} : ws)], "postprocess": (d) => d[0].concat([d[1]])},
+    {"name": "__", "symbols": ["__$ebnf$1"]},
+    {"name": "_$ebnf$1", "symbols": []},
+    {"name": "_$ebnf$1", "symbols": ["_$ebnf$1", (lexer.has("ws") ? {type: "ws"} : ws)], "postprocess": (d) => d[0].concat([d[1]])},
+    {"name": "_", "symbols": ["_$ebnf$1"]}
   ],
   ParserStart: "input",
 };

--- a/packages/penrose-core/src/types/errors.d.ts
+++ b/packages/penrose-core/src/types/errors.d.ts
@@ -156,6 +156,7 @@ interface ParseError {
   message: string;
 }
 
+// COMBAK Maybe this should be a TaggedSubstanceError?
 interface SelectorDeclTypeError {
   tag: "SelectorDeclTypeError";
   typeName: identifier;

--- a/packages/penrose-core/src/types/errors.d.ts
+++ b/packages/penrose-core/src/types/errors.d.ts
@@ -33,7 +33,13 @@ type DomainError =
   | NotTypeConsInSubtype
   | NotTypeConsInPrelude;
 
-type StyleError = ParseError | GenericStyleError;
+// COMBAK: Move it from the other file
+type StyleError =
+  // Selector errors (from Substance)
+  // | SelectorDeclTypeError
+  // Misc errors
+  | ParseError
+  | GenericStyleError;
 
 interface GenericStyleError {
   tag: "GenericStyleError";

--- a/packages/penrose-core/src/types/errors.d.ts
+++ b/packages/penrose-core/src/types/errors.d.ts
@@ -7,8 +7,7 @@
 type PenroseError =
   | (DomainError & { errorType: "DomainError" })
   | (SubstanceError & { errorType: "SubstanceError" })
-  | (StyleError & { errorType: "StyleError" })
-  | StyError; // COMBAK: Remove this
+  | (StyleError & { errorType: "StyleError" });
 
 // TODO: does type var ever appear in Substance? If not, can we encode that at the type level?
 type SubstanceError =
@@ -125,6 +124,7 @@ type StyleError =
   // Misc errors
   | ParseError
   | GenericStyleError
+  | StyleErrorList
   // Selector errors (from Substance)
   | SelectorDeclTypeError
   | SelectorVarMultipleDecl
@@ -151,12 +151,16 @@ interface GenericStyleError {
   messages: string[];
 }
 
+interface StyleErrorList {
+  tag: "StyleErrorList";
+  errors: StyleError[];
+}
+
 interface ParseError {
   tag: "ParseError";
   message: string;
 }
 
-// COMBAK Maybe this should be a TaggedSubstanceError?
 interface SelectorDeclTypeError {
   tag: "SelectorDeclTypeError";
   typeName: identifier;

--- a/packages/penrose-core/src/types/errors.d.ts
+++ b/packages/penrose-core/src/types/errors.d.ts
@@ -131,13 +131,20 @@ type StyleError =
   | SelectorDeclTypeMismatch
   | SelectorRelTypeMismatch
   | TaggedSubstanceError
-  // Block errors (deletion)
+  // Translation errors (deletion)
   | DeletedPropWithNoSubObjError
   | DeletedPropWithNoFieldError
   | DeletedPropWithNoGPIError
   | CircularPathAlias
   | DeletedNonexistentFieldError
-  | DeletedVectorElemError;
+  | DeletedVectorElemError
+  // Translation errors (insertion)
+  | InsertedPathWithoutOverrideError
+  | InsertedPropWithNoFieldError
+  | InsertedPropWithNoGPIError
+  // Runtime errors
+  | RuntimeValueTypeError
+  ;
 
 interface GenericStyleError {
   tag: "GenericStyleError";
@@ -212,6 +219,35 @@ interface DeletedNonexistentFieldError {
 interface DeletedVectorElemError {
   tag: "DeletedVectorElemError";
   path: Path;
+};
+
+interface InsertedPathWithoutOverrideError {
+  tag: "InsertedPathWithoutOverrideError";
+  path: Path;
+};
+
+interface InsertedPropWithNoFieldError {
+  tag: "InsertedPropWithNoFieldError";
+  subObj: BindingForm;
+  field: Identifier;
+  property: Identifier;
+  path: Path;
+};
+
+interface InsertedPropWithNoGPIError {
+  tag: "InsertedPropWithNoGPIError";
+  subObj: BindingForm;
+  field: Identifier;
+  property: Identifier;
+  path: Path;
+};
+
+// TODO(errors): use identifiers here
+interface RuntimeValueTypeError {
+  tag: "RuntimeValueTypeError";
+  path: Path;
+  expectedType: string;
+  actualType: string;
 };
 
 //#endregion Style errors

--- a/packages/penrose-core/src/types/errors.d.ts
+++ b/packages/penrose-core/src/types/errors.d.ts
@@ -7,7 +7,8 @@
 type PenroseError =
   | (DomainError & { errorType: "DomainError" })
   | (SubstanceError & { errorType: "SubstanceError" })
-  | (StyleError & { errorType: "StyleError" });
+  | (StyleError & { errorType: "StyleError" })
+  | StyError; // COMBAK: Remove this
 
 // TODO: does type var ever appear in Substance? If not, can we encode that at the type level?
 type SubstanceError =
@@ -32,24 +33,6 @@ type DomainError =
   | CyclicSubtypes
   | NotTypeConsInSubtype
   | NotTypeConsInPrelude;
-
-// COMBAK: Move it from the other file
-type StyleError =
-  // Selector errors (from Substance)
-  // | SelectorDeclTypeError
-  // Misc errors
-  | ParseError
-  | GenericStyleError;
-
-interface GenericStyleError {
-  tag: "GenericStyleError";
-  messages: string[];
-}
-
-interface ParseError {
-  tag: "ParseError";
-  message: string;
-}
 
 interface UnexpectedExprForNestedPred {
   tag: "UnexpectedExprForNestedPred";
@@ -135,3 +118,100 @@ interface FatalError {
 type ErrorSource = ASTNode;
 
 //#endregion
+
+//#region Style errors
+
+type StyleError =
+  // Misc errors
+  | ParseError
+  | GenericStyleError
+  // Selector errors (from Substance)
+  | SelectorDeclTypeError
+  | SelectorVarMultipleDecl
+  | SelectorDeclTypeMismatch
+  | SelectorRelTypeMismatch
+  | TaggedSubstanceError
+  // Block errors (deletion)
+  | DeletedPropWithNoSubObjError
+  | DeletedPropWithNoFieldError
+  | DeletedPropWithNoGPIError
+  | CircularPathAlias
+  | DeletedNonexistentFieldError
+  | DeletedVectorElemError;
+
+interface GenericStyleError {
+  tag: "GenericStyleError";
+  messages: string[];
+}
+
+interface ParseError {
+  tag: "ParseError";
+  message: string;
+}
+
+interface SelectorDeclTypeError {
+  tag: "SelectorDeclTypeError";
+  typeName: identifier;
+};
+
+interface SelectorVarMultipleDecl {
+  tag: "SelectorVarMultipleDecl";
+  varName: BindingForm;
+};
+
+interface SelectorDeclTypeMismatch {
+  tag: "SelectorDeclTypeMismatch";
+  subType: TypeConsApp;
+  styType: TypeConsApp;
+};
+
+interface SelectorRelTypeMismatch {
+  tag: "SelectorRelTypeMismatch";
+  varType: TypeConsApp;
+  exprType: TypeConsApp;
+};
+
+interface TaggedSubstanceError {
+  tag: "TaggedSubstanceError";
+  error: SubstanceError
+};
+
+interface DeletedPropWithNoSubObjError {
+  tag: "DeletedPropWithNoSubObjError";
+  subObj: BindingForm;
+  path: Path;
+};
+
+interface DeletedPropWithNoFieldError {
+  tag: "DeletedPropWithNoFieldError";
+  subObj: BindingForm;
+  field: Identifier;
+  path: Path;
+};
+
+interface CircularPathAlias {
+  tag: "CircularPathAlias";
+  path: Path;
+};
+
+interface DeletedPropWithNoGPIError {
+  tag: "DeletedPropWithNoGPIError";
+  subObj: BindingForm;
+  field: Identifier;
+  property: Identifier;
+  path: Path;
+};
+
+interface DeletedNonexistentFieldError {
+  tag: "DeletedNonexistentFieldError";
+  subObj: BindingForm;
+  field: Identifier;
+  path: Path;
+};
+
+interface DeletedVectorElemError {
+  tag: "DeletedVectorElemError";
+  path: Path;
+};
+
+//#endregion Style errors

--- a/packages/penrose-core/src/types/types.d.ts
+++ b/packages/penrose-core/src/types/types.d.ts
@@ -56,7 +56,7 @@ type TrMap<T> = { [k: string]: { [k: string]: FieldExpr<T> } };
 interface ITrans<T> {
   // TODO: compGraph
   trMap: TrMap<T>;
-  warnings: StyError[];
+  warnings: StyleError[];
 }
 
 type FieldExpr<T> = IFExpr<T> | IFGPI<T>;

--- a/packages/penrose-core/src/types/types.d.ts
+++ b/packages/penrose-core/src/types/types.d.ts
@@ -56,7 +56,7 @@ type TrMap<T> = { [k: string]: { [k: string]: FieldExpr<T> } };
 interface ITrans<T> {
   // TODO: compGraph
   trMap: TrMap<T>;
-  warnings: string[];
+  warnings: StyError[];
 }
 
 type FieldExpr<T> = IFExpr<T> | IFGPI<T>;
@@ -1681,7 +1681,7 @@ interface ErrorSource {
   node: ASTNode;
 }
 
-type Warning = string;
+type Warning = StyError;
 //#endregion
 
 //#region Style errors
@@ -1695,6 +1695,12 @@ type StyError =
   | SelectorDeclTypeMismatch
   | SelectorRelTypeMismatch
   | TaggedSubstanceError
+  | DeletedPropWithNoSubObjError
+  | DeletedPropWithNoFieldError
+  | DeletedPropWithNoGPIError
+  | CircularPathAlias
+  | DeletedNonexistentFieldError
+  | DeletedVectorElemError
   | string;
 
 interface SelectorDeclTypeError {
@@ -1723,4 +1729,43 @@ interface TaggedSubstanceError {
   tag: "TaggedSubstanceError";
   error: SubstanceError
 };
+
+interface DeletedPropWithNoSubObjError {
+  tag: "DeletedPropWithNoSubObjError";
+  subObj: BindingForm;
+  path: Path;
+};
+
+interface DeletedPropWithNoFieldError {
+  tag: "DeletedPropWithNoFieldError";
+  subObj: BindingForm;
+  field: Identifier;
+  path: Path;
+};
+
+interface CircularPathAlias {
+  tag: "CircularPathAlias";
+  path: Path;
+};
+
+interface DeletedPropWithNoGPIError {
+  tag: "DeletedPropWithNoGPIError";
+  subObj: BindingForm;
+  field: Identifier;
+  property: Identifier;
+  path: Path;
+};
+
+interface DeletedNonexistentFieldError {
+  tag: "DeletedNonexistentFieldError";
+  subObj: BindingForm;
+  field: Identifier;
+  path: Path;
+};
+
+interface DeletedVectorElemError {
+  tag: "DeletedVectorElemError";
+  path: Path;
+};
+
 //#endregion

--- a/packages/penrose-core/src/types/types.d.ts
+++ b/packages/penrose-core/src/types/types.d.ts
@@ -1582,8 +1582,8 @@ interface ISelEnv {
   // Variable => [Substance or Style variable, original data structure with program locs etc]
   skipBlock: Bool;
   header: Maybe<Header>; // Just for debugging
-  warnings: StyErrors;
-  errors: StyErrors;
+  warnings: StyleErrors;
+  errors: StyleErrors;
 }
 // Currently used to track if any Substance variables appear in a selector but not a Substance program (in which case, we skip the block)
 
@@ -1644,7 +1644,7 @@ interface Identifier extends ASTNode {
 
 //#region
 
-type StyErrors = StyError[];
+type StyleErrors = StyleError[];
 // TODO: Convert this to StyleError[]
 
 interface Left<A> {
@@ -1681,91 +1681,5 @@ interface ErrorSource {
   node: ASTNode;
 }
 
-type Warning = StyError;
-//#endregion
-
-//#region Style errors
-// COMBAK move out into Error.ts and combine with Error after all style types are converted, and remove string, and get rid of showStyErr
-// At that point, remove genericStyleError use
-
-type StyError =
-  // Selector errors (from Substance)
-  | SelectorDeclTypeError
-  | SelectorVarMultipleDecl
-  | SelectorDeclTypeMismatch
-  | SelectorRelTypeMismatch
-  | TaggedSubstanceError
-  | DeletedPropWithNoSubObjError
-  | DeletedPropWithNoFieldError
-  | DeletedPropWithNoGPIError
-  | CircularPathAlias
-  | DeletedNonexistentFieldError
-  | DeletedVectorElemError
-  | string;
-
-interface SelectorDeclTypeError {
-  tag: "SelectorDeclTypeError";
-  typeName: identifier;
-};
-
-interface SelectorVarMultipleDecl {
-  tag: "SelectorVarMultipleDecl";
-  varName: BindingForm;
-};
-
-interface SelectorDeclTypeMismatch {
-  tag: "SelectorDeclTypeMismatch";
-  subType: TypeConsApp;
-  styType: TypeConsApp;
-};
-
-interface SelectorRelTypeMismatch {
-  tag: "SelectorRelTypeMismatch";
-  varType: TypeConsApp;
-  exprType: TypeConsApp;
-};
-
-interface TaggedSubstanceError {
-  tag: "TaggedSubstanceError";
-  error: SubstanceError
-};
-
-interface DeletedPropWithNoSubObjError {
-  tag: "DeletedPropWithNoSubObjError";
-  subObj: BindingForm;
-  path: Path;
-};
-
-interface DeletedPropWithNoFieldError {
-  tag: "DeletedPropWithNoFieldError";
-  subObj: BindingForm;
-  field: Identifier;
-  path: Path;
-};
-
-interface CircularPathAlias {
-  tag: "CircularPathAlias";
-  path: Path;
-};
-
-interface DeletedPropWithNoGPIError {
-  tag: "DeletedPropWithNoGPIError";
-  subObj: BindingForm;
-  field: Identifier;
-  property: Identifier;
-  path: Path;
-};
-
-interface DeletedNonexistentFieldError {
-  tag: "DeletedNonexistentFieldError";
-  subObj: BindingForm;
-  field: Identifier;
-  path: Path;
-};
-
-interface DeletedVectorElemError {
-  tag: "DeletedVectorElemError";
-  path: Path;
-};
-
+type Warning = StyleError;
 //#endregion

--- a/packages/penrose-core/src/types/types.d.ts
+++ b/packages/penrose-core/src/types/types.d.ts
@@ -1644,7 +1644,7 @@ interface Identifier extends ASTNode {
 
 //#region
 
-type StyErrors = string[];
+type StyErrors = StyError[];
 // TODO: Convert this to StyleError[]
 
 interface Left<A> {
@@ -1682,4 +1682,45 @@ interface ErrorSource {
 }
 
 type Warning = string;
+//#endregion
+
+//#region Style errors
+// COMBAK move out into Error.ts and combine with Error after all style types are converted, and remove string, and get rid of showStyErr
+// At that point, remove genericStyleError use
+
+type StyError =
+  // Selector errors (from Substance)
+  | SelectorDeclTypeError
+  | SelectorVarMultipleDecl
+  | SelectorDeclTypeMismatch
+  | SelectorRelTypeMismatch
+  | TaggedSubstanceError
+  | string;
+
+interface SelectorDeclTypeError {
+  tag: "SelectorDeclTypeError";
+  typeName: identifier;
+};
+
+interface SelectorVarMultipleDecl {
+  tag: "SelectorVarMultipleDecl";
+  varName: BindingForm;
+};
+
+interface SelectorDeclTypeMismatch {
+  tag: "SelectorDeclTypeMismatch";
+  subType: TypeConsApp;
+  styType: TypeConsApp;
+};
+
+interface SelectorRelTypeMismatch {
+  tag: "SelectorRelTypeMismatch";
+  varType: TypeConsApp;
+  exprType: TypeConsApp;
+};
+
+interface TaggedSubstanceError {
+  tag: "TaggedSubstanceError";
+  error: SubstanceError
+};
 //#endregion

--- a/packages/penrose-core/src/utils/Error.ts
+++ b/packages/penrose-core/src/utils/Error.ts
@@ -1,9 +1,18 @@
 import { showType } from "compiler/Domain";
+import { prettyPrintPath } from "utils/OtherUtils";
 import { Maybe, Result } from "true-myth";
 const { or, and, ok, err, andThen, match, ap, unsafelyUnwrap, isErr, unsafelyGetErr } = Result;
 
 //#region Style errors
 // COMBAK combine with overall `show` function
+
+// COMBAK What's a better way to model warnings?
+export const styWarnings = [
+  "DeletedPropWithNoSubObjError",
+  "DeletedPropWithNoFieldError",
+  "DeletedPropWithNoGPIError",
+  "DeletedNonexistentFieldError",
+];
 
 // COMBAK suggest improvements
 export const showStyErr = (e: StyError): string => {
@@ -30,6 +39,31 @@ export const showStyErr = (e: StyError): string => {
 
       case "TaggedSubstanceError": {
         return showError(e.error); // Substance error
+      };
+
+      case "DeletedPropWithNoSubObjError": {
+        return `Sub obj '${e.subObj.contents.value}' has no fields; can't delete path '${prettyPrintPath(e.path)}'`;
+      };
+
+      case "DeletedPropWithNoFieldError": {
+        return `Sub obj '${e.subObj.contents.value}' already lacks field ${e.field.value}; can't delete path '${prettyPrintPath(e.path)}'`;
+      };
+
+      case "CircularPathAlias": {
+        return `Path ${prettyPrintPath(e.path)} was aliased to itself`;
+      };
+
+      case "DeletedPropWithNoGPIError": {
+        return `Sub obj '${e.subObj.contents.value}' does not have GPI '${e.field.value}'; cannot delete property '${e.property.value} in ${prettyPrintPath(e.path)}'`;
+      };
+
+      // TODO: Use input path to report location?
+      case "DeletedNonexistentFieldError": {
+        return `Trying to delete '${e.field.value} from SubObj '${e.subObj.contents.value}', which already lacks the field`;
+      };
+
+      case "DeletedVectorElemError": {
+        return `Cannot delete an element of a vector: ${prettyPrintPath(e.path)}`;
       };
 
       default: {

--- a/packages/penrose-core/src/utils/Error.ts
+++ b/packages/penrose-core/src/utils/Error.ts
@@ -134,19 +134,22 @@ export const showError = (
     // COMBAK suggest improvements after reporting errors
 
     case "SelectorDeclTypeError": {
+      // COMBAK Maybe this should be a TaggedSubstanceError?
       return "Substance type error in declaration in selector";
     }
 
     case "SelectorVarMultipleDecl": {
-      return "Style pattern statement has already declared the variable";
+      return "Style pattern statement has already declared the variable ${error.varName.value}";
     }
 
     case "SelectorDeclTypeMismatch": {
-      return "mismatched types or wrong subtypes between Substance and Style variables in selector";
+      // COMBAK: Add code for prettyprinting types
+      return "Mismatched types or wrong subtypes between Substance and Style variables in selector";
     };
 
     case "SelectorRelTypeMismatch": {
-      return "mismatched types or wrong subtypes between variable and expression in relational statement in selector";
+      // COMBAK: Add code for prettyprinting types
+      return "Mismatched types or wrong subtypes between variable and expression in relational statement in selector";
     };
 
     case "TaggedSubstanceError": {

--- a/packages/penrose-core/src/utils/Error.ts
+++ b/packages/penrose-core/src/utils/Error.ts
@@ -1,6 +1,48 @@
 import { showType } from "compiler/Domain";
 import { Maybe, Result } from "true-myth";
-const { or, and, ok, err, andThen, match, ap, unsafelyUnwrap, isErr } = Result;
+const { or, and, ok, err, andThen, match, ap, unsafelyUnwrap, isErr, unsafelyGetErr } = Result;
+
+//#region Style errors
+// COMBAK combine with overall `show` function
+
+// COMBAK suggest improvements
+export const showStyErr = (e: StyError): string => {
+  // COMBAK fix these matches after strings are gone
+  console.log("showing sty err COMBAK", e);
+
+  if (typeof e === "object") {
+    switch (e.tag) {
+      case "SelectorDeclTypeError": {
+        return "Substance type error in declaration in selector";
+      }
+
+      case "SelectorVarMultipleDecl": {
+        return "Style pattern statement has already declared the variable";
+      }
+
+      case "SelectorDeclTypeMismatch": {
+        return "mismatched types or wrong subtypes between Substance and Style variables in selector";
+      };
+
+      case "SelectorRelTypeMismatch": {
+        return "mismatched types or wrong subtypes between variable and expression in relational statement in selector";
+      };
+
+      case "TaggedSubstanceError": {
+        return showError(e.error); // Substance error
+      };
+
+      default: {
+        throw Error("unknown error");
+      }
+    }
+  } else if (typeof e === "string") {
+    return e;
+  }
+  throw Error("unknown tag");
+};
+
+//#endregion
 
 // #region error rendering and construction
 
@@ -90,27 +132,27 @@ export const showError = (
       const { sourceExpr, sourceType, expectedExpr, expectedType } = error;
       return `${expectedType.args.length} arguments expected for type ${
         expectedType.name.value
-      } (defined at ${loc(expectedExpr)}), but ${
+        } (defined at ${loc(expectedExpr)}), but ${
         sourceType.args.length
-      } arguments were given for ${sourceType.name.value} at ${loc(
-        sourceExpr
-      )} `;
+        } arguments were given for ${sourceType.name.value} at ${loc(
+          sourceExpr
+        )} `;
     }
     case "ArgLengthMismatch": {
       const { name, argsGiven, argsExpected, sourceExpr, expectedExpr } = error;
       return `${name.value} expects ${
         argsExpected.length
-      } arguments (originally defined at ${loc(expectedExpr)}), but was given ${
+        } arguments (originally defined at ${loc(expectedExpr)}), but was given ${
         argsGiven.length
-      } arguments instead at ${loc(sourceExpr)}.`;
+        } arguments instead at ${loc(sourceExpr)}.`;
     }
     case "DeconstructNonconstructor": {
       const { variable, field } = error.deconstructor;
       return `Becuase ${variable.value} is not bound to a constructor, ${
         variable.value
-      }.${field.value} (at ${loc(
-        error.deconstructor
-      )}) does not correspond to a field value.`;
+        }.${field.value} (at ${loc(
+          error.deconstructor
+        )}) does not correspond to a field value.`;
     }
     case "UnexpectedExprForNestedPred": {
       const { sourceExpr, sourceType, expectedExpr } = error;
@@ -249,17 +291,17 @@ export const parseError = (message: string): ParseError => ({
   message,
 });
 
-export const genericStyleError = (messages: string[]): PenroseError => ({
+export const genericStyleError = (messages: StyError[]): PenroseError => ({
   errorType: "StyleError",
   tag: "GenericStyleError",
-  messages,
+  messages: messages.map(showStyErr),
 });
 
 // const loc = (node: ASTNode) => `${node.start.line}:${node.start.col}`;
 // TODO: Show file name
 const loc = (node: ASTNode) =>
   `line ${node.start.line}, column ${node.start.col + 1} of ${
-    node.nodeType
+  node.nodeType
   } program`;
 
 // #endregion
@@ -322,6 +364,7 @@ export {
   match,
   unsafelyUnwrap,
   isErr,
+  unsafelyGetErr
 };
 
 // #endregion

--- a/packages/penrose-core/src/utils/Error.ts
+++ b/packages/penrose-core/src/utils/Error.ts
@@ -178,6 +178,23 @@ export const showError = (
       return `Cannot delete an element of a vector: ${prettyPrintPath(error.path)}`;
     };
 
+    case "InsertedPathWithoutOverrideError": {
+      return "Overriding path ${prettyPrintPath(error.path)} without override flag set";
+    };
+
+    case "InsertedPropWithNoFieldError": {
+      return `Sub obj '${error.subObj.contents.value}' does not have Field '${error.field.value}'; cannot add property '${error.property.value} in ${prettyPrintPath(error.path)}'`;
+    };
+
+    case "InsertedPropWithNoGPIError": {
+      return `Sub obj '${error.subObj.contents.value}' has field but does not have GPI '${error.field.value}'; cannot add property '${error.property.value} in ${prettyPrintPath(error.path)}'. Expected GPI.`;
+    };
+
+    // TODO(errors): use identifiers here
+    case "RuntimeValueTypeError": {
+      return `Runtime type error in looking up path '${prettyPrintPath(error.path)}''s value in translation. Expected type: ${error.expectedType}. Got type: ${error.actualType}.`;
+    };
+
     // ----- END STYLE ERRORS
 
     case "Fatal": {

--- a/packages/penrose-core/src/utils/Error.ts
+++ b/packages/penrose-core/src/utils/Error.ts
@@ -18,9 +18,6 @@ export const showError = (
   error: DomainError | SubstanceError | StyleError
 ): string => {
   switch (error.tag) {
-    case "GenericStyleError": {
-      return `DEBUG: Style failed with errors:\n ${error.messages.join("\n")}`;
-    }
     case "ParseError":
       return error.message;
     case "TypeDeclared": {
@@ -133,9 +130,17 @@ export const showError = (
     // ---- BEGIN STYLE ERRORS
     // COMBAK suggest improvements after reporting errors
 
+    case "GenericStyleError": {
+      return `DEBUG: Style failed with errors:\n ${error.messages.join("\n")}`;
+    }
+
     case "SelectorDeclTypeError": {
       // COMBAK Maybe this should be a TaggedSubstanceError?
       return "Substance type error in declaration in selector";
+    }
+
+    case "StyleErrorList": {
+      return error.errors.map(showError).join(", ");
     }
 
     case "SelectorVarMultipleDecl": {
@@ -330,16 +335,16 @@ export const parseError = (message: string): ParseError => ({
 });
 
 // If there are multiple errors, just return the tag of the first one
-export const firstStyleError = (messages: StyleError[]): PenroseError => {
-  if (!messages.length) {
+export const toStyleErrors = (errors: StyleError[]): PenroseError => {
+  if (!errors.length) {
     throw Error("internal error: expected at least one Style error");
   }
 
   return {
     errorType: "StyleError",
-    tag: messages[0].tag, // COMBAK: is this confusing for showError?
-    messages: messages.map(showError),
-  }
+    tag: "StyleErrorList",
+    errors
+  };
 };
 
 export const genericStyleError = (messages: StyleError[]): PenroseError => ({

--- a/packages/penrose-core/src/utils/Error.ts
+++ b/packages/penrose-core/src/utils/Error.ts
@@ -179,7 +179,7 @@ export const showError = (
     };
 
     case "InsertedPathWithoutOverrideError": {
-      return "Overriding path ${prettyPrintPath(error.path)} without override flag set";
+      return `Overriding path ${prettyPrintPath(error.path)} without override flag set`;
     };
 
     case "InsertedPropWithNoFieldError": {


### PR DESCRIPTION
# Description

Related issue/PR: #446 

This PR improves the Style compiler error-handling so that all existing errors are modeled and reported separately, and adds tests for most of them.

Note that this is a **first pass** at cleaning up the errors that **already exist** in the Style compiler; I anticipate that actually using the system will help us discover many more kinds of errors that should be reported, and in other parts of the system, especially at runtime.

# Implementation strategy and design decisions

The PR follows the strategy broadly described in https://github.com/penrose/penrose/pull/446#issuecomment-772064166. 

It extends `errors.d.ts` with error types and `showError` in `Error.ts` with error-printing code. Tests are in `Style.test.ts`. Runtime errors are in `insertExpr`.

Errors are roughly split up between misc errors, selector checking errors, errors in generating the translation (deleting or inserting paths), and runtime errors.

# Examples with steps to reproduce them

Run the test suite: `yarn run test -t Compiler --watchAll=true`

# Checklist

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] New and existing tests pass locally using `yarn test`
- [ ] I ran `yarn docs` and there were no errors when generating the HTML site
- [x] My code follows the style guidelines of this project (e.g.: no ESLint warnings)

# Open questions

- [ ] There are a couple of modeled errors that aren't properly thrown because the system fails with a different error before then (see a couple of examples in `Style.test.ts`), so their tests are commented out. Ideally, these should be caught earlier, at the point of failure.
- [ ] Improve the amount of information reported by `showError`.
- [ ] Improve handling of warnings in `compileStyle`. First, they are accumulated as warnings in the `Translation` but maybe they should be fatal? (Unless there are some design problems with Style that make them unavoidable, as has happened in the past?) Second, all warnings are currently treated as errors anyway.
- [ ] Improve handling of multiple errors; currently Style compiler reports the tag of the first error, plus the messages for all of them.
- [ ] Suggest ways to improve errors.
- [ ] Handle runtime errors.
