### PR TITLE
Do more Style/translation checking statically

### DIFF
--- a/examples/set-theory-domain/venn-3d.sty
+++ b/examples/set-theory-domain/venn-3d.sty
@@ -1,8 +1,6 @@
 Set x {
     x.shape = Circle {
-    -- Test case
-        -- strokeWidth : 0
-        strokeWidth : x.r
+        strokeWidth : 0.
     }
 
     x.shading = Image {
@@ -26,18 +24,12 @@ Set x {
         h: 0.5 * x.shape.r
     }
 
-    -- Test case 1
     ensure contains(x.shape, x.text)
-    -- ensure contains(x.shape.zzz, x.text)
-
     ensure minSize(x.shape)
     ensure maxSize(x.shape)
     encourage sameCenter(x.text, x.shape)
 
-    -- Test case 2
     x.shape below x.text
-    -- x.kdjhfd below x.text
-
     x.shading below x.shape
     x.shadow below x.shading
 }

--- a/examples/set-theory-domain/venn-3d.sty
+++ b/examples/set-theory-domain/venn-3d.sty
@@ -1,6 +1,8 @@
 Set x {
     x.shape = Circle {
+        -- Test case 0
         strokeWidth : 0.
+        -- strokeWidth : x.r
     }
 
     x.shading = Image {
@@ -24,12 +26,18 @@ Set x {
         h: 0.5 * x.shape.r
     }
 
+    -- Test case 1
     ensure contains(x.shape, x.text)
+    -- ensure contains(x.shape.zzz, x.text)
+
     ensure minSize(x.shape)
     ensure maxSize(x.shape)
     encourage sameCenter(x.text, x.shape)
 
+    -- Test case 2
     x.shape below x.text
+    -- x.kdjhfd below x.text
+
     x.shading below x.shape
     x.shadow below x.shading
 }

--- a/examples/set-theory-domain/venn-3d.sty
+++ b/examples/set-theory-domain/venn-3d.sty
@@ -1,6 +1,8 @@
 Set x {
     x.shape = Circle {
-        strokeWidth : 0
+    -- Test case
+        -- strokeWidth : 0
+        strokeWidth : x.r
     }
 
     x.shading = Image {
@@ -24,11 +26,18 @@ Set x {
         h: 0.5 * x.shape.r
     }
 
+    -- Test case 1
     ensure contains(x.shape, x.text)
+    -- ensure contains(x.shape.zzz, x.text)
+
     ensure minSize(x.shape)
     ensure maxSize(x.shape)
     encourage sameCenter(x.text, x.shape)
+
+    -- Test case 2
     x.shape below x.text
+    -- x.kdjhfd below x.text
+
     x.shading below x.shape
     x.shadow below x.shading
 }

--- a/examples/set-theory-domain/venn.sty
+++ b/examples/set-theory-domain/venn.sty
@@ -17,7 +17,7 @@ forall Set x {
 forall Set x; Set y
 where IsSubset(x, y) {
 
-    ensure smallerThan(x.icon, y.icon)
+    ensure smallerThan(x.icon.zzz, y.icon)
     ensure outsideOf(y.text, x.icon)
     ensure contains(y.icon, x.icon, 5.0)
     x.icon above y.icon

--- a/examples/set-theory-domain/venn.sty
+++ b/examples/set-theory-domain/venn.sty
@@ -17,7 +17,7 @@ forall Set x {
 forall Set x; Set y
 where IsSubset(x, y) {
 
-    ensure smallerThan(x.icon.zzz, y.icon)
+    ensure smallerThan(x.icon, y.icon)
     ensure outsideOf(y.text, x.icon)
     ensure contains(y.icon, x.icon, 5.0)
     x.icon above y.icon

--- a/packages/browser-ui/src/App.tsx
+++ b/packages/browser-ui/src/App.tsx
@@ -10,6 +10,7 @@ import {
   prepareState,
   stateInitial,
   stepUntilConvergence,
+  showError
 } from "@penrose/core";
 
 /**
@@ -175,7 +176,8 @@ class App extends React.Component<any, ICanvasState> {
         } else {
           void console.error(
             "Failed to compile with errors:",
-            compileRes.error
+            compileRes.error,
+            compileRes.error.errors.map(showError)
           );
         }
       },

--- a/packages/core/src/compiler/Style.test.ts
+++ b/packages/core/src/compiler/Style.test.ts
@@ -275,7 +275,9 @@ describe("Compiler", () => {
         (res) => S.compileStyle(styProg, ...res),
         subRes
       );
-      expectErrorOf(styRes, errorType);
+      describe(errorType, () => {
+        expectErrorOf(styRes, errorType);
+      });
     };
 
     const errorStyProgs = {
@@ -295,6 +297,29 @@ describe("Compiler", () => {
         `forall Set x; Point y
 where IsSubset(y, x) { }`,
       ],
+
+      // ---------- Block static errors
+
+      InvalidGPITypeError: [`forall Set x { x.icon = Circl { } }`],
+
+      // COMBAK: Check that multiple wrong properties are checked -- i.e. this dict ontology has to be extended so that one program can have multiple errors
+      InvalidGPIPropertyError:
+        [`forall Set x {  
+          x.icon = Circle { 
+           centre: (0.0, 0.0) 
+           r: 9.
+           diameter: 100.
+         } 
+       }`],
+
+      // Have to do a nested search in expressions for this
+      InvalidFunctionNameError: [`forall Set x { x.icon = Circle { r: ksajfksdafksfh(0.0, "hi") } }`,
+        `forall Set x { x.icon = Circle { r: get(0.0, sjkfhsdk("hi")) } }`,
+        `forall Set x { x.icon = Circle { r: wjhkej(0.0, sjkfhsdk("hi")) } }`],
+
+      InvalidObjectiveNameError: [`forall Set x { encourage sjdhfksha(0.0) }`],
+
+      InvalidConstraintNameError: [`forall Set x { ensure jahfkjdhf(0.0) }`],
 
       // ------- Translation errors (deletion)
       DeletedPropWithNoSubObjError: [`forall Set x { delete y.z.p }`],
@@ -352,6 +377,38 @@ delete x.z.p }`,
 }`,
       ],
 
+      // ----------- Translation validation errors
+      // TODO(errors): check multiple errors
+
+      // TODO(errors): This throws too early, gives InsertedPathWithoutOverrideError -- correctly throws error but may be misleading
+
+      // NonexistentNameError:
+      //   [`forall Set x { A.z = 0. }`],
+
+      NonexistentFieldError:
+        [`forall Set x { x.icon = Circle { r: x.r } }`],
+      NonexistentGPIError:
+        [`forall Set x {  
+         x.z = x.c.p
+       }`],
+      NonexistentPropertyError:
+        [`forall Set x {  
+          x.icon = Circle { 
+           r: 9.
+           center: (x.icon.z, 0.0)
+         } 
+       }`],
+      ExpectedGPIGotFieldError:
+        [`forall Set x { 
+           x.z = 1.0 
+           x.y = x.z.p
+}`],
+      InvalidAccessPathError:
+        [`forall Set x { 
+           x.z = 1.0 
+           x.y = x.z[0]
+}`],
+
       // ---------- Runtime errors (insertExpr)
 
       // COMBAK / TODO(errors): Test this more thoroughly
@@ -386,6 +443,8 @@ delete x.z.p }`,
     // Test that each program yields its error type
     for (const [errorType, styProgs] of Object.entries(errorStyProgs)) {
       for (const styProg of styProgs) {
+        // TODO(error): improve this so it becomes individual tests, using the framework
+        // console.log("testing", errorType);
         testStyProgForError(styProg, errorType);
       }
     }

--- a/packages/core/src/compiler/Style.ts
+++ b/packages/core/src/compiler/Style.ts
@@ -2444,7 +2444,7 @@ const convertFns = (fns: Either<StyleOptFn, StyleOptFn>[]): [Fn[], Fn[]] => {
 
 // Extract number from a more complicated type
 // also ported from `lookupPaths`
-const getNum = (e: TagExpr<VarAD> | IFGPI<VarAD> | StyleError): number => {
+const getNum = (e: TagExpr<VarAD> | IFGPI<VarAD>): number => {
   if (e.tag === "OptEval") {
     if (e.contents.tag === "Fix") {
       return e.contents.contents;

--- a/packages/core/src/compiler/venn-3d-test.sty
+++ b/packages/core/src/compiler/venn-3d-test.sty
@@ -1,6 +1,10 @@
+-- Program for real test cases for Style errors
+
 Set x {
     x.shape = Circle {
+        -- Test case 0
         strokeWidth : 0.
+        -- strokeWidth : x.r
     }
 
     x.shading = Image {
@@ -24,12 +28,18 @@ Set x {
         h: 0.5 * x.shape.r
     }
 
+    -- Test case 1
     ensure contains(x.shape, x.text)
+    -- ensure contains(x.shape.zzz, x.text)
+
     ensure minSize(x.shape)
     ensure maxSize(x.shape)
     encourage sameCenter(x.text, x.shape)
 
+    -- Test case 2
     x.shape below x.text
+    -- x.kdjhfd below x.text
+
     x.shading below x.shape
     x.shadow below x.shading
 }
@@ -40,7 +50,11 @@ where IsSubset(x, y) {
     ensure outsideOf(y.text, x.shape)
     ensure contains(y.shape, x.shape, 5.0)
     x.shape above y.shape
+
+    -- Test case 3
     y.text below x.shape
+    -- y.text.z below x.shape
+
     x.shadow above y.shape
 }
 

--- a/packages/core/src/engine/EngineUtils.ts
+++ b/packages/core/src/engine/EngineUtils.ts
@@ -12,204 +12,204 @@ const clone = rfdc({ proto: false, circles: false });
 
 // For wrapping temp Style errors until figuring out how they should be categorized
 export const wrapErr = (s: string): StyleError => {
-  return {
-    tag: "GenericStyleError",
-    messages: [s],
-  };
+    return {
+        tag: "GenericStyleError",
+        messages: [s],
+    };
 };
 
 // TODO(errors): should these kinds of errors be caught by block statics rather than failing at runtime?
 export const runtimeValueTypeError = (
-  path: Path,
-  expectedType: string,
-  actualType: string
+    path: Path,
+    expectedType: string,
+    actualType: string
 ): StyleError => {
-  return {
-    tag: "RuntimeValueTypeError",
-    path,
-    expectedType,
-    actualType,
-  };
+    return {
+        tag: "RuntimeValueTypeError",
+        path,
+        expectedType,
+        actualType,
+    };
 };
 
 // Generic utils for mapping over values
 
 export function mapTup2<T, S>(f: (arg: T) => S, t: [T, T]): [S, S] {
-  // TODO: Polygon seems to be getting through with null to the frontend with previously working set examples -- not sure why?
-  // TODO: Should do null checks more systematically across the translation
-  if (t[0] === null || t[1] === null) {
-    return ([varOf(0.0), varOf(0.0)] as unknown) as [S, S];
-  }
+    // TODO: Polygon seems to be getting through with null to the frontend with previously working set examples -- not sure why?
+    // TODO: Should do null checks more systematically across the translation
+    if (t[0] === null || t[1] === null) {
+        return ([varOf(0.0), varOf(0.0)] as unknown) as [S, S];
+    }
 
-  return [f(t[0]), f(t[1])];
+    return [f(t[0]), f(t[1])];
 }
 
 function mapTup3<T, S>(f: (arg: T) => S, t: [T, T, T]): [S, S, S] {
-  return [f(t[0]), f(t[1]), f(t[2])];
+    return [f(t[0]), f(t[1]), f(t[2])];
 }
 
 function mapTup4<T, S>(f: (arg: T) => S, t: [T, T, T, T]): [S, S, S, S] {
-  return [f(t[0]), f(t[1]), f(t[2]), f(t[3])];
+    return [f(t[0]), f(t[1]), f(t[2]), f(t[3])];
 }
 
 function mapTup2LList<T, S>(f: (arg: T) => S, xss: [T, T][][]): [S, S][][] {
-  return xss.map((xs) => xs.map((t) => [f(t[0]), f(t[1])]));
+    return xss.map((xs) => xs.map((t) => [f(t[0]), f(t[1])]));
 }
 
 // Mapping over values
 
 function mapFloat<T, S>(f: (arg: T) => S, v: IFloatV<T>): IFloatV<S> {
-  return {
-    tag: "FloatV",
-    contents: f(v.contents),
-  };
+    return {
+        tag: "FloatV",
+        contents: f(v.contents),
+    };
 }
 
 function mapPt<T, S>(f: (arg: T) => S, v: IPtV<T>): IPtV<S> {
-  return {
-    tag: "PtV",
-    contents: mapTup2(f, v.contents) as [S, S],
-  };
+    return {
+        tag: "PtV",
+        contents: mapTup2(f, v.contents) as [S, S],
+    };
 }
 
 function mapPtList<T, S>(f: (arg: T) => S, v: IPtListV<T>): IPtListV<S> {
-  return {
-    tag: "PtListV",
-    contents: v.contents.map((t) => mapTup2(f, t)),
-  };
+    return {
+        tag: "PtListV",
+        contents: v.contents.map((t) => mapTup2(f, t)),
+    };
 }
 
 function mapList<T, S>(f: (arg: T) => S, v: IListV<T>): IListV<S> {
-  return {
-    tag: "ListV",
-    contents: v.contents.map(f),
-  };
+    return {
+        tag: "ListV",
+        contents: v.contents.map(f),
+    };
 }
 
 function mapVector<T, S>(f: (arg: T) => S, v: IVectorV<T>): IVectorV<S> {
-  return {
-    tag: "VectorV",
-    contents: v.contents.map(f),
-  };
+    return {
+        tag: "VectorV",
+        contents: v.contents.map(f),
+    };
 }
 
 function mapTup<T, S>(f: (arg: T) => S, v: ITupV<T>): ITupV<S> {
-  return {
-    tag: "TupV",
-    contents: mapTup2(f, v.contents),
-  };
+    return {
+        tag: "TupV",
+        contents: mapTup2(f, v.contents),
+    };
 }
 
 function mapLList<T, S>(f: (arg: T) => S, v: ILListV<T>): ILListV<S> {
-  return {
-    tag: "LListV",
-    contents: v.contents.map((e) => e.map(f)),
-  };
+    return {
+        tag: "LListV",
+        contents: v.contents.map((e) => e.map(f)),
+    };
 }
 
 function mapMatrix<T, S>(f: (arg: T) => S, v: IMatrixV<T>): IMatrixV<S> {
-  return {
-    tag: "MatrixV",
-    contents: v.contents.map((e) => e.map(f)),
-  };
+    return {
+        tag: "MatrixV",
+        contents: v.contents.map((e) => e.map(f)),
+    };
 }
 
 function mapHMatrix<T, S>(f: (arg: T) => S, v: IHMatrixV<T>): IHMatrixV<S> {
-  const m = v.contents;
-  return {
-    tag: "HMatrixV",
-    contents: {
-      // TODO: This could probably be a generic map over object values
-      xScale: f(m.xScale),
-      xSkew: f(m.xSkew),
-      yScale: f(m.yScale),
-      ySkew: f(m.ySkew),
-      dx: f(m.dx),
-      dy: f(m.dy),
-    },
-  };
+    const m = v.contents;
+    return {
+        tag: "HMatrixV",
+        contents: {
+            // TODO: This could probably be a generic map over object values
+            xScale: f(m.xScale),
+            xSkew: f(m.xSkew),
+            yScale: f(m.yScale),
+            ySkew: f(m.ySkew),
+            dx: f(m.dx),
+            dy: f(m.dy),
+        },
+    };
 }
 
 function mapPolygon<T, S>(f: (arg: T) => S, v: IPolygonV<T>): IPolygonV<S> {
-  const xs0 = mapTup2LList(f, v.contents[0]);
-  const xs1 = mapTup2LList(f, v.contents[1]);
-  const xs2 = [mapTup2(f, v.contents[2][0]), mapTup2(f, v.contents[2][1])] as [
-    [S, S],
-    [S, S]
-  ];
-  const xs3 = v.contents[3].map((e) => mapTup2(f, e));
+    const xs0 = mapTup2LList(f, v.contents[0]);
+    const xs1 = mapTup2LList(f, v.contents[1]);
+    const xs2 = [mapTup2(f, v.contents[2][0]), mapTup2(f, v.contents[2][1])] as [
+        [S, S],
+        [S, S]
+    ];
+    const xs3 = v.contents[3].map((e) => mapTup2(f, e));
 
-  return {
-    tag: "PolygonV",
-    contents: [xs0, xs1, xs2, xs3],
-  };
+    return {
+        tag: "PolygonV",
+        contents: [xs0, xs1, xs2, xs3],
+    };
 }
 
 function mapElem<T, S>(f: (arg: T) => S, e: Elem<T>): Elem<S> {
-  if (e.tag === "Pt" || e.tag === "QuadBezJoin") {
-    return {
-      tag: e.tag,
-      contents: mapTup2(f, e.contents),
-    };
-  } else if (e.tag === "CubicBezJoin" || e.tag === "QuadBez") {
-    return {
-      tag: e.tag,
-      contents: mapTup2((x) => mapTup2(f, x), e.contents),
-    };
-  } else if (e.tag === "CubicBez") {
-    return {
-      tag: e.tag,
-      contents: mapTup3((x) => mapTup2(f, x), e.contents),
-    };
-  } else {
-    throw Error("unknown tag in bezier curve type conversion");
-  }
+    if (e.tag === "Pt" || e.tag === "QuadBezJoin") {
+        return {
+            tag: e.tag,
+            contents: mapTup2(f, e.contents),
+        };
+    } else if (e.tag === "CubicBezJoin" || e.tag === "QuadBez") {
+        return {
+            tag: e.tag,
+            contents: mapTup2((x) => mapTup2(f, x), e.contents),
+        };
+    } else if (e.tag === "CubicBez") {
+        return {
+            tag: e.tag,
+            contents: mapTup3((x) => mapTup2(f, x), e.contents),
+        };
+    } else {
+        throw Error("unknown tag in bezier curve type conversion");
+    }
 }
 
 function mapSubpath<T, S>(f: (arg: T) => S, s: SubPath<T>): SubPath<S> {
-  return {
-    tag: s.tag,
-    contents: s.contents.map((e) => mapElem(f, e)),
-  };
+    return {
+        tag: s.tag,
+        contents: s.contents.map((e) => mapElem(f, e)),
+    };
 }
 
 function mapPathData<T, S>(f: (arg: T) => S, v: IPathDataV<T>): IPathDataV<S> {
-  return {
-    tag: "PathDataV",
-    contents: v.contents.map((e) => mapSubpath(f, e)),
-  };
+    return {
+        tag: "PathDataV",
+        contents: v.contents.map((e) => mapSubpath(f, e)),
+    };
 }
 
 function mapColorInner<T, S>(f: (arg: T) => S, v: Color<T>): Color<S> {
-  if (v.tag === "RGBA") {
-    const rgb = v.contents;
-    return {
-      tag: "RGBA",
-      contents: mapTup4(f, rgb),
-    };
-  } else if (v.tag === "HSVA") {
-    const hsv = v.contents;
-    return {
-      tag: "HSVA",
-      contents: mapTup4(f, hsv),
-    };
-  } else {
-    throw Error("unexpected color tag");
-  }
+    if (v.tag === "RGBA") {
+        const rgb = v.contents;
+        return {
+            tag: "RGBA",
+            contents: mapTup4(f, rgb),
+        };
+    } else if (v.tag === "HSVA") {
+        const hsv = v.contents;
+        return {
+            tag: "HSVA",
+            contents: mapTup4(f, hsv),
+        };
+    } else {
+        throw Error("unexpected color tag");
+    }
 }
 
 function mapColor<T, S>(f: (arg: T) => S, v: IColorV<T>): IColorV<S> {
-  return {
-    tag: "ColorV",
-    contents: mapColorInner(f, v.contents),
-  };
+    return {
+        tag: "ColorV",
+        contents: mapColorInner(f, v.contents),
+    };
 }
 
 function mapPalette<T, S>(f: (arg: T) => S, v: IPaletteV<T>): IPaletteV<S> {
-  return {
-    tag: "PaletteV",
-    contents: v.contents.map((e) => mapColorInner(f, e)),
-  };
+    return {
+        tag: "PaletteV",
+        contents: v.contents.map((e) => mapColorInner(f, e)),
+    };
 }
 
 // Utils for converting types of values
@@ -217,161 +217,161 @@ function mapPalette<T, S>(f: (arg: T) => S, v: IPaletteV<T>): IPaletteV<S> {
 // Expects `f` to be a function between numeric types (e.g. number -> VarAD, VarAD -> number, AD var -> VarAD ...)
 // Coerces any non-numeric types
 export function mapValueNumeric<T, S>(f: (arg: T) => S, v: Value<T>): Value<S> {
-  const nonnumericValueTypes = [
-    "BoolV",
-    "StrV",
-    "ColorV",
-    "PaletteV",
-    "FileV",
-    "StyleV",
-    "IntV",
-  ];
+    const nonnumericValueTypes = [
+        "BoolV",
+        "StrV",
+        "ColorV",
+        "PaletteV",
+        "FileV",
+        "StyleV",
+        "IntV",
+    ];
 
-  if (v.tag === "FloatV") {
-    return mapFloat(f, v);
-  } else if (v.tag === "PtV") {
-    return mapPt(f, v);
-  } else if (v.tag === "PtListV") {
-    return mapPtList(f, v);
-  } else if (v.tag === "ListV") {
-    return mapList(f, v);
-  } else if (v.tag === "VectorV") {
-    return mapVector(f, v);
-  } else if (v.tag === "MatrixV") {
-    return mapMatrix(f, v);
-  } else if (v.tag === "TupV") {
-    return mapTup(f, v);
-  } else if (v.tag === "LListV") {
-    return mapLList(f, v);
-  } else if (v.tag === "HMatrixV") {
-    return mapHMatrix(f, v);
-  } else if (v.tag === "PolygonV") {
-    return mapPolygon(f, v);
-  } else if (v.tag === "ColorV") {
-    return mapColor(f, v);
-  } else if (v.tag === "PaletteV") {
-    return mapPalette(f, v);
-  } else if (v.tag === "PathDataV") {
-    return mapPathData(f, v);
-  } else if (nonnumericValueTypes.includes(v.tag)) {
-    return v as Value<S>;
-  } else {
-    throw Error(
-      `unimplemented conversion from autodiff types for numeric types for value type '${v.tag}'`
-    );
-  }
+    if (v.tag === "FloatV") {
+        return mapFloat(f, v);
+    } else if (v.tag === "PtV") {
+        return mapPt(f, v);
+    } else if (v.tag === "PtListV") {
+        return mapPtList(f, v);
+    } else if (v.tag === "ListV") {
+        return mapList(f, v);
+    } else if (v.tag === "VectorV") {
+        return mapVector(f, v);
+    } else if (v.tag === "MatrixV") {
+        return mapMatrix(f, v);
+    } else if (v.tag === "TupV") {
+        return mapTup(f, v);
+    } else if (v.tag === "LListV") {
+        return mapLList(f, v);
+    } else if (v.tag === "HMatrixV") {
+        return mapHMatrix(f, v);
+    } else if (v.tag === "PolygonV") {
+        return mapPolygon(f, v);
+    } else if (v.tag === "ColorV") {
+        return mapColor(f, v);
+    } else if (v.tag === "PaletteV") {
+        return mapPalette(f, v);
+    } else if (v.tag === "PathDataV") {
+        return mapPathData(f, v);
+    } else if (nonnumericValueTypes.includes(v.tag)) {
+        return v as Value<S>;
+    } else {
+        throw Error(
+            `unimplemented conversion from autodiff types for numeric types for value type '${v.tag}'`
+        );
+    }
 }
 
 export const valueAutodiffToNumber = (v: Value<VarAD>): Value<number> =>
-  mapValueNumeric(numOf, v);
+    mapValueNumeric(numOf, v);
 
 export const valueNumberToAutodiff = (v: Value<number>): Value<VarAD> =>
-  mapValueNumeric(varOf, v);
+    mapValueNumeric(varOf, v);
 
 export const valueNumberToAutodiffConst = (v: Value<number>): Value<VarAD> =>
-  mapValueNumeric(constOfIf, v); // COMBAK: Really this should be constOf... I don't know why some inputs are already converted to VarADs?
+    mapValueNumeric(constOfIf, v); // COMBAK: Really this should be constOf... I don't know why some inputs are already converted to VarADs?
 
 export const tagExprNumberToAutodiff = (v: TagExpr<number>): TagExpr<VarAD> =>
-  mapTagExpr(constOfIf, v);
+    mapTagExpr(constOfIf, v);
 
 // Walk translation to convert all TagExprs (tagged Done or Pending) in the state to VarADs
 // (This is because, when decoded from backend, it's not yet in VarAD form -- although this code could be phased out if the translation becomes completely generated in the frontend)
 
 export function mapTagExpr<T, S>(f: (arg: T) => S, e: TagExpr<T>): TagExpr<S> {
-  if (e.tag === "Done") {
-    return {
-      tag: "Done",
-      contents: mapValueNumeric(f, e.contents),
-    };
-  } else if (e.tag === "Pending") {
-    return {
-      tag: "Pending",
-      contents: mapValueNumeric(f, e.contents),
-    };
-  } else if (e.tag === "OptEval") {
-    // We don't convert expressions because any numbers encountered in them will be converted by the evaluator (to VarAD) as needed
-    // TODO: Need to convert expressions to numbers, or back to varying? I guess `varyingPaths` is the source of truth
-    return e;
-  } else {
-    throw Error("unrecognized tag");
-  }
+    if (e.tag === "Done") {
+        return {
+            tag: "Done",
+            contents: mapValueNumeric(f, e.contents),
+        };
+    } else if (e.tag === "Pending") {
+        return {
+            tag: "Pending",
+            contents: mapValueNumeric(f, e.contents),
+        };
+    } else if (e.tag === "OptEval") {
+        // We don't convert expressions because any numbers encountered in them will be converted by the evaluator (to VarAD) as needed
+        // TODO: Need to convert expressions to numbers, or back to varying? I guess `varyingPaths` is the source of truth
+        return e;
+    } else {
+        throw Error("unrecognized tag");
+    }
 }
 
 export function mapGPIExpr<T, S>(f: (arg: T) => S, e: GPIExpr<T>): GPIExpr<S> {
-  const propDict = Object.entries(e[1]).map(([prop, val]) => [
-    prop,
-    mapTagExpr(f, val),
-  ]);
+    const propDict = Object.entries(e[1]).map(([prop, val]) => [
+        prop,
+        mapTagExpr(f, val),
+    ]);
 
-  return [e[0], Object.fromEntries(propDict)];
+    return [e[0], Object.fromEntries(propDict)];
 }
 
 export function mapTranslation<T, S>(
-  f: (arg: T) => S,
-  trans: ITrans<T>
+    f: (arg: T) => S,
+    trans: ITrans<T>
 ): ITrans<S> {
-  const newTrMap = Object.entries(trans.trMap).map(([name, fdict]) => {
-    const fdict2 = Object.entries(fdict).map(([prop, val]) => {
-      if (val.tag === "FExpr") {
-        return [prop, { tag: "FExpr", contents: mapTagExpr(f, val.contents) }];
-      } else if (val.tag === "FGPI") {
-        return [prop, { tag: "FGPI", contents: mapGPIExpr(f, val.contents) }];
-      } else {
-        console.log(prop, val);
-        throw Error("unknown tag on field expr");
-      }
+    const newTrMap = Object.entries(trans.trMap).map(([name, fdict]) => {
+        const fdict2 = Object.entries(fdict).map(([prop, val]) => {
+            if (val.tag === "FExpr") {
+                return [prop, { tag: "FExpr", contents: mapTagExpr(f, val.contents) }];
+            } else if (val.tag === "FGPI") {
+                return [prop, { tag: "FGPI", contents: mapGPIExpr(f, val.contents) }];
+            } else {
+                console.log(prop, val);
+                throw Error("unknown tag on field expr");
+            }
+        });
+
+        return [name, Object.fromEntries(fdict2)];
     });
 
-    return [name, Object.fromEntries(fdict2)];
-  });
-
-  return {
-    ...trans,
-    trMap: Object.fromEntries(newTrMap),
-  };
+    return {
+        ...trans,
+        trMap: Object.fromEntries(newTrMap),
+    };
 }
 
 // TODO: Check the input type?
 export const makeTranslationDifferentiable = (trans: any): Translation => {
-  return mapTranslation(varOf, trans);
+    return mapTranslation(varOf, trans);
 };
 
 export const makeTranslationNumeric = (trans: Translation): ITrans<number> => {
-  return mapTranslation(numOf, trans);
+    return mapTranslation(numOf, trans);
 };
 
 //#region translation operations
 
 const dummySourceLoc = (): SourceLoc => {
-  return { line: -1, col: -1 };
+    return { line: -1, col: -1 };
 };
 
 const floatValToExpr = (e: Value<VarAD>): Expr => {
-  if (e.tag !== "FloatV") {
-    throw Error("expected to insert vector elem of type float");
-  }
-  return {
-    nodeType: "dummyExpr",
-    children: [],
-    start: dummySourceLoc(),
-    end: dummySourceLoc(),
-    tag: "Fix",
-    contents: e.contents.val,
-    // COMBAK: This apparently held a VarAD before the AFloat grammar change? Is doing ".val" going to break something?
-  };
+    if (e.tag !== "FloatV") {
+        throw Error("expected to insert vector elem of type float");
+    }
+    return {
+        nodeType: "dummyExpr",
+        children: [],
+        start: dummySourceLoc(),
+        end: dummySourceLoc(),
+        tag: "Fix",
+        contents: e.contents.val,
+        // COMBAK: This apparently held a VarAD before the AFloat grammar change? Is doing ".val" going to break something?
+    };
 };
 
 const mkPropertyDict = (
-  decls: PropertyDecl[]
+    decls: PropertyDecl[]
 ): { [k: string]: TagExpr<VarAD> } => {
-  const gpi = {};
+    const gpi = {};
 
-  for (const decl of decls) {
-    // TODO(error/warning): Warn if any of these properties are duplicated or do not exist in the shape constructor
-    gpi[decl.name.value] = { tag: "OptEval", contents: decl.value };
-  }
+    for (const decl of decls) {
+        // TODO(error/warning): Warn if any of these properties are duplicated or do not exist in the shape constructor
+        gpi[decl.name.value] = { tag: "OptEval", contents: decl.value };
+    }
 
-  return gpi;
+    return gpi;
 };
 
 /**
@@ -384,24 +384,24 @@ const mkPropertyDict = (
 
 // TODO: Test this
 export const insertGPI = (
-  path: Path,
-  gpi: IFGPI<VarAD>,
-  trans: Translation
+    path: Path,
+    gpi: IFGPI<VarAD>,
+    trans: Translation
 ): Translation => {
-  let name, field;
+    let name, field;
 
-  switch (path.tag) {
-    case "FieldPath": {
-      [name, field] = [path.name, path.field];
-      // TODO: warning / error here
-      trans.trMap[name.contents.value][field.value] = gpi;
-      return trans;
-    }
+    switch (path.tag) {
+        case "FieldPath": {
+            [name, field] = [path.name, path.field];
+            // TODO: warning / error here
+            trans.trMap[name.contents.value][field.value] = gpi;
+            return trans;
+        }
 
-    default: {
-      throw Error("expected GPI");
+        default: {
+            throw Error("expected GPI");
+        }
     }
-  }
 };
 
 // This function is a combination of `addField` and `addProperty` from `Style.hs`
@@ -409,359 +409,359 @@ export const insertGPI = (
 // TODO(error/warn): Improve these warning/error messages (especially for overrides) and distinguish the fatal ones
 // TODO(error): rewrite to use the same pattern as `findExprSafe`
 export const insertExpr = (
-  path: Path,
-  expr: TagExpr<VarAD>,
-  initTrans: Translation,
-  compiling = false,
-  override = false
+    path: Path,
+    expr: TagExpr<VarAD>,
+    initTrans: Translation,
+    compiling = false,
+    override = false
 ): Translation => {
-  let trans = initTrans;
-  let name, field, prop;
+    let trans = initTrans;
+    let name, field, prop;
 
-  switch (path.tag) {
-    case "FieldPath": {
-      [name, field] = [path.name, path.field];
-
-      // Initialize the field dict if it hasn't been initialized
-      if (!trans.trMap[name.contents.value]) {
-        trans.trMap[name.contents.value] = {};
-      }
-
-      let fexpr: FieldExpr<VarAD> = { tag: "FExpr", contents: expr };
-
-      // If it's a GPI, instantiate it (rule Line-Set-Ctor); otherwise put it in the translation as-is
-      if (expr.tag === "OptEval") {
-        const gpi: Expr = expr.contents;
-        if (gpi.tag === "GPIDecl") {
-          const [nm, decls]: [Identifier, PropertyDecl[]] = [
-            gpi.shapeName,
-            gpi.properties,
-          ];
-
-          fexpr = {
-            tag: "FGPI",
-            contents: [nm.value, mkPropertyDict(decls)],
-          };
-        }
-      }
-
-      // Check overrides before initialization
-      if (
-        compiling &&
-        !override &&
-        trans.trMap[name.contents.value].hasOwnProperty(field.value)
-      ) {
-        trans = addWarn(trans, {
-          tag: "InsertedPathWithoutOverrideError",
-          path,
-        }); // TODO(error): Should this be an error?
-      }
-
-      // For any non-GPI thing, just put it in the translation
-      // NOTE: this will overwrite existing expressions
-      trans.trMap[name.contents.value][field.value] = fexpr;
-      return trans;
-    }
-
-    case "PropertyPath": {
-      [name, field, prop] = [path.name, path.field, path.property];
-
-      if (!trans.trMap[name.contents.value]) {
-        trans.trMap[name.contents.value] = {};
-      }
-
-      const fieldRes: FieldExpr<IVarAD> =
-        trans.trMap[name.contents.value][field.value];
-
-      // TODO(errors): Catch error if SubObj, etc don't exist -- but should these kinds of errors be caught by block statics rather than failing at runtime?
-      if (!fieldRes) {
-        // TODO(errors): Catch error if field doesn't exist
-        return addWarn(trans, {
-          tag: "InsertedPropWithNoFieldError",
-          subObj: name,
-          field,
-          property: prop,
-          path,
-        });
-      }
-
-      if (fieldRes.tag === "FExpr") {
-        // Deal with GPI aliasing (i.e. only happens if a GPI is aliased to another, and some operation is performed on the aliased GPI's property, it happens to the original)
-        // TODO: Test this
-        if (fieldRes.contents.tag === "OptEval") {
-          if (fieldRes.contents.contents.tag === "FieldPath") {
-            const p = fieldRes.contents.contents;
-            if (
-              p.name.contents.value === name.contents.value &&
-              p.field.value === field.value
-            ) {
-              if (compiling) {
-                return addWarn(trans, { tag: "CircularPathAlias", path });
-              }
-              // TODO(errors): Use "showErrors" not these ad-hoc errors
-              const err = `path was aliased to itself`;
-              throw Error(err);
-            }
-            const newPath = clone(path);
-            return insertExpr(
-              {
-                ...newPath,
-                tag: "PropertyPath",
-                name: p.name, // Note use of alias
-                field: p.field, // Note use of alias
-                property: path.property,
-              },
-              expr,
-              trans
-            );
-          }
-        }
-
-        // TODO(error)
-        if (compiling) {
-          return addWarn(trans, {
-            tag: "InsertedPropWithNoGPIError",
-            subObj: name,
-            field,
-            property: prop,
-            path,
-          });
-        }
-        const err = `Err: Sub obj '${name.contents.value}' does not have GPI '${field.value}'; cannot add property '${prop.value}'`;
-        throw Error(err);
-      } else if (fieldRes.tag === "FGPI") {
-        const [, properties] = fieldRes.contents;
-
-        // TODO(error): check for field/property overrides of paths that don't already exist
-        // TODO(error): if there are multiple matches, override errors behave oddly...
-        if (compiling && !override && properties.hasOwnProperty(prop.value)) {
-          trans = addWarn(trans, {
-            tag: "InsertedPathWithoutOverrideError",
-            path,
-          });
-        }
-
-        properties[prop.value] = expr;
-        return trans;
-      } else {
-        throw Error("unexpected tag");
-      }
-    }
-
-    // TODO(error): deal with override for accesspaths? I don't know if you can currently write something like `override A.shape.center[0] = 5.` in Style
-    case "AccessPath": {
-      const [innerPath, indices] = [path.path, path.indices];
-
-      switch (innerPath.tag) {
+    switch (path.tag) {
         case "FieldPath": {
-          // a.x[0] = e
-          [name, field] = [innerPath.name, innerPath.field];
-          const res = trans.trMap[name.contents.value][field.value];
-          if (res.tag !== "FExpr") {
-            if (compiling) {
-              return addWarn(
-                trans,
-                runtimeValueTypeError(path, "Float", "GPI")
-              );
-            }
-            const err = "did not expect GPI in vector access";
-            throw Error(err);
-          }
-          const res2: TagExpr<IVarAD> = res.contents;
-          // Deal with vector expressions
-          if (res2.tag === "OptEval") {
-            const res3: Expr = res2.contents;
-            if (res3.tag !== "Vector") {
-              if (compiling) {
-                return addWarn(
-                  trans,
-                  runtimeValueTypeError(path, "Vector", res3.tag)
-                );
-              }
-              const err = "expected Vector";
-              throw Error(err);
-            }
-            const res4: Expr[] = res3.contents;
+            [name, field] = [path.name, path.field];
 
+            // Initialize the field dict if it hasn't been initialized
+            if (!trans.trMap[name.contents.value]) {
+                trans.trMap[name.contents.value] = {};
+            }
+
+            let fexpr: FieldExpr<VarAD> = { tag: "FExpr", contents: expr };
+
+            // If it's a GPI, instantiate it (rule Line-Set-Ctor); otherwise put it in the translation as-is
             if (expr.tag === "OptEval") {
-              res4[exprToNumber(indices[0])] = expr.contents;
-            } else if (expr.tag === "Done") {
-              res4[exprToNumber(indices[0])] = floatValToExpr(expr.contents);
-            } else {
-              if (compiling) {
-                return addWarn(
-                  trans,
-                  runtimeValueTypeError(path, "Float", "Pending float")
-                );
-              }
-              const err = "unexpected pending val";
-              throw Error(err);
+                const gpi: Expr = expr.contents;
+                if (gpi.tag === "GPIDecl") {
+                    const [nm, decls]: [Identifier, PropertyDecl[]] = [
+                        gpi.shapeName,
+                        gpi.properties,
+                    ];
+
+                    fexpr = {
+                        tag: "FGPI",
+                        contents: [nm.value, mkPropertyDict(decls)],
+                    };
+                }
             }
 
+            // Check overrides before initialization
+            if (
+                compiling &&
+                !override &&
+                trans.trMap[name.contents.value].hasOwnProperty(field.value)
+            ) {
+                trans = addWarn(trans, {
+                    tag: "InsertedPathWithoutOverrideError",
+                    path,
+                }); // TODO(error): Should this be an error?
+            }
+
+            // For any non-GPI thing, just put it in the translation
+            // NOTE: this will overwrite existing expressions
+            trans.trMap[name.contents.value][field.value] = fexpr;
             return trans;
-          } else if (res2.tag === "Done") {
-            // Deal with vector values
-            const res3: Value<IVarAD> = res2.contents;
-            if (res3.tag !== "VectorV") {
-              const err = "expected Vector";
-              if (compiling) {
-                return addWarn(
-                  trans,
-                  runtimeValueTypeError(path, "Vector", "res3.tag")
-                );
-              }
-              throw Error(err);
-            }
-            const res4: IVarAD[] = res3.contents;
-
-            if (expr.tag === "Done" && expr.contents.tag === "FloatV") {
-              res4[exprToNumber(indices[0])] = expr.contents.contents;
-            } else {
-              if (compiling) {
-                return addWarn(
-                  trans,
-                  runtimeValueTypeError(path, "Float", expr.tag)
-                );
-              }
-              const err = "unexpected val";
-              throw Error(err);
-            }
-
-            return trans;
-          } else {
-            if (compiling) {
-              // TODO(errors): expected type?
-              return addWarn(
-                trans,
-                runtimeValueTypeError(path, "Float", res2.tag)
-              );
-            }
-            const err = "unexpected tag";
-            throw Error(err);
-          }
         }
 
         case "PropertyPath": {
-          const ip = innerPath as IPropertyPath;
-          // a.x.y[0] = e
-          [name, field, prop] = [ip.name, ip.field, ip.property];
-          const gpi = trans.trMap[name.contents.value][
-            field.value
-          ] as IFGPI<VarAD>;
-          const [, properties] = gpi.contents;
-          const res = properties[prop.value];
+            [name, field, prop] = [path.name, path.field, path.property];
 
-          if (res.tag === "OptEval") {
-            // Deal with vector expresions
-            const res2 = res.contents;
-            if (res2.tag !== "Vector") {
-              if (compiling) {
-                return addWarn(
-                  trans,
-                  runtimeValueTypeError(path, "Vector", res2.tag)
-                );
-              }
-              const err = "expected Vector";
-              throw Error(err);
+            if (!trans.trMap[name.contents.value]) {
+                trans.trMap[name.contents.value] = {};
             }
-            const res3 = res2.contents;
 
-            if (expr.tag === "OptEval") {
-              res3[exprToNumber(indices[0])] = expr.contents;
-            } else if (expr.tag === "Done") {
-              res3[exprToNumber(indices[0])] = floatValToExpr(expr.contents);
+            const fieldRes: FieldExpr<IVarAD> =
+                trans.trMap[name.contents.value][field.value];
+
+            // TODO(errors): Catch error if SubObj, etc don't exist -- but should these kinds of errors be caught by block statics rather than failing at runtime?
+            if (!fieldRes) {
+                // TODO(errors): Catch error if field doesn't exist
+                return addWarn(trans, {
+                    tag: "InsertedPropWithNoFieldError",
+                    subObj: name,
+                    field,
+                    property: prop,
+                    path,
+                });
+            }
+
+            if (fieldRes.tag === "FExpr") {
+                // Deal with GPI aliasing (i.e. only happens if a GPI is aliased to another, and some operation is performed on the aliased GPI's property, it happens to the original)
+                // TODO: Test this
+                if (fieldRes.contents.tag === "OptEval") {
+                    if (fieldRes.contents.contents.tag === "FieldPath") {
+                        const p = fieldRes.contents.contents;
+                        if (
+                            p.name.contents.value === name.contents.value &&
+                            p.field.value === field.value
+                        ) {
+                            if (compiling) {
+                                return addWarn(trans, { tag: "CircularPathAlias", path });
+                            }
+                            // TODO(errors): Use "showErrors" not these ad-hoc errors
+                            const err = `path was aliased to itself`;
+                            throw Error(err);
+                        }
+                        const newPath = clone(path);
+                        return insertExpr(
+                            {
+                                ...newPath,
+                                tag: "PropertyPath",
+                                name: p.name, // Note use of alias
+                                field: p.field, // Note use of alias
+                                property: path.property,
+                            },
+                            expr,
+                            trans
+                        );
+                    }
+                }
+
+                // TODO(error)
+                if (compiling) {
+                    return addWarn(trans, {
+                        tag: "InsertedPropWithNoGPIError",
+                        subObj: name,
+                        field,
+                        property: prop,
+                        path,
+                    });
+                }
+                const err = `Err: Sub obj '${name.contents.value}' does not have GPI '${field.value}'; cannot add property '${prop.value}'`;
+                throw Error(err);
+            } else if (fieldRes.tag === "FGPI") {
+                const [, properties] = fieldRes.contents;
+
+                // TODO(error): check for field/property overrides of paths that don't already exist
+                // TODO(error): if there are multiple matches, override errors behave oddly...
+                if (compiling && !override && properties.hasOwnProperty(prop.value)) {
+                    trans = addWarn(trans, {
+                        tag: "InsertedPathWithoutOverrideError",
+                        path,
+                    });
+                }
+
+                properties[prop.value] = expr;
+                return trans;
             } else {
-              if (compiling) {
-                return addWarn(
-                  trans,
-                  runtimeValueTypeError(path, "Float", expr.tag)
-                );
-              }
-              const err = "unexpected pending val";
-              throw Error(err);
+                throw Error("unexpected tag");
             }
-
-            return trans;
-          } else if (res.tag === "Done") {
-            // Deal with vector values
-            const res2 = res.contents;
-            if (res2.tag !== "VectorV") {
-              if (compiling) {
-                return addWarn(
-                  trans,
-                  runtimeValueTypeError(path, "Vector", res2.tag)
-                );
-              }
-              const err = "expected Vector";
-              throw Error(err);
-            }
-            const res3 = res2.contents;
-
-            if (expr.tag === "Done" && expr.contents.tag === "FloatV") {
-              res3[exprToNumber(indices[0])] = expr.contents.contents;
-            } else {
-              if (compiling) {
-                return addWarn(
-                  trans,
-                  runtimeValueTypeError(path, "Float", expr.tag)
-                );
-              }
-              const err = "unexpected val";
-              throw Error(err);
-            }
-
-            return trans;
-          } else {
-            throw Error("internal error: unexpected tag");
-          }
         }
 
-        default:
-          throw Error(
-            "internal error: should not have nested AccessPath in AccessPath"
-          );
-      }
-    }
-  }
+        // TODO(error): deal with override for accesspaths? I don't know if you can currently write something like `override A.shape.center[0] = 5.` in Style
+        case "AccessPath": {
+            const [innerPath, indices] = [path.path, path.indices];
 
-  throw Error("internal error: unknown tag");
+            switch (innerPath.tag) {
+                case "FieldPath": {
+                    // a.x[0] = e
+                    [name, field] = [innerPath.name, innerPath.field];
+                    const res = trans.trMap[name.contents.value][field.value];
+                    if (res.tag !== "FExpr") {
+                        if (compiling) {
+                            return addWarn(
+                                trans,
+                                runtimeValueTypeError(path, "Float", "GPI")
+                            );
+                        }
+                        const err = "did not expect GPI in vector access";
+                        throw Error(err);
+                    }
+                    const res2: TagExpr<IVarAD> = res.contents;
+                    // Deal with vector expressions
+                    if (res2.tag === "OptEval") {
+                        const res3: Expr = res2.contents;
+                        if (res3.tag !== "Vector") {
+                            if (compiling) {
+                                return addWarn(
+                                    trans,
+                                    runtimeValueTypeError(path, "Vector", res3.tag)
+                                );
+                            }
+                            const err = "expected Vector";
+                            throw Error(err);
+                        }
+                        const res4: Expr[] = res3.contents;
+
+                        if (expr.tag === "OptEval") {
+                            res4[exprToNumber(indices[0])] = expr.contents;
+                        } else if (expr.tag === "Done") {
+                            res4[exprToNumber(indices[0])] = floatValToExpr(expr.contents);
+                        } else {
+                            if (compiling) {
+                                return addWarn(
+                                    trans,
+                                    runtimeValueTypeError(path, "Float", "Pending float")
+                                );
+                            }
+                            const err = "unexpected pending val";
+                            throw Error(err);
+                        }
+
+                        return trans;
+                    } else if (res2.tag === "Done") {
+                        // Deal with vector values
+                        const res3: Value<IVarAD> = res2.contents;
+                        if (res3.tag !== "VectorV") {
+                            const err = "expected Vector";
+                            if (compiling) {
+                                return addWarn(
+                                    trans,
+                                    runtimeValueTypeError(path, "Vector", "res3.tag")
+                                );
+                            }
+                            throw Error(err);
+                        }
+                        const res4: IVarAD[] = res3.contents;
+
+                        if (expr.tag === "Done" && expr.contents.tag === "FloatV") {
+                            res4[exprToNumber(indices[0])] = expr.contents.contents;
+                        } else {
+                            if (compiling) {
+                                return addWarn(
+                                    trans,
+                                    runtimeValueTypeError(path, "Float", expr.tag)
+                                );
+                            }
+                            const err = "unexpected val";
+                            throw Error(err);
+                        }
+
+                        return trans;
+                    } else {
+                        if (compiling) {
+                            // TODO(errors): expected type?
+                            return addWarn(
+                                trans,
+                                runtimeValueTypeError(path, "Float", res2.tag)
+                            );
+                        }
+                        const err = "unexpected tag";
+                        throw Error(err);
+                    }
+                }
+
+                case "PropertyPath": {
+                    const ip = innerPath as IPropertyPath;
+                    // a.x.y[0] = e
+                    [name, field, prop] = [ip.name, ip.field, ip.property];
+                    const gpi = trans.trMap[name.contents.value][
+                        field.value
+                    ] as IFGPI<VarAD>;
+                    const [, properties] = gpi.contents;
+                    const res = properties[prop.value];
+
+                    if (res.tag === "OptEval") {
+                        // Deal with vector expresions
+                        const res2 = res.contents;
+                        if (res2.tag !== "Vector") {
+                            if (compiling) {
+                                return addWarn(
+                                    trans,
+                                    runtimeValueTypeError(path, "Vector", res2.tag)
+                                );
+                            }
+                            const err = "expected Vector";
+                            throw Error(err);
+                        }
+                        const res3 = res2.contents;
+
+                        if (expr.tag === "OptEval") {
+                            res3[exprToNumber(indices[0])] = expr.contents;
+                        } else if (expr.tag === "Done") {
+                            res3[exprToNumber(indices[0])] = floatValToExpr(expr.contents);
+                        } else {
+                            if (compiling) {
+                                return addWarn(
+                                    trans,
+                                    runtimeValueTypeError(path, "Float", expr.tag)
+                                );
+                            }
+                            const err = "unexpected pending val";
+                            throw Error(err);
+                        }
+
+                        return trans;
+                    } else if (res.tag === "Done") {
+                        // Deal with vector values
+                        const res2 = res.contents;
+                        if (res2.tag !== "VectorV") {
+                            if (compiling) {
+                                return addWarn(
+                                    trans,
+                                    runtimeValueTypeError(path, "Vector", res2.tag)
+                                );
+                            }
+                            const err = "expected Vector";
+                            throw Error(err);
+                        }
+                        const res3 = res2.contents;
+
+                        if (expr.tag === "Done" && expr.contents.tag === "FloatV") {
+                            res3[exprToNumber(indices[0])] = expr.contents.contents;
+                        } else {
+                            if (compiling) {
+                                return addWarn(
+                                    trans,
+                                    runtimeValueTypeError(path, "Float", expr.tag)
+                                );
+                            }
+                            const err = "unexpected val";
+                            throw Error(err);
+                        }
+
+                        return trans;
+                    } else {
+                        throw Error("internal error: unexpected tag");
+                    }
+                }
+
+                default:
+                    throw Error(
+                        "internal error: should not have nested AccessPath in AccessPath"
+                    );
+            }
+        }
+    }
+
+    throw Error("internal error: unknown tag");
 };
 
 // Mutates translation
 export const insertExprs = (
-  ps: Path[],
-  es: TagExpr<VarAD>[],
-  tr: Translation
+    ps: Path[],
+    es: TagExpr<VarAD>[],
+    tr: Translation
 ): Translation => {
-  if (ps.length !== es.length) {
-    throw Error("length should be the same");
-  }
+    if (ps.length !== es.length) {
+        throw Error("length should be the same");
+    }
 
-  let tr2 = tr;
-  for (let i = 0; i < ps.length; i++) {
-    // Tr gets mutated
-    tr2 = insertExpr(ps[i], es[i], tr);
-  }
+    let tr2 = tr;
+    for (let i = 0; i < ps.length; i++) {
+        // Tr gets mutated
+        tr2 = insertExpr(ps[i], es[i], tr);
+    }
 
-  return tr2;
+    return tr2;
 };
 
 export const isTagExpr = (e: any): e is TagExpr<VarAD> => {
-  return e.tag === "OptEval" || e.tag === "Done" || e.tag === "Pending";
+    return e.tag === "OptEval" || e.tag === "Done" || e.tag === "Pending";
 };
 
 // Version of findExpr if you expect to not encounter any errors (e.g., if it's being used after the translation has already been checked)
 export const findExprSafe = (
-  trans: Translation,
-  path: Path
+    trans: Translation,
+    path: Path
 ): TagExpr<VarAD> | IFGPI<VarAD> => {
 
-  const res = findExpr(trans, path);
-  if (res.tag !== "FGPI" && !isTagExpr(res)) { // Is an error
-    throw Error(showError(res));
-  }
+    const res = findExpr(trans, path);
+    if (res.tag !== "FGPI" && !isTagExpr(res)) { // Is an error
+        throw Error(showError(res));
+    }
 
-  return res;
+    return res;
 };
 
 /**
@@ -773,130 +773,130 @@ export const findExprSafe = (
  * TODO: the optional type here exist because GPI is not an expression in Style yet. It's not the most sustainable pattern w.r.t to our current way to typecasting the result using `as`.
  */
 export const findExpr = (
-  trans: Translation,
-  path: Path
+    trans: Translation,
+    path: Path
 ): TagExpr<VarAD> | IFGPI<VarAD> | StyleError => {
-  let name, field, prop;
+    let name, field, prop;
 
-  switch (path.tag) {
-    case "FieldPath": {
-      [name, field] = [path.name.contents.value, path.field.value];
-      const fields = trans.trMap[name];
-      if (!fields) {
-        return { tag: "NonexistentNameError", name: path.name.contents, path };
-      }
+    switch (path.tag) {
+        case "FieldPath": {
+            [name, field] = [path.name.contents.value, path.field.value];
+            const fields = trans.trMap[name];
+            if (!fields) {
+                return { tag: "NonexistentNameError", name: path.name.contents, path };
+            }
 
-      // Type cast to field expression
-      const fieldExpr = fields[field];
+            // Type cast to field expression
+            const fieldExpr = fields[field];
 
-      if (!fieldExpr) {
-        return { tag: "NonexistentFieldError", field: path.field, path };
-      }
+            if (!fieldExpr) {
+                return { tag: "NonexistentFieldError", field: path.field, path };
+            }
 
-      switch (fieldExpr.tag) {
-        case "FGPI":
-          return fieldExpr;
-        case "FExpr":
-          return fieldExpr.contents;
-      }
+            switch (fieldExpr.tag) {
+                case "FGPI":
+                    return fieldExpr;
+                case "FExpr":
+                    return fieldExpr.contents;
+            }
+        }
+
+        case "PropertyPath": {
+            [name, field, prop] = [
+                path.name.contents.value,
+                path.field.value,
+                path.property.value,
+            ];
+
+            const fieldsP = trans.trMap[name];
+            if (!fieldsP) {
+                return { tag: "NonexistentNameError", name: path.name.contents, path };
+            }
+
+            // Type cast to FGPI and get the properties
+            const gpi = fieldsP[field];
+
+            if (!gpi) {
+                return { tag: "NonexistentGPIError", gpi: path.field, path };
+            }
+
+            switch (gpi.tag) {
+                case "FExpr": {
+                    return { tag: "ExpectedGPIGotFieldError", field: path.field, path };
+                }
+                case "FGPI": {
+                    const [, propDict] = gpi.contents;
+                    const propRes = propDict[prop];
+                    if (!propRes) {
+                        return { tag: "NonexistentPropertyError", property: path.property, path };
+                    }
+                    return propRes;
+                }
+            }
+        }
+
+        case "AccessPath": {
+            // Have to look up AccessPaths first, since they make a recursive call, and are not invalid paths themselves
+            const res = findExpr(trans, path.path);
+            const i = exprToNumber(path.indices[0]); // COMBAK VECTORS: Currently only supports 1D vectors
+
+            if (res.tag === "OptEval") {
+                const res2: Expr = res.contents;
+
+                if (res2.tag === "Vector") {
+                    const inner: Expr = res2.contents[i];
+                    return { tag: "OptEval", contents: inner };
+                } else {
+                    return { tag: "InvalidAccessPathError", path };
+                }
+            } else if (res.tag === "Done") {
+                if (res.contents.tag === "VectorV") {
+                    const inner: VarAD = res.contents.contents[i];
+                    return { tag: "Done", contents: { tag: "FloatV", contents: inner } };
+                } else {
+                    return { tag: "InvalidAccessPathError", path };
+                }
+            } else {
+                return { tag: "InvalidAccessPathError", path };
+            }
+        }
     }
 
-    case "PropertyPath": {
-      [name, field, prop] = [
-        path.name.contents.value,
-        path.field.value,
-        path.property.value,
-      ];
-
-      const fieldsP = trans.trMap[name];
-      if (!fieldsP) {
-        return { tag: "NonexistentNameError", name: path.name.contents, path };
-      }
-
-      // Type cast to FGPI and get the properties
-      const gpi = fieldsP[field];
-
-      if (!gpi) {
-        return { tag: "NonexistentGPIError", gpi: path.field, path };
-      }
-
-      switch (gpi.tag) {
-        case "FExpr": {
-          return { tag: "ExpectedGPIGotFieldError", field: path.field, path };
-        }
-        case "FGPI": {
-          const [, propDict] = gpi.contents;
-          const propRes = propDict[prop];
-          if (!propRes) {
-            return { tag: "NonexistentPropertyError", property: path.property, path };
-          }
-        }
-      }
-    }
-
-    case "AccessPath": {
-      // Have to look up AccessPaths first, since they make a recursive call, and are not invalid paths themselves
-      const p2: IAccessPath = path as IAccessPath; // COMBAK: Not sure why it can't infer AccessPath type here?
-      const res = findExpr(trans, p2.path);
-      const i = exprToNumber(p2.indices[0]); // COMBAK VECTORS: Currently only supports 1D vectors
-
-      if (res.tag === "OptEval") {
-        const res2: Expr = res.contents;
-
-        if (res2.tag === "Vector") {
-          const inner: Expr = res2.contents[i];
-          return { tag: "OptEval", contents: inner };
-        } else {
-          return { tag: "InvalidAccessPathError", path };
-        }
-      } else if (res.tag === "Done") {
-        if (res.contents.tag === "VectorV") {
-          const inner: VarAD = res.contents.contents[i];
-          return { tag: "Done", contents: { tag: "FloatV", contents: inner } };
-        } else {
-          return { tag: "InvalidAccessPathError", path };
-        }
-      } else {
-        return { tag: "InvalidAccessPathError", path };
-      }
-    }
-  }
-
-  throw Error("internal error: unknown tag");
+    throw Error("internal error: unknown tag");
 };
 
 //#endregion
 
 export const isPath = (expr: Expr): expr is Path => {
-  return ["FieldPath", "PropertyPath", "AccessPath", "LocalVar"].includes(
-    expr.tag
-  );
+    return ["FieldPath", "PropertyPath", "AccessPath", "LocalVar"].includes(
+        expr.tag
+    );
 };
 
 export const exprToNumber = (e: Expr): number => {
-  if (e.tag === "Fix") {
-    return e.contents;
-  }
-  throw Error("expecting expr to be number");
+    if (e.tag === "Fix") {
+        return e.contents;
+    }
+    throw Error("expecting expr to be number");
 };
 
 export const numToExpr = (n: number): Expr => {
-  return {
-    nodeType: "dummyExpr",
-    children: [],
-    start: dummySourceLoc(),
-    end: dummySourceLoc(),
-    tag: "Fix",
-    contents: n,
-  };
+    return {
+        nodeType: "dummyExpr",
+        children: [],
+        start: dummySourceLoc(),
+        end: dummySourceLoc(),
+        tag: "Fix",
+        contents: n,
+    };
 };
 
 // Add warning to the end of the existing list
 export const addWarn = (tr: Translation, warn: Warning): Translation => {
-  return {
-    ...tr,
-    warnings: tr.warnings.concat(warn),
-  };
+    return {
+        ...tr,
+        warnings: tr.warnings.concat(warn),
+    };
 };
 
 // COMBAK: consolidate prettyprinting code
@@ -909,12 +909,12 @@ export const initConstraintWeight = 10e-3;
 const defaultLbfgsMemSize = 17;
 
 export const defaultLbfgsParams: LbfgsParams = {
-  lastState: { tag: "Nothing" },
-  lastGrad: { tag: "Nothing" },
-  s_list: [],
-  y_list: [],
-  numUnconstrSteps: 0,
-  memSize: defaultLbfgsMemSize,
+    lastState: { tag: "Nothing" },
+    lastGrad: { tag: "Nothing" },
+    s_list: [],
+    y_list: [],
+    numUnconstrSteps: 0,
+    memSize: defaultLbfgsMemSize,
 };
 
 //#endregion

--- a/packages/core/src/engine/Evaluator.ts
+++ b/packages/core/src/engine/Evaluator.ts
@@ -1,39 +1,40 @@
 import { checkComp, compDict } from "contrib/Functions";
 import {
-  mapTranslation,
-  valueAutodiffToNumber,
-  insertExpr,
-  isPath,
-  exprToNumber,
-  numToExpr,
+    mapTranslation,
+    valueAutodiffToNumber,
+    insertExpr,
+    isPath,
+    exprToNumber,
+    numToExpr,
+    findExprSafe
 } from "engine/EngineUtils";
 import { concat, mapValues, pickBy, values, zip } from "lodash";
 import seedrandom, { prng } from "seedrandom";
 import { Shape, Value } from "types/shapeTypes";
 import {
-  floatVal,
-  prettyPrintPath,
-  prettyPrintExpr,
-  prettyPrintFn,
+    floatVal,
+    prettyPrintPath,
+    prettyPrintExpr,
+    prettyPrintFn,
 } from "utils/OtherUtils";
 import {
-  add,
-  constOf,
-  constOfIf,
-  differentiable,
-  div,
-  mul,
-  neg,
-  numOf,
-  ops,
-  sub,
-  squared,
-  sqrt,
-  inverse,
-  absVal,
-  gt,
-  lt,
-  ifCond,
+    add,
+    constOf,
+    constOfIf,
+    differentiable,
+    div,
+    mul,
+    neg,
+    numOf,
+    ops,
+    sub,
+    squared,
+    sqrt,
+    inverse,
+    absVal,
+    gt,
+    lt,
+    ifCond,
 } from "./Autodiff";
 
 // For deep-cloning the translation
@@ -50,19 +51,19 @@ const clone = rfdc({ proto: false, circles: false });
 
 // COMBAK: Import the dummy functions from Style -> EngineUtils
 const dummySourceLoc = (): SourceLoc => {
-  return { line: -1, col: -1 };
+    return { line: -1, col: -1 };
 };
 
 const dummyIdentifier = (name: string): Identifier => {
-  return {
-    nodeType: "dummyNode",
-    children: [],
-    type: "value",
-    value: name,
-    tag: "Identifier",
-    start: dummySourceLoc(),
-    end: dummySourceLoc(),
-  };
+    return {
+        nodeType: "dummyNode",
+        children: [],
+        type: "value",
+        value: name,
+        tag: "Identifier",
+        start: dummySourceLoc(),
+        end: dummySourceLoc(),
+    };
 };
 /**
  * Evaluate all shapes in the `State` by walking the `Translation` data structure, finding out all shape expressions (`FGPI` expressions computed by the Style compiler), and evaluating every property in each shape.
@@ -72,79 +73,79 @@ const dummyIdentifier = (name: string): Identifier => {
  * NOTE: need to manage the random seed. In the backend we delibrately discard the new random seed within each of the opt session for consistent results.
  */
 export const evalShapes = (s: State): State => {
-  // Update the stale varyingMap from the translation
-  // TODO: Evaluating the shapes for display is still done via interpretation on VarADs; not compiled
+    // Update the stale varyingMap from the translation
+    // TODO: Evaluating the shapes for display is still done via interpretation on VarADs; not compiled
 
-  const varyingValuesDiff = s.varyingValues.map(differentiable);
-  s.varyingMap = genPathMap(s.varyingPaths, varyingValuesDiff);
+    const varyingValuesDiff = s.varyingValues.map(differentiable);
+    s.varyingMap = genPathMap(s.varyingPaths, varyingValuesDiff);
 
-  const varyingMapList = zip(s.varyingPaths, varyingValuesDiff) as [
-    Path,
-    VarAD
-  ][];
+    const varyingMapList = zip(s.varyingPaths, varyingValuesDiff) as [
+        Path,
+        VarAD
+    ][];
 
-  const optDebugInfo = {
-    gradient: genPathMap(s.varyingPaths, s.params.lastGradient),
-    gradientPreconditioned: genPathMap(
-      s.varyingPaths,
-      s.params.lastGradientPreconditioned
-    ),
-  };
+    const optDebugInfo = {
+        gradient: genPathMap(s.varyingPaths, s.params.lastGradient),
+        gradientPreconditioned: genPathMap(
+            s.varyingPaths,
+            s.params.lastGradientPreconditioned
+        ),
+    };
 
-  // Insert all varying vals
-  const transWithVarying = insertVaryings(s.translation, varyingMapList);
+    // Insert all varying vals
+    const transWithVarying = insertVaryings(s.translation, varyingMapList);
 
-  // Clone translation to use in this top-level call, because it mutates the translation while interpreting the energy function in order to cache/reuse VarAD (computation) results
-  const trans = clone(transWithVarying);
+    // Clone translation to use in this top-level call, because it mutates the translation while interpreting the energy function in order to cache/reuse VarAD (computation) results
+    const trans = clone(transWithVarying);
 
-  // Find out all the GPI expressions in the translation
-  const shapeExprs: IFGPI<VarAD>[] = s.shapePaths.map(
-    (p: Path) => findExpr(trans, p) as IFGPI<VarAD>
-  );
+    // Find out all the GPI expressions in the translation
+    const shapeExprs: IFGPI<VarAD>[] = s.shapePaths.map(
+        (p: Path) => findExprSafe(trans, p) as IFGPI<VarAD>
+    );
 
-  // throw Error("TODO");
+    console.log("shapePaths", s.shapePaths.map(prettyPrintPath));
 
-  // Evaluate each of the shapes (note: the translation is mutated, not returned)
-  const [shapesEvaled, transEvaled]: [
-    Shape[],
-    Translation
-  ] = shapeExprs.reduce(
-    ([currShapes, tr]: [Shape[], Translation], e: IFGPI<VarAD>) =>
-      evalShape(e, tr, s.varyingMap, currShapes, optDebugInfo),
-    [[], trans]
-  );
+    // Evaluate each of the shapes (note: the translation is mutated, not returned)
+    const [shapesEvaled, transEvaled]: [
+        Shape[],
+        Translation
+    ] = shapeExprs.reduce(
+        ([currShapes, tr]: [Shape[], Translation], e: IFGPI<VarAD>) =>
+            evalShape(e, tr, s.varyingMap, currShapes, optDebugInfo),
+        [[], trans]
+    );
 
-  if (s.shapeOrdering.length < shapesEvaled.length) {
-    console.error("Invalid shape layering of length", s.shapeOrdering.length);
-  }
+    if (s.shapeOrdering.length < shapesEvaled.length) {
+        console.error("Invalid shape layering of length", s.shapeOrdering.length);
+    }
 
-  // Sort the shapes by ordering--note the null assertion
-  const sortedShapesEvaled: Shape[] = s.shapeOrdering.map(
-    (name) =>
-      shapesEvaled.find(({ properties }) => sameName(properties.name, name))!
-  );
+    // Sort the shapes by ordering--note the null assertion
+    const sortedShapesEvaled: Shape[] = s.shapeOrdering.map(
+        (name) =>
+            shapesEvaled.find(({ properties }) => sameName(properties.name, name))!
+    );
 
-  // TODO: do we still need this check for non-empty labels?
-  // const nonEmpties = sortedShapes.filter(notEmptyLabel);
+    // TODO: do we still need this check for non-empty labels?
+    // const nonEmpties = sortedShapes.filter(notEmptyLabel);
 
-  // Update the state with the new list of shapes
-  // (This is a shallow copy of the state btw, not a deep copy)
-  return { ...s, shapes: sortedShapesEvaled };
+    // Update the state with the new list of shapes
+    // (This is a shallow copy of the state btw, not a deep copy)
+    return { ...s, shapes: sortedShapesEvaled };
 };
 
 const sameName = (given: Value<number>, expected: string): boolean => {
-  if (given.tag !== "StrV") {
-    return false;
-  }
-  if (typeof given.contents !== "string") {
-    throw Error("expected string GPI name");
-  }
-  return given.contents === expected;
+    if (given.tag !== "StrV") {
+        return false;
+    }
+    if (typeof given.contents !== "string") {
+        throw Error("expected string GPI name");
+    }
+    return given.contents === expected;
 };
 
 const doneFloat = (n: VarAD): TagExpr<VarAD> => ({
-  tag: "Done",
-  contents: { tag: "FloatV", contents: n },
+    tag: "Done",
+    contents: { tag: "FloatV", contents: n },
 });
 
 /**
@@ -155,14 +156,14 @@ const doneFloat = (n: VarAD): TagExpr<VarAD> => ({
  * @returns {Translation}
  */
 export const insertVaryings = (
-  trans: Translation,
-  varyingMap: [Path, VarAD][]
+    trans: Translation,
+    varyingMap: [Path, VarAD][]
 ): Translation => {
-  return varyingMap.reduce(
-    (tr: Translation, [path, val]: [Path, VarAD]) =>
-      insertExpr(path, doneFloat(val), tr),
-    trans
-  );
+    return varyingMap.reduce(
+        (tr: Translation, [path, val]: [Path, VarAD]) =>
+            insertExpr(path, doneFloat(val), tr),
+        trans
+    );
 };
 
 /**
@@ -173,26 +174,26 @@ export const insertVaryings = (
  * @param varyingMap Varying paths and values
  */
 export const evalFns = (
-  fns: Fn[],
-  trans: Translation,
-  varyingMap: VaryMap<VarAD>
+    fns: Fn[],
+    trans: Translation,
+    varyingMap: VaryMap<VarAD>
 ): FnDone<VarAD>[] => fns.map((f) => evalFn(f, trans, varyingMap));
 
 const evalFn = (
-  fn: Fn,
-  trans: Translation,
-  varyingMap: VaryMap<VarAD>
+    fn: Fn,
+    trans: Translation,
+    varyingMap: VaryMap<VarAD>
 ): FnDone<VarAD> => {
-  const noOptDebugInfo = {
-    gradient: new Map(),
-    gradientPreconditioned: new Map(),
-  };
+    const noOptDebugInfo = {
+        gradient: new Map(),
+        gradientPreconditioned: new Map(),
+    };
 
-  return {
-    name: fn.fname,
-    args: evalExprs(fn.fargs, trans, varyingMap, noOptDebugInfo),
-    optType: fn.optType,
-  };
+    return {
+        name: fn.fname,
+        args: evalExprs(fn.fargs, trans, varyingMap, noOptDebugInfo),
+        optType: fn.optType,
+    };
 };
 
 /**
@@ -205,45 +206,45 @@ const evalFn = (
  *
  */
 export const evalShape = (
-  shapeExpr: IFGPI<VarAD>, // <number>?
-  trans: Translation,
-  varyingVars: VaryMap,
-  shapes: Shape[],
-  optDebugInfo: OptDebugInfo
+    shapeExpr: IFGPI<VarAD>, // <number>?
+    trans: Translation,
+    varyingVars: VaryMap,
+    shapes: Shape[],
+    optDebugInfo: OptDebugInfo
 ): [Shape[], Translation] => {
-  const [shapeType, propExprs] = shapeExpr.contents;
+    const [shapeType, propExprs] = shapeExpr.contents;
 
-  // Make sure all props are evaluated to values instead of shapes
-  const props = mapValues(
-    propExprs,
-    (prop: TagExpr<VarAD>): Value<number> => {
-      // TODO: Refactor these cases to be more concise
-      if (prop.tag === "OptEval") {
-        // For display, evaluate expressions with autodiff types (incl. varying vars as AD types), then convert to numbers
-        // (The tradeoff for using autodiff types is that evaluating the display step will be a little slower, but then we won't have to write two versions of all computations)
-        const res: Value<VarAD> = (evalExpr(
-          prop.contents,
-          trans,
-          varyingVars,
-          optDebugInfo
-        ) as IVal<VarAD>).contents;
-        const resDisplay: Value<number> = valueAutodiffToNumber(res);
-        return resDisplay;
-      } else if (prop.tag === "Done") {
-        return valueAutodiffToNumber(prop.contents);
-      } else if (prop.tag === "Pending") {
-        // Pending expressions are just converted because they get converted back to numbers later
-        const res = valueAutodiffToNumber(prop.contents);
-        return res;
-      } else {
-        throw Error("unknown tag");
-      }
-    }
-  );
+    // Make sure all props are evaluated to values instead of shapes
+    const props = mapValues(
+        propExprs,
+        (prop: TagExpr<VarAD>): Value<number> => {
+            // TODO: Refactor these cases to be more concise
+            if (prop.tag === "OptEval") {
+                // For display, evaluate expressions with autodiff types (incl. varying vars as AD types), then convert to numbers
+                // (The tradeoff for using autodiff types is that evaluating the display step will be a little slower, but then we won't have to write two versions of all computations)
+                const res: Value<VarAD> = (evalExpr(
+                    prop.contents,
+                    trans,
+                    varyingVars,
+                    optDebugInfo
+                ) as IVal<VarAD>).contents;
+                const resDisplay: Value<number> = valueAutodiffToNumber(res);
+                return resDisplay;
+            } else if (prop.tag === "Done") {
+                return valueAutodiffToNumber(prop.contents);
+            } else if (prop.tag === "Pending") {
+                // Pending expressions are just converted because they get converted back to numbers later
+                const res = valueAutodiffToNumber(prop.contents);
+                return res;
+            } else {
+                throw Error("unknown tag");
+            }
+        }
+    );
 
-  const shape: Shape = { shapeType, properties: props };
+    const shape: Shape = { shapeType, properties: props };
 
-  return [[...shapes, shape], trans];
+    return [[...shapes, shape], trans];
 };
 
 /**
@@ -255,43 +256,43 @@ export const evalShape = (
  *
  */
 export const evalExprs = (
-  es: Expr[],
-  trans: Translation,
-  varyingVars?: VaryMap<VarAD>,
-  optDebugInfo?: OptDebugInfo
+    es: Expr[],
+    trans: Translation,
+    varyingVars?: VaryMap<VarAD>,
+    optDebugInfo?: OptDebugInfo
 ): ArgVal<VarAD>[] =>
-  es.map((e) => evalExpr(e, trans, varyingVars, optDebugInfo));
+    es.map((e) => evalExpr(e, trans, varyingVars, optDebugInfo));
 
 function toFloatVal(a: ArgVal<VarAD>): VarAD {
-  if (a.tag === "Val") {
-    const res = a.contents;
-    if (res.tag === "FloatV") {
-      return res.contents;
-    } else if (res.tag === "IntV") {
-      return constOf(res.contents);
+    if (a.tag === "Val") {
+        const res = a.contents;
+        if (res.tag === "FloatV") {
+            return res.contents;
+        } else if (res.tag === "IntV") {
+            return constOf(res.contents);
+        } else {
+            console.log("res", res);
+            throw Error("Expected floating type in list");
+        }
     } else {
-      console.log("res", res);
-      throw Error("Expected floating type in list");
+        console.log("res", a);
+        throw Error("Expected value (non-GPI) type in list");
     }
-  } else {
-    console.log("res", a);
-    throw Error("Expected value (non-GPI) type in list");
-  }
 }
 
 function toVecVal<T>(a: ArgVal<T>): T[] {
-  if (a.tag === "Val") {
-    const res = a.contents;
-    if (res.tag === "VectorV") {
-      return res.contents;
+    if (a.tag === "Val") {
+        const res = a.contents;
+        if (res.tag === "VectorV") {
+            return res.contents;
+        } else {
+            console.log("res", res);
+            throw Error("Expected vector type in list");
+        }
     } else {
-      console.log("res", res);
-      throw Error("Expected vector type in list");
+        console.log("res", a);
+        throw Error("Expected value (non-GPI) type in list");
     }
-  } else {
-    console.log("res", a);
-    throw Error("Expected value (non-GPI) type in list");
-  }
 }
 
 /**
@@ -306,345 +307,345 @@ function toVecVal<T>(a: ArgVal<T>): T[] {
  * TODO: break cycles; optimize lookup
  */
 export const evalExpr = (
-  e: Expr,
-  trans: Translation,
-  varyingVars?: VaryMap<VarAD>,
-  optDebugInfo?: OptDebugInfo
+    e: Expr,
+    trans: Translation,
+    varyingVars?: VaryMap<VarAD>,
+    optDebugInfo?: OptDebugInfo
 ): ArgVal<VarAD> => {
-  // console.log("evalExpr", e);
+    // console.log("evalExpr", e);
 
-  switch (e.tag) {
-    // COMBAK: Deal with ints
-    // case "IntLit": {
-    //   return { tag: "Val", contents: { tag: "IntV", contents: e.contents } };
-    // }
+    switch (e.tag) {
+        // COMBAK: Deal with ints
+        // case "IntLit": {
+        //   return { tag: "Val", contents: { tag: "IntV", contents: e.contents } };
+        // }
 
-    case "StringLit": {
-      return { tag: "Val", contents: { tag: "StrV", contents: e.contents } };
-    }
-
-    case "BoolLit": {
-      return { tag: "Val", contents: { tag: "BoolV", contents: e.contents } };
-    }
-
-    case "Vary": {
-      console.error("expr", e, "trans", trans, "varyingVars", varyingVars);
-      throw new Error("encountered an unsubstituted varying value");
-    }
-
-    case "Fix": {
-      const val = e.contents;
-
-      // Don't convert to VarAD if it's already been converted
-      return {
-        tag: "Val",
-        // Fixed number is stored in translation as number, made differentiable when encountered
-        contents: {
-          tag: "FloatV",
-          contents: constOfIf(val),
-        },
-      };
-    }
-
-    case "UOp": {
-      const [uOp, expr] = [e.op, e.arg];
-      // TODO: use the type system to narrow down Value to Float and Int?
-      const arg = evalExpr(expr, trans, varyingVars, optDebugInfo).contents;
-      return {
-        tag: "Val",
-        // HACK: coerce the type for now to let the compiler finish
-        contents: evalUOp(uOp, arg as IFloatV<VarAD> | IIntV),
-      };
-    }
-
-    case "BinOp": {
-      const [binOp, e1, e2] = [e.op, e.left, e.right];
-
-      const [val1, val2] = evalExprs(
-        [e1, e2],
-        trans,
-        varyingVars,
-        optDebugInfo
-      );
-
-      const res = evalBinOp(
-        binOp,
-        val1.contents as Value<VarAD>,
-        val2.contents as Value<VarAD>
-      );
-
-      return {
-        tag: "Val",
-        // HACK: coerce the type for now to let the compiler finish
-        contents: res,
-      };
-    }
-
-    case "Tuple": {
-      const argVals = evalExprs(e.contents, trans, varyingVars, optDebugInfo);
-      if (argVals.length !== 2) {
-        console.log(argVals);
-        throw Error("Expected tuple of length 2");
-      }
-      return {
-        tag: "Val",
-        contents: {
-          tag: "TupV",
-          contents: [toFloatVal(argVals[0]), toFloatVal(argVals[1])],
-        },
-      };
-    }
-    case "List": {
-      const argVals = evalExprs(e.contents, trans, varyingVars, optDebugInfo);
-
-      // The below code makes a type assumption about the whole list, based on the first elements
-      // Is there a better way to implement parametric lists in typescript?
-      if (!argVals[0]) {
-        // Empty list
-        return {
-          tag: "Val",
-          contents: {
-            tag: "ListV",
-            contents: [] as VarAD[],
-          },
-        };
-      }
-
-      if (argVals[0].tag === "Val") {
-        // List contains floats
-        if (argVals[0].contents.tag === "FloatV") {
-          return {
-            tag: "Val",
-            contents: {
-              tag: "ListV",
-              contents: argVals.map(toFloatVal),
-            },
-          };
-        } else if (argVals[0].contents.tag === "VectorV") {
-          // List contains vectors
-          return {
-            tag: "Val",
-            contents: {
-              tag: "LListV", // NOTE: The type has changed from ListV to LListV! That's because ListV's `T` is "not parametric enough" to represent a list of elements
-              contents: argVals.map(toVecVal),
-            } as ILListV<VarAD>,
-          };
-        }
-      } else {
-        console.error("list elems", argVals);
-        throw Error("unsupported element in list");
-      }
-    }
-
-    case "ListAccess": {
-      throw Error("List access expression not (yet) supported");
-    }
-
-    case "Vector": {
-      const argVals = evalExprs(e.contents, trans, varyingVars, optDebugInfo);
-
-      // Matrices are parsed as a list of vectors, so when we encounter vectors as elements, we assume it's a matrix, and convert it to a matrix of lists
-      if (argVals[0].tag !== "Val") {
-        throw Error("expected val");
-      }
-      if (argVals[0].contents.tag === "VectorV") {
-        return {
-          tag: "Val",
-          contents: {
-            tag: "MatrixV",
-            contents: argVals.map(toVecVal),
-          },
-        };
-      }
-
-      // Otherwise return vec (list of nums)
-      return {
-        tag: "Val",
-        contents: {
-          tag: "VectorV",
-          contents: argVals.map(toFloatVal),
-        },
-      };
-    }
-
-    case "Matrix": {
-      // This tag is here, but actually, matrices are parsed as lists of vectors, so this case is never hit
-      console.log("matrix e", e);
-      throw new Error(`cannot evaluate expression of type ${e.tag}`);
-    }
-
-    case "VectorAccess": {
-      // COMBAK: Deprecate Vector/MatrixAccess
-      // throw Error("deprecated");
-
-      const [e1, e2] = e.contents;
-
-      const v1 = resolvePath(e1, trans, varyingVars, optDebugInfo);
-      const v2 = evalExpr(e2, trans, varyingVars, optDebugInfo);
-
-      if (v1.tag !== "Val") {
-        throw Error("expected val");
-      }
-      if (v2.tag !== "Val") {
-        throw Error("expected val");
-      }
-
-      // COMBAK: Do float to int conversion in a more principled way. For now, convert float to int on demand
-      if (v2.contents.tag === "FloatV") {
-        // COMBAK: (ISSUE): Indices should not have "Fix"
-        const iObj: IVarAD = v2.contents.contents;
-        v2.contents = {
-          tag: "IntV",
-          contents: Math.floor(numOf(iObj)),
-        };
-      }
-
-      if (v2.contents.tag !== "IntV") {
-        throw Error("expected int");
-      }
-
-      const i: number = v2.contents.contents;
-
-      // LList access (since any expr with brackets is parsed as a vector access
-      if (v1.contents.tag === "LListV") {
-        const llist = v1.contents.contents;
-        if (i < 0 || i > llist.length) throw Error("access out of bounds");
-        return { tag: "Val", contents: { tag: "VectorV", contents: llist[i] } };
-      }
-
-      // Vector access
-      if (v1.contents.tag !== "VectorV") {
-        console.log("results", v1, v2);
-        throw Error("expected Vector");
-      }
-      const vec = v1.contents.contents;
-      if (i < 0 || i > vec.length) throw Error("access out of bounds");
-
-      return {
-        tag: "Val",
-        contents: { tag: "FloatV", contents: vec[i] },
-      };
-    }
-
-    case "MatrixAccess": {
-      // COMBAK: Deprecate Vector/MatrixAccess
-      // throw Error("deprecated");
-
-      const [e1, e2] = e.contents;
-      const v1 = resolvePath(e1, trans, varyingVars, optDebugInfo);
-      const v2s = evalExprs(e2, trans, varyingVars, optDebugInfo);
-
-      const indices: number[] = v2s.map((v2) => {
-        if (v2.tag !== "Val") {
-          throw Error("expected val");
-        }
-        if (v2.contents.tag !== "IntV") {
-          throw Error("expected int");
-        }
-        return v2.contents.contents;
-      });
-
-      if (v1.tag !== "Val") {
-        throw Error("expected val");
-      }
-
-      if (v1.contents.tag !== "MatrixV") {
-        throw Error("expected Matrix");
-      }
-
-      // m[i][j] <-- m's ith row, jth column
-      const mat = v1.contents.contents;
-      // TODO: Currently only supports 2D matrices
-      if (!indices.length || indices.length !== 2) {
-        throw Error("expected 2 indices to access matrix");
-      }
-
-      const [i, j] = indices;
-      if (i < 0 || i > mat.length - 1) throw Error("`i` access out of bounds");
-      const vec = mat[i];
-      if (j < 0 || j > vec.length - 1) throw Error("`j` access out of bounds");
-
-      return {
-        tag: "Val",
-        contents: { tag: "FloatV", contents: vec[j] },
-      };
-    }
-
-    case "CompApp": {
-      const [fnName, argExprs] = [e.name.value, e.args];
-
-      if (fnName === "derivative" || fnName === "derivativePreconditioned") {
-        // Special function: don't look up the path's value, but its gradient's value
-
-        if (argExprs.length !== 1) {
-          throw Error(
-            `expected 1 argument to ${fnName}; got ${argExprs.length}`
-          );
+        case "StringLit": {
+            return { tag: "Val", contents: { tag: "StrV", contents: e.contents } };
         }
 
-        let p = argExprs[0]; // special function can only have one argument
-
-        // Vector and matrix accesses are the only way to refer to an anon varying var
-        // p.tag !== "EPath"
-        if (
-          !isPath(p) &&
-          p.tag !== "VectorAccess" &&
-          p.tag !== "MatrixAccess"
-        ) {
-          throw Error(`expected 1 path as argument to ${fnName}; got ${p.tag}`);
+        case "BoolLit": {
+            return { tag: "Val", contents: { tag: "BoolV", contents: e.contents } };
         }
 
-        if (p.tag === "VectorAccess") {
-          p = {
-            // convert to AccessPath schema
-            nodeType: "dummyNode",
-            children: [],
-            start: dummySourceLoc(),
-            end: dummySourceLoc(),
-            tag: "AccessPath",
-            // contents: [p.contents[0], [p.contents[1].contents]],
-            path: p.contents[0],
-            indices: [p.contents[1]],
-          };
-        } else if (p.tag === "MatrixAccess") {
-          p = {
-            // convert to AccessPath schema
-            nodeType: "dummyNode",
-            children: [],
-            start: dummySourceLoc(),
-            end: dummySourceLoc(),
-            tag: "AccessPath",
-            path: p.contents[0],
-            indices: p.contents[1],
-          };
+        case "Vary": {
+            console.error("expr", e, "trans", trans, "varyingVars", varyingVars);
+            throw new Error("encountered an unsubstituted varying value");
         }
 
-        return {
-          tag: "Val",
-          contents: compDict[fnName](
-            optDebugInfo as OptDebugInfo,
-            JSON.stringify(p) // COMBAK: Test that derivatives still work. Might break due to JSON.stringify(p) changing?
-          ),
-        };
-      }
+        case "Fix": {
+            const val = e.contents;
 
-      // eval all args
-      const args = evalExprs(argExprs, trans, varyingVars, optDebugInfo);
-      const argValues = args.map((a) => argValue(a));
-      checkComp(fnName, args);
+            // Don't convert to VarAD if it's already been converted
+            return {
+                tag: "Val",
+                // Fixed number is stored in translation as number, made differentiable when encountered
+                contents: {
+                    tag: "FloatV",
+                    contents: constOfIf(val),
+                },
+            };
+        }
 
-      // retrieve comp function from a global dict and call the function
-      return { tag: "Val", contents: compDict[fnName](...argValues) };
+        case "UOp": {
+            const [uOp, expr] = [e.op, e.arg];
+            // TODO: use the type system to narrow down Value to Float and Int?
+            const arg = evalExpr(expr, trans, varyingVars, optDebugInfo).contents;
+            return {
+                tag: "Val",
+                // HACK: coerce the type for now to let the compiler finish
+                contents: evalUOp(uOp, arg as IFloatV<VarAD> | IIntV),
+            };
+        }
+
+        case "BinOp": {
+            const [binOp, e1, e2] = [e.op, e.left, e.right];
+
+            const [val1, val2] = evalExprs(
+                [e1, e2],
+                trans,
+                varyingVars,
+                optDebugInfo
+            );
+
+            const res = evalBinOp(
+                binOp,
+                val1.contents as Value<VarAD>,
+                val2.contents as Value<VarAD>
+            );
+
+            return {
+                tag: "Val",
+                // HACK: coerce the type for now to let the compiler finish
+                contents: res,
+            };
+        }
+
+        case "Tuple": {
+            const argVals = evalExprs(e.contents, trans, varyingVars, optDebugInfo);
+            if (argVals.length !== 2) {
+                console.log(argVals);
+                throw Error("Expected tuple of length 2");
+            }
+            return {
+                tag: "Val",
+                contents: {
+                    tag: "TupV",
+                    contents: [toFloatVal(argVals[0]), toFloatVal(argVals[1])],
+                },
+            };
+        }
+        case "List": {
+            const argVals = evalExprs(e.contents, trans, varyingVars, optDebugInfo);
+
+            // The below code makes a type assumption about the whole list, based on the first elements
+            // Is there a better way to implement parametric lists in typescript?
+            if (!argVals[0]) {
+                // Empty list
+                return {
+                    tag: "Val",
+                    contents: {
+                        tag: "ListV",
+                        contents: [] as VarAD[],
+                    },
+                };
+            }
+
+            if (argVals[0].tag === "Val") {
+                // List contains floats
+                if (argVals[0].contents.tag === "FloatV") {
+                    return {
+                        tag: "Val",
+                        contents: {
+                            tag: "ListV",
+                            contents: argVals.map(toFloatVal),
+                        },
+                    };
+                } else if (argVals[0].contents.tag === "VectorV") {
+                    // List contains vectors
+                    return {
+                        tag: "Val",
+                        contents: {
+                            tag: "LListV", // NOTE: The type has changed from ListV to LListV! That's because ListV's `T` is "not parametric enough" to represent a list of elements
+                            contents: argVals.map(toVecVal),
+                        } as ILListV<VarAD>,
+                    };
+                }
+            } else {
+                console.error("list elems", argVals);
+                throw Error("unsupported element in list");
+            }
+        }
+
+        case "ListAccess": {
+            throw Error("List access expression not (yet) supported");
+        }
+
+        case "Vector": {
+            const argVals = evalExprs(e.contents, trans, varyingVars, optDebugInfo);
+
+            // Matrices are parsed as a list of vectors, so when we encounter vectors as elements, we assume it's a matrix, and convert it to a matrix of lists
+            if (argVals[0].tag !== "Val") {
+                throw Error("expected val");
+            }
+            if (argVals[0].contents.tag === "VectorV") {
+                return {
+                    tag: "Val",
+                    contents: {
+                        tag: "MatrixV",
+                        contents: argVals.map(toVecVal),
+                    },
+                };
+            }
+
+            // Otherwise return vec (list of nums)
+            return {
+                tag: "Val",
+                contents: {
+                    tag: "VectorV",
+                    contents: argVals.map(toFloatVal),
+                },
+            };
+        }
+
+        case "Matrix": {
+            // This tag is here, but actually, matrices are parsed as lists of vectors, so this case is never hit
+            console.log("matrix e", e);
+            throw new Error(`cannot evaluate expression of type ${e.tag}`);
+        }
+
+        case "VectorAccess": {
+            // COMBAK: Deprecate Vector/MatrixAccess
+            // throw Error("deprecated");
+
+            const [e1, e2] = e.contents;
+
+            const v1 = resolvePath(e1, trans, varyingVars, optDebugInfo);
+            const v2 = evalExpr(e2, trans, varyingVars, optDebugInfo);
+
+            if (v1.tag !== "Val") {
+                throw Error("expected val");
+            }
+            if (v2.tag !== "Val") {
+                throw Error("expected val");
+            }
+
+            // COMBAK: Do float to int conversion in a more principled way. For now, convert float to int on demand
+            if (v2.contents.tag === "FloatV") {
+                // COMBAK: (ISSUE): Indices should not have "Fix"
+                const iObj: IVarAD = v2.contents.contents;
+                v2.contents = {
+                    tag: "IntV",
+                    contents: Math.floor(numOf(iObj)),
+                };
+            }
+
+            if (v2.contents.tag !== "IntV") {
+                throw Error("expected int");
+            }
+
+            const i: number = v2.contents.contents;
+
+            // LList access (since any expr with brackets is parsed as a vector access
+            if (v1.contents.tag === "LListV") {
+                const llist = v1.contents.contents;
+                if (i < 0 || i > llist.length) throw Error("access out of bounds");
+                return { tag: "Val", contents: { tag: "VectorV", contents: llist[i] } };
+            }
+
+            // Vector access
+            if (v1.contents.tag !== "VectorV") {
+                console.log("results", v1, v2);
+                throw Error("expected Vector");
+            }
+            const vec = v1.contents.contents;
+            if (i < 0 || i > vec.length) throw Error("access out of bounds");
+
+            return {
+                tag: "Val",
+                contents: { tag: "FloatV", contents: vec[i] },
+            };
+        }
+
+        case "MatrixAccess": {
+            // COMBAK: Deprecate Vector/MatrixAccess
+            // throw Error("deprecated");
+
+            const [e1, e2] = e.contents;
+            const v1 = resolvePath(e1, trans, varyingVars, optDebugInfo);
+            const v2s = evalExprs(e2, trans, varyingVars, optDebugInfo);
+
+            const indices: number[] = v2s.map((v2) => {
+                if (v2.tag !== "Val") {
+                    throw Error("expected val");
+                }
+                if (v2.contents.tag !== "IntV") {
+                    throw Error("expected int");
+                }
+                return v2.contents.contents;
+            });
+
+            if (v1.tag !== "Val") {
+                throw Error("expected val");
+            }
+
+            if (v1.contents.tag !== "MatrixV") {
+                throw Error("expected Matrix");
+            }
+
+            // m[i][j] <-- m's ith row, jth column
+            const mat = v1.contents.contents;
+            // TODO: Currently only supports 2D matrices
+            if (!indices.length || indices.length !== 2) {
+                throw Error("expected 2 indices to access matrix");
+            }
+
+            const [i, j] = indices;
+            if (i < 0 || i > mat.length - 1) throw Error("`i` access out of bounds");
+            const vec = mat[i];
+            if (j < 0 || j > vec.length - 1) throw Error("`j` access out of bounds");
+
+            return {
+                tag: "Val",
+                contents: { tag: "FloatV", contents: vec[j] },
+            };
+        }
+
+        case "CompApp": {
+            const [fnName, argExprs] = [e.name.value, e.args];
+
+            if (fnName === "derivative" || fnName === "derivativePreconditioned") {
+                // Special function: don't look up the path's value, but its gradient's value
+
+                if (argExprs.length !== 1) {
+                    throw Error(
+                        `expected 1 argument to ${fnName}; got ${argExprs.length}`
+                    );
+                }
+
+                let p = argExprs[0]; // special function can only have one argument
+
+                // Vector and matrix accesses are the only way to refer to an anon varying var
+                // p.tag !== "EPath"
+                if (
+                    !isPath(p) &&
+                    p.tag !== "VectorAccess" &&
+                    p.tag !== "MatrixAccess"
+                ) {
+                    throw Error(`expected 1 path as argument to ${fnName}; got ${p.tag}`);
+                }
+
+                if (p.tag === "VectorAccess") {
+                    p = {
+                        // convert to AccessPath schema
+                        nodeType: "dummyNode",
+                        children: [],
+                        start: dummySourceLoc(),
+                        end: dummySourceLoc(),
+                        tag: "AccessPath",
+                        // contents: [p.contents[0], [p.contents[1].contents]],
+                        path: p.contents[0],
+                        indices: [p.contents[1]],
+                    };
+                } else if (p.tag === "MatrixAccess") {
+                    p = {
+                        // convert to AccessPath schema
+                        nodeType: "dummyNode",
+                        children: [],
+                        start: dummySourceLoc(),
+                        end: dummySourceLoc(),
+                        tag: "AccessPath",
+                        path: p.contents[0],
+                        indices: p.contents[1],
+                    };
+                }
+
+                return {
+                    tag: "Val",
+                    contents: compDict[fnName](
+                        optDebugInfo as OptDebugInfo,
+                        JSON.stringify(p) // COMBAK: Test that derivatives still work. Might break due to JSON.stringify(p) changing?
+                    ),
+                };
+            }
+
+            // eval all args
+            const args = evalExprs(argExprs, trans, varyingVars, optDebugInfo);
+            const argValues = args.map((a) => argValue(a));
+            checkComp(fnName, args);
+
+            // retrieve comp function from a global dict and call the function
+            return { tag: "Val", contents: compDict[fnName](...argValues) };
+        }
+
+        default: {
+            if (isPath(e)) {
+                return resolvePath(e, trans, varyingVars, optDebugInfo);
+            }
+
+            throw new Error(`cannot evaluate expression of type ${e.tag}`);
+        }
     }
-
-    default: {
-      if (isPath(e)) {
-        return resolvePath(e, trans, varyingVars, optDebugInfo);
-      }
-
-      throw new Error(`cannot evaluate expression of type ${e.tag}`);
-    }
-  }
 };
 
 /**
@@ -657,157 +658,157 @@ export const evalExpr = (
  * Looks up varying vars first
  */
 export const resolvePath = (
-  path: Path,
-  trans: Translation,
-  varyingMap?: VaryMap<VarAD>,
-  optDebugInfo?: OptDebugInfo
+    path: Path,
+    trans: Translation,
+    varyingMap?: VaryMap<VarAD>,
+    optDebugInfo?: OptDebugInfo
 ): ArgVal<VarAD> => {
-  // HACK: this is a temporary way to consistently compare paths. We will need to make varymap much more efficient
-  let varyingVal = varyingMap?.get(JSON.stringify(path));
+    // HACK: this is a temporary way to consistently compare paths. We will need to make varymap much more efficient
+    let varyingVal = varyingMap?.get(JSON.stringify(path));
 
-  if (varyingVal) {
-    return floatVal(varyingVal);
-  } else {
-    // NOTE: a VectorAccess or MatrixAccess to varying variables isn't looked up in the varying paths (since `VectorAccess`, etc. in `evalExpr` don't call `resolvePath`; it works because varying vars are inserted into the translation (see `evalEnergyOn`)
-    // NOTE: varyingMap includes vars of form AccessPath but not Vector/Matrix access
-    if (path.tag === "AccessPath") {
-      // Evaluate it as Vector or Matrix access as appropriate (COMBAK: Deprecate Vector/Matrix access on second pass, and also remove Vector/Matrix conversion to accesspath for derivative debugging computations)
+    if (varyingVal) {
+        return floatVal(varyingVal);
+    } else {
+        // NOTE: a VectorAccess or MatrixAccess to varying variables isn't looked up in the varying paths (since `VectorAccess`, etc. in `evalExpr` don't call `resolvePath`; it works because varying vars are inserted into the translation (see `evalEnergyOn`)
+        // NOTE: varyingMap includes vars of form AccessPath but not Vector/Matrix access
+        if (path.tag === "AccessPath") {
+            // Evaluate it as Vector or Matrix access as appropriate (COMBAK: Deprecate Vector/Matrix access on second pass, and also remove Vector/Matrix conversion to accesspath for derivative debugging computations)
 
-      // console.log("path", path);
-      // console.log("trans", trans);
-      // console.log("varyingMap", varyingMap);
+            // console.log("path", path);
+            // console.log("trans", trans);
+            // console.log("varyingMap", varyingMap);
 
-      if (path.indices.length === 1) {
-        // Vector
+            if (path.indices.length === 1) {
+                // Vector
 
-        // if (path.path.tag === "FieldPath") {
-        //   if (path.path.field.value === "markerLine") {
-        //     debugger;
-        //   }
-        // }
+                // if (path.path.tag === "FieldPath") {
+                //   if (path.path.field.value === "markerLine") {
+                //     debugger;
+                //   }
+                // }
 
-        const e: Expr = {
-          ...path,
-          tag: "VectorAccess",
-          contents: [path.path, path.indices[0]],
-        };
-        return evalExpr(e, trans, varyingMap, optDebugInfo);
-      } else if (path.indices.length === 2) {
-        // Matrix
-        const e: Expr = {
-          ...path,
-          tag: "MatrixAccess",
-          contents: [path.path, path.indices],
-        };
-        return evalExpr(e, trans, varyingMap, optDebugInfo);
-      } else throw Error("unsupported number of indices in AccessPath");
-    }
-
-    if (path.tag === "InternalLocalVar" || path.tag === "LocalVar") {
-      throw Error("should not encounter local var in evaluation");
-    }
-
-    const gpiOrExpr = findExpr(trans, path);
-
-    switch (gpiOrExpr.tag) {
-      case "FGPI": {
-        const [type, props] = gpiOrExpr.contents;
-
-        // Evaluate GPI (i.e. each property path in GPI -- NOT necessarily the path's expression)
-        const evaledProps = mapValues(props, (p, propName) => {
-          const propertyPath: IPropertyPath = {
-            ...path,
-            tag: "PropertyPath",
-            name: path.name,
-            field: path.field,
-            property: dummyIdentifier(propName),
-          };
-
-          if (p.tag === "OptEval") {
-            // Evaluate each property path and cache the results (so, e.g. the next lookup just returns a Value)
-            // `resolve path A.val.x = f(z, y)` ===> `f(z, y) evaluates to c` ===>
-            // `set A.val.x = r` ===> `next lookup of A.val.x yields c instead of computing f(z, y)`
-            const propertyPathExpr = propertyPath as Path;
-            const val: Value<VarAD> = (evalExpr(
-              propertyPathExpr,
-              trans,
-              varyingMap,
-              optDebugInfo
-            ) as IVal<VarAD>).contents;
-            const transNew = insertExpr(
-              propertyPath,
-              { tag: "Done", contents: val },
-              trans
-            );
-            return val;
-          } else {
-            // Look up in varyingMap to see if there is a fresh value
-            varyingVal = varyingMap?.get(JSON.stringify(propertyPath));
-            if (varyingVal) {
-              return { tag: "FloatV", contents: varyingVal };
-            } else {
-              return p.contents;
-            }
-          }
-        });
-
-        // No need to cache evaluated GPI as each of its individual properties should have been cached on evaluation
-        return {
-          tag: "GPI",
-          contents: [type, evaledProps] as GPI<VarAD>,
-        };
-      }
-
-      // Otherwise, either evaluate or return the expression
-      default: {
-        const expr: TagExpr<VarAD> = gpiOrExpr;
-
-        if (expr.tag === "OptEval") {
-          // Evaluate the expression and cache the results (so, e.g. the next lookup just returns a Value)
-          const res: ArgVal<VarAD> = evalExpr(
-            expr.contents,
-            trans,
-            varyingMap,
-            optDebugInfo
-          );
-
-          if (res.tag === "Val") {
-            const transNew = insertExpr(
-              path,
-              { tag: "Done", contents: res.contents },
-              trans
-            );
-            return res;
-          } else if (res.tag === "GPI") {
-            throw Error(
-              "Field expression evaluated to GPI when this case was eliminated"
-            );
-          } else {
-            throw Error("Unknown tag");
-          }
-        } else if (expr.tag === "Done" || expr.tag === "Pending") {
-          // Already done, just return results of lookup -- this is a cache hit
-          return { tag: "Val", contents: expr.contents };
-        } else {
-          throw Error("Unexpected tag");
+                const e: Expr = {
+                    ...path,
+                    tag: "VectorAccess",
+                    contents: [path.path, path.indices[0]],
+                };
+                return evalExpr(e, trans, varyingMap, optDebugInfo);
+            } else if (path.indices.length === 2) {
+                // Matrix
+                const e: Expr = {
+                    ...path,
+                    tag: "MatrixAccess",
+                    contents: [path.path, path.indices],
+                };
+                return evalExpr(e, trans, varyingMap, optDebugInfo);
+            } else throw Error("unsupported number of indices in AccessPath");
         }
-      }
+
+        if (path.tag === "InternalLocalVar" || path.tag === "LocalVar") {
+            throw Error("should not encounter local var in evaluation");
+        }
+
+        const gpiOrExpr = findExprSafe(trans, path);
+
+        switch (gpiOrExpr.tag) {
+            case "FGPI": {
+                const [type, props] = gpiOrExpr.contents;
+
+                // Evaluate GPI (i.e. each property path in GPI -- NOT necessarily the path's expression)
+                const evaledProps = mapValues(props, (p, propName) => {
+                    const propertyPath: IPropertyPath = {
+                        ...path,
+                        tag: "PropertyPath",
+                        name: path.name,
+                        field: path.field,
+                        property: dummyIdentifier(propName),
+                    };
+
+                    if (p.tag === "OptEval") {
+                        // Evaluate each property path and cache the results (so, e.g. the next lookup just returns a Value)
+                        // `resolve path A.val.x = f(z, y)` ===> `f(z, y) evaluates to c` ===>
+                        // `set A.val.x = r` ===> `next lookup of A.val.x yields c instead of computing f(z, y)`
+                        const propertyPathExpr = propertyPath as Path;
+                        const val: Value<VarAD> = (evalExpr(
+                            propertyPathExpr,
+                            trans,
+                            varyingMap,
+                            optDebugInfo
+                        ) as IVal<VarAD>).contents;
+                        const transNew = insertExpr(
+                            propertyPath,
+                            { tag: "Done", contents: val },
+                            trans
+                        );
+                        return val;
+                    } else {
+                        // Look up in varyingMap to see if there is a fresh value
+                        varyingVal = varyingMap?.get(JSON.stringify(propertyPath));
+                        if (varyingVal) {
+                            return { tag: "FloatV", contents: varyingVal };
+                        } else {
+                            return p.contents;
+                        }
+                    }
+                });
+
+                // No need to cache evaluated GPI as each of its individual properties should have been cached on evaluation
+                return {
+                    tag: "GPI",
+                    contents: [type, evaledProps] as GPI<VarAD>,
+                };
+            }
+
+            // Otherwise, either evaluate or return the expression
+            default: {
+                const expr: TagExpr<VarAD> = gpiOrExpr;
+
+                if (expr.tag === "OptEval") {
+                    // Evaluate the expression and cache the results (so, e.g. the next lookup just returns a Value)
+                    const res: ArgVal<VarAD> = evalExpr(
+                        expr.contents,
+                        trans,
+                        varyingMap,
+                        optDebugInfo
+                    );
+
+                    if (res.tag === "Val") {
+                        const transNew = insertExpr(
+                            path,
+                            { tag: "Done", contents: res.contents },
+                            trans
+                        );
+                        return res;
+                    } else if (res.tag === "GPI") {
+                        throw Error(
+                            "Field expression evaluated to GPI when this case was eliminated"
+                        );
+                    } else {
+                        throw Error("Unknown tag");
+                    }
+                } else if (expr.tag === "Done" || expr.tag === "Pending") {
+                    // Already done, just return results of lookup -- this is a cache hit
+                    return { tag: "Val", contents: expr.contents };
+                } else {
+                    throw Error("Unexpected tag");
+                }
+            }
+        }
     }
-  }
 };
 
 // HACK: remove the type wrapper for the argument
 export const argValue = (e: ArgVal<VarAD>) => {
-  switch (e.tag) {
-    case "GPI": // strip the `GPI` tag
-      return e.contents;
-    case "Val": // strip both `Val` and type annotation like `FloatV`
-      return e.contents.contents;
-  }
+    switch (e.tag) {
+        case "GPI": // strip the `GPI` tag
+            return e.contents;
+        case "Val": // strip both `Val` and type annotation like `FloatV`
+            return e.contents.contents;
+    }
 };
 
 export const intToFloat = (v: IIntV): IFloatV<VarAD> => {
-  return { tag: "FloatV", contents: constOf(v.contents) };
+    return { tag: "FloatV", contents: constOf(v.contents) };
 };
 
 /**
@@ -817,126 +818,126 @@ export const intToFloat = (v: IIntV): IFloatV<VarAD> => {
  * @param arg the argument, must be float or int
  */
 export const evalBinOp = (
-  op: BinaryOp,
-  v1: Value<VarAD>,
-  v2: Value<VarAD>
+    op: BinaryOp,
+    v1: Value<VarAD>,
+    v2: Value<VarAD>
 ): Value<VarAD> => {
-  // Promote int to float
-  if (v1.tag === "IntV" && v2.tag === "FloatV") {
-    return evalBinOp(op, intToFloat(v1), v2);
-  } else if (v1.tag === "FloatV" && v2.tag === "IntV") {
-    return evalBinOp(op, v1, intToFloat(v2));
-  }
-
-  // NOTE: need to explicitly check the types so the compiler will understand
-  if (v1.tag === "FloatV" && v2.tag === "FloatV") {
-    let res;
-
-    switch (op) {
-      case "BPlus": {
-        res = add(v1.contents, v2.contents);
-        break;
-      }
-
-      case "BMinus": {
-        res = sub(v1.contents, v2.contents);
-        break;
-      }
-
-      case "Multiply": {
-        res = mul(v1.contents, v2.contents);
-        break;
-      }
-
-      case "Divide": {
-        res = div(v1.contents, v2.contents);
-        break;
-      }
-
-      case "Exp": {
-        throw Error("Pow op unimplemented");
-        // res = v1.contents.powStrict(v2.contents);
-        break;
-      }
+    // Promote int to float
+    if (v1.tag === "IntV" && v2.tag === "FloatV") {
+        return evalBinOp(op, intToFloat(v1), v2);
+    } else if (v1.tag === "FloatV" && v2.tag === "IntV") {
+        return evalBinOp(op, v1, intToFloat(v2));
     }
 
-    return { tag: "FloatV", contents: res };
-  } else if (v1.tag === "IntV" && v2.tag === "IntV") {
-    const returnType = "IntV";
-    let res;
+    // NOTE: need to explicitly check the types so the compiler will understand
+    if (v1.tag === "FloatV" && v2.tag === "FloatV") {
+        let res;
 
-    switch (op) {
-      case "BPlus": {
-        res = v1.contents + v2.contents;
-        break;
-      }
+        switch (op) {
+            case "BPlus": {
+                res = add(v1.contents, v2.contents);
+                break;
+            }
 
-      case "BMinus": {
-        res = v1.contents - v2.contents;
-        break;
-      }
+            case "BMinus": {
+                res = sub(v1.contents, v2.contents);
+                break;
+            }
 
-      case "Multiply": {
-        res = v1.contents * v2.contents;
-        break;
-      }
+            case "Multiply": {
+                res = mul(v1.contents, v2.contents);
+                break;
+            }
 
-      case "Divide": {
-        res = v1.contents / v2.contents;
-        return { tag: "FloatV", contents: constOf(res) };
-      }
+            case "Divide": {
+                res = div(v1.contents, v2.contents);
+                break;
+            }
 
-      case "Exp": {
-        res = Math.pow(v1.contents, v2.contents);
-        break;
-      }
+            case "Exp": {
+                throw Error("Pow op unimplemented");
+                // res = v1.contents.powStrict(v2.contents);
+                break;
+            }
+        }
+
+        return { tag: "FloatV", contents: res };
+    } else if (v1.tag === "IntV" && v2.tag === "IntV") {
+        const returnType = "IntV";
+        let res;
+
+        switch (op) {
+            case "BPlus": {
+                res = v1.contents + v2.contents;
+                break;
+            }
+
+            case "BMinus": {
+                res = v1.contents - v2.contents;
+                break;
+            }
+
+            case "Multiply": {
+                res = v1.contents * v2.contents;
+                break;
+            }
+
+            case "Divide": {
+                res = v1.contents / v2.contents;
+                return { tag: "FloatV", contents: constOf(res) };
+            }
+
+            case "Exp": {
+                res = Math.pow(v1.contents, v2.contents);
+                break;
+            }
+        }
+
+        return { tag: "IntV", contents: res };
+    } else if (v1.tag === "VectorV" && v2.tag === "VectorV") {
+        let res;
+
+        switch (op) {
+            case "BPlus": {
+                res = ops.vadd(v1.contents, v2.contents);
+                break;
+            }
+
+            case "BMinus": {
+                res = ops.vsub(v1.contents, v2.contents);
+                break;
+            }
+        }
+
+        return { tag: "VectorV", contents: res as VarAD[] };
+    } else if (v1.tag === "FloatV" && v2.tag === "VectorV") {
+        let res;
+
+        switch (op) {
+            case "Multiply": {
+                res = ops.vmul(v1.contents, v2.contents);
+                break;
+            }
+        }
+        return { tag: "VectorV", contents: res as VarAD[] };
+    } else if (v1.tag === "VectorV" && v2.tag === "FloatV") {
+        let res;
+
+        switch (op) {
+            case "Divide": {
+                res = ops.vdiv(v1.contents, v2.contents);
+                break;
+            }
+        }
+
+        return { tag: "VectorV", contents: res as VarAD[] };
+    } else {
+        throw new Error(
+            `the types of two operands to ${op} are not supported: ${v1.tag}, ${v2.tag}`
+        );
     }
 
-    return { tag: "IntV", contents: res };
-  } else if (v1.tag === "VectorV" && v2.tag === "VectorV") {
-    let res;
-
-    switch (op) {
-      case "BPlus": {
-        res = ops.vadd(v1.contents, v2.contents);
-        break;
-      }
-
-      case "BMinus": {
-        res = ops.vsub(v1.contents, v2.contents);
-        break;
-      }
-    }
-
-    return { tag: "VectorV", contents: res as VarAD[] };
-  } else if (v1.tag === "FloatV" && v2.tag === "VectorV") {
-    let res;
-
-    switch (op) {
-      case "Multiply": {
-        res = ops.vmul(v1.contents, v2.contents);
-        break;
-      }
-    }
-    return { tag: "VectorV", contents: res as VarAD[] };
-  } else if (v1.tag === "VectorV" && v2.tag === "FloatV") {
-    let res;
-
-    switch (op) {
-      case "Divide": {
-        res = ops.vdiv(v1.contents, v2.contents);
-        break;
-      }
-    }
-
-    return { tag: "VectorV", contents: res as VarAD[] };
-  } else {
-    throw new Error(
-      `the types of two operands to ${op} are not supported: ${v1.tag}, ${v2.tag}`
-    );
-  }
-
-  return v1; // TODO hack
+    return v1; // TODO hack
 };
 
 /**
@@ -946,92 +947,27 @@ export const evalBinOp = (
  * @param arg the argument, must be float or int
  */
 export const evalUOp = (
-  op: UnaryOp,
-  arg: IFloatV<VarAD> | IIntV | IVectorV<VarAD>
+    op: UnaryOp,
+    arg: IFloatV<VarAD> | IIntV | IVectorV<VarAD>
 ): Value<VarAD> => {
-  if (arg.tag === "FloatV") {
-    switch (op) {
-      case "UMinus":
-        return { ...arg, contents: neg(arg.contents) };
+    if (arg.tag === "FloatV") {
+        switch (op) {
+            case "UMinus":
+                return { ...arg, contents: neg(arg.contents) };
+        }
+    } else if (arg.tag === "IntV") {
+        switch (op) {
+            case "UMinus":
+                return { ...arg, contents: -arg.contents };
+        }
+    } else if (arg.tag === "VectorV") {
+        switch (op) {
+            case "UMinus":
+                return { ...arg, contents: ops.vneg(arg.contents) };
+        }
+    } else {
+        throw Error("unary op undefined on type ${arg.tag}, op ${op}");
     }
-  } else if (arg.tag === "IntV") {
-    switch (op) {
-      case "UMinus":
-        return { ...arg, contents: -arg.contents };
-    }
-  } else if (arg.tag === "VectorV") {
-    switch (op) {
-      case "UMinus":
-        return { ...arg, contents: ops.vneg(arg.contents) };
-    }
-  } else {
-    throw Error("unary op undefined on type ${arg.tag}, op ${op}");
-  }
-};
-
-/**
- * Finds an expression in a translation given a field or property path.
- *
- * @param trans - a translation from `State`
- * @param path - a path to an expression
- * @returns an expression
- *
- * TODO: the optional type here exist because GPI is not an expression in Style yet. It's not the most sustainable pattern w.r.t to our current way to typecasting the result using `as`.
- */
-export const findExpr = (
-  trans: Translation,
-  path: Path
-): TagExpr<VarAD> | IFGPI<VarAD> => {
-  let name, field, prop;
-
-  switch (path.tag) {
-    case "FieldPath": {
-      [name, field] = [path.name, path.field];
-      // Type cast to field expression
-      const fieldExpr = trans.trMap[name.contents.value][field.value];
-
-      if (!fieldExpr) {
-        throw Error(
-          `Could not find field '${prettyPrintPath(path)}' in translation`
-        );
-      }
-
-      switch (fieldExpr.tag) {
-        case "FGPI":
-          return fieldExpr;
-        case "FExpr":
-          return fieldExpr.contents;
-      }
-    }
-
-    case "PropertyPath": {
-      [name, field, prop] = [path.name, path.field, path.property];
-      // Type cast to FGPI and get the properties
-      const gpi = trans.trMap[name.contents.value][field.value];
-
-      if (!gpi) {
-        throw Error(
-          `Could not find GPI '${prettyPrintPath(path)}' in translation`
-        );
-      }
-
-      switch (gpi.tag) {
-        case "FExpr":
-          throw new Error("field path leads to an expression, not a GPI");
-        case "FGPI":
-          const [, propDict] = gpi.contents;
-          return propDict[prop.value];
-      }
-    }
-
-    case "AccessPath": {
-      throw Error("TODO");
-    }
-
-    default: {
-      throw Error("unsupported tag in findExpr");
-    }
-  }
 };
 
 /**
@@ -1040,27 +976,27 @@ export const findExpr = (
  * @param json plain object encoding `State` of the diagram
  */
 export const decodeState = (json: any): State => {
-  // const rng: prng = seedrandom(json.rng, { global: true });
-  const state = {
-    ...json,
-    varyingValues: json.varyingState,
-    translation: json.transr,
-    originalTranslation: clone(json.transr),
-    shapes: json.shapesr.map(([n, props]: any) => {
-      return { shapeType: n, properties: props };
-    }),
-    varyingMap: genPathMap(json.varyingPaths, json.varyingState),
-    params: json.paramsr,
-    pendingMap: new Map(),
-    rng: undefined,
-  };
-  // cache energy function
-  // state.overallObjective = evalEnergyOn(state);
-  delete state.shapesr;
-  delete state.transr;
-  delete state.paramsr;
-  // delete state.varyingState;
-  return state as State;
+    // const rng: prng = seedrandom(json.rng, { global: true });
+    const state = {
+        ...json,
+        varyingValues: json.varyingState,
+        translation: json.transr,
+        originalTranslation: clone(json.transr),
+        shapes: json.shapesr.map(([n, props]: any) => {
+            return { shapeType: n, properties: props };
+        }),
+        varyingMap: genPathMap(json.varyingPaths, json.varyingState),
+        params: json.paramsr,
+        pendingMap: new Map(),
+        rng: undefined,
+    };
+    // cache energy function
+    // state.overallObjective = evalEnergyOn(state);
+    delete state.shapesr;
+    delete state.transr;
+    delete state.paramsr;
+    // delete state.varyingState;
+    return state as State;
 };
 
 /**
@@ -1070,64 +1006,64 @@ export const decodeState = (json: any): State => {
  * @param state typed `State` object
  */
 export const encodeState = (state: State): any => {
-  // console.log("mapped translation", mapTranslation(numOf, state.translation));
-  // console.log("original translation", state.originalTranslation);
+    // console.log("mapped translation", mapTranslation(numOf, state.translation));
+    // console.log("original translation", state.originalTranslation);
 
-  // console.log("shapes", state.shapes);
-  // console.log("shapesr", state.shapes
-  //   .map(values)
-  //   .map(([n, props]) => [n, pickBy(props, (p: any) => !p.omit)]));
+    // console.log("shapes", state.shapes);
+    // console.log("shapesr", state.shapes
+    //   .map(values)
+    //   .map(([n, props]) => [n, pickBy(props, (p: any) => !p.omit)]));
 
-  const json = {
-    ...state,
-    varyingState: state.varyingValues,
-    paramsr: state.params, // TODO: careful about the list of variables
-    // transr: mapTranslation(numOf, state.translation), // Only send numbers to backend
-    transr: state.originalTranslation, // Only send numbers to backend
-    // NOTE: clean up all additional props and turn objects into lists
-    shapesr: state.shapes
-      .map(values)
-      .map(([n, props]) => [n, pickBy(props, (p: any) => !p.omit)]),
-  } as any;
-  delete json.varyingMap;
-  delete json.translation;
-  delete json.varyingValues;
-  delete json.shapes;
-  delete json.params;
-  json.paramsr.optStatus = { tag: "NewIter" };
-  return json;
+    const json = {
+        ...state,
+        varyingState: state.varyingValues,
+        paramsr: state.params, // TODO: careful about the list of variables
+        // transr: mapTranslation(numOf, state.translation), // Only send numbers to backend
+        transr: state.originalTranslation, // Only send numbers to backend
+        // NOTE: clean up all additional props and turn objects into lists
+        shapesr: state.shapes
+            .map(values)
+            .map(([n, props]) => [n, pickBy(props, (p: any) => !p.omit)]),
+    } as any;
+    delete json.varyingMap;
+    delete json.translation;
+    delete json.varyingValues;
+    delete json.shapes;
+    delete json.params;
+    json.paramsr.optStatus = { tag: "NewIter" };
+    return json;
 };
 
 export const cleanShapes = (shapes: Shape[]): Shape[] =>
-  shapes.map(({ shapeType, properties }: Shape) => ({
-    shapeType,
-    properties: pickBy(properties, (p: any) => !p.omit),
-  })) as Shape[];
+    shapes.map(({ shapeType, properties }: Shape) => ({
+        shapeType,
+        properties: pickBy(properties, (p: any) => !p.omit),
+    })) as Shape[];
 
 // Generate a map from paths to values, where the key is the JSON stringified version of the path
 export function genPathMap<T>(
-  paths: Path[],
-  vals: T[] // TODO: Distinguish between VarAD variables and constants?
+    paths: Path[],
+    vals: T[] // TODO: Distinguish between VarAD variables and constants?
 ): Map<string, T> {
-  if (!paths || !vals) {
-    return new Map(); // Empty, e.g. when the state is decoded, there is no gradient
-  }
+    if (!paths || !vals) {
+        return new Map(); // Empty, e.g. when the state is decoded, there is no gradient
+    }
 
-  if (vals.length !== paths.length) {
-    console.log(paths, vals);
-    throw new Error(
-      "Different numbers of varying vars vs. paths: " +
-        paths.length +
-        ", " +
-        vals.length
-    );
-  }
-  const res = new Map();
-  paths.forEach((path, index) => res.set(JSON.stringify(path), vals[index]));
+    if (vals.length !== paths.length) {
+        console.log(paths, vals);
+        throw new Error(
+            "Different numbers of varying vars vs. paths: " +
+            paths.length +
+            ", " +
+            vals.length
+        );
+    }
+    const res = new Map();
+    paths.forEach((path, index) => res.set(JSON.stringify(path), vals[index]));
 
-  // console.log("gen path map", res);
-  // throw Error("TODO");
-  return res;
+    // console.log("gen path map", res);
+    // throw Error("TODO");
+    return res;
 }
 
 // //////////////////////////////////////////////////////////////////////////////

--- a/packages/core/src/engine/Evaluator.ts
+++ b/packages/core/src/engine/Evaluator.ts
@@ -1,46 +1,50 @@
 import { checkComp, compDict } from "contrib/Functions";
 import {
-    mapTranslation,
-    valueAutodiffToNumber,
-    insertExpr,
-    isPath,
-    exprToNumber,
-    numToExpr,
-    findExprSafe
+  mapTranslation,
+  valueAutodiffToNumber,
+  insertExpr,
+  isPath,
+  exprToNumber,
+  numToExpr,
+  findExprSafe,
 } from "engine/EngineUtils";
 import { concat, mapValues, pickBy, values, zip } from "lodash";
 import seedrandom, { prng } from "seedrandom";
 import { Shape, Value } from "types/shapeTypes";
 import {
-    floatVal,
-    prettyPrintPath,
-    prettyPrintExpr,
-    prettyPrintFn,
+  floatVal,
+  prettyPrintPath,
+  prettyPrintExpr,
+  prettyPrintFn,
 } from "utils/OtherUtils";
 import {
-    add,
-    constOf,
-    constOfIf,
-    differentiable,
-    div,
-    mul,
-    neg,
-    numOf,
-    ops,
-    sub,
-    squared,
-    sqrt,
-    inverse,
-    absVal,
-    gt,
-    lt,
-    ifCond,
+  add,
+  constOf,
+  constOfIf,
+  differentiable,
+  div,
+  mul,
+  neg,
+  numOf,
+  ops,
+  sub,
+  squared,
+  sqrt,
+  inverse,
+  absVal,
+  gt,
+  lt,
+  ifCond,
 } from "./Autodiff";
+
+import consola, { LogLevel } from "consola";
 
 // For deep-cloning the translation
 // Note: the translation should not have cycles! If it does, use the approach that `Optimizer` takes to `clone` (clearing the VarADs).
 import rfdc from "rfdc";
 const clone = rfdc({ proto: false, circles: false });
+
+const log = consola.create({ level: LogLevel.Warn }).withScope("Evaluator");
 
 // //////////////////////////////////////////////////////////////////////////////
 // Evaluator
@@ -51,19 +55,19 @@ const clone = rfdc({ proto: false, circles: false });
 
 // COMBAK: Import the dummy functions from Style -> EngineUtils
 const dummySourceLoc = (): SourceLoc => {
-    return { line: -1, col: -1 };
+  return { line: -1, col: -1 };
 };
 
 const dummyIdentifier = (name: string): Identifier => {
-    return {
-        nodeType: "dummyNode",
-        children: [],
-        type: "value",
-        value: name,
-        tag: "Identifier",
-        start: dummySourceLoc(),
-        end: dummySourceLoc(),
-    };
+  return {
+    nodeType: "dummyNode",
+    children: [],
+    type: "value",
+    value: name,
+    tag: "Identifier",
+    start: dummySourceLoc(),
+    end: dummySourceLoc(),
+  };
 };
 /**
  * Evaluate all shapes in the `State` by walking the `Translation` data structure, finding out all shape expressions (`FGPI` expressions computed by the Style compiler), and evaluating every property in each shape.
@@ -73,79 +77,79 @@ const dummyIdentifier = (name: string): Identifier => {
  * NOTE: need to manage the random seed. In the backend we delibrately discard the new random seed within each of the opt session for consistent results.
  */
 export const evalShapes = (s: State): State => {
-    // Update the stale varyingMap from the translation
-    // TODO: Evaluating the shapes for display is still done via interpretation on VarADs; not compiled
+  // Update the stale varyingMap from the translation
+  // TODO: Evaluating the shapes for display is still done via interpretation on VarADs; not compiled
 
-    const varyingValuesDiff = s.varyingValues.map(differentiable);
-    s.varyingMap = genPathMap(s.varyingPaths, varyingValuesDiff);
+  const varyingValuesDiff = s.varyingValues.map(differentiable);
+  s.varyingMap = genPathMap(s.varyingPaths, varyingValuesDiff);
 
-    const varyingMapList = zip(s.varyingPaths, varyingValuesDiff) as [
-        Path,
-        VarAD
-    ][];
+  const varyingMapList = zip(s.varyingPaths, varyingValuesDiff) as [
+    Path,
+    VarAD
+  ][];
 
-    const optDebugInfo = {
-        gradient: genPathMap(s.varyingPaths, s.params.lastGradient),
-        gradientPreconditioned: genPathMap(
-            s.varyingPaths,
-            s.params.lastGradientPreconditioned
-        ),
-    };
+  const optDebugInfo = {
+    gradient: genPathMap(s.varyingPaths, s.params.lastGradient),
+    gradientPreconditioned: genPathMap(
+      s.varyingPaths,
+      s.params.lastGradientPreconditioned
+    ),
+  };
 
-    // Insert all varying vals
-    const transWithVarying = insertVaryings(s.translation, varyingMapList);
+  // Insert all varying vals
+  const transWithVarying = insertVaryings(s.translation, varyingMapList);
 
-    // Clone translation to use in this top-level call, because it mutates the translation while interpreting the energy function in order to cache/reuse VarAD (computation) results
-    const trans = clone(transWithVarying);
+  // Clone translation to use in this top-level call, because it mutates the translation while interpreting the energy function in order to cache/reuse VarAD (computation) results
+  const trans = clone(transWithVarying);
 
-    // Find out all the GPI expressions in the translation
-    const shapeExprs: IFGPI<VarAD>[] = s.shapePaths.map(
-        (p: Path) => findExprSafe(trans, p) as IFGPI<VarAD>
-    );
+  // Find out all the GPI expressions in the translation
+  const shapeExprs: IFGPI<VarAD>[] = s.shapePaths.map(
+    (p: Path) => findExprSafe(trans, p) as IFGPI<VarAD>
+  );
 
-    console.log("shapePaths", s.shapePaths.map(prettyPrintPath));
+  log.info("shapePaths", s.shapePaths.map(prettyPrintPath));
 
-    // Evaluate each of the shapes (note: the translation is mutated, not returned)
-    const [shapesEvaled, transEvaled]: [
-        Shape[],
-        Translation
-    ] = shapeExprs.reduce(
-        ([currShapes, tr]: [Shape[], Translation], e: IFGPI<VarAD>) =>
-            evalShape(e, tr, s.varyingMap, currShapes, optDebugInfo),
-        [[], trans]
-    );
+  // Evaluate each of the shapes (note: the translation is mutated, not returned)
+  const [shapesEvaled, transEvaled]: [
+    Shape[],
+    Translation
+  ] = shapeExprs.reduce(
+    ([currShapes, tr]: [Shape[], Translation], e: IFGPI<VarAD>) =>
+      evalShape(e, tr, s.varyingMap, currShapes, optDebugInfo),
+    [[], trans]
+  );
 
-    if (s.shapeOrdering.length < shapesEvaled.length) {
-        console.error("Invalid shape layering of length", s.shapeOrdering.length);
-    }
+  if (s.shapeOrdering.length < shapesEvaled.length) {
+    console.error("Invalid shape layering of length", s.shapeOrdering.length);
+  }
 
-    // Sort the shapes by ordering--note the null assertion
-    const sortedShapesEvaled: Shape[] = s.shapeOrdering.map(
-        (name) =>
-            shapesEvaled.find(({ properties }) => sameName(properties.name, name))!
-    );
+  // Sort the shapes by ordering--note the null assertion
+  const sortedShapesEvaled: Shape[] = s.shapeOrdering.map(
+    (name) =>
+      shapesEvaled.find(({ properties }) => sameName(properties.name, name))!
+  );
 
-    // TODO: do we still need this check for non-empty labels?
-    // const nonEmpties = sortedShapes.filter(notEmptyLabel);
+  // TODO: do we still need this check for non-empty labels?
+  // const nonEmpties = sortedShapes.filter(notEmptyLabel);
 
-    // Update the state with the new list of shapes
-    // (This is a shallow copy of the state btw, not a deep copy)
-    return { ...s, shapes: sortedShapesEvaled };
+  // Update the state with the new list of shapes
+  // (This is a shallow copy of the state btw, not a deep copy)
+  return { ...s, shapes: sortedShapesEvaled };
 };
 
 const sameName = (given: Value<number>, expected: string): boolean => {
-    if (given.tag !== "StrV") {
-        return false;
-    }
-    if (typeof given.contents !== "string") {
-        throw Error("expected string GPI name");
-    }
-    return given.contents === expected;
+  if (given.tag !== "StrV") {
+    return false;
+  }
+  if (typeof given.contents !== "string") {
+    throw Error("expected string GPI name");
+  }
+  return given.contents === expected;
 };
 
 const doneFloat = (n: VarAD): TagExpr<VarAD> => ({
-    tag: "Done",
-    contents: { tag: "FloatV", contents: n },
+  tag: "Done",
+  contents: { tag: "FloatV", contents: n },
 });
 
 /**
@@ -156,14 +160,14 @@ const doneFloat = (n: VarAD): TagExpr<VarAD> => ({
  * @returns {Translation}
  */
 export const insertVaryings = (
-    trans: Translation,
-    varyingMap: [Path, VarAD][]
+  trans: Translation,
+  varyingMap: [Path, VarAD][]
 ): Translation => {
-    return varyingMap.reduce(
-        (tr: Translation, [path, val]: [Path, VarAD]) =>
-            insertExpr(path, doneFloat(val), tr),
-        trans
-    );
+  return varyingMap.reduce(
+    (tr: Translation, [path, val]: [Path, VarAD]) =>
+      insertExpr(path, doneFloat(val), tr),
+    trans
+  );
 };
 
 /**
@@ -174,26 +178,26 @@ export const insertVaryings = (
  * @param varyingMap Varying paths and values
  */
 export const evalFns = (
-    fns: Fn[],
-    trans: Translation,
-    varyingMap: VaryMap<VarAD>
+  fns: Fn[],
+  trans: Translation,
+  varyingMap: VaryMap<VarAD>
 ): FnDone<VarAD>[] => fns.map((f) => evalFn(f, trans, varyingMap));
 
 const evalFn = (
-    fn: Fn,
-    trans: Translation,
-    varyingMap: VaryMap<VarAD>
+  fn: Fn,
+  trans: Translation,
+  varyingMap: VaryMap<VarAD>
 ): FnDone<VarAD> => {
-    const noOptDebugInfo = {
-        gradient: new Map(),
-        gradientPreconditioned: new Map(),
-    };
+  const noOptDebugInfo = {
+    gradient: new Map(),
+    gradientPreconditioned: new Map(),
+  };
 
-    return {
-        name: fn.fname,
-        args: evalExprs(fn.fargs, trans, varyingMap, noOptDebugInfo),
-        optType: fn.optType,
-    };
+  return {
+    name: fn.fname,
+    args: evalExprs(fn.fargs, trans, varyingMap, noOptDebugInfo),
+    optType: fn.optType,
+  };
 };
 
 /**
@@ -206,45 +210,45 @@ const evalFn = (
  *
  */
 export const evalShape = (
-    shapeExpr: IFGPI<VarAD>, // <number>?
-    trans: Translation,
-    varyingVars: VaryMap,
-    shapes: Shape[],
-    optDebugInfo: OptDebugInfo
+  shapeExpr: IFGPI<VarAD>, // <number>?
+  trans: Translation,
+  varyingVars: VaryMap,
+  shapes: Shape[],
+  optDebugInfo: OptDebugInfo
 ): [Shape[], Translation] => {
-    const [shapeType, propExprs] = shapeExpr.contents;
+  const [shapeType, propExprs] = shapeExpr.contents;
 
-    // Make sure all props are evaluated to values instead of shapes
-    const props = mapValues(
-        propExprs,
-        (prop: TagExpr<VarAD>): Value<number> => {
-            // TODO: Refactor these cases to be more concise
-            if (prop.tag === "OptEval") {
-                // For display, evaluate expressions with autodiff types (incl. varying vars as AD types), then convert to numbers
-                // (The tradeoff for using autodiff types is that evaluating the display step will be a little slower, but then we won't have to write two versions of all computations)
-                const res: Value<VarAD> = (evalExpr(
-                    prop.contents,
-                    trans,
-                    varyingVars,
-                    optDebugInfo
-                ) as IVal<VarAD>).contents;
-                const resDisplay: Value<number> = valueAutodiffToNumber(res);
-                return resDisplay;
-            } else if (prop.tag === "Done") {
-                return valueAutodiffToNumber(prop.contents);
-            } else if (prop.tag === "Pending") {
-                // Pending expressions are just converted because they get converted back to numbers later
-                const res = valueAutodiffToNumber(prop.contents);
-                return res;
-            } else {
-                throw Error("unknown tag");
-            }
-        }
-    );
+  // Make sure all props are evaluated to values instead of shapes
+  const props = mapValues(
+    propExprs,
+    (prop: TagExpr<VarAD>): Value<number> => {
+      // TODO: Refactor these cases to be more concise
+      if (prop.tag === "OptEval") {
+        // For display, evaluate expressions with autodiff types (incl. varying vars as AD types), then convert to numbers
+        // (The tradeoff for using autodiff types is that evaluating the display step will be a little slower, but then we won't have to write two versions of all computations)
+        const res: Value<VarAD> = (evalExpr(
+          prop.contents,
+          trans,
+          varyingVars,
+          optDebugInfo
+        ) as IVal<VarAD>).contents;
+        const resDisplay: Value<number> = valueAutodiffToNumber(res);
+        return resDisplay;
+      } else if (prop.tag === "Done") {
+        return valueAutodiffToNumber(prop.contents);
+      } else if (prop.tag === "Pending") {
+        // Pending expressions are just converted because they get converted back to numbers later
+        const res = valueAutodiffToNumber(prop.contents);
+        return res;
+      } else {
+        throw Error("unknown tag");
+      }
+    }
+  );
 
-    const shape: Shape = { shapeType, properties: props };
+  const shape: Shape = { shapeType, properties: props };
 
-    return [[...shapes, shape], trans];
+  return [[...shapes, shape], trans];
 };
 
 /**
@@ -256,43 +260,43 @@ export const evalShape = (
  *
  */
 export const evalExprs = (
-    es: Expr[],
-    trans: Translation,
-    varyingVars?: VaryMap<VarAD>,
-    optDebugInfo?: OptDebugInfo
+  es: Expr[],
+  trans: Translation,
+  varyingVars?: VaryMap<VarAD>,
+  optDebugInfo?: OptDebugInfo
 ): ArgVal<VarAD>[] =>
-    es.map((e) => evalExpr(e, trans, varyingVars, optDebugInfo));
+  es.map((e) => evalExpr(e, trans, varyingVars, optDebugInfo));
 
 function toFloatVal(a: ArgVal<VarAD>): VarAD {
-    if (a.tag === "Val") {
-        const res = a.contents;
-        if (res.tag === "FloatV") {
-            return res.contents;
-        } else if (res.tag === "IntV") {
-            return constOf(res.contents);
-        } else {
-            console.log("res", res);
-            throw Error("Expected floating type in list");
-        }
+  if (a.tag === "Val") {
+    const res = a.contents;
+    if (res.tag === "FloatV") {
+      return res.contents;
+    } else if (res.tag === "IntV") {
+      return constOf(res.contents);
     } else {
-        console.log("res", a);
-        throw Error("Expected value (non-GPI) type in list");
+      console.log("res", res);
+      throw Error("Expected floating type in list");
     }
+  } else {
+    console.log("res", a);
+    throw Error("Expected value (non-GPI) type in list");
+  }
 }
 
 function toVecVal<T>(a: ArgVal<T>): T[] {
-    if (a.tag === "Val") {
-        const res = a.contents;
-        if (res.tag === "VectorV") {
-            return res.contents;
-        } else {
-            console.log("res", res);
-            throw Error("Expected vector type in list");
-        }
+  if (a.tag === "Val") {
+    const res = a.contents;
+    if (res.tag === "VectorV") {
+      return res.contents;
     } else {
-        console.log("res", a);
-        throw Error("Expected value (non-GPI) type in list");
+      console.log("res", res);
+      throw Error("Expected vector type in list");
     }
+  } else {
+    console.log("res", a);
+    throw Error("Expected value (non-GPI) type in list");
+  }
 }
 
 /**
@@ -307,345 +311,345 @@ function toVecVal<T>(a: ArgVal<T>): T[] {
  * TODO: break cycles; optimize lookup
  */
 export const evalExpr = (
-    e: Expr,
-    trans: Translation,
-    varyingVars?: VaryMap<VarAD>,
-    optDebugInfo?: OptDebugInfo
+  e: Expr,
+  trans: Translation,
+  varyingVars?: VaryMap<VarAD>,
+  optDebugInfo?: OptDebugInfo
 ): ArgVal<VarAD> => {
-    // console.log("evalExpr", e);
+  // console.log("evalExpr", e);
 
-    switch (e.tag) {
-        // COMBAK: Deal with ints
-        // case "IntLit": {
-        //   return { tag: "Val", contents: { tag: "IntV", contents: e.contents } };
-        // }
+  switch (e.tag) {
+    // COMBAK: Deal with ints
+    // case "IntLit": {
+    //   return { tag: "Val", contents: { tag: "IntV", contents: e.contents } };
+    // }
 
-        case "StringLit": {
-            return { tag: "Val", contents: { tag: "StrV", contents: e.contents } };
-        }
-
-        case "BoolLit": {
-            return { tag: "Val", contents: { tag: "BoolV", contents: e.contents } };
-        }
-
-        case "Vary": {
-            console.error("expr", e, "trans", trans, "varyingVars", varyingVars);
-            throw new Error("encountered an unsubstituted varying value");
-        }
-
-        case "Fix": {
-            const val = e.contents;
-
-            // Don't convert to VarAD if it's already been converted
-            return {
-                tag: "Val",
-                // Fixed number is stored in translation as number, made differentiable when encountered
-                contents: {
-                    tag: "FloatV",
-                    contents: constOfIf(val),
-                },
-            };
-        }
-
-        case "UOp": {
-            const [uOp, expr] = [e.op, e.arg];
-            // TODO: use the type system to narrow down Value to Float and Int?
-            const arg = evalExpr(expr, trans, varyingVars, optDebugInfo).contents;
-            return {
-                tag: "Val",
-                // HACK: coerce the type for now to let the compiler finish
-                contents: evalUOp(uOp, arg as IFloatV<VarAD> | IIntV),
-            };
-        }
-
-        case "BinOp": {
-            const [binOp, e1, e2] = [e.op, e.left, e.right];
-
-            const [val1, val2] = evalExprs(
-                [e1, e2],
-                trans,
-                varyingVars,
-                optDebugInfo
-            );
-
-            const res = evalBinOp(
-                binOp,
-                val1.contents as Value<VarAD>,
-                val2.contents as Value<VarAD>
-            );
-
-            return {
-                tag: "Val",
-                // HACK: coerce the type for now to let the compiler finish
-                contents: res,
-            };
-        }
-
-        case "Tuple": {
-            const argVals = evalExprs(e.contents, trans, varyingVars, optDebugInfo);
-            if (argVals.length !== 2) {
-                console.log(argVals);
-                throw Error("Expected tuple of length 2");
-            }
-            return {
-                tag: "Val",
-                contents: {
-                    tag: "TupV",
-                    contents: [toFloatVal(argVals[0]), toFloatVal(argVals[1])],
-                },
-            };
-        }
-        case "List": {
-            const argVals = evalExprs(e.contents, trans, varyingVars, optDebugInfo);
-
-            // The below code makes a type assumption about the whole list, based on the first elements
-            // Is there a better way to implement parametric lists in typescript?
-            if (!argVals[0]) {
-                // Empty list
-                return {
-                    tag: "Val",
-                    contents: {
-                        tag: "ListV",
-                        contents: [] as VarAD[],
-                    },
-                };
-            }
-
-            if (argVals[0].tag === "Val") {
-                // List contains floats
-                if (argVals[0].contents.tag === "FloatV") {
-                    return {
-                        tag: "Val",
-                        contents: {
-                            tag: "ListV",
-                            contents: argVals.map(toFloatVal),
-                        },
-                    };
-                } else if (argVals[0].contents.tag === "VectorV") {
-                    // List contains vectors
-                    return {
-                        tag: "Val",
-                        contents: {
-                            tag: "LListV", // NOTE: The type has changed from ListV to LListV! That's because ListV's `T` is "not parametric enough" to represent a list of elements
-                            contents: argVals.map(toVecVal),
-                        } as ILListV<VarAD>,
-                    };
-                }
-            } else {
-                console.error("list elems", argVals);
-                throw Error("unsupported element in list");
-            }
-        }
-
-        case "ListAccess": {
-            throw Error("List access expression not (yet) supported");
-        }
-
-        case "Vector": {
-            const argVals = evalExprs(e.contents, trans, varyingVars, optDebugInfo);
-
-            // Matrices are parsed as a list of vectors, so when we encounter vectors as elements, we assume it's a matrix, and convert it to a matrix of lists
-            if (argVals[0].tag !== "Val") {
-                throw Error("expected val");
-            }
-            if (argVals[0].contents.tag === "VectorV") {
-                return {
-                    tag: "Val",
-                    contents: {
-                        tag: "MatrixV",
-                        contents: argVals.map(toVecVal),
-                    },
-                };
-            }
-
-            // Otherwise return vec (list of nums)
-            return {
-                tag: "Val",
-                contents: {
-                    tag: "VectorV",
-                    contents: argVals.map(toFloatVal),
-                },
-            };
-        }
-
-        case "Matrix": {
-            // This tag is here, but actually, matrices are parsed as lists of vectors, so this case is never hit
-            console.log("matrix e", e);
-            throw new Error(`cannot evaluate expression of type ${e.tag}`);
-        }
-
-        case "VectorAccess": {
-            // COMBAK: Deprecate Vector/MatrixAccess
-            // throw Error("deprecated");
-
-            const [e1, e2] = e.contents;
-
-            const v1 = resolvePath(e1, trans, varyingVars, optDebugInfo);
-            const v2 = evalExpr(e2, trans, varyingVars, optDebugInfo);
-
-            if (v1.tag !== "Val") {
-                throw Error("expected val");
-            }
-            if (v2.tag !== "Val") {
-                throw Error("expected val");
-            }
-
-            // COMBAK: Do float to int conversion in a more principled way. For now, convert float to int on demand
-            if (v2.contents.tag === "FloatV") {
-                // COMBAK: (ISSUE): Indices should not have "Fix"
-                const iObj: IVarAD = v2.contents.contents;
-                v2.contents = {
-                    tag: "IntV",
-                    contents: Math.floor(numOf(iObj)),
-                };
-            }
-
-            if (v2.contents.tag !== "IntV") {
-                throw Error("expected int");
-            }
-
-            const i: number = v2.contents.contents;
-
-            // LList access (since any expr with brackets is parsed as a vector access
-            if (v1.contents.tag === "LListV") {
-                const llist = v1.contents.contents;
-                if (i < 0 || i > llist.length) throw Error("access out of bounds");
-                return { tag: "Val", contents: { tag: "VectorV", contents: llist[i] } };
-            }
-
-            // Vector access
-            if (v1.contents.tag !== "VectorV") {
-                console.log("results", v1, v2);
-                throw Error("expected Vector");
-            }
-            const vec = v1.contents.contents;
-            if (i < 0 || i > vec.length) throw Error("access out of bounds");
-
-            return {
-                tag: "Val",
-                contents: { tag: "FloatV", contents: vec[i] },
-            };
-        }
-
-        case "MatrixAccess": {
-            // COMBAK: Deprecate Vector/MatrixAccess
-            // throw Error("deprecated");
-
-            const [e1, e2] = e.contents;
-            const v1 = resolvePath(e1, trans, varyingVars, optDebugInfo);
-            const v2s = evalExprs(e2, trans, varyingVars, optDebugInfo);
-
-            const indices: number[] = v2s.map((v2) => {
-                if (v2.tag !== "Val") {
-                    throw Error("expected val");
-                }
-                if (v2.contents.tag !== "IntV") {
-                    throw Error("expected int");
-                }
-                return v2.contents.contents;
-            });
-
-            if (v1.tag !== "Val") {
-                throw Error("expected val");
-            }
-
-            if (v1.contents.tag !== "MatrixV") {
-                throw Error("expected Matrix");
-            }
-
-            // m[i][j] <-- m's ith row, jth column
-            const mat = v1.contents.contents;
-            // TODO: Currently only supports 2D matrices
-            if (!indices.length || indices.length !== 2) {
-                throw Error("expected 2 indices to access matrix");
-            }
-
-            const [i, j] = indices;
-            if (i < 0 || i > mat.length - 1) throw Error("`i` access out of bounds");
-            const vec = mat[i];
-            if (j < 0 || j > vec.length - 1) throw Error("`j` access out of bounds");
-
-            return {
-                tag: "Val",
-                contents: { tag: "FloatV", contents: vec[j] },
-            };
-        }
-
-        case "CompApp": {
-            const [fnName, argExprs] = [e.name.value, e.args];
-
-            if (fnName === "derivative" || fnName === "derivativePreconditioned") {
-                // Special function: don't look up the path's value, but its gradient's value
-
-                if (argExprs.length !== 1) {
-                    throw Error(
-                        `expected 1 argument to ${fnName}; got ${argExprs.length}`
-                    );
-                }
-
-                let p = argExprs[0]; // special function can only have one argument
-
-                // Vector and matrix accesses are the only way to refer to an anon varying var
-                // p.tag !== "EPath"
-                if (
-                    !isPath(p) &&
-                    p.tag !== "VectorAccess" &&
-                    p.tag !== "MatrixAccess"
-                ) {
-                    throw Error(`expected 1 path as argument to ${fnName}; got ${p.tag}`);
-                }
-
-                if (p.tag === "VectorAccess") {
-                    p = {
-                        // convert to AccessPath schema
-                        nodeType: "dummyNode",
-                        children: [],
-                        start: dummySourceLoc(),
-                        end: dummySourceLoc(),
-                        tag: "AccessPath",
-                        // contents: [p.contents[0], [p.contents[1].contents]],
-                        path: p.contents[0],
-                        indices: [p.contents[1]],
-                    };
-                } else if (p.tag === "MatrixAccess") {
-                    p = {
-                        // convert to AccessPath schema
-                        nodeType: "dummyNode",
-                        children: [],
-                        start: dummySourceLoc(),
-                        end: dummySourceLoc(),
-                        tag: "AccessPath",
-                        path: p.contents[0],
-                        indices: p.contents[1],
-                    };
-                }
-
-                return {
-                    tag: "Val",
-                    contents: compDict[fnName](
-                        optDebugInfo as OptDebugInfo,
-                        JSON.stringify(p) // COMBAK: Test that derivatives still work. Might break due to JSON.stringify(p) changing?
-                    ),
-                };
-            }
-
-            // eval all args
-            const args = evalExprs(argExprs, trans, varyingVars, optDebugInfo);
-            const argValues = args.map((a) => argValue(a));
-            checkComp(fnName, args);
-
-            // retrieve comp function from a global dict and call the function
-            return { tag: "Val", contents: compDict[fnName](...argValues) };
-        }
-
-        default: {
-            if (isPath(e)) {
-                return resolvePath(e, trans, varyingVars, optDebugInfo);
-            }
-
-            throw new Error(`cannot evaluate expression of type ${e.tag}`);
-        }
+    case "StringLit": {
+      return { tag: "Val", contents: { tag: "StrV", contents: e.contents } };
     }
+
+    case "BoolLit": {
+      return { tag: "Val", contents: { tag: "BoolV", contents: e.contents } };
+    }
+
+    case "Vary": {
+      console.error("expr", e, "trans", trans, "varyingVars", varyingVars);
+      throw new Error("encountered an unsubstituted varying value");
+    }
+
+    case "Fix": {
+      const val = e.contents;
+
+      // Don't convert to VarAD if it's already been converted
+      return {
+        tag: "Val",
+        // Fixed number is stored in translation as number, made differentiable when encountered
+        contents: {
+          tag: "FloatV",
+          contents: constOfIf(val),
+        },
+      };
+    }
+
+    case "UOp": {
+      const [uOp, expr] = [e.op, e.arg];
+      // TODO: use the type system to narrow down Value to Float and Int?
+      const arg = evalExpr(expr, trans, varyingVars, optDebugInfo).contents;
+      return {
+        tag: "Val",
+        // HACK: coerce the type for now to let the compiler finish
+        contents: evalUOp(uOp, arg as IFloatV<VarAD> | IIntV),
+      };
+    }
+
+    case "BinOp": {
+      const [binOp, e1, e2] = [e.op, e.left, e.right];
+
+      const [val1, val2] = evalExprs(
+        [e1, e2],
+        trans,
+        varyingVars,
+        optDebugInfo
+      );
+
+      const res = evalBinOp(
+        binOp,
+        val1.contents as Value<VarAD>,
+        val2.contents as Value<VarAD>
+      );
+
+      return {
+        tag: "Val",
+        // HACK: coerce the type for now to let the compiler finish
+        contents: res,
+      };
+    }
+
+    case "Tuple": {
+      const argVals = evalExprs(e.contents, trans, varyingVars, optDebugInfo);
+      if (argVals.length !== 2) {
+        console.log(argVals);
+        throw Error("Expected tuple of length 2");
+      }
+      return {
+        tag: "Val",
+        contents: {
+          tag: "TupV",
+          contents: [toFloatVal(argVals[0]), toFloatVal(argVals[1])],
+        },
+      };
+    }
+    case "List": {
+      const argVals = evalExprs(e.contents, trans, varyingVars, optDebugInfo);
+
+      // The below code makes a type assumption about the whole list, based on the first elements
+      // Is there a better way to implement parametric lists in typescript?
+      if (!argVals[0]) {
+        // Empty list
+        return {
+          tag: "Val",
+          contents: {
+            tag: "ListV",
+            contents: [] as VarAD[],
+          },
+        };
+      }
+
+      if (argVals[0].tag === "Val") {
+        // List contains floats
+        if (argVals[0].contents.tag === "FloatV") {
+          return {
+            tag: "Val",
+            contents: {
+              tag: "ListV",
+              contents: argVals.map(toFloatVal),
+            },
+          };
+        } else if (argVals[0].contents.tag === "VectorV") {
+          // List contains vectors
+          return {
+            tag: "Val",
+            contents: {
+              tag: "LListV", // NOTE: The type has changed from ListV to LListV! That's because ListV's `T` is "not parametric enough" to represent a list of elements
+              contents: argVals.map(toVecVal),
+            } as ILListV<VarAD>,
+          };
+        }
+      } else {
+        console.error("list elems", argVals);
+        throw Error("unsupported element in list");
+      }
+    }
+
+    case "ListAccess": {
+      throw Error("List access expression not (yet) supported");
+    }
+
+    case "Vector": {
+      const argVals = evalExprs(e.contents, trans, varyingVars, optDebugInfo);
+
+      // Matrices are parsed as a list of vectors, so when we encounter vectors as elements, we assume it's a matrix, and convert it to a matrix of lists
+      if (argVals[0].tag !== "Val") {
+        throw Error("expected val");
+      }
+      if (argVals[0].contents.tag === "VectorV") {
+        return {
+          tag: "Val",
+          contents: {
+            tag: "MatrixV",
+            contents: argVals.map(toVecVal),
+          },
+        };
+      }
+
+      // Otherwise return vec (list of nums)
+      return {
+        tag: "Val",
+        contents: {
+          tag: "VectorV",
+          contents: argVals.map(toFloatVal),
+        },
+      };
+    }
+
+    case "Matrix": {
+      // This tag is here, but actually, matrices are parsed as lists of vectors, so this case is never hit
+      console.log("matrix e", e);
+      throw new Error(`cannot evaluate expression of type ${e.tag}`);
+    }
+
+    case "VectorAccess": {
+      // COMBAK: Deprecate Vector/MatrixAccess
+      // throw Error("deprecated");
+
+      const [e1, e2] = e.contents;
+
+      const v1 = resolvePath(e1, trans, varyingVars, optDebugInfo);
+      const v2 = evalExpr(e2, trans, varyingVars, optDebugInfo);
+
+      if (v1.tag !== "Val") {
+        throw Error("expected val");
+      }
+      if (v2.tag !== "Val") {
+        throw Error("expected val");
+      }
+
+      // COMBAK: Do float to int conversion in a more principled way. For now, convert float to int on demand
+      if (v2.contents.tag === "FloatV") {
+        // COMBAK: (ISSUE): Indices should not have "Fix"
+        const iObj: IVarAD = v2.contents.contents;
+        v2.contents = {
+          tag: "IntV",
+          contents: Math.floor(numOf(iObj)),
+        };
+      }
+
+      if (v2.contents.tag !== "IntV") {
+        throw Error("expected int");
+      }
+
+      const i: number = v2.contents.contents;
+
+      // LList access (since any expr with brackets is parsed as a vector access
+      if (v1.contents.tag === "LListV") {
+        const llist = v1.contents.contents;
+        if (i < 0 || i > llist.length) throw Error("access out of bounds");
+        return { tag: "Val", contents: { tag: "VectorV", contents: llist[i] } };
+      }
+
+      // Vector access
+      if (v1.contents.tag !== "VectorV") {
+        console.log("results", v1, v2);
+        throw Error("expected Vector");
+      }
+      const vec = v1.contents.contents;
+      if (i < 0 || i > vec.length) throw Error("access out of bounds");
+
+      return {
+        tag: "Val",
+        contents: { tag: "FloatV", contents: vec[i] },
+      };
+    }
+
+    case "MatrixAccess": {
+      // COMBAK: Deprecate Vector/MatrixAccess
+      // throw Error("deprecated");
+
+      const [e1, e2] = e.contents;
+      const v1 = resolvePath(e1, trans, varyingVars, optDebugInfo);
+      const v2s = evalExprs(e2, trans, varyingVars, optDebugInfo);
+
+      const indices: number[] = v2s.map((v2) => {
+        if (v2.tag !== "Val") {
+          throw Error("expected val");
+        }
+        if (v2.contents.tag !== "IntV") {
+          throw Error("expected int");
+        }
+        return v2.contents.contents;
+      });
+
+      if (v1.tag !== "Val") {
+        throw Error("expected val");
+      }
+
+      if (v1.contents.tag !== "MatrixV") {
+        throw Error("expected Matrix");
+      }
+
+      // m[i][j] <-- m's ith row, jth column
+      const mat = v1.contents.contents;
+      // TODO: Currently only supports 2D matrices
+      if (!indices.length || indices.length !== 2) {
+        throw Error("expected 2 indices to access matrix");
+      }
+
+      const [i, j] = indices;
+      if (i < 0 || i > mat.length - 1) throw Error("`i` access out of bounds");
+      const vec = mat[i];
+      if (j < 0 || j > vec.length - 1) throw Error("`j` access out of bounds");
+
+      return {
+        tag: "Val",
+        contents: { tag: "FloatV", contents: vec[j] },
+      };
+    }
+
+    case "CompApp": {
+      const [fnName, argExprs] = [e.name.value, e.args];
+
+      if (fnName === "derivative" || fnName === "derivativePreconditioned") {
+        // Special function: don't look up the path's value, but its gradient's value
+
+        if (argExprs.length !== 1) {
+          throw Error(
+            `expected 1 argument to ${fnName}; got ${argExprs.length}`
+          );
+        }
+
+        let p = argExprs[0]; // special function can only have one argument
+
+        // Vector and matrix accesses are the only way to refer to an anon varying var
+        // p.tag !== "EPath"
+        if (
+          !isPath(p) &&
+          p.tag !== "VectorAccess" &&
+          p.tag !== "MatrixAccess"
+        ) {
+          throw Error(`expected 1 path as argument to ${fnName}; got ${p.tag}`);
+        }
+
+        if (p.tag === "VectorAccess") {
+          p = {
+            // convert to AccessPath schema
+            nodeType: "dummyNode",
+            children: [],
+            start: dummySourceLoc(),
+            end: dummySourceLoc(),
+            tag: "AccessPath",
+            // contents: [p.contents[0], [p.contents[1].contents]],
+            path: p.contents[0],
+            indices: [p.contents[1]],
+          };
+        } else if (p.tag === "MatrixAccess") {
+          p = {
+            // convert to AccessPath schema
+            nodeType: "dummyNode",
+            children: [],
+            start: dummySourceLoc(),
+            end: dummySourceLoc(),
+            tag: "AccessPath",
+            path: p.contents[0],
+            indices: p.contents[1],
+          };
+        }
+
+        return {
+          tag: "Val",
+          contents: compDict[fnName](
+            optDebugInfo as OptDebugInfo,
+            JSON.stringify(p) // COMBAK: Test that derivatives still work. Might break due to JSON.stringify(p) changing?
+          ),
+        };
+      }
+
+      // eval all args
+      const args = evalExprs(argExprs, trans, varyingVars, optDebugInfo);
+      const argValues = args.map((a) => argValue(a));
+      checkComp(fnName, args);
+
+      // retrieve comp function from a global dict and call the function
+      return { tag: "Val", contents: compDict[fnName](...argValues) };
+    }
+
+    default: {
+      if (isPath(e)) {
+        return resolvePath(e, trans, varyingVars, optDebugInfo);
+      }
+
+      throw new Error(`cannot evaluate expression of type ${e.tag}`);
+    }
+  }
 };
 
 /**
@@ -658,157 +662,157 @@ export const evalExpr = (
  * Looks up varying vars first
  */
 export const resolvePath = (
-    path: Path,
-    trans: Translation,
-    varyingMap?: VaryMap<VarAD>,
-    optDebugInfo?: OptDebugInfo
+  path: Path,
+  trans: Translation,
+  varyingMap?: VaryMap<VarAD>,
+  optDebugInfo?: OptDebugInfo
 ): ArgVal<VarAD> => {
-    // HACK: this is a temporary way to consistently compare paths. We will need to make varymap much more efficient
-    let varyingVal = varyingMap?.get(JSON.stringify(path));
+  // HACK: this is a temporary way to consistently compare paths. We will need to make varymap much more efficient
+  let varyingVal = varyingMap?.get(JSON.stringify(path));
 
-    if (varyingVal) {
-        return floatVal(varyingVal);
-    } else {
-        // NOTE: a VectorAccess or MatrixAccess to varying variables isn't looked up in the varying paths (since `VectorAccess`, etc. in `evalExpr` don't call `resolvePath`; it works because varying vars are inserted into the translation (see `evalEnergyOn`)
-        // NOTE: varyingMap includes vars of form AccessPath but not Vector/Matrix access
-        if (path.tag === "AccessPath") {
-            // Evaluate it as Vector or Matrix access as appropriate (COMBAK: Deprecate Vector/Matrix access on second pass, and also remove Vector/Matrix conversion to accesspath for derivative debugging computations)
+  if (varyingVal) {
+    return floatVal(varyingVal);
+  } else {
+    // NOTE: a VectorAccess or MatrixAccess to varying variables isn't looked up in the varying paths (since `VectorAccess`, etc. in `evalExpr` don't call `resolvePath`; it works because varying vars are inserted into the translation (see `evalEnergyOn`)
+    // NOTE: varyingMap includes vars of form AccessPath but not Vector/Matrix access
+    if (path.tag === "AccessPath") {
+      // Evaluate it as Vector or Matrix access as appropriate (COMBAK: Deprecate Vector/Matrix access on second pass, and also remove Vector/Matrix conversion to accesspath for derivative debugging computations)
 
-            // console.log("path", path);
-            // console.log("trans", trans);
-            // console.log("varyingMap", varyingMap);
+      // console.log("path", path);
+      // console.log("trans", trans);
+      // console.log("varyingMap", varyingMap);
 
-            if (path.indices.length === 1) {
-                // Vector
+      if (path.indices.length === 1) {
+        // Vector
 
-                // if (path.path.tag === "FieldPath") {
-                //   if (path.path.field.value === "markerLine") {
-                //     debugger;
-                //   }
-                // }
+        // if (path.path.tag === "FieldPath") {
+        //   if (path.path.field.value === "markerLine") {
+        //     debugger;
+        //   }
+        // }
 
-                const e: Expr = {
-                    ...path,
-                    tag: "VectorAccess",
-                    contents: [path.path, path.indices[0]],
-                };
-                return evalExpr(e, trans, varyingMap, optDebugInfo);
-            } else if (path.indices.length === 2) {
-                // Matrix
-                const e: Expr = {
-                    ...path,
-                    tag: "MatrixAccess",
-                    contents: [path.path, path.indices],
-                };
-                return evalExpr(e, trans, varyingMap, optDebugInfo);
-            } else throw Error("unsupported number of indices in AccessPath");
-        }
-
-        if (path.tag === "InternalLocalVar" || path.tag === "LocalVar") {
-            throw Error("should not encounter local var in evaluation");
-        }
-
-        const gpiOrExpr = findExprSafe(trans, path);
-
-        switch (gpiOrExpr.tag) {
-            case "FGPI": {
-                const [type, props] = gpiOrExpr.contents;
-
-                // Evaluate GPI (i.e. each property path in GPI -- NOT necessarily the path's expression)
-                const evaledProps = mapValues(props, (p, propName) => {
-                    const propertyPath: IPropertyPath = {
-                        ...path,
-                        tag: "PropertyPath",
-                        name: path.name,
-                        field: path.field,
-                        property: dummyIdentifier(propName),
-                    };
-
-                    if (p.tag === "OptEval") {
-                        // Evaluate each property path and cache the results (so, e.g. the next lookup just returns a Value)
-                        // `resolve path A.val.x = f(z, y)` ===> `f(z, y) evaluates to c` ===>
-                        // `set A.val.x = r` ===> `next lookup of A.val.x yields c instead of computing f(z, y)`
-                        const propertyPathExpr = propertyPath as Path;
-                        const val: Value<VarAD> = (evalExpr(
-                            propertyPathExpr,
-                            trans,
-                            varyingMap,
-                            optDebugInfo
-                        ) as IVal<VarAD>).contents;
-                        const transNew = insertExpr(
-                            propertyPath,
-                            { tag: "Done", contents: val },
-                            trans
-                        );
-                        return val;
-                    } else {
-                        // Look up in varyingMap to see if there is a fresh value
-                        varyingVal = varyingMap?.get(JSON.stringify(propertyPath));
-                        if (varyingVal) {
-                            return { tag: "FloatV", contents: varyingVal };
-                        } else {
-                            return p.contents;
-                        }
-                    }
-                });
-
-                // No need to cache evaluated GPI as each of its individual properties should have been cached on evaluation
-                return {
-                    tag: "GPI",
-                    contents: [type, evaledProps] as GPI<VarAD>,
-                };
-            }
-
-            // Otherwise, either evaluate or return the expression
-            default: {
-                const expr: TagExpr<VarAD> = gpiOrExpr;
-
-                if (expr.tag === "OptEval") {
-                    // Evaluate the expression and cache the results (so, e.g. the next lookup just returns a Value)
-                    const res: ArgVal<VarAD> = evalExpr(
-                        expr.contents,
-                        trans,
-                        varyingMap,
-                        optDebugInfo
-                    );
-
-                    if (res.tag === "Val") {
-                        const transNew = insertExpr(
-                            path,
-                            { tag: "Done", contents: res.contents },
-                            trans
-                        );
-                        return res;
-                    } else if (res.tag === "GPI") {
-                        throw Error(
-                            "Field expression evaluated to GPI when this case was eliminated"
-                        );
-                    } else {
-                        throw Error("Unknown tag");
-                    }
-                } else if (expr.tag === "Done" || expr.tag === "Pending") {
-                    // Already done, just return results of lookup -- this is a cache hit
-                    return { tag: "Val", contents: expr.contents };
-                } else {
-                    throw Error("Unexpected tag");
-                }
-            }
-        }
+        const e: Expr = {
+          ...path,
+          tag: "VectorAccess",
+          contents: [path.path, path.indices[0]],
+        };
+        return evalExpr(e, trans, varyingMap, optDebugInfo);
+      } else if (path.indices.length === 2) {
+        // Matrix
+        const e: Expr = {
+          ...path,
+          tag: "MatrixAccess",
+          contents: [path.path, path.indices],
+        };
+        return evalExpr(e, trans, varyingMap, optDebugInfo);
+      } else throw Error("unsupported number of indices in AccessPath");
     }
+
+    if (path.tag === "InternalLocalVar" || path.tag === "LocalVar") {
+      throw Error("should not encounter local var in evaluation");
+    }
+
+    const gpiOrExpr = findExprSafe(trans, path);
+
+    switch (gpiOrExpr.tag) {
+      case "FGPI": {
+        const [type, props] = gpiOrExpr.contents;
+
+        // Evaluate GPI (i.e. each property path in GPI -- NOT necessarily the path's expression)
+        const evaledProps = mapValues(props, (p, propName) => {
+          const propertyPath: IPropertyPath = {
+            ...path,
+            tag: "PropertyPath",
+            name: path.name,
+            field: path.field,
+            property: dummyIdentifier(propName),
+          };
+
+          if (p.tag === "OptEval") {
+            // Evaluate each property path and cache the results (so, e.g. the next lookup just returns a Value)
+            // `resolve path A.val.x = f(z, y)` ===> `f(z, y) evaluates to c` ===>
+            // `set A.val.x = r` ===> `next lookup of A.val.x yields c instead of computing f(z, y)`
+            const propertyPathExpr = propertyPath as Path;
+            const val: Value<VarAD> = (evalExpr(
+              propertyPathExpr,
+              trans,
+              varyingMap,
+              optDebugInfo
+            ) as IVal<VarAD>).contents;
+            const transNew = insertExpr(
+              propertyPath,
+              { tag: "Done", contents: val },
+              trans
+            );
+            return val;
+          } else {
+            // Look up in varyingMap to see if there is a fresh value
+            varyingVal = varyingMap?.get(JSON.stringify(propertyPath));
+            if (varyingVal) {
+              return { tag: "FloatV", contents: varyingVal };
+            } else {
+              return p.contents;
+            }
+          }
+        });
+
+        // No need to cache evaluated GPI as each of its individual properties should have been cached on evaluation
+        return {
+          tag: "GPI",
+          contents: [type, evaledProps] as GPI<VarAD>,
+        };
+      }
+
+      // Otherwise, either evaluate or return the expression
+      default: {
+        const expr: TagExpr<VarAD> = gpiOrExpr;
+
+        if (expr.tag === "OptEval") {
+          // Evaluate the expression and cache the results (so, e.g. the next lookup just returns a Value)
+          const res: ArgVal<VarAD> = evalExpr(
+            expr.contents,
+            trans,
+            varyingMap,
+            optDebugInfo
+          );
+
+          if (res.tag === "Val") {
+            const transNew = insertExpr(
+              path,
+              { tag: "Done", contents: res.contents },
+              trans
+            );
+            return res;
+          } else if (res.tag === "GPI") {
+            throw Error(
+              "Field expression evaluated to GPI when this case was eliminated"
+            );
+          } else {
+            throw Error("Unknown tag");
+          }
+        } else if (expr.tag === "Done" || expr.tag === "Pending") {
+          // Already done, just return results of lookup -- this is a cache hit
+          return { tag: "Val", contents: expr.contents };
+        } else {
+          throw Error("Unexpected tag");
+        }
+      }
+    }
+  }
 };
 
 // HACK: remove the type wrapper for the argument
 export const argValue = (e: ArgVal<VarAD>) => {
-    switch (e.tag) {
-        case "GPI": // strip the `GPI` tag
-            return e.contents;
-        case "Val": // strip both `Val` and type annotation like `FloatV`
-            return e.contents.contents;
-    }
+  switch (e.tag) {
+    case "GPI": // strip the `GPI` tag
+      return e.contents;
+    case "Val": // strip both `Val` and type annotation like `FloatV`
+      return e.contents.contents;
+  }
 };
 
 export const intToFloat = (v: IIntV): IFloatV<VarAD> => {
-    return { tag: "FloatV", contents: constOf(v.contents) };
+  return { tag: "FloatV", contents: constOf(v.contents) };
 };
 
 /**
@@ -818,126 +822,126 @@ export const intToFloat = (v: IIntV): IFloatV<VarAD> => {
  * @param arg the argument, must be float or int
  */
 export const evalBinOp = (
-    op: BinaryOp,
-    v1: Value<VarAD>,
-    v2: Value<VarAD>
+  op: BinaryOp,
+  v1: Value<VarAD>,
+  v2: Value<VarAD>
 ): Value<VarAD> => {
-    // Promote int to float
-    if (v1.tag === "IntV" && v2.tag === "FloatV") {
-        return evalBinOp(op, intToFloat(v1), v2);
-    } else if (v1.tag === "FloatV" && v2.tag === "IntV") {
-        return evalBinOp(op, v1, intToFloat(v2));
+  // Promote int to float
+  if (v1.tag === "IntV" && v2.tag === "FloatV") {
+    return evalBinOp(op, intToFloat(v1), v2);
+  } else if (v1.tag === "FloatV" && v2.tag === "IntV") {
+    return evalBinOp(op, v1, intToFloat(v2));
+  }
+
+  // NOTE: need to explicitly check the types so the compiler will understand
+  if (v1.tag === "FloatV" && v2.tag === "FloatV") {
+    let res;
+
+    switch (op) {
+      case "BPlus": {
+        res = add(v1.contents, v2.contents);
+        break;
+      }
+
+      case "BMinus": {
+        res = sub(v1.contents, v2.contents);
+        break;
+      }
+
+      case "Multiply": {
+        res = mul(v1.contents, v2.contents);
+        break;
+      }
+
+      case "Divide": {
+        res = div(v1.contents, v2.contents);
+        break;
+      }
+
+      case "Exp": {
+        throw Error("Pow op unimplemented");
+        // res = v1.contents.powStrict(v2.contents);
+        break;
+      }
     }
 
-    // NOTE: need to explicitly check the types so the compiler will understand
-    if (v1.tag === "FloatV" && v2.tag === "FloatV") {
-        let res;
+    return { tag: "FloatV", contents: res };
+  } else if (v1.tag === "IntV" && v2.tag === "IntV") {
+    const returnType = "IntV";
+    let res;
 
-        switch (op) {
-            case "BPlus": {
-                res = add(v1.contents, v2.contents);
-                break;
-            }
+    switch (op) {
+      case "BPlus": {
+        res = v1.contents + v2.contents;
+        break;
+      }
 
-            case "BMinus": {
-                res = sub(v1.contents, v2.contents);
-                break;
-            }
+      case "BMinus": {
+        res = v1.contents - v2.contents;
+        break;
+      }
 
-            case "Multiply": {
-                res = mul(v1.contents, v2.contents);
-                break;
-            }
+      case "Multiply": {
+        res = v1.contents * v2.contents;
+        break;
+      }
 
-            case "Divide": {
-                res = div(v1.contents, v2.contents);
-                break;
-            }
+      case "Divide": {
+        res = v1.contents / v2.contents;
+        return { tag: "FloatV", contents: constOf(res) };
+      }
 
-            case "Exp": {
-                throw Error("Pow op unimplemented");
-                // res = v1.contents.powStrict(v2.contents);
-                break;
-            }
-        }
-
-        return { tag: "FloatV", contents: res };
-    } else if (v1.tag === "IntV" && v2.tag === "IntV") {
-        const returnType = "IntV";
-        let res;
-
-        switch (op) {
-            case "BPlus": {
-                res = v1.contents + v2.contents;
-                break;
-            }
-
-            case "BMinus": {
-                res = v1.contents - v2.contents;
-                break;
-            }
-
-            case "Multiply": {
-                res = v1.contents * v2.contents;
-                break;
-            }
-
-            case "Divide": {
-                res = v1.contents / v2.contents;
-                return { tag: "FloatV", contents: constOf(res) };
-            }
-
-            case "Exp": {
-                res = Math.pow(v1.contents, v2.contents);
-                break;
-            }
-        }
-
-        return { tag: "IntV", contents: res };
-    } else if (v1.tag === "VectorV" && v2.tag === "VectorV") {
-        let res;
-
-        switch (op) {
-            case "BPlus": {
-                res = ops.vadd(v1.contents, v2.contents);
-                break;
-            }
-
-            case "BMinus": {
-                res = ops.vsub(v1.contents, v2.contents);
-                break;
-            }
-        }
-
-        return { tag: "VectorV", contents: res as VarAD[] };
-    } else if (v1.tag === "FloatV" && v2.tag === "VectorV") {
-        let res;
-
-        switch (op) {
-            case "Multiply": {
-                res = ops.vmul(v1.contents, v2.contents);
-                break;
-            }
-        }
-        return { tag: "VectorV", contents: res as VarAD[] };
-    } else if (v1.tag === "VectorV" && v2.tag === "FloatV") {
-        let res;
-
-        switch (op) {
-            case "Divide": {
-                res = ops.vdiv(v1.contents, v2.contents);
-                break;
-            }
-        }
-
-        return { tag: "VectorV", contents: res as VarAD[] };
-    } else {
-        throw new Error(
-            `the types of two operands to ${op} are not supported: ${v1.tag}, ${v2.tag}`
-        );
+      case "Exp": {
+        res = Math.pow(v1.contents, v2.contents);
+        break;
+      }
     }
 
-    return v1; // TODO hack
+    return { tag: "IntV", contents: res };
+  } else if (v1.tag === "VectorV" && v2.tag === "VectorV") {
+    let res;
+
+    switch (op) {
+      case "BPlus": {
+        res = ops.vadd(v1.contents, v2.contents);
+        break;
+      }
+
+      case "BMinus": {
+        res = ops.vsub(v1.contents, v2.contents);
+        break;
+      }
+    }
+
+    return { tag: "VectorV", contents: res as VarAD[] };
+  } else if (v1.tag === "FloatV" && v2.tag === "VectorV") {
+    let res;
+
+    switch (op) {
+      case "Multiply": {
+        res = ops.vmul(v1.contents, v2.contents);
+        break;
+      }
+    }
+    return { tag: "VectorV", contents: res as VarAD[] };
+  } else if (v1.tag === "VectorV" && v2.tag === "FloatV") {
+    let res;
+
+    switch (op) {
+      case "Divide": {
+        res = ops.vdiv(v1.contents, v2.contents);
+        break;
+      }
+    }
+
+    return { tag: "VectorV", contents: res as VarAD[] };
+  } else {
+    throw new Error(
+      `the types of two operands to ${op} are not supported: ${v1.tag}, ${v2.tag}`
+    );
+  }
+
+  return v1; // TODO hack
 };
 
 /**
@@ -947,27 +951,27 @@ export const evalBinOp = (
  * @param arg the argument, must be float or int
  */
 export const evalUOp = (
-    op: UnaryOp,
-    arg: IFloatV<VarAD> | IIntV | IVectorV<VarAD>
+  op: UnaryOp,
+  arg: IFloatV<VarAD> | IIntV | IVectorV<VarAD>
 ): Value<VarAD> => {
-    if (arg.tag === "FloatV") {
-        switch (op) {
-            case "UMinus":
-                return { ...arg, contents: neg(arg.contents) };
-        }
-    } else if (arg.tag === "IntV") {
-        switch (op) {
-            case "UMinus":
-                return { ...arg, contents: -arg.contents };
-        }
-    } else if (arg.tag === "VectorV") {
-        switch (op) {
-            case "UMinus":
-                return { ...arg, contents: ops.vneg(arg.contents) };
-        }
-    } else {
-        throw Error("unary op undefined on type ${arg.tag}, op ${op}");
+  if (arg.tag === "FloatV") {
+    switch (op) {
+      case "UMinus":
+        return { ...arg, contents: neg(arg.contents) };
     }
+  } else if (arg.tag === "IntV") {
+    switch (op) {
+      case "UMinus":
+        return { ...arg, contents: -arg.contents };
+    }
+  } else if (arg.tag === "VectorV") {
+    switch (op) {
+      case "UMinus":
+        return { ...arg, contents: ops.vneg(arg.contents) };
+    }
+  } else {
+    throw Error("unary op undefined on type ${arg.tag}, op ${op}");
+  }
 };
 
 /**
@@ -976,27 +980,27 @@ export const evalUOp = (
  * @param json plain object encoding `State` of the diagram
  */
 export const decodeState = (json: any): State => {
-    // const rng: prng = seedrandom(json.rng, { global: true });
-    const state = {
-        ...json,
-        varyingValues: json.varyingState,
-        translation: json.transr,
-        originalTranslation: clone(json.transr),
-        shapes: json.shapesr.map(([n, props]: any) => {
-            return { shapeType: n, properties: props };
-        }),
-        varyingMap: genPathMap(json.varyingPaths, json.varyingState),
-        params: json.paramsr,
-        pendingMap: new Map(),
-        rng: undefined,
-    };
-    // cache energy function
-    // state.overallObjective = evalEnergyOn(state);
-    delete state.shapesr;
-    delete state.transr;
-    delete state.paramsr;
-    // delete state.varyingState;
-    return state as State;
+  // const rng: prng = seedrandom(json.rng, { global: true });
+  const state = {
+    ...json,
+    varyingValues: json.varyingState,
+    translation: json.transr,
+    originalTranslation: clone(json.transr),
+    shapes: json.shapesr.map(([n, props]: any) => {
+      return { shapeType: n, properties: props };
+    }),
+    varyingMap: genPathMap(json.varyingPaths, json.varyingState),
+    params: json.paramsr,
+    pendingMap: new Map(),
+    rng: undefined,
+  };
+  // cache energy function
+  // state.overallObjective = evalEnergyOn(state);
+  delete state.shapesr;
+  delete state.transr;
+  delete state.paramsr;
+  // delete state.varyingState;
+  return state as State;
 };
 
 /**
@@ -1006,64 +1010,64 @@ export const decodeState = (json: any): State => {
  * @param state typed `State` object
  */
 export const encodeState = (state: State): any => {
-    // console.log("mapped translation", mapTranslation(numOf, state.translation));
-    // console.log("original translation", state.originalTranslation);
+  // console.log("mapped translation", mapTranslation(numOf, state.translation));
+  // console.log("original translation", state.originalTranslation);
 
-    // console.log("shapes", state.shapes);
-    // console.log("shapesr", state.shapes
-    //   .map(values)
-    //   .map(([n, props]) => [n, pickBy(props, (p: any) => !p.omit)]));
+  // console.log("shapes", state.shapes);
+  // console.log("shapesr", state.shapes
+  //   .map(values)
+  //   .map(([n, props]) => [n, pickBy(props, (p: any) => !p.omit)]));
 
-    const json = {
-        ...state,
-        varyingState: state.varyingValues,
-        paramsr: state.params, // TODO: careful about the list of variables
-        // transr: mapTranslation(numOf, state.translation), // Only send numbers to backend
-        transr: state.originalTranslation, // Only send numbers to backend
-        // NOTE: clean up all additional props and turn objects into lists
-        shapesr: state.shapes
-            .map(values)
-            .map(([n, props]) => [n, pickBy(props, (p: any) => !p.omit)]),
-    } as any;
-    delete json.varyingMap;
-    delete json.translation;
-    delete json.varyingValues;
-    delete json.shapes;
-    delete json.params;
-    json.paramsr.optStatus = { tag: "NewIter" };
-    return json;
+  const json = {
+    ...state,
+    varyingState: state.varyingValues,
+    paramsr: state.params, // TODO: careful about the list of variables
+    // transr: mapTranslation(numOf, state.translation), // Only send numbers to backend
+    transr: state.originalTranslation, // Only send numbers to backend
+    // NOTE: clean up all additional props and turn objects into lists
+    shapesr: state.shapes
+      .map(values)
+      .map(([n, props]) => [n, pickBy(props, (p: any) => !p.omit)]),
+  } as any;
+  delete json.varyingMap;
+  delete json.translation;
+  delete json.varyingValues;
+  delete json.shapes;
+  delete json.params;
+  json.paramsr.optStatus = { tag: "NewIter" };
+  return json;
 };
 
 export const cleanShapes = (shapes: Shape[]): Shape[] =>
-    shapes.map(({ shapeType, properties }: Shape) => ({
-        shapeType,
-        properties: pickBy(properties, (p: any) => !p.omit),
-    })) as Shape[];
+  shapes.map(({ shapeType, properties }: Shape) => ({
+    shapeType,
+    properties: pickBy(properties, (p: any) => !p.omit),
+  })) as Shape[];
 
 // Generate a map from paths to values, where the key is the JSON stringified version of the path
 export function genPathMap<T>(
-    paths: Path[],
-    vals: T[] // TODO: Distinguish between VarAD variables and constants?
+  paths: Path[],
+  vals: T[] // TODO: Distinguish between VarAD variables and constants?
 ): Map<string, T> {
-    if (!paths || !vals) {
-        return new Map(); // Empty, e.g. when the state is decoded, there is no gradient
-    }
+  if (!paths || !vals) {
+    return new Map(); // Empty, e.g. when the state is decoded, there is no gradient
+  }
 
-    if (vals.length !== paths.length) {
-        console.log(paths, vals);
-        throw new Error(
-            "Different numbers of varying vars vs. paths: " +
-            paths.length +
-            ", " +
-            vals.length
-        );
-    }
-    const res = new Map();
-    paths.forEach((path, index) => res.set(JSON.stringify(path), vals[index]));
+  if (vals.length !== paths.length) {
+    console.log(paths, vals);
+    throw new Error(
+      "Different numbers of varying vars vs. paths: " +
+        paths.length +
+        ", " +
+        vals.length
+    );
+  }
+  const res = new Map();
+  paths.forEach((path, index) => res.set(JSON.stringify(path), vals[index]));
 
-    // console.log("gen path map", res);
-    // throw Error("TODO");
-    return res;
+  // console.log("gen path map", res);
+  // throw Error("TODO");
+  return res;
 }
 
 // //////////////////////////////////////////////////////////////////////////////

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,17 +1,17 @@
 import { checkDomain, compileDomain, Env, parseDomain } from "compiler/Domain";
 import { compileStyle } from "compiler/Style";
 import {
-  checkSubstance,
-  compileSubstance,
-  parseSubstance,
-  SubstanceEnv,
+    checkSubstance,
+    compileSubstance,
+    parseSubstance,
+    SubstanceEnv,
 } from "compiler/Substance";
 import { evalShapes } from "engine/Evaluator";
 import { initializeMat, step } from "engine/Optimizer";
 import { insertPending } from "engine/PropagateUpdate";
 import RenderStatic, {
-  RenderInteractive,
-  RenderShape,
+    RenderInteractive,
+    RenderShape,
 } from "renderer/Renderer";
 import { notEmptyLabel, resampleBest, sortShapes } from "renderer/ShapeDef";
 import * as ShapeTypes from "types/shapeTypes";
@@ -26,7 +26,7 @@ import { bBoxDims, toHex } from "utils/Util";
  * @param numSamples number of samples to choose from
  */
 export const resample = (state: State, numSamples: number): State => {
-  return resampleBest(state, numSamples);
+    return resampleBest(state, numSamples);
 };
 
 /**
@@ -35,7 +35,7 @@ export const resample = (state: State, numSamples: number): State => {
  * @param numSteps number of steps to take (default: 1)
  */
 export const stepState = (state: State, numSteps = 1): State => {
-  return step(state, numSteps);
+    return step(state, numSteps);
 };
 
 /**
@@ -43,11 +43,11 @@ export const stepState = (state: State, numSteps = 1): State => {
  * @param state current state
  */
 export const stepUntilConvergence = (state: State): State => {
-  const numSteps = 1;
-  let currentState = state;
-  while (!stateConverged(currentState))
-    currentState = step(currentState, numSteps);
-  return currentState;
+    const numSteps = 1;
+    let currentState = state;
+    while (!stateConverged(currentState))
+        currentState = step(currentState, numSteps);
+    return currentState;
 };
 
 /**
@@ -59,20 +59,20 @@ export const stepUntilConvergence = (state: State): State => {
  * @param node a node in the DOM tree
  */
 export const diagram = async (
-  domainProg: string,
-  subProg: string,
-  styProg: string,
-  node: HTMLElement
+    domainProg: string,
+    subProg: string,
+    styProg: string,
+    node: HTMLElement
 ): Promise<void> => {
-  const res = compileTrio(domainProg, subProg, styProg);
-  if (res.isOk()) {
-    const state: State = await prepareState(res.value);
-    const optimized = stepUntilConvergence(state);
-    node.appendChild(RenderStatic(optimized));
-  } else
-    throw Error(
-      `Error when generating Penrose diagram: ${showError(res.error)}`
-    );
+    const res = compileTrio(domainProg, subProg, styProg);
+    if (res.isOk()) {
+        const state: State = await prepareState(res.value);
+        const optimized = stepUntilConvergence(state);
+        node.appendChild(RenderStatic(optimized));
+    } else
+        throw Error(
+            `Error when generating Penrose diagram: ${showError(res.error)}`
+        );
 };
 
 /**
@@ -84,27 +84,27 @@ export const diagram = async (
  * @param node a node in the DOM tree
  */
 export const interactiveDiagram = async (
-  domainProg: string,
-  subProg: string,
-  styProg: string,
-  node: HTMLElement
+    domainProg: string,
+    subProg: string,
+    styProg: string,
+    node: HTMLElement
 ): Promise<void> => {
-  const updateData = (state: State) => {
-    const stepped = stepUntilConvergence(state);
-    node.replaceChild(
-      RenderInteractive(stepped, updateData),
-      node.firstChild as Node
-    );
-  };
-  const res = compileTrio(domainProg, subProg, styProg);
-  if (res.isOk()) {
-    const state: State = await prepareState(res.value);
-    const optimized = stepUntilConvergence(state);
-    node.appendChild(RenderInteractive(optimized, updateData));
-  } else
-    throw Error(
-      `Error when generating Penrose diagram: ${showError(res.error)}`
-    );
+    const updateData = (state: State) => {
+        const stepped = stepUntilConvergence(state);
+        node.replaceChild(
+            RenderInteractive(stepped, updateData),
+            node.firstChild as Node
+        );
+    };
+    const res = compileTrio(domainProg, subProg, styProg);
+    if (res.isOk()) {
+        const state: State = await prepareState(res.value);
+        const optimized = stepUntilConvergence(state);
+        node.appendChild(RenderInteractive(optimized, updateData));
+    } else
+        throw Error(
+            `Error when generating Penrose diagram: ${showError(res.error)}`
+        );
 };
 
 /**
@@ -114,23 +114,23 @@ export const interactiveDiagram = async (
  * @param styProg a Style program string
  */
 export const compileTrio = (
-  domainProg: string,
-  subProg: string,
-  styProg: string
+    domainProg: string,
+    subProg: string,
+    styProg: string
 ): Result<State, PenroseError> => {
-  const domainRes: Result<Env, PenroseError> = compileDomain(domainProg);
+    const domainRes: Result<Env, PenroseError> = compileDomain(domainProg);
 
-  const subRes: Result<[SubstanceEnv, Env], PenroseError> = andThen(
-    (env) => compileSubstance(subProg, env),
-    domainRes
-  );
+    const subRes: Result<[SubstanceEnv, Env], PenroseError> = andThen(
+        (env) => compileSubstance(subProg, env),
+        domainRes
+    );
 
-  const styRes: Result<State, PenroseError> = andThen(
-    (res) => compileStyle(styProg, ...res),
-    subRes
-  );
+    const styRes: Result<State, PenroseError> = andThen(
+        (res) => compileStyle(styProg, ...res),
+        subRes
+    );
 
-  return styRes;
+    return styRes;
 };
 
 /**
@@ -138,33 +138,33 @@ export const compileTrio = (
  * @param state an initial diagram state
  */
 export const prepareState = async (state: State): Promise<State> => {
-  await initializeMat();
-  // TODO:L errors
-  const stateAD = {
-    ...state,
-    originalTranslation: state.originalTranslation,
-  };
+    await initializeMat();
+    // TODO:L errors
+    const stateAD = {
+        ...state,
+        originalTranslation: state.originalTranslation,
+    };
 
-  // After the pending values load, they only use the evaluated shapes (all in terms of numbers)
-  // The results of the pending values are then stored back in the translation as autodiff types
-  const stateEvaled: State = evalShapes(stateAD);
+    // After the pending values load, they only use the evaluated shapes (all in terms of numbers)
+    // The results of the pending values are then stored back in the translation as autodiff types
+    const stateEvaled: State = evalShapes(stateAD);
 
-  const labelCache: LabelCache = await collectLabels(stateEvaled.shapes);
+    const labelCache: LabelCache = await collectLabels(stateEvaled.shapes);
 
-  const sortedShapes: Shape[] = sortShapes(
-    stateEvaled.shapes,
-    stateEvaled.shapeOrdering
-  );
+    const sortedShapes: Shape[] = sortShapes(
+        stateEvaled.shapes,
+        stateEvaled.shapeOrdering
+    );
 
-  const nonEmpties = sortedShapes.filter(notEmptyLabel);
+    const nonEmpties = sortedShapes.filter(notEmptyLabel);
 
-  const stateWithPendingProperties = insertPending({
-    ...stateEvaled,
-    labelCache,
-    shapes: nonEmpties,
-  });
+    const stateWithPendingProperties = insertPending({
+        ...stateEvaled,
+        labelCache,
+        shapes: nonEmpties,
+    });
 
-  return stateWithPendingProperties;
+    return stateWithPendingProperties;
 };
 
 /**
@@ -172,28 +172,29 @@ export const prepareState = async (state: State): Promise<State> => {
  * @param state current state
  */
 export const stateConverged = (state: State): boolean =>
-  state.params.optStatus.tag === "EPConverged";
+    state.params.optStatus.tag === "EPConverged";
 
 /**
  * Returns true if state is the initial frame
  * @param state current state
  */
 export const stateInitial = (state: State): boolean =>
-  state.params.optStatus.tag === "NewIter";
+    state.params.optStatus.tag === "NewIter";
 
 export type PenroseState = State;
 
 export {
-  compileDomain,
-  compileSubstance,
-  checkDomain,
-  checkSubstance,
-  parseSubstance,
-  parseDomain,
-  RenderStatic,
-  RenderShape,
-  RenderInteractive,
-  ShapeTypes,
-  bBoxDims,
-  toHex,
+    compileDomain,
+    compileSubstance,
+    checkDomain,
+    checkSubstance,
+    parseSubstance,
+    parseDomain,
+    RenderStatic,
+    RenderShape,
+    RenderInteractive,
+    ShapeTypes,
+    bBoxDims,
+    toHex,
+    showError
 };

--- a/packages/core/src/types/errors.d.ts
+++ b/packages/core/src/types/errors.d.ts
@@ -131,6 +131,12 @@ type StyleError =
   | SelectorDeclTypeMismatch
   | SelectorRelTypeMismatch
   | TaggedSubstanceError
+  // Block static errors
+  | InvalidGPITypeError
+  | InvalidGPIPropertyError
+  | InvalidFunctionNameError
+  | InvalidObjectiveNameError
+  | InvalidConstraintNameError
   // Translation errors (deletion)
   | DeletedPropWithNoSubObjError
   | DeletedPropWithNoFieldError
@@ -142,8 +148,30 @@ type StyleError =
   | InsertedPathWithoutOverrideError
   | InsertedPropWithNoFieldError
   | InsertedPropWithNoGPIError
+  // Translation validation errors
+  | NonexistentNameError
+  | NonexistentFieldError
+  | NonexistentGPIError
+  | NonexistentPropertyError
+  | ExpectedGPIGotFieldError
+  | InvalidAccessPathError
   // Runtime errors
   | RuntimeValueTypeError;
+
+type StyleWarning =
+  | IntOrFloat;
+
+type StyleWarnings = StyleWarning[];
+
+interface StyleResults {
+  errors: StyleErrors;
+  warnings: StyleWarnings;
+}
+
+interface IntOrFloat {
+  tag: "IntOrFloat";
+  message: string;
+}; // COMBAK: Use this in block checking
 
 interface GenericStyleError {
   tag: "GenericStyleError";
@@ -186,6 +214,40 @@ interface TaggedSubstanceError {
   tag: "TaggedSubstanceError";
   error: SubstanceError;
 }
+
+//#region Block statics
+
+interface InvalidGPITypeError {
+  tag: "InvalidGPITypeError";
+  givenType: Identifier;
+  // expectedType: string;
+};
+
+interface InvalidGPIPropertyError {
+  tag: "InvalidGPIPropertyError";
+  givenProperty: Identifier;
+  // expectedProperty: string;
+};
+
+interface InvalidFunctionNameError {
+  tag: "InvalidFunctionNameError";
+  givenName: Identifier;
+  // expectedName: string;
+};
+
+interface InvalidObjectiveNameError {
+  tag: "InvalidObjectiveNameError";
+  givenName: Identifier;
+  // expectedName: string;
+};
+
+interface InvalidConstraintNameError {
+  tag: "InvalidConstraintNameError";
+  givenName: Identifier;
+  // expectedName: string;
+};
+
+//#endregion Block statics
 
 interface DeletedPropWithNoSubObjError {
   tag: "DeletedPropWithNoSubObjError";
@@ -245,6 +307,45 @@ interface InsertedPropWithNoGPIError {
   property: Identifier;
   path: Path;
 }
+
+//#region Translation validation errors
+
+interface NonexistentNameError {
+  tag: "NonexistentNameError";
+  name: Identifier;
+  path: Path;
+};
+
+interface NonexistentFieldError {
+  tag: "NonexistentFieldError";
+  field: Identifier;
+  path: Path;
+};
+
+interface NonexistentGPIError {
+  tag: "NonexistentGPIError";
+  gpi: Identifier;
+  path: Path;
+};
+
+interface NonexistentPropertyError {
+  tag: "NonexistentPropertyError";
+  property: Identifier;
+  path: Path;
+};
+
+interface ExpectedGPIGotFieldError {
+  tag: "ExpectedGPIGotFieldError";
+  field: Identifier;
+  path: Path;
+};
+
+interface InvalidAccessPathError {
+  tag: "InvalidAccessPathError";
+  path: Path;
+};
+
+//#endregion Translation validation errors
 
 // TODO(errors): use identifiers here
 interface RuntimeValueTypeError {

--- a/packages/core/src/types/errors.d.ts
+++ b/packages/core/src/types/errors.d.ts
@@ -158,8 +158,7 @@ type StyleError =
   // Runtime errors
   | RuntimeValueTypeError;
 
-type StyleWarning =
-  | IntOrFloat;
+type StyleWarning = IntOrFloat;
 
 type StyleWarnings = StyleWarning[];
 
@@ -171,7 +170,7 @@ interface StyleResults {
 interface IntOrFloat {
   tag: "IntOrFloat";
   message: string;
-}; // COMBAK: Use this in block checking
+} // COMBAK: Use this in block checking
 
 interface GenericStyleError {
   tag: "GenericStyleError";
@@ -221,31 +220,31 @@ interface InvalidGPITypeError {
   tag: "InvalidGPITypeError";
   givenType: Identifier;
   // expectedType: string;
-};
+}
 
 interface InvalidGPIPropertyError {
   tag: "InvalidGPIPropertyError";
   givenProperty: Identifier;
-  // expectedProperty: string;
-};
+  expectedProperties: string[];
+}
 
 interface InvalidFunctionNameError {
   tag: "InvalidFunctionNameError";
   givenName: Identifier;
   // expectedName: string;
-};
+}
 
 interface InvalidObjectiveNameError {
   tag: "InvalidObjectiveNameError";
   givenName: Identifier;
   // expectedName: string;
-};
+}
 
 interface InvalidConstraintNameError {
   tag: "InvalidConstraintNameError";
   givenName: Identifier;
   // expectedName: string;
-};
+}
 
 //#endregion Block statics
 
@@ -314,36 +313,36 @@ interface NonexistentNameError {
   tag: "NonexistentNameError";
   name: Identifier;
   path: Path;
-};
+}
 
 interface NonexistentFieldError {
   tag: "NonexistentFieldError";
   field: Identifier;
   path: Path;
-};
+}
 
 interface NonexistentGPIError {
   tag: "NonexistentGPIError";
   gpi: Identifier;
   path: Path;
-};
+}
 
 interface NonexistentPropertyError {
   tag: "NonexistentPropertyError";
   property: Identifier;
   path: Path;
-};
+}
 
 interface ExpectedGPIGotFieldError {
   tag: "ExpectedGPIGotFieldError";
   field: Identifier;
   path: Path;
-};
+}
 
 interface InvalidAccessPathError {
   tag: "InvalidAccessPathError";
   path: Path;
-};
+}
 
 //#endregion Translation validation errors
 

--- a/packages/core/src/utils/Error.ts
+++ b/packages/core/src/utils/Error.ts
@@ -1,18 +1,19 @@
 import { prettyPrintPath } from "utils/OtherUtils";
 import { Maybe, Result } from "true-myth";
 const {
-    or,
-    and,
-    ok,
-    err,
-    andThen,
-    match,
-    ap,
-    unsafelyUnwrap,
-    isErr,
-    unsafelyGetErr,
+  or,
+  and,
+  ok,
+  err,
+  andThen,
+  match,
+  ap,
+  unsafelyUnwrap,
+  isErr,
+  unsafelyGetErr,
 } = Result;
 
+import { ShapeDef, shapedefs } from "renderer/ShapeDef";
 // #region error rendering and construction
 
 /**
@@ -20,504 +21,530 @@ const {
  * @param t Type to be printed
  */
 export const showType = (t: Type): string => {
-    if (t.tag === "Prop") {
-        return "Prop";
-    } else if (t.tag === "TypeVar") {
-        return `'${t.name.value}`;
-    } else {
-        const { name, args } = t;
-        if (args.length > 0) {
-            const argStrs = args.map(showType);
-            return `${name.value}(${argStrs.join(", ")})`;
-        } else return `${name.value}`;
-    }
+  if (t.tag === "Prop") {
+    return "Prop";
+  } else if (t.tag === "TypeVar") {
+    return `'${t.name.value}`;
+  } else {
+    const { name, args } = t;
+    if (args.length > 0) {
+      const argStrs = args.map(showType);
+      return `${name.value}(${argStrs.join(", ")})`;
+    } else return `${name.value}`;
+  }
 };
 // COMBAK What's a better way to model warnings?
 export const styWarnings = [
-    "DeletedPropWithNoSubObjError",
-    "DeletedPropWithNoFieldError",
-    "DeletedPropWithNoGPIError",
-    "DeletedNonexistentFieldError",
+  "DeletedPropWithNoSubObjError",
+  "DeletedPropWithNoFieldError",
+  "DeletedPropWithNoGPIError",
+  "DeletedNonexistentFieldError",
 ];
 
 // TODO: fix template formatting
 export const showError = (
-    error: DomainError | SubstanceError | StyleError
+  error: DomainError | SubstanceError | StyleError
 ): string => {
-    switch (error.tag) {
-        case "ParseError":
-            return error.message;
-        case "TypeDeclared": {
-            return `Type ${error.typeName.value} already exists.`;
-        }
-        // TODO: abstract out this pattern if it becomes more common
-        case "VarNotFound": {
-            const { variable, possibleVars } = error;
-            const msg = `Variable ${variable.value} (at ${loc(
-                variable
-            )}) does not exist.`;
-            if (possibleVars) {
-                const suggestions = possibleVars.join(", ");
-                return msg + ` Declared variables are: ${suggestions}`;
-            } else return msg;
-        }
-        case "TypeNotFound": {
-            const { typeName, possibleTypes } = error;
-            const msg = `Type ${typeName.value} (at ${loc(
-                typeName
-            )}) does not exist.`;
-            if (possibleTypes) {
-                const suggestions = possibleTypes
-                    .map(({ value }: Identifier) => value)
-                    .join(", ");
-                return msg + ` Possible types are: ${suggestions}`;
-            } else return msg;
-        }
-        case "TypeVarNotFound": {
-            return `Type variable ${error.typeVar.name.value} (at ${loc(
-                error.typeVar
-            )}) does not exist.`;
-        }
-        case "DuplicateName": {
-            const { firstDefined, name, location } = error;
-            return `Name ${name.value} (at ${loc(
-                location
-            )}) already exists, first declared at ${loc(firstDefined)}.`;
-        }
-        case "NotTypeConsInSubtype": {
-            if (error.type.tag === "Prop") {
-                return `Prop (at ${loc(
-                    error.type
-                )}) is not a type constructor. Only type constructors are allowed in subtyping relations.`;
-            } else {
-                return `${error.type.name.value} (at ${loc(
-                    error.type
-                )}) is not a type constructor. Only type constructors are allowed in subtyping relations.`;
-            }
-        }
-        case "CyclicSubtypes": {
-            return `Subtyping relations in this program form a cycle. Cycles of types are:\n${showCycles(
-                error.cycles
-            )}`;
-        }
-        case "NotTypeConsInPrelude": {
-            if (error.type.tag === "Prop") {
-                return `Prop (at ${loc(
-                    error.type
-                )}) is not a type constructor. Only type constructors are allowed for prelude values.`;
-            } else {
-                return `${error.type.name.value} (at ${loc(
-                    error.type
-                )}) is not a type constructor. Only type constructors are allowed in prelude values.`;
-            }
-        }
-        case "TypeMismatch": {
-            const { sourceExpr, sourceType, expectedExpr, expectedType } = error;
-            return `The type of the expression at ${loc(sourceExpr)} '${showType(
-                sourceType
-            )}' does not match with the expected type '${showType(
-                expectedType
-            )}' derived from the expression at ${loc(expectedExpr)}.`;
-        }
-        case "TypeArgLengthMismatch": {
-            const { sourceExpr, sourceType, expectedExpr, expectedType } = error;
-            return `${expectedType.args.length} arguments expected for type ${expectedType.name.value
-                } (defined at ${loc(expectedExpr)}), but ${sourceType.args.length
-                } arguments were given for ${sourceType.name.value} at ${loc(
-                    sourceExpr
-                )} `;
-        }
-        case "ArgLengthMismatch": {
-            const { name, argsGiven, argsExpected, sourceExpr, expectedExpr } = error;
-            return `${name.value} expects ${argsExpected.length
-                } arguments (originally defined at ${loc(expectedExpr)}), but was given ${argsGiven.length
-                } arguments instead at ${loc(sourceExpr)}.`;
-        }
-        case "DeconstructNonconstructor": {
-            const { variable, field } = error.deconstructor;
-            return `Becuase ${variable.value} is not bound to a constructor, ${variable.value
-                }.${field.value} (at ${loc(
-                    error.deconstructor
-                )}) does not correspond to a field value.`;
-        }
-        case "UnexpectedExprForNestedPred": {
-            const { sourceExpr, sourceType, expectedExpr } = error;
-            return `A nested predicate is expected (defined at ${loc(
-                expectedExpr
-            )}), but an expression of '${showType(
-                sourceType
-            )}' type was given at ${loc(sourceExpr)}.`;
-        }
-
-        // ---- BEGIN STYLE ERRORS
-        // COMBAK suggest improvements after reporting errors
-
-        case "GenericStyleError": {
-            return `DEBUG: Style failed with errors:\n ${error.messages.join("\n")}`;
-        }
-
-        case "SelectorDeclTypeError": {
-            // COMBAK Maybe this should be a TaggedSubstanceError?
-            return "Substance type error in declaration in selector";
-        }
-
-        case "StyleErrorList": {
-            return error.errors.map(showError).join(", ");
-        }
-
-        case "SelectorVarMultipleDecl": {
-            return "Style pattern statement has already declared the variable ${error.varName.value}";
-        }
-
-        case "SelectorDeclTypeMismatch": {
-            // COMBAK: Add code for prettyprinting types
-            return "Mismatched types or wrong subtypes between Substance and Style variables in selector";
-        }
-
-        case "SelectorRelTypeMismatch": {
-            // COMBAK: Add code for prettyprinting types
-            return "Mismatched types or wrong subtypes between variable and expression in relational statement in selector";
-        }
-
-        case "TaggedSubstanceError": {
-            return showError(error.error); // Substance error
-        }
-
-        // --- BEGIN BLOCK STATIC ERRORS
-
-        case "InvalidGPITypeError": {
-            return `Got invalid GPI type ${error.givenType.value}.`;
-            // COMBAK: GPI type suggestions, or just print the list
-        };
-
-        case "InvalidGPIPropertyError": {
-            return `Got invalid GPI property ${error.givenProperty.value}.`;
-            // COMBAK: GPI property suggestions, or just print the list
-        };
-
-        case "InvalidFunctionNameError": {
-            return `Got invalid Function name ${error.givenName.value}.`;
-            // COMBAK: Function suggestions, or just print the list
-        };
-
-        case "InvalidObjectiveNameError": {
-            return `Got invalid objective name ${error.givenName.value}.`;
-            // COMBAK: Objective suggestions, or just print the list
-        };
-
-        case "InvalidConstraintNameError": {
-            return `Got invalid constraint name ${error.givenName.value}.`;
-            // COMBAK: Constraint suggestions, or just print the list
-        };
-
-        // --- END BLOCK STATIC ERRORS
-
-        case "DeletedPropWithNoSubObjError": {
-            return `Sub obj '${error.subObj.contents.value
-                }' has no fields; can't delete path '${prettyPrintPath(error.path)}'`;
-        }
-
-        case "DeletedPropWithNoFieldError": {
-            return `Sub obj '${error.subObj.contents.value}' already lacks field ${error.field.value
-                }; can't delete path '${prettyPrintPath(error.path)}'`;
-        }
-
-        case "CircularPathAlias": {
-            return `Path ${prettyPrintPath(error.path)} was aliased to itself`;
-        }
-
-        case "DeletedPropWithNoGPIError": {
-            return `Sub obj '${error.subObj.contents.value}' does not have GPI '${error.field.value
-                }'; cannot delete property '${error.property.value} in ${prettyPrintPath(
-                    error.path
-                )}'`;
-        }
-
-        // TODO: Use input path to report location?
-        case "DeletedNonexistentFieldError": {
-            return `Trying to delete '${error.field.value} from SubObj '${error.subObj.contents.value}', which already lacks the field`;
-        }
-
-        case "DeletedVectorElemError": {
-            return `Cannot delete an element of a vector: ${prettyPrintPath(
-                error.path
-            )}`;
-        }
-
-        case "InsertedPathWithoutOverrideError": {
-            return `Overriding path ${prettyPrintPath(
-                error.path
-            )} without override flag set`;
-        }
-
-        case "InsertedPropWithNoFieldError": {
-            return `Sub obj '${error.subObj.contents.value}' does not have Field '${error.field.value
-                }'; cannot add property '${error.property.value} in ${prettyPrintPath(
-                    error.path
-                )}'`;
-        }
-
-        case "InsertedPropWithNoGPIError": {
-            return `Sub obj '${error.subObj.contents.value
-                }' has field but does not have GPI '${error.field.value
-                }'; cannot add property '${error.property.value} in ${prettyPrintPath(
-                    error.path
-                )}'. Expected GPI.`;
-        }
-
-        // ----- BEGIN TRANSLATION VALIDATION ERRORS
-
-        case "NonexistentNameError": {
-            return `Error looking up path '${prettyPrintPath(error.path)}' in translation. Name ${error.name.value} does not exist.`;
-        };
-
-        case "NonexistentFieldError": {
-            return `Error looking up path '${prettyPrintPath(error.path)}' in translation. Field ${error.field.value} does not exist.`;
-        };
-
-        case "NonexistentGPIError": {
-            return `Error looking up path '${prettyPrintPath(error.path)}' in translation. GPI ${error.gpi.value} does not exist.`;
-        };
-
-        case "NonexistentPropertyError": {
-            return `Error looking up path '${prettyPrintPath(error.path)}' in translation. Property ${error.property.value} does not exist.`;
-        };
-
-        case "ExpectedGPIGotFieldError": {
-            return `Error looking up path '${prettyPrintPath(error.path)}' in translation. Expected GPI ${error.field.value} does not exist; got a field instead.`;
-        };
-
-        case "InvalidAccessPathError": {
-            return `Error looking up path '${prettyPrintPath(error.path)}' in translation.`;
-        };
-
-        // ----- END TRANSLATION VALIDATION ERRORS
-
-        // TODO(errors): use identifiers here
-        case "RuntimeValueTypeError": {
-            return `Runtime type error in looking up path '${prettyPrintPath(
-                error.path
-            )}''s value in translation. Expected type: ${error.expectedType
-                }. Got type: ${error.actualType}.`;
-        }
-
-        // ----- END STYLE ERRORS
-
-        case "Fatal": {
-            return `FATAL: ${error.message}`;
-        }
+  switch (error.tag) {
+    case "ParseError":
+      return error.message;
+    case "TypeDeclared": {
+      return `Type ${error.typeName.value} already exists.`;
     }
+    // TODO: abstract out this pattern if it becomes more common
+    case "VarNotFound": {
+      const { variable, possibleVars } = error;
+      const msg = `Variable ${variable.value} (at ${loc(
+        variable
+      )}) does not exist.`;
+      if (possibleVars) {
+        const suggestions = possibleVars.join(", ");
+        return msg + ` Declared variables are: ${suggestions}`;
+      } else return msg;
+    }
+    case "TypeNotFound": {
+      const { typeName, possibleTypes } = error;
+      const msg = `Type ${typeName.value} (at ${loc(
+        typeName
+      )}) does not exist.`;
+      if (possibleTypes) {
+        const suggestions = possibleTypes
+          .map(({ value }: Identifier) => value)
+          .join(", ");
+        return msg + ` Possible types are: ${suggestions}`;
+      } else return msg;
+    }
+    case "TypeVarNotFound": {
+      return `Type variable ${error.typeVar.name.value} (at ${loc(
+        error.typeVar
+      )}) does not exist.`;
+    }
+    case "DuplicateName": {
+      const { firstDefined, name, location } = error;
+      return `Name ${name.value} (at ${loc(
+        location
+      )}) already exists, first declared at ${loc(firstDefined)}.`;
+    }
+    case "NotTypeConsInSubtype": {
+      if (error.type.tag === "Prop") {
+        return `Prop (at ${loc(
+          error.type
+        )}) is not a type constructor. Only type constructors are allowed in subtyping relations.`;
+      } else {
+        return `${error.type.name.value} (at ${loc(
+          error.type
+        )}) is not a type constructor. Only type constructors are allowed in subtyping relations.`;
+      }
+    }
+    case "CyclicSubtypes": {
+      return `Subtyping relations in this program form a cycle. Cycles of types are:\n${showCycles(
+        error.cycles
+      )}`;
+    }
+    case "NotTypeConsInPrelude": {
+      if (error.type.tag === "Prop") {
+        return `Prop (at ${loc(
+          error.type
+        )}) is not a type constructor. Only type constructors are allowed for prelude values.`;
+      } else {
+        return `${error.type.name.value} (at ${loc(
+          error.type
+        )}) is not a type constructor. Only type constructors are allowed in prelude values.`;
+      }
+    }
+    case "TypeMismatch": {
+      const { sourceExpr, sourceType, expectedExpr, expectedType } = error;
+      return `The type of the expression at ${loc(sourceExpr)} '${showType(
+        sourceType
+      )}' does not match with the expected type '${showType(
+        expectedType
+      )}' derived from the expression at ${loc(expectedExpr)}.`;
+    }
+    case "TypeArgLengthMismatch": {
+      const { sourceExpr, sourceType, expectedExpr, expectedType } = error;
+      return `${expectedType.args.length} arguments expected for type ${
+        expectedType.name.value
+      } (defined at ${loc(expectedExpr)}), but ${
+        sourceType.args.length
+      } arguments were given for ${sourceType.name.value} at ${loc(
+        sourceExpr
+      )} `;
+    }
+    case "ArgLengthMismatch": {
+      const { name, argsGiven, argsExpected, sourceExpr, expectedExpr } = error;
+      return `${name.value} expects ${
+        argsExpected.length
+      } arguments (originally defined at ${loc(expectedExpr)}), but was given ${
+        argsGiven.length
+      } arguments instead at ${loc(sourceExpr)}.`;
+    }
+    case "DeconstructNonconstructor": {
+      const { variable, field } = error.deconstructor;
+      return `Becuase ${variable.value} is not bound to a constructor, ${
+        variable.value
+      }.${field.value} (at ${loc(
+        error.deconstructor
+      )}) does not correspond to a field value.`;
+    }
+    case "UnexpectedExprForNestedPred": {
+      const { sourceExpr, sourceType, expectedExpr } = error;
+      return `A nested predicate is expected (defined at ${loc(
+        expectedExpr
+      )}), but an expression of '${showType(
+        sourceType
+      )}' type was given at ${loc(sourceExpr)}.`;
+    }
+
+    // ---- BEGIN STYLE ERRORS
+    // COMBAK suggest improvements after reporting errors
+
+    case "GenericStyleError": {
+      return `DEBUG: Style failed with errors:\n ${error.messages.join("\n")}`;
+    }
+
+    case "SelectorDeclTypeError": {
+      // COMBAK Maybe this should be a TaggedSubstanceError?
+      return "Substance type error in declaration in selector";
+    }
+
+    case "StyleErrorList": {
+      return error.errors.map(showError).join(", ");
+    }
+
+    case "SelectorVarMultipleDecl": {
+      return "Style pattern statement has already declared the variable ${error.varName.value}";
+    }
+
+    case "SelectorDeclTypeMismatch": {
+      // COMBAK: Add code for prettyprinting types
+      return "Mismatched types or wrong subtypes between Substance and Style variables in selector";
+    }
+
+    case "SelectorRelTypeMismatch": {
+      // COMBAK: Add code for prettyprinting types
+      return "Mismatched types or wrong subtypes between variable and expression in relational statement in selector";
+    }
+
+    case "TaggedSubstanceError": {
+      return showError(error.error); // Substance error
+    }
+
+    // --- BEGIN BLOCK STATIC ERRORS
+
+    case "InvalidGPITypeError": {
+      const shapeNames: string[] = shapedefs.map((e: ShapeDef) => e.shapeType);
+      return `Got invalid GPI type ${error.givenType.value}. Available shape types: ${shapeNames}`;
+    }
+
+    case "InvalidGPIPropertyError": {
+      return `Got invalid GPI property ${error.givenProperty.value}. Available properties: ${error.expectedProperties}`;
+    }
+
+    case "InvalidFunctionNameError": {
+      return `Got invalid Function name ${error.givenName.value}.`;
+      // COMBAK: Function suggestions, or just print the list
+    }
+
+    case "InvalidObjectiveNameError": {
+      return `Got invalid objective name ${error.givenName.value}.`;
+      // COMBAK: Objective suggestions, or just print the list
+    }
+
+    case "InvalidConstraintNameError": {
+      return `Got invalid constraint name ${error.givenName.value}.`;
+      // COMBAK: Constraint suggestions, or just print the list
+    }
+
+    // --- END BLOCK STATIC ERRORS
+
+    case "DeletedPropWithNoSubObjError": {
+      return `Sub obj '${
+        error.subObj.contents.value
+      }' has no fields; can't delete path '${prettyPrintPath(error.path)}'`;
+    }
+
+    case "DeletedPropWithNoFieldError": {
+      return `Sub obj '${error.subObj.contents.value}' already lacks field ${
+        error.field.value
+      }; can't delete path '${prettyPrintPath(error.path)}'`;
+    }
+
+    case "CircularPathAlias": {
+      return `Path ${prettyPrintPath(error.path)} was aliased to itself`;
+    }
+
+    case "DeletedPropWithNoGPIError": {
+      return `Sub obj '${error.subObj.contents.value}' does not have GPI '${
+        error.field.value
+      }'; cannot delete property '${error.property.value} in ${prettyPrintPath(
+        error.path
+      )}'`;
+    }
+
+    // TODO: Use input path to report location?
+    case "DeletedNonexistentFieldError": {
+      return `Trying to delete '${error.field.value} from SubObj '${error.subObj.contents.value}', which already lacks the field`;
+    }
+
+    case "DeletedVectorElemError": {
+      return `Cannot delete an element of a vector: ${prettyPrintPath(
+        error.path
+      )}`;
+    }
+
+    case "InsertedPathWithoutOverrideError": {
+      return `Overriding path ${prettyPrintPath(
+        error.path
+      )} without override flag set`;
+    }
+
+    case "InsertedPropWithNoFieldError": {
+      return `Sub obj '${error.subObj.contents.value}' does not have Field '${
+        error.field.value
+      }'; cannot add property '${error.property.value} in ${prettyPrintPath(
+        error.path
+      )}'`;
+    }
+
+    case "InsertedPropWithNoGPIError": {
+      return `Sub obj '${
+        error.subObj.contents.value
+      }' has field but does not have GPI '${
+        error.field.value
+      }'; cannot add property '${error.property.value} in ${prettyPrintPath(
+        error.path
+      )}'. Expected GPI.`;
+    }
+
+    // ----- BEGIN TRANSLATION VALIDATION ERRORS
+
+    case "NonexistentNameError": {
+      return `Error looking up path '${prettyPrintPath(
+        error.path
+      )}' in translation. Name ${error.name.value} does not exist.`;
+    }
+
+    case "NonexistentFieldError": {
+      return `Error looking up path '${prettyPrintPath(
+        error.path
+      )}' in translation. Field ${error.field.value} does not exist.`;
+    }
+
+    case "NonexistentGPIError": {
+      return `Error looking up path '${prettyPrintPath(
+        error.path
+      )}' in translation. GPI ${error.gpi.value} does not exist.`;
+    }
+
+    case "NonexistentPropertyError": {
+      return `Error looking up path '${prettyPrintPath(
+        error.path
+      )}' in translation. Property ${error.property.value} does not exist.`;
+    }
+
+    case "ExpectedGPIGotFieldError": {
+      return `Error looking up path '${prettyPrintPath(
+        error.path
+      )}' in translation. Expected GPI ${
+        error.field.value
+      } does not exist; got a field instead.`;
+    }
+
+    case "InvalidAccessPathError": {
+      return `Error looking up path '${prettyPrintPath(
+        error.path
+      )}' in translation.`;
+    }
+
+    // ----- END TRANSLATION VALIDATION ERRORS
+
+    // TODO(errors): use identifiers here
+    case "RuntimeValueTypeError": {
+      return `Runtime type error in looking up path '${prettyPrintPath(
+        error.path
+      )}''s value in translation. Expected type: ${
+        error.expectedType
+      }. Got type: ${error.actualType}.`;
+    }
+
+    // ----- END STYLE ERRORS
+
+    case "Fatal": {
+      return `FATAL: ${error.message}`;
+    }
+  }
 };
 
 const showCycles = (cycles: string[][]) => {
-    const pathString = (path: string[]) => path.join(" -> ");
-    return cycles.map(pathString).join("\n");
+  const pathString = (path: string[]) => path.join(" -> ");
+  return cycles.map(pathString).join("\n");
 };
 
 export const cyclicSubtypes = (cycles: string[][]): CyclicSubtypes => ({
-    tag: "CyclicSubtypes",
-    cycles,
+  tag: "CyclicSubtypes",
+  cycles,
 });
 
 export const notTypeConsInPrelude = (
-    type: Prop | TypeVar
+  type: Prop | TypeVar
 ): NotTypeConsInPrelude => ({
-    tag: "NotTypeConsInPrelude",
-    type,
+  tag: "NotTypeConsInPrelude",
+  type,
 });
 
 export const notTypeConsInSubtype = (
-    type: Prop | TypeVar
+  type: Prop | TypeVar
 ): NotTypeConsInSubtype => ({
-    tag: "NotTypeConsInSubtype",
-    type,
+  tag: "NotTypeConsInSubtype",
+  type,
 });
 
 // action constructors for error
 export const duplicateName = (
-    name: Identifier,
-    location: ASTNode,
-    firstDefined: ASTNode
+  name: Identifier,
+  location: ASTNode,
+  firstDefined: ASTNode
 ): DuplicateName => ({
-    tag: "DuplicateName",
-    name,
-    location,
-    firstDefined,
+  tag: "DuplicateName",
+  name,
+  location,
+  firstDefined,
 });
 
 export const typeNotFound = (
-    typeName: Identifier,
-    possibleTypes?: Identifier[]
+  typeName: Identifier,
+  possibleTypes?: Identifier[]
 ): TypeNotFound => ({
-    tag: "TypeNotFound",
-    typeName,
-    possibleTypes,
+  tag: "TypeNotFound",
+  typeName,
+  possibleTypes,
 });
 
 export const varNotFound = (
-    variable: Identifier,
-    possibleVars?: string[]
+  variable: Identifier,
+  possibleVars?: string[]
 ): VarNotFound => ({
-    tag: "VarNotFound",
-    variable,
-    possibleVars,
+  tag: "VarNotFound",
+  variable,
+  possibleVars,
 });
 
 export const typeMismatch = (
-    sourceType: TypeConstructor,
-    expectedType: TypeConstructor,
-    sourceExpr: ASTNode,
-    expectedExpr: ASTNode
+  sourceType: TypeConstructor,
+  expectedType: TypeConstructor,
+  sourceExpr: ASTNode,
+  expectedExpr: ASTNode
 ): TypeMismatch => ({
-    tag: "TypeMismatch",
-    sourceExpr,
-    sourceType,
-    expectedExpr,
-    expectedType,
+  tag: "TypeMismatch",
+  sourceExpr,
+  sourceType,
+  expectedExpr,
+  expectedType,
 });
 
 export const unexpectedExprForNestedPred = (
-    sourceType: TypeConstructor,
-    sourceExpr: ASTNode,
-    expectedExpr: ASTNode
+  sourceType: TypeConstructor,
+  sourceExpr: ASTNode,
+  expectedExpr: ASTNode
 ): UnexpectedExprForNestedPred => ({
-    tag: "UnexpectedExprForNestedPred",
-    sourceType,
-    sourceExpr,
-    expectedExpr,
+  tag: "UnexpectedExprForNestedPred",
+  sourceType,
+  sourceExpr,
+  expectedExpr,
 });
 
 export const argLengthMismatch = (
-    name: Identifier,
-    argsGiven: SubExpr[],
-    argsExpected: Arg[],
-    sourceExpr: ASTNode,
-    expectedExpr: ASTNode
+  name: Identifier,
+  argsGiven: SubExpr[],
+  argsExpected: Arg[],
+  sourceExpr: ASTNode,
+  expectedExpr: ASTNode
 ): ArgLengthMismatch => ({
-    tag: "ArgLengthMismatch",
-    name,
-    argsGiven,
-    argsExpected,
-    sourceExpr,
-    expectedExpr,
+  tag: "ArgLengthMismatch",
+  name,
+  argsGiven,
+  argsExpected,
+  sourceExpr,
+  expectedExpr,
 });
 
 export const typeArgLengthMismatch = (
-    sourceType: TypeConstructor,
-    expectedType: TypeConstructor,
-    sourceExpr: ASTNode,
-    expectedExpr: ASTNode
+  sourceType: TypeConstructor,
+  expectedType: TypeConstructor,
+  sourceExpr: ASTNode,
+  expectedExpr: ASTNode
 ): TypeArgLengthMismatch => ({
-    tag: "TypeArgLengthMismatch",
-    sourceExpr,
-    sourceType,
-    expectedExpr,
-    expectedType,
+  tag: "TypeArgLengthMismatch",
+  sourceExpr,
+  sourceType,
+  expectedExpr,
+  expectedType,
 });
 
 export const deconstructNonconstructor = (
-    deconstructor: Deconstructor
+  deconstructor: Deconstructor
 ): DeconstructNonconstructor => ({
-    tag: "DeconstructNonconstructor",
-    deconstructor,
+  tag: "DeconstructNonconstructor",
+  deconstructor,
 });
 
 export const fatalError = (message: string): FatalError => ({
-    tag: "Fatal",
-    message,
+  tag: "Fatal",
+  message,
 });
 
 export const parseError = (message: string): ParseError => ({
-    tag: "ParseError",
-    message,
+  tag: "ParseError",
+  message,
 });
 
 // If there are multiple errors, just return the tag of the first one
 export const toStyleErrors = (errors: StyleError[]): PenroseError => {
-    if (!errors.length) {
-        throw Error("internal error: expected at least one Style error");
-    }
+  if (!errors.length) {
+    throw Error("internal error: expected at least one Style error");
+  }
 
-    return {
-        errorType: "StyleError",
-        tag: "StyleErrorList",
-        errors,
-    };
+  return {
+    errorType: "StyleError",
+    tag: "StyleErrorList",
+    errors,
+  };
 };
 
 export const genericStyleError = (messages: StyleError[]): PenroseError => ({
-    errorType: "StyleError",
-    tag: "GenericStyleError",
-    messages: messages.map(showError),
+  errorType: "StyleError",
+  tag: "GenericStyleError",
+  messages: messages.map(showError),
 });
 
 // const loc = (node: ASTNode) => `${node.start.line}:${node.start.col}`;
 // TODO: Show file name
 const loc = (node: ASTNode) =>
-    `line ${node.start.line}, column ${node.start.col + 1} of ${node.nodeType
-    } program`;
+  `line ${node.start.line}, column ${node.start.col + 1} of ${
+    node.nodeType
+  } program`;
 
 // #endregion
 
 // #region Either monad
 
 export const every = <Ok, Error>(
-    ...results: Result<Ok, Error>[]
+  ...results: Result<Ok, Error>[]
 ): Result<Ok, Error> =>
-    results.reduce(
-        (currentResult: Result<Ok, Error>, nextResult: Result<Ok, Error>) =>
-            and(nextResult, currentResult),
-        results[0] // TODO: separate out this element in argument
-    );
+  results.reduce(
+    (currentResult: Result<Ok, Error>, nextResult: Result<Ok, Error>) =>
+      and(nextResult, currentResult),
+    results[0] // TODO: separate out this element in argument
+  );
 
 export const safeChain = <Item, Ok, Error>(
-    itemList: Item[],
-    func: (nextItem: Item, currentResult: Ok) => Result<Ok, Error>,
-    initialResult: Result<Ok, Error>
+  itemList: Item[],
+  func: (nextItem: Item, currentResult: Ok) => Result<Ok, Error>,
+  initialResult: Result<Ok, Error>
 ): Result<Ok, Error> =>
-    itemList.reduce(
-        (currentResult: Result<Ok, Error>, nextItem: Item) =>
-            andThen((res: Ok) => func(nextItem, res), currentResult),
-        initialResult
-    );
+  itemList.reduce(
+    (currentResult: Result<Ok, Error>, nextItem: Item) =>
+      andThen((res: Ok) => func(nextItem, res), currentResult),
+    initialResult
+  );
 
 /**
  * Hand-written version of `Result.all`.
  */
 export const all = <Ok, Error>(
-    results: Result<Ok, Error>[]
+  results: Result<Ok, Error>[]
 ): Result<Ok[], Error> => {
-    return results.reduce(
-        (
-            currentResults: Result<Ok[], Error>,
-            nextResult: Result<Ok, Error>
-        ): Result<Ok[], Error> =>
-            currentResults.match({
-                Ok: (current: Ok[]) =>
-                    nextResult.match({
-                        Ok: (next: Ok) => ok([...current, next]),
-                        Err: (e: Error) => err(e),
-                    }),
-                Err: (e: Error) => err(e),
-            }),
-        ok([])
-    );
+  return results.reduce(
+    (
+      currentResults: Result<Ok[], Error>,
+      nextResult: Result<Ok, Error>
+    ): Result<Ok[], Error> =>
+      currentResults.match({
+        Ok: (current: Ok[]) =>
+          nextResult.match({
+            Ok: (next: Ok) => ok([...current, next]),
+            Err: (e: Error) => err(e),
+          }),
+        Err: (e: Error) => err(e),
+      }),
+    ok([])
+  );
 };
 
 // NOTE: re-export all true-myth types to reduce boilerplate
 export {
-    Maybe,
-    Result,
-    and,
-    or,
-    ok,
-    err,
-    andThen,
-    ap,
-    match,
-    unsafelyUnwrap,
-    isErr,
-    unsafelyGetErr,
+  Maybe,
+  Result,
+  and,
+  or,
+  ok,
+  err,
+  andThen,
+  ap,
+  match,
+  unsafelyUnwrap,
+  isErr,
+  unsafelyGetErr,
 };
 
 // #endregion

--- a/packages/core/src/utils/Error.ts
+++ b/packages/core/src/utils/Error.ts
@@ -1,16 +1,16 @@
 import { prettyPrintPath } from "utils/OtherUtils";
 import { Maybe, Result } from "true-myth";
 const {
-  or,
-  and,
-  ok,
-  err,
-  andThen,
-  match,
-  ap,
-  unsafelyUnwrap,
-  isErr,
-  unsafelyGetErr,
+    or,
+    and,
+    ok,
+    err,
+    andThen,
+    match,
+    ap,
+    unsafelyUnwrap,
+    isErr,
+    unsafelyGetErr,
 } = Result;
 
 // #region error rendering and construction
@@ -20,517 +20,504 @@ const {
  * @param t Type to be printed
  */
 export const showType = (t: Type): string => {
-  if (t.tag === "Prop") {
-    return "Prop";
-  } else if (t.tag === "TypeVar") {
-    return `'${t.name.value}`;
-  } else {
-    const { name, args } = t;
-    if (args.length > 0) {
-      const argStrs = args.map(showType);
-      return `${name.value}(${argStrs.join(", ")})`;
-    } else return `${name.value}`;
-  }
+    if (t.tag === "Prop") {
+        return "Prop";
+    } else if (t.tag === "TypeVar") {
+        return `'${t.name.value}`;
+    } else {
+        const { name, args } = t;
+        if (args.length > 0) {
+            const argStrs = args.map(showType);
+            return `${name.value}(${argStrs.join(", ")})`;
+        } else return `${name.value}`;
+    }
 };
 // COMBAK What's a better way to model warnings?
 export const styWarnings = [
-  "DeletedPropWithNoSubObjError",
-  "DeletedPropWithNoFieldError",
-  "DeletedPropWithNoGPIError",
-  "DeletedNonexistentFieldError",
+    "DeletedPropWithNoSubObjError",
+    "DeletedPropWithNoFieldError",
+    "DeletedPropWithNoGPIError",
+    "DeletedNonexistentFieldError",
 ];
 
 // TODO: fix template formatting
 export const showError = (
-  error: DomainError | SubstanceError | StyleError
+    error: DomainError | SubstanceError | StyleError
 ): string => {
-  switch (error.tag) {
-    case "ParseError":
-      return error.message;
-    case "TypeDeclared": {
-      return `Type ${error.typeName.value} already exists.`;
+    switch (error.tag) {
+        case "ParseError":
+            return error.message;
+        case "TypeDeclared": {
+            return `Type ${error.typeName.value} already exists.`;
+        }
+        // TODO: abstract out this pattern if it becomes more common
+        case "VarNotFound": {
+            const { variable, possibleVars } = error;
+            const msg = `Variable ${variable.value} (at ${loc(
+                variable
+            )}) does not exist.`;
+            if (possibleVars) {
+                const suggestions = possibleVars.join(", ");
+                return msg + ` Declared variables are: ${suggestions}`;
+            } else return msg;
+        }
+        case "TypeNotFound": {
+            const { typeName, possibleTypes } = error;
+            const msg = `Type ${typeName.value} (at ${loc(
+                typeName
+            )}) does not exist.`;
+            if (possibleTypes) {
+                const suggestions = possibleTypes
+                    .map(({ value }: Identifier) => value)
+                    .join(", ");
+                return msg + ` Possible types are: ${suggestions}`;
+            } else return msg;
+        }
+        case "TypeVarNotFound": {
+            return `Type variable ${error.typeVar.name.value} (at ${loc(
+                error.typeVar
+            )}) does not exist.`;
+        }
+        case "DuplicateName": {
+            const { firstDefined, name, location } = error;
+            return `Name ${name.value} (at ${loc(
+                location
+            )}) already exists, first declared at ${loc(firstDefined)}.`;
+        }
+        case "NotTypeConsInSubtype": {
+            if (error.type.tag === "Prop") {
+                return `Prop (at ${loc(
+                    error.type
+                )}) is not a type constructor. Only type constructors are allowed in subtyping relations.`;
+            } else {
+                return `${error.type.name.value} (at ${loc(
+                    error.type
+                )}) is not a type constructor. Only type constructors are allowed in subtyping relations.`;
+            }
+        }
+        case "CyclicSubtypes": {
+            return `Subtyping relations in this program form a cycle. Cycles of types are:\n${showCycles(
+                error.cycles
+            )}`;
+        }
+        case "NotTypeConsInPrelude": {
+            if (error.type.tag === "Prop") {
+                return `Prop (at ${loc(
+                    error.type
+                )}) is not a type constructor. Only type constructors are allowed for prelude values.`;
+            } else {
+                return `${error.type.name.value} (at ${loc(
+                    error.type
+                )}) is not a type constructor. Only type constructors are allowed in prelude values.`;
+            }
+        }
+        case "TypeMismatch": {
+            const { sourceExpr, sourceType, expectedExpr, expectedType } = error;
+            return `The type of the expression at ${loc(sourceExpr)} '${showType(
+                sourceType
+            )}' does not match with the expected type '${showType(
+                expectedType
+            )}' derived from the expression at ${loc(expectedExpr)}.`;
+        }
+        case "TypeArgLengthMismatch": {
+            const { sourceExpr, sourceType, expectedExpr, expectedType } = error;
+            return `${expectedType.args.length} arguments expected for type ${expectedType.name.value
+                } (defined at ${loc(expectedExpr)}), but ${sourceType.args.length
+                } arguments were given for ${sourceType.name.value} at ${loc(
+                    sourceExpr
+                )} `;
+        }
+        case "ArgLengthMismatch": {
+            const { name, argsGiven, argsExpected, sourceExpr, expectedExpr } = error;
+            return `${name.value} expects ${argsExpected.length
+                } arguments (originally defined at ${loc(expectedExpr)}), but was given ${argsGiven.length
+                } arguments instead at ${loc(sourceExpr)}.`;
+        }
+        case "DeconstructNonconstructor": {
+            const { variable, field } = error.deconstructor;
+            return `Becuase ${variable.value} is not bound to a constructor, ${variable.value
+                }.${field.value} (at ${loc(
+                    error.deconstructor
+                )}) does not correspond to a field value.`;
+        }
+        case "UnexpectedExprForNestedPred": {
+            const { sourceExpr, sourceType, expectedExpr } = error;
+            return `A nested predicate is expected (defined at ${loc(
+                expectedExpr
+            )}), but an expression of '${showType(
+                sourceType
+            )}' type was given at ${loc(sourceExpr)}.`;
+        }
+
+        // ---- BEGIN STYLE ERRORS
+        // COMBAK suggest improvements after reporting errors
+
+        case "GenericStyleError": {
+            return `DEBUG: Style failed with errors:\n ${error.messages.join("\n")}`;
+        }
+
+        case "SelectorDeclTypeError": {
+            // COMBAK Maybe this should be a TaggedSubstanceError?
+            return "Substance type error in declaration in selector";
+        }
+
+        case "StyleErrorList": {
+            return error.errors.map(showError).join(", ");
+        }
+
+        case "SelectorVarMultipleDecl": {
+            return "Style pattern statement has already declared the variable ${error.varName.value}";
+        }
+
+        case "SelectorDeclTypeMismatch": {
+            // COMBAK: Add code for prettyprinting types
+            return "Mismatched types or wrong subtypes between Substance and Style variables in selector";
+        }
+
+        case "SelectorRelTypeMismatch": {
+            // COMBAK: Add code for prettyprinting types
+            return "Mismatched types or wrong subtypes between variable and expression in relational statement in selector";
+        }
+
+        case "TaggedSubstanceError": {
+            return showError(error.error); // Substance error
+        }
+
+        // --- BEGIN BLOCK STATIC ERRORS
+
+        case "InvalidGPITypeError": {
+            return `Got invalid GPI type ${error.givenType.value}.`;
+            // COMBAK: GPI type suggestions, or just print the list
+        };
+
+        case "InvalidGPIPropertyError": {
+            return `Got invalid GPI property ${error.givenProperty.value}.`;
+            // COMBAK: GPI property suggestions, or just print the list
+        };
+
+        case "InvalidFunctionNameError": {
+            return `Got invalid Function name ${error.givenName.value}.`;
+            // COMBAK: Function suggestions, or just print the list
+        };
+
+        case "InvalidObjectiveNameError": {
+            return `Got invalid objective name ${error.givenName.value}.`;
+            // COMBAK: Objective suggestions, or just print the list
+        };
+
+        case "InvalidConstraintNameError": {
+            return `Got invalid constraint name ${error.givenName.value}.`;
+            // COMBAK: Constraint suggestions, or just print the list
+        };
+
+        // --- END BLOCK STATIC ERRORS
+
+        case "DeletedPropWithNoSubObjError": {
+            return `Sub obj '${error.subObj.contents.value
+                }' has no fields; can't delete path '${prettyPrintPath(error.path)}'`;
+        }
+
+        case "DeletedPropWithNoFieldError": {
+            return `Sub obj '${error.subObj.contents.value}' already lacks field ${error.field.value
+                }; can't delete path '${prettyPrintPath(error.path)}'`;
+        }
+
+        case "CircularPathAlias": {
+            return `Path ${prettyPrintPath(error.path)} was aliased to itself`;
+        }
+
+        case "DeletedPropWithNoGPIError": {
+            return `Sub obj '${error.subObj.contents.value}' does not have GPI '${error.field.value
+                }'; cannot delete property '${error.property.value} in ${prettyPrintPath(
+                    error.path
+                )}'`;
+        }
+
+        // TODO: Use input path to report location?
+        case "DeletedNonexistentFieldError": {
+            return `Trying to delete '${error.field.value} from SubObj '${error.subObj.contents.value}', which already lacks the field`;
+        }
+
+        case "DeletedVectorElemError": {
+            return `Cannot delete an element of a vector: ${prettyPrintPath(
+                error.path
+            )}`;
+        }
+
+        case "InsertedPathWithoutOverrideError": {
+            return `Overriding path ${prettyPrintPath(
+                error.path
+            )} without override flag set`;
+        }
+
+        case "InsertedPropWithNoFieldError": {
+            return `Sub obj '${error.subObj.contents.value}' does not have Field '${error.field.value
+                }'; cannot add property '${error.property.value} in ${prettyPrintPath(
+                    error.path
+                )}'`;
+        }
+
+        case "InsertedPropWithNoGPIError": {
+            return `Sub obj '${error.subObj.contents.value
+                }' has field but does not have GPI '${error.field.value
+                }'; cannot add property '${error.property.value} in ${prettyPrintPath(
+                    error.path
+                )}'. Expected GPI.`;
+        }
+
+        // ----- BEGIN TRANSLATION VALIDATION ERRORS
+
+        case "NonexistentNameError": {
+            return `Error looking up path '${prettyPrintPath(error.path)}' in translation. Name ${error.name.value} does not exist.`;
+        };
+
+        case "NonexistentFieldError": {
+            return `Error looking up path '${prettyPrintPath(error.path)}' in translation. Field ${error.field.value} does not exist.`;
+        };
+
+        case "NonexistentGPIError": {
+            return `Error looking up path '${prettyPrintPath(error.path)}' in translation. GPI ${error.gpi.value} does not exist.`;
+        };
+
+        case "NonexistentPropertyError": {
+            return `Error looking up path '${prettyPrintPath(error.path)}' in translation. Property ${error.property.value} does not exist.`;
+        };
+
+        case "ExpectedGPIGotFieldError": {
+            return `Error looking up path '${prettyPrintPath(error.path)}' in translation. Expected GPI ${error.field.value} does not exist; got a field instead.`;
+        };
+
+        case "InvalidAccessPathError": {
+            return `Error looking up path '${prettyPrintPath(error.path)}' in translation.`;
+        };
+
+        // ----- END TRANSLATION VALIDATION ERRORS
+
+        // TODO(errors): use identifiers here
+        case "RuntimeValueTypeError": {
+            return `Runtime type error in looking up path '${prettyPrintPath(
+                error.path
+            )}''s value in translation. Expected type: ${error.expectedType
+                }. Got type: ${error.actualType}.`;
+        }
+
+        // ----- END STYLE ERRORS
+
+        case "Fatal": {
+            return `FATAL: ${error.message}`;
+        }
     }
-    // TODO: abstract out this pattern if it becomes more common
-    case "VarNotFound": {
-      const { variable, possibleVars } = error;
-      const msg = `Variable ${variable.value} (at ${loc(
-        variable
-      )}) does not exist.`;
-      if (possibleVars) {
-        const suggestions = possibleVars.join(", ");
-        return msg + ` Declared variables are: ${suggestions}`;
-      } else return msg;
-    }
-    case "TypeNotFound": {
-      const { typeName, possibleTypes } = error;
-      const msg = `Type ${typeName.value} (at ${loc(
-        typeName
-      )}) does not exist.`;
-      if (possibleTypes) {
-        const suggestions = possibleTypes
-          .map(({ value }: Identifier) => value)
-          .join(", ");
-        return msg + ` Possible types are: ${suggestions}`;
-      } else return msg;
-    }
-    case "TypeVarNotFound": {
-      return `Type variable ${error.typeVar.name.value} (at ${loc(
-        error.typeVar
-      )}) does not exist.`;
-    }
-    case "DuplicateName": {
-      const { firstDefined, name, location } = error;
-      return `Name ${name.value} (at ${loc(
-        location
-      )}) already exists, first declared at ${loc(firstDefined)}.`;
-    }
-    case "NotTypeConsInSubtype": {
-      if (error.type.tag === "Prop") {
-        return `Prop (at ${loc(
-          error.type
-        )}) is not a type constructor. Only type constructors are allowed in subtyping relations.`;
-      } else {
-        return `${error.type.name.value} (at ${loc(
-          error.type
-        )}) is not a type constructor. Only type constructors are allowed in subtyping relations.`;
-      }
-    }
-    case "CyclicSubtypes": {
-      return `Subtyping relations in this program form a cycle. Cycles of types are:\n${showCycles(
-        error.cycles
-      )}`;
-    }
-    case "NotTypeConsInPrelude": {
-      if (error.type.tag === "Prop") {
-        return `Prop (at ${loc(
-          error.type
-        )}) is not a type constructor. Only type constructors are allowed for prelude values.`;
-      } else {
-        return `${error.type.name.value} (at ${loc(
-          error.type
-        )}) is not a type constructor. Only type constructors are allowed in prelude values.`;
-      }
-    }
-    case "TypeMismatch": {
-      const { sourceExpr, sourceType, expectedExpr, expectedType } = error;
-      return `The type of the expression at ${loc(sourceExpr)} '${showType(
-        sourceType
-      )}' does not match with the expected type '${showType(
-        expectedType
-      )}' derived from the expression at ${loc(expectedExpr)}.`;
-    }
-    case "TypeArgLengthMismatch": {
-      const { sourceExpr, sourceType, expectedExpr, expectedType } = error;
-      return `${expectedType.args.length} arguments expected for type ${
-        expectedType.name.value
-      } (defined at ${loc(expectedExpr)}), but ${
-        sourceType.args.length
-      } arguments were given for ${sourceType.name.value} at ${loc(
-        sourceExpr
-      )} `;
-    }
-    case "ArgLengthMismatch": {
-      const { name, argsGiven, argsExpected, sourceExpr, expectedExpr } = error;
-      return `${name.value} expects ${
-        argsExpected.length
-      } arguments (originally defined at ${loc(expectedExpr)}), but was given ${
-        argsGiven.length
-      } arguments instead at ${loc(sourceExpr)}.`;
-    }
-    case "DeconstructNonconstructor": {
-      const { variable, field } = error.deconstructor;
-      return `Becuase ${variable.value} is not bound to a constructor, ${
-        variable.value
-      }.${field.value} (at ${loc(
-        error.deconstructor
-      )}) does not correspond to a field value.`;
-    }
-    case "UnexpectedExprForNestedPred": {
-      const { sourceExpr, sourceType, expectedExpr } = error;
-      return `A nested predicate is expected (defined at ${loc(
-        expectedExpr
-      )}), but an expression of '${showType(
-        sourceType
-      )}' type was given at ${loc(sourceExpr)}.`;
-    }
-
-    // ---- BEGIN STYLE ERRORS
-    // COMBAK suggest improvements after reporting errors
-
-    case "GenericStyleError": {
-      return `DEBUG: Style failed with errors:\n ${error.messages.join("\n")}`;
-    }
-
-    case "SelectorDeclTypeError": {
-      // COMBAK Maybe this should be a TaggedSubstanceError?
-      return "Substance type error in declaration in selector";
-    }
-
-    case "StyleErrorList": {
-      return error.errors.map(showError).join(", ");
-    }
-
-    case "SelectorVarMultipleDecl": {
-      return "Style pattern statement has already declared the variable ${error.varName.value}";
-    }
-
-    case "SelectorDeclTypeMismatch": {
-      // COMBAK: Add code for prettyprinting types
-      return "Mismatched types or wrong subtypes between Substance and Style variables in selector";
-    }
-
-    case "SelectorRelTypeMismatch": {
-      // COMBAK: Add code for prettyprinting types
-      return "Mismatched types or wrong subtypes between variable and expression in relational statement in selector";
-    }
-
-    case "TaggedSubstanceError": {
-      return showError(error.error); // Substance error
-    }
-
-    // --- BEGIN BLOCK STATIC ERRORS
-
-    case "InvalidGPITypeError": {
-      return `Got invalid GPI type ${error.givenType.value}.`;
-      // COMBAK: GPI type suggestions, or just print the list
-    };
-
-    case "InvalidGPIPropertyError": {
-      return `Got invalid GPI property ${error.givenProperty.value}.`;
-      // COMBAK: GPI property suggestions, or just print the list
-    };
-
-    case "InvalidFunctionNameError": {
-      return `Got invalid Function name ${error.givenName.value}.`;
-      // COMBAK: Function suggestions, or just print the list
-    };
-
-    case "InvalidObjectiveNameError": {
-      return `Got invalid objective name ${error.givenName.value}.`;
-      // COMBAK: Objective suggestions, or just print the list
-    };
-
-    case "InvalidConstraintNameError": {
-      return `Got invalid constraint name ${error.givenName.value}.`;
-      // COMBAK: Constraint suggestions, or just print the list
-    };
-
-    // --- END BLOCK STATIC ERRORS
-
-    case "DeletedPropWithNoSubObjError": {
-      return `Sub obj '${
-        error.subObj.contents.value
-      }' has no fields; can't delete path '${prettyPrintPath(error.path)}'`;
-    }
-
-    case "DeletedPropWithNoFieldError": {
-      return `Sub obj '${error.subObj.contents.value}' already lacks field ${
-        error.field.value
-      }; can't delete path '${prettyPrintPath(error.path)}'`;
-    }
-
-    case "CircularPathAlias": {
-      return `Path ${prettyPrintPath(error.path)} was aliased to itself`;
-    }
-
-    case "DeletedPropWithNoGPIError": {
-      return `Sub obj '${error.subObj.contents.value}' does not have GPI '${
-        error.field.value
-      }'; cannot delete property '${error.property.value} in ${prettyPrintPath(
-        error.path
-      )}'`;
-    }
-
-    // TODO: Use input path to report location?
-    case "DeletedNonexistentFieldError": {
-      return `Trying to delete '${error.field.value} from SubObj '${error.subObj.contents.value}', which already lacks the field`;
-    }
-
-    case "DeletedVectorElemError": {
-      return `Cannot delete an element of a vector: ${prettyPrintPath(
-        error.path
-      )}`;
-    }
-
-    case "InsertedPathWithoutOverrideError": {
-      return `Overriding path ${prettyPrintPath(
-        error.path
-      )} without override flag set`;
-    }
-
-    case "InsertedPropWithNoFieldError": {
-      return `Sub obj '${error.subObj.contents.value}' does not have Field '${
-        error.field.value
-      }'; cannot add property '${error.property.value} in ${prettyPrintPath(
-        error.path
-      )}'`;
-    }
-
-    case "InsertedPropWithNoGPIError": {
-      return `Sub obj '${
-        error.subObj.contents.value
-      }' has field but does not have GPI '${
-        error.field.value
-      }'; cannot add property '${error.property.value} in ${prettyPrintPath(
-        error.path
-      )}'. Expected GPI.`;
-    }
-
-    // ----- BEGIN TRANSLATION VALIDATION ERRORS
-
-    case "NonexistentNameError": {
-      return `Error looking up path '${prettyPrintPath(error.path)}'' in translation. Name ${error.name.value} does not exist.`;
-    };
-
-    case "NonexistentFieldError": {
-      return `Error looking up path '${prettyPrintPath(error.path)}'' in translation. Field ${error.field.value} does not exist.`;
-    };
-
-    case "NonexistentGPIError": {
-      return `Error looking up path '${prettyPrintPath(error.path)}'' in translation. GPI ${error.gpi.value} does not exist.`;
-    };
-
-    case "NonexistentPropertyError": {
-      return `Error looking up path '${prettyPrintPath(error.path)}'' in translation. Property ${error.property.value} does not exist.`;
-    };
-
-    case "ExpectedGPIGotFieldError": {
-      return `Error looking up path '${prettyPrintPath(error.path)}'' in translation. Expected GPI ${error.field.value} does not exist; got a field instead.`;
-    };
-
-    case "InvalidAccessPathError": {
-      return `Error looking up path '${prettyPrintPath(error.path)}'' in translation.`;
-    };
-
-    // ----- END TRANSLATION VALIDATION ERRORS
-
-    // TODO(errors): use identifiers here
-    case "RuntimeValueTypeError": {
-      return `Runtime type error in looking up path '${prettyPrintPath(
-        error.path
-      )}''s value in translation. Expected type: ${
-        error.expectedType
-      }. Got type: ${error.actualType}.`;
-    }
-
-    // ----- END STYLE ERRORS
-
-    case "Fatal": {
-      return `FATAL: ${error.message}`;
-    }
-  }
 };
 
 const showCycles = (cycles: string[][]) => {
-  const pathString = (path: string[]) => path.join(" -> ");
-  return cycles.map(pathString).join("\n");
+    const pathString = (path: string[]) => path.join(" -> ");
+    return cycles.map(pathString).join("\n");
 };
 
 export const cyclicSubtypes = (cycles: string[][]): CyclicSubtypes => ({
-  tag: "CyclicSubtypes",
-  cycles,
+    tag: "CyclicSubtypes",
+    cycles,
 });
 
 export const notTypeConsInPrelude = (
-  type: Prop | TypeVar
+    type: Prop | TypeVar
 ): NotTypeConsInPrelude => ({
-  tag: "NotTypeConsInPrelude",
-  type,
+    tag: "NotTypeConsInPrelude",
+    type,
 });
 
 export const notTypeConsInSubtype = (
-  type: Prop | TypeVar
+    type: Prop | TypeVar
 ): NotTypeConsInSubtype => ({
-  tag: "NotTypeConsInSubtype",
-  type,
+    tag: "NotTypeConsInSubtype",
+    type,
 });
 
 // action constructors for error
 export const duplicateName = (
-  name: Identifier,
-  location: ASTNode,
-  firstDefined: ASTNode
+    name: Identifier,
+    location: ASTNode,
+    firstDefined: ASTNode
 ): DuplicateName => ({
-  tag: "DuplicateName",
-  name,
-  location,
-  firstDefined,
+    tag: "DuplicateName",
+    name,
+    location,
+    firstDefined,
 });
 
 export const typeNotFound = (
-  typeName: Identifier,
-  possibleTypes?: Identifier[]
+    typeName: Identifier,
+    possibleTypes?: Identifier[]
 ): TypeNotFound => ({
-  tag: "TypeNotFound",
-  typeName,
-  possibleTypes,
+    tag: "TypeNotFound",
+    typeName,
+    possibleTypes,
 });
 
 export const varNotFound = (
-  variable: Identifier,
-  possibleVars?: string[]
+    variable: Identifier,
+    possibleVars?: string[]
 ): VarNotFound => ({
-  tag: "VarNotFound",
-  variable,
-  possibleVars,
+    tag: "VarNotFound",
+    variable,
+    possibleVars,
 });
 
 export const typeMismatch = (
-  sourceType: TypeConstructor,
-  expectedType: TypeConstructor,
-  sourceExpr: ASTNode,
-  expectedExpr: ASTNode
+    sourceType: TypeConstructor,
+    expectedType: TypeConstructor,
+    sourceExpr: ASTNode,
+    expectedExpr: ASTNode
 ): TypeMismatch => ({
-  tag: "TypeMismatch",
-  sourceExpr,
-  sourceType,
-  expectedExpr,
-  expectedType,
+    tag: "TypeMismatch",
+    sourceExpr,
+    sourceType,
+    expectedExpr,
+    expectedType,
 });
 
 export const unexpectedExprForNestedPred = (
-  sourceType: TypeConstructor,
-  sourceExpr: ASTNode,
-  expectedExpr: ASTNode
+    sourceType: TypeConstructor,
+    sourceExpr: ASTNode,
+    expectedExpr: ASTNode
 ): UnexpectedExprForNestedPred => ({
-  tag: "UnexpectedExprForNestedPred",
-  sourceType,
-  sourceExpr,
-  expectedExpr,
+    tag: "UnexpectedExprForNestedPred",
+    sourceType,
+    sourceExpr,
+    expectedExpr,
 });
 
 export const argLengthMismatch = (
-  name: Identifier,
-  argsGiven: SubExpr[],
-  argsExpected: Arg[],
-  sourceExpr: ASTNode,
-  expectedExpr: ASTNode
+    name: Identifier,
+    argsGiven: SubExpr[],
+    argsExpected: Arg[],
+    sourceExpr: ASTNode,
+    expectedExpr: ASTNode
 ): ArgLengthMismatch => ({
-  tag: "ArgLengthMismatch",
-  name,
-  argsGiven,
-  argsExpected,
-  sourceExpr,
-  expectedExpr,
+    tag: "ArgLengthMismatch",
+    name,
+    argsGiven,
+    argsExpected,
+    sourceExpr,
+    expectedExpr,
 });
 
 export const typeArgLengthMismatch = (
-  sourceType: TypeConstructor,
-  expectedType: TypeConstructor,
-  sourceExpr: ASTNode,
-  expectedExpr: ASTNode
+    sourceType: TypeConstructor,
+    expectedType: TypeConstructor,
+    sourceExpr: ASTNode,
+    expectedExpr: ASTNode
 ): TypeArgLengthMismatch => ({
-  tag: "TypeArgLengthMismatch",
-  sourceExpr,
-  sourceType,
-  expectedExpr,
-  expectedType,
+    tag: "TypeArgLengthMismatch",
+    sourceExpr,
+    sourceType,
+    expectedExpr,
+    expectedType,
 });
 
 export const deconstructNonconstructor = (
-  deconstructor: Deconstructor
+    deconstructor: Deconstructor
 ): DeconstructNonconstructor => ({
-  tag: "DeconstructNonconstructor",
-  deconstructor,
+    tag: "DeconstructNonconstructor",
+    deconstructor,
 });
 
 export const fatalError = (message: string): FatalError => ({
-  tag: "Fatal",
-  message,
+    tag: "Fatal",
+    message,
 });
 
 export const parseError = (message: string): ParseError => ({
-  tag: "ParseError",
-  message,
+    tag: "ParseError",
+    message,
 });
 
 // If there are multiple errors, just return the tag of the first one
 export const toStyleErrors = (errors: StyleError[]): PenroseError => {
-  if (!errors.length) {
-    throw Error("internal error: expected at least one Style error");
-  }
+    if (!errors.length) {
+        throw Error("internal error: expected at least one Style error");
+    }
 
-  return {
-    errorType: "StyleError",
-    tag: "StyleErrorList",
-    errors,
-  };
+    return {
+        errorType: "StyleError",
+        tag: "StyleErrorList",
+        errors,
+    };
 };
 
 export const genericStyleError = (messages: StyleError[]): PenroseError => ({
-  errorType: "StyleError",
-  tag: "GenericStyleError",
-  messages: messages.map(showError),
+    errorType: "StyleError",
+    tag: "GenericStyleError",
+    messages: messages.map(showError),
 });
 
 // const loc = (node: ASTNode) => `${node.start.line}:${node.start.col}`;
 // TODO: Show file name
 const loc = (node: ASTNode) =>
-  `line ${node.start.line}, column ${node.start.col + 1} of ${
-    node.nodeType
-  } program`;
+    `line ${node.start.line}, column ${node.start.col + 1} of ${node.nodeType
+    } program`;
 
 // #endregion
 
 // #region Either monad
 
 export const every = <Ok, Error>(
-  ...results: Result<Ok, Error>[]
+    ...results: Result<Ok, Error>[]
 ): Result<Ok, Error> =>
-  results.reduce(
-    (currentResult: Result<Ok, Error>, nextResult: Result<Ok, Error>) =>
-      and(nextResult, currentResult),
-    results[0] // TODO: separate out this element in argument
-  );
+    results.reduce(
+        (currentResult: Result<Ok, Error>, nextResult: Result<Ok, Error>) =>
+            and(nextResult, currentResult),
+        results[0] // TODO: separate out this element in argument
+    );
 
 export const safeChain = <Item, Ok, Error>(
-  itemList: Item[],
-  func: (nextItem: Item, currentResult: Ok) => Result<Ok, Error>,
-  initialResult: Result<Ok, Error>
+    itemList: Item[],
+    func: (nextItem: Item, currentResult: Ok) => Result<Ok, Error>,
+    initialResult: Result<Ok, Error>
 ): Result<Ok, Error> =>
-  itemList.reduce(
-    (currentResult: Result<Ok, Error>, nextItem: Item) =>
-      andThen((res: Ok) => func(nextItem, res), currentResult),
-    initialResult
-  );
+    itemList.reduce(
+        (currentResult: Result<Ok, Error>, nextItem: Item) =>
+            andThen((res: Ok) => func(nextItem, res), currentResult),
+        initialResult
+    );
 
 /**
  * Hand-written version of `Result.all`.
  */
 export const all = <Ok, Error>(
-  results: Result<Ok, Error>[]
+    results: Result<Ok, Error>[]
 ): Result<Ok[], Error> => {
-  return results.reduce(
-    (
-      currentResults: Result<Ok[], Error>,
-      nextResult: Result<Ok, Error>
-    ): Result<Ok[], Error> =>
-      currentResults.match({
-        Ok: (current: Ok[]) =>
-          nextResult.match({
-            Ok: (next: Ok) => ok([...current, next]),
-            Err: (e: Error) => err(e),
-          }),
-        Err: (e: Error) => err(e),
-      }),
-    ok([])
-  );
+    return results.reduce(
+        (
+            currentResults: Result<Ok[], Error>,
+            nextResult: Result<Ok, Error>
+        ): Result<Ok[], Error> =>
+            currentResults.match({
+                Ok: (current: Ok[]) =>
+                    nextResult.match({
+                        Ok: (next: Ok) => ok([...current, next]),
+                        Err: (e: Error) => err(e),
+                    }),
+                Err: (e: Error) => err(e),
+            }),
+        ok([])
+    );
 };
 
 // NOTE: re-export all true-myth types to reduce boilerplate
 export {
-  Maybe,
-  Result,
-  and,
-  or,
-  ok,
-  err,
-  andThen,
-  ap,
-  match,
-  unsafelyUnwrap,
-  isErr,
-  unsafelyGetErr,
+    Maybe,
+    Result,
+    and,
+    or,
+    ok,
+    err,
+    andThen,
+    ap,
+    match,
+    unsafelyUnwrap,
+    isErr,
+    unsafelyGetErr,
 };
 
 // #endregion

--- a/packages/core/src/utils/Error.ts
+++ b/packages/core/src/utils/Error.ts
@@ -188,6 +188,35 @@ export const showError = (
       return showError(error.error); // Substance error
     }
 
+    // --- BEGIN BLOCK STATIC ERRORS
+
+    case "InvalidGPITypeError": {
+      return `Got invalid GPI type ${error.givenType.value}.`;
+      // COMBAK: GPI type suggestions, or just print the list
+    };
+
+    case "InvalidGPIPropertyError": {
+      return `Got invalid GPI property ${error.givenProperty.value}.`;
+      // COMBAK: GPI property suggestions, or just print the list
+    };
+
+    case "InvalidFunctionNameError": {
+      return `Got invalid Function name ${error.givenName.value}.`;
+      // COMBAK: Function suggestions, or just print the list
+    };
+
+    case "InvalidObjectiveNameError": {
+      return `Got invalid objective name ${error.givenName.value}.`;
+      // COMBAK: Objective suggestions, or just print the list
+    };
+
+    case "InvalidConstraintNameError": {
+      return `Got invalid constraint name ${error.givenName.value}.`;
+      // COMBAK: Constraint suggestions, or just print the list
+    };
+
+    // --- END BLOCK STATIC ERRORS
+
     case "DeletedPropWithNoSubObjError": {
       return `Sub obj '${
         error.subObj.contents.value
@@ -246,6 +275,34 @@ export const showError = (
         error.path
       )}'. Expected GPI.`;
     }
+
+    // ----- BEGIN TRANSLATION VALIDATION ERRORS
+
+    case "NonexistentNameError": {
+      return `Error looking up path '${prettyPrintPath(error.path)}'' in translation. Name ${error.name.value} does not exist.`;
+    };
+
+    case "NonexistentFieldError": {
+      return `Error looking up path '${prettyPrintPath(error.path)}'' in translation. Field ${error.field.value} does not exist.`;
+    };
+
+    case "NonexistentGPIError": {
+      return `Error looking up path '${prettyPrintPath(error.path)}'' in translation. GPI ${error.gpi.value} does not exist.`;
+    };
+
+    case "NonexistentPropertyError": {
+      return `Error looking up path '${prettyPrintPath(error.path)}'' in translation. Property ${error.property.value} does not exist.`;
+    };
+
+    case "ExpectedGPIGotFieldError": {
+      return `Error looking up path '${prettyPrintPath(error.path)}'' in translation. Expected GPI ${error.field.value} does not exist; got a field instead.`;
+    };
+
+    case "InvalidAccessPathError": {
+      return `Error looking up path '${prettyPrintPath(error.path)}'' in translation.`;
+    };
+
+    // ----- END TRANSLATION VALIDATION ERRORS
 
     // TODO(errors): use identifiers here
     case "RuntimeValueTypeError": {


### PR DESCRIPTION
# Description

**Motivation**: Currently Style does not fail if code does not run, just like JS. So if there is some wrong Style code that does not appear in the energy graph or the shape graph, we don’t report errors. Also, errors are currently thrown at eval-time (JS runtime) and mostly unchecked, so they result in cryptic messages from the JS runtime. 

**Proposal**: Check correctness of the blocks while making the translation, as well as the whole translation before evaluating it, and give people better errors ahead of time, that refer to source locations.

**Implementation**: This PR adds more static checking to Style and the translation:

1. Check the Style AST to make sure all shape, objective, constraint, and function names exist.
2. Check the initialized translation to make sure that all user-mentioned paths exist.

This prevents a large class of runtime JS errors.

Related issue/PR: #473 #474 #475
Related notes: 2/11/21 meeting notes

# Implementation strategy and design decisions

Expressions (`Expr`) are folded over recursively to aggregate all errors.

# Examples with steps to reproduce them

See `compiler/Style.test.ts` and `compiler/venn-3d.sty`.

# Checklist

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] New and existing tests pass locally using `yarn test`
- [x] I ran `yarn docs` and there were no errors when generating the HTML site
- [x] My code follows the style guidelines of this project (e.g.: no ESLint warnings)

# Open questions

Questions that require more discussion or to be addressed in future development:

- [ ] Implement further Style/translation checks described in 2/11/21 meeting notes (e.g. typechecking)
- [ ] Fix any errors that are commented out because a different error is thrown (e.g. `NonexistentNameError`)
- [ ] Report better errors and fixes (use `Identifier`s; reverse-map Substance object translation information to the substitution and Style variable that generated it)
- [ ] Test that multiple errors in a Style program work correctly
- [ ] Make `compiler/venn-3d.sty` a test suite