### PR TITLE
Better error handling for browser-ui

### DIFF
--- a/packages/browser-ui/src/inspector/Errors.tsx
+++ b/packages/browser-ui/src/inspector/Errors.tsx
@@ -1,0 +1,19 @@
+import { showError } from "@penrose/core";
+import * as React from "react";
+import IViewProps from "./views/IViewProps";
+const Errors: React.FC<IViewProps> = ({ error }: IViewProps) => {
+  if (!error) {
+    return (
+      <div style={{ padding: "1em", fontSize: "1em", color: "#4f4f4f" }}>
+        no errors
+      </div>
+    );
+  }
+  return (
+    <div style={{ padding: "1em" }}>
+      <div style={{ fontWeight: 700 }}>1 error:</div>
+      <pre>{showError(error).toString()}</pre>
+    </div>
+  );
+};
+export default Errors;

--- a/packages/browser-ui/src/inspector/Inspector.tsx
+++ b/packages/browser-ui/src/inspector/Inspector.tsx
@@ -4,10 +4,11 @@ import * as React from "react";
 import ErrorBoundary from "./ErrorBoundary";
 import Timeline from "./views/Timeline";
 import viewMap from "./views/viewMap";
-import { PenroseState } from "@penrose/core";
+import { PenroseError, PenroseState } from "@penrose/core";
 
 interface IProps {
   history: PenroseState[];
+  error: PenroseError | null;
   onClose(): void;
   modShapes(state: PenroseState): void;
 }
@@ -22,19 +23,19 @@ class Inspector extends React.Component<IProps, IInspectState> {
   public readonly state = {
     // connectionLog: [],
     selectedFrame: -1,
-    selectedView: "frames",
+    selectedView: "frames"
   };
   // public appendToConnectionLog = (status: ConnectionStatus | string) =>
   // this.setState({ connectionLog: [...this.state.connectionLog, status] });
 
   public selectFrame = (frame: number) => {
     this.setState({
-      selectedFrame: frame === this.state.selectedFrame ? -1 : frame,
+      selectedFrame: frame === this.state.selectedFrame ? -1 : frame
     });
   };
   public render() {
     const { selectedFrame } = this.state;
-    const { history, modShapes } = this.props;
+    const { history, modShapes, error } = this.props;
     const currentFrame =
       history.length === 0
         ? null
@@ -47,6 +48,7 @@ class Inspector extends React.Component<IProps, IInspectState> {
       frameIndex: selectedFrame,
       history,
       modShapes,
+      error
     };
     return (
       <div
@@ -56,7 +58,7 @@ class Inspector extends React.Component<IProps, IInspectState> {
           height: "100%",
           overflow: "hidden",
           boxSizing: "border-box",
-          paddingBottom: "1em",
+          paddingBottom: "1em"
         }}
       >
         <Timeline {...commonProps} />
@@ -64,7 +66,15 @@ class Inspector extends React.Component<IProps, IInspectState> {
           <Tabs>
             <TabList>
               {Object.keys(viewMap).map((view: string) => (
-                <Tab key={`tab-${view}`}>{view}</Tab>
+                <Tab key={`tab-${view}`}>
+                  {view}
+                  {view === "errors" && error && (
+                    <span style={{ fontWeight: 800, color: "#ff5c5c" }}>
+                      {" "}
+                      (1)
+                    </span>
+                  )}
+                </Tab>
               ))}
             </TabList>
             <TabPanels>
@@ -74,7 +84,7 @@ class Inspector extends React.Component<IProps, IInspectState> {
                     style={{
                       height: "100%",
                       overflow: "auto",
-                      boxSizing: "border-box",
+                      boxSizing: "border-box"
                     }}
                   >
                     <ErrorBoundary>

--- a/packages/browser-ui/src/inspector/views/Frames.tsx
+++ b/packages/browser-ui/src/inspector/views/Frames.tsx
@@ -6,7 +6,7 @@ class Frames extends React.Component<IViewProps> {
   public render() {
     const { history, frame } = this.props;
     if (frame === null) {
-      return <p>empty</p>;
+      return <p style={{ padding: "1em" }}>empty</p>;
     }
     return (
       <div style={{ padding: "1em" }}>

--- a/packages/browser-ui/src/inspector/views/IViewProps.tsx
+++ b/packages/browser-ui/src/inspector/views/IViewProps.tsx
@@ -1,4 +1,4 @@
-import { PenroseState } from "@penrose/core";
+import { PenroseError, PenroseState } from "@penrose/core";
 
 export interface IViewProps {
   // Switches the current frame to index in history
@@ -10,5 +10,6 @@ export interface IViewProps {
   // Either a valid index in History
   frameIndex: number;
   modShapes(state: PenroseState): void; // todo - null check
+  error: PenroseError | null;
 }
 export default IViewProps;

--- a/packages/browser-ui/src/inspector/views/viewMap.tsx
+++ b/packages/browser-ui/src/inspector/views/viewMap.tsx
@@ -1,10 +1,12 @@
 import Frames from "./Frames";
 import ShapeView from "./ShapeView";
 import Mod from "./Mod";
+import Errors from "inspector/Errors";
 const viewMap = {
   frames: Frames,
+  errors: Errors,
   // logs: LogView,
   shapes: ShapeView,
-  mod: Mod,
+  mod: Mod
 };
 export default viewMap;

--- a/packages/core/src/compiler/Domain.test.ts
+++ b/packages/core/src/compiler/Domain.test.ts
@@ -3,6 +3,7 @@ import * as fs from "fs";
 import * as nearley from "nearley";
 import grammar from "parser/DomainParser";
 import * as path from "path";
+import { PenroseError } from "types/errors";
 import { Result, showError } from "utils/Error";
 
 const outputDir = "/tmp/contexts";

--- a/packages/core/src/compiler/Domain.ts
+++ b/packages/core/src/compiler/Domain.ts
@@ -5,6 +5,13 @@ import nearley from "nearley";
 import domainGrammar from "parser/DomainParser";
 import { idOf } from "parser/ParserUtil";
 import {
+  ParseError,
+  DomainError,
+  TypeNotFound,
+  TypeVarNotFound,
+  PenroseError,
+} from "types/errors";
+import {
   and,
   andThen,
   cyclicSubtypes,

--- a/packages/core/src/compiler/Style.test.ts
+++ b/packages/core/src/compiler/Style.test.ts
@@ -8,6 +8,7 @@ import {
   SubstanceEnv,
 } from "compiler/Substance";
 import * as fs from "fs";
+import { PenroseError } from "types/errors";
 import _ from "lodash";
 import * as path from "path";
 import { andThen, unsafelyUnwrap, Result, showError } from "utils/Error";
@@ -303,19 +304,22 @@ where IsSubset(y, x) { }`,
       InvalidGPITypeError: [`forall Set x { x.icon = Circl { } }`],
 
       // COMBAK: Check that multiple wrong properties are checked -- i.e. this dict ontology has to be extended so that one program can have multiple errors
-      InvalidGPIPropertyError:
-        [`forall Set x {  
+      InvalidGPIPropertyError: [
+        `forall Set x {  
           x.icon = Circle { 
            centre: (0.0, 0.0) 
            r: 9.
            diameter: 100.
          } 
-       }`],
+       }`,
+      ],
 
       // Have to do a nested search in expressions for this
-      InvalidFunctionNameError: [`forall Set x { x.icon = Circle { r: ksajfksdafksfh(0.0, "hi") } }`,
+      InvalidFunctionNameError: [
+        `forall Set x { x.icon = Circle { r: ksajfksdafksfh(0.0, "hi") } }`,
         `forall Set x { x.icon = Circle { r: get(0.0, sjkfhsdk("hi")) } }`,
-        `forall Set x { x.icon = Circle { r: wjhkej(0.0, sjkfhsdk("hi")) } }`],
+        `forall Set x { x.icon = Circle { r: wjhkej(0.0, sjkfhsdk("hi")) } }`,
+      ],
 
       InvalidObjectiveNameError: [`forall Set x { encourage sjdhfksha(0.0) }`],
 
@@ -385,29 +389,32 @@ delete x.z.p }`,
       // NonexistentNameError:
       //   [`forall Set x { A.z = 0. }`],
 
-      NonexistentFieldError:
-        [`forall Set x { x.icon = Circle { r: x.r } }`],
-      NonexistentGPIError:
-        [`forall Set x {  
+      NonexistentFieldError: [`forall Set x { x.icon = Circle { r: x.r } }`],
+      NonexistentGPIError: [
+        `forall Set x {  
          x.z = x.c.p
-       }`],
-      NonexistentPropertyError:
-        [`forall Set x {  
+       }`,
+      ],
+      NonexistentPropertyError: [
+        `forall Set x {  
           x.icon = Circle { 
            r: 9.
            center: (x.icon.z, 0.0)
          } 
-       }`],
-      ExpectedGPIGotFieldError:
-        [`forall Set x { 
+       }`,
+      ],
+      ExpectedGPIGotFieldError: [
+        `forall Set x { 
            x.z = 1.0 
            x.y = x.z.p
-}`],
-      InvalidAccessPathError:
-        [`forall Set x { 
+}`,
+      ],
+      InvalidAccessPathError: [
+        `forall Set x { 
            x.z = 1.0 
            x.y = x.z[0]
-}`],
+}`,
+      ],
 
       // ---------- Runtime errors (insertExpr)
 

--- a/packages/core/src/compiler/Style.ts
+++ b/packages/core/src/compiler/Style.ts
@@ -43,6 +43,14 @@ import { checkTypeConstructor, Env, isDeclaredSubtype } from "./Domain";
 import { compDict } from "contrib/Functions";
 import { objDict, constrDict } from "contrib/Constraints";
 import { prettyPrintPath } from "utils/OtherUtils";
+import {
+  SubstanceError,
+  StyleResults,
+  StyleWarnings,
+  ParseError,
+  PenroseError,
+  StyleError,
+} from "types/errors";
 
 const log = consola
   .create({ level: LogLevel.Warn })

--- a/packages/core/src/compiler/Substance.test.ts
+++ b/packages/core/src/compiler/Substance.test.ts
@@ -2,6 +2,7 @@ import * as fs from "fs";
 import * as nearley from "nearley";
 import grammar from "parser/SubstanceParser";
 import * as path from "path";
+import { PenroseError } from "types/errors";
 import { Result, showError, showType } from "utils/Error";
 import { compileDomain, Env } from "./Domain";
 import { compileSubstance, SubstanceEnv } from "./Substance";

--- a/packages/core/src/compiler/Substance.ts
+++ b/packages/core/src/compiler/Substance.ts
@@ -3,6 +3,7 @@ import { findIndex, zip } from "lodash";
 import nearley from "nearley";
 import { idOf } from "parser/ParserUtil";
 import substanceGrammar from "parser/SubstanceParser";
+import { ParseError, PenroseError, SubstanceError } from "types/errors";
 import {
   andThen,
   argLengthMismatch,

--- a/packages/core/src/engine/EngineUtils.ts
+++ b/packages/core/src/engine/EngineUtils.ts
@@ -6,210 +6,211 @@ import { showError } from "utils/Error";
 import * as _ from "lodash";
 import { Elem, SubPath, Value } from "types/shapeTypes";
 import rfdc from "rfdc";
+import { StyleError, Warning } from "types/errors";
 const clone = rfdc({ proto: false, circles: false });
 
 // TODO: Is there a way to write these mapping/conversion functions with less boilerplate?
 
 // For wrapping temp Style errors until figuring out how they should be categorized
 export const wrapErr = (s: string): StyleError => {
-    return {
-        tag: "GenericStyleError",
-        messages: [s],
-    };
+  return {
+    tag: "GenericStyleError",
+    messages: [s],
+  };
 };
 
 // TODO(errors): should these kinds of errors be caught by block statics rather than failing at runtime?
 export const runtimeValueTypeError = (
-    path: Path,
-    expectedType: string,
-    actualType: string
+  path: Path,
+  expectedType: string,
+  actualType: string
 ): StyleError => {
-    return {
-        tag: "RuntimeValueTypeError",
-        path,
-        expectedType,
-        actualType,
-    };
+  return {
+    tag: "RuntimeValueTypeError",
+    path,
+    expectedType,
+    actualType,
+  };
 };
 
 // Generic utils for mapping over values
 
 export function mapTup2<T, S>(f: (arg: T) => S, t: [T, T]): [S, S] {
-    // TODO: Polygon seems to be getting through with null to the frontend with previously working set examples -- not sure why?
-    // TODO: Should do null checks more systematically across the translation
-    if (t[0] === null || t[1] === null) {
-        return ([varOf(0.0), varOf(0.0)] as unknown) as [S, S];
-    }
+  // TODO: Polygon seems to be getting through with null to the frontend with previously working set examples -- not sure why?
+  // TODO: Should do null checks more systematically across the translation
+  if (t[0] === null || t[1] === null) {
+    return ([varOf(0.0), varOf(0.0)] as unknown) as [S, S];
+  }
 
-    return [f(t[0]), f(t[1])];
+  return [f(t[0]), f(t[1])];
 }
 
 function mapTup3<T, S>(f: (arg: T) => S, t: [T, T, T]): [S, S, S] {
-    return [f(t[0]), f(t[1]), f(t[2])];
+  return [f(t[0]), f(t[1]), f(t[2])];
 }
 
 function mapTup4<T, S>(f: (arg: T) => S, t: [T, T, T, T]): [S, S, S, S] {
-    return [f(t[0]), f(t[1]), f(t[2]), f(t[3])];
+  return [f(t[0]), f(t[1]), f(t[2]), f(t[3])];
 }
 
 function mapTup2LList<T, S>(f: (arg: T) => S, xss: [T, T][][]): [S, S][][] {
-    return xss.map((xs) => xs.map((t) => [f(t[0]), f(t[1])]));
+  return xss.map((xs) => xs.map((t) => [f(t[0]), f(t[1])]));
 }
 
 // Mapping over values
 
 function mapFloat<T, S>(f: (arg: T) => S, v: IFloatV<T>): IFloatV<S> {
-    return {
-        tag: "FloatV",
-        contents: f(v.contents),
-    };
+  return {
+    tag: "FloatV",
+    contents: f(v.contents),
+  };
 }
 
 function mapPt<T, S>(f: (arg: T) => S, v: IPtV<T>): IPtV<S> {
-    return {
-        tag: "PtV",
-        contents: mapTup2(f, v.contents) as [S, S],
-    };
+  return {
+    tag: "PtV",
+    contents: mapTup2(f, v.contents) as [S, S],
+  };
 }
 
 function mapPtList<T, S>(f: (arg: T) => S, v: IPtListV<T>): IPtListV<S> {
-    return {
-        tag: "PtListV",
-        contents: v.contents.map((t) => mapTup2(f, t)),
-    };
+  return {
+    tag: "PtListV",
+    contents: v.contents.map((t) => mapTup2(f, t)),
+  };
 }
 
 function mapList<T, S>(f: (arg: T) => S, v: IListV<T>): IListV<S> {
-    return {
-        tag: "ListV",
-        contents: v.contents.map(f),
-    };
+  return {
+    tag: "ListV",
+    contents: v.contents.map(f),
+  };
 }
 
 function mapVector<T, S>(f: (arg: T) => S, v: IVectorV<T>): IVectorV<S> {
-    return {
-        tag: "VectorV",
-        contents: v.contents.map(f),
-    };
+  return {
+    tag: "VectorV",
+    contents: v.contents.map(f),
+  };
 }
 
 function mapTup<T, S>(f: (arg: T) => S, v: ITupV<T>): ITupV<S> {
-    return {
-        tag: "TupV",
-        contents: mapTup2(f, v.contents),
-    };
+  return {
+    tag: "TupV",
+    contents: mapTup2(f, v.contents),
+  };
 }
 
 function mapLList<T, S>(f: (arg: T) => S, v: ILListV<T>): ILListV<S> {
-    return {
-        tag: "LListV",
-        contents: v.contents.map((e) => e.map(f)),
-    };
+  return {
+    tag: "LListV",
+    contents: v.contents.map((e) => e.map(f)),
+  };
 }
 
 function mapMatrix<T, S>(f: (arg: T) => S, v: IMatrixV<T>): IMatrixV<S> {
-    return {
-        tag: "MatrixV",
-        contents: v.contents.map((e) => e.map(f)),
-    };
+  return {
+    tag: "MatrixV",
+    contents: v.contents.map((e) => e.map(f)),
+  };
 }
 
 function mapHMatrix<T, S>(f: (arg: T) => S, v: IHMatrixV<T>): IHMatrixV<S> {
-    const m = v.contents;
-    return {
-        tag: "HMatrixV",
-        contents: {
-            // TODO: This could probably be a generic map over object values
-            xScale: f(m.xScale),
-            xSkew: f(m.xSkew),
-            yScale: f(m.yScale),
-            ySkew: f(m.ySkew),
-            dx: f(m.dx),
-            dy: f(m.dy),
-        },
-    };
+  const m = v.contents;
+  return {
+    tag: "HMatrixV",
+    contents: {
+      // TODO: This could probably be a generic map over object values
+      xScale: f(m.xScale),
+      xSkew: f(m.xSkew),
+      yScale: f(m.yScale),
+      ySkew: f(m.ySkew),
+      dx: f(m.dx),
+      dy: f(m.dy),
+    },
+  };
 }
 
 function mapPolygon<T, S>(f: (arg: T) => S, v: IPolygonV<T>): IPolygonV<S> {
-    const xs0 = mapTup2LList(f, v.contents[0]);
-    const xs1 = mapTup2LList(f, v.contents[1]);
-    const xs2 = [mapTup2(f, v.contents[2][0]), mapTup2(f, v.contents[2][1])] as [
-        [S, S],
-        [S, S]
-    ];
-    const xs3 = v.contents[3].map((e) => mapTup2(f, e));
+  const xs0 = mapTup2LList(f, v.contents[0]);
+  const xs1 = mapTup2LList(f, v.contents[1]);
+  const xs2 = [mapTup2(f, v.contents[2][0]), mapTup2(f, v.contents[2][1])] as [
+    [S, S],
+    [S, S]
+  ];
+  const xs3 = v.contents[3].map((e) => mapTup2(f, e));
 
-    return {
-        tag: "PolygonV",
-        contents: [xs0, xs1, xs2, xs3],
-    };
+  return {
+    tag: "PolygonV",
+    contents: [xs0, xs1, xs2, xs3],
+  };
 }
 
 function mapElem<T, S>(f: (arg: T) => S, e: Elem<T>): Elem<S> {
-    if (e.tag === "Pt" || e.tag === "QuadBezJoin") {
-        return {
-            tag: e.tag,
-            contents: mapTup2(f, e.contents),
-        };
-    } else if (e.tag === "CubicBezJoin" || e.tag === "QuadBez") {
-        return {
-            tag: e.tag,
-            contents: mapTup2((x) => mapTup2(f, x), e.contents),
-        };
-    } else if (e.tag === "CubicBez") {
-        return {
-            tag: e.tag,
-            contents: mapTup3((x) => mapTup2(f, x), e.contents),
-        };
-    } else {
-        throw Error("unknown tag in bezier curve type conversion");
-    }
+  if (e.tag === "Pt" || e.tag === "QuadBezJoin") {
+    return {
+      tag: e.tag,
+      contents: mapTup2(f, e.contents),
+    };
+  } else if (e.tag === "CubicBezJoin" || e.tag === "QuadBez") {
+    return {
+      tag: e.tag,
+      contents: mapTup2((x) => mapTup2(f, x), e.contents),
+    };
+  } else if (e.tag === "CubicBez") {
+    return {
+      tag: e.tag,
+      contents: mapTup3((x) => mapTup2(f, x), e.contents),
+    };
+  } else {
+    throw Error("unknown tag in bezier curve type conversion");
+  }
 }
 
 function mapSubpath<T, S>(f: (arg: T) => S, s: SubPath<T>): SubPath<S> {
-    return {
-        tag: s.tag,
-        contents: s.contents.map((e) => mapElem(f, e)),
-    };
+  return {
+    tag: s.tag,
+    contents: s.contents.map((e) => mapElem(f, e)),
+  };
 }
 
 function mapPathData<T, S>(f: (arg: T) => S, v: IPathDataV<T>): IPathDataV<S> {
-    return {
-        tag: "PathDataV",
-        contents: v.contents.map((e) => mapSubpath(f, e)),
-    };
+  return {
+    tag: "PathDataV",
+    contents: v.contents.map((e) => mapSubpath(f, e)),
+  };
 }
 
 function mapColorInner<T, S>(f: (arg: T) => S, v: Color<T>): Color<S> {
-    if (v.tag === "RGBA") {
-        const rgb = v.contents;
-        return {
-            tag: "RGBA",
-            contents: mapTup4(f, rgb),
-        };
-    } else if (v.tag === "HSVA") {
-        const hsv = v.contents;
-        return {
-            tag: "HSVA",
-            contents: mapTup4(f, hsv),
-        };
-    } else {
-        throw Error("unexpected color tag");
-    }
+  if (v.tag === "RGBA") {
+    const rgb = v.contents;
+    return {
+      tag: "RGBA",
+      contents: mapTup4(f, rgb),
+    };
+  } else if (v.tag === "HSVA") {
+    const hsv = v.contents;
+    return {
+      tag: "HSVA",
+      contents: mapTup4(f, hsv),
+    };
+  } else {
+    throw Error("unexpected color tag");
+  }
 }
 
 function mapColor<T, S>(f: (arg: T) => S, v: IColorV<T>): IColorV<S> {
-    return {
-        tag: "ColorV",
-        contents: mapColorInner(f, v.contents),
-    };
+  return {
+    tag: "ColorV",
+    contents: mapColorInner(f, v.contents),
+  };
 }
 
 function mapPalette<T, S>(f: (arg: T) => S, v: IPaletteV<T>): IPaletteV<S> {
-    return {
-        tag: "PaletteV",
-        contents: v.contents.map((e) => mapColorInner(f, e)),
-    };
+  return {
+    tag: "PaletteV",
+    contents: v.contents.map((e) => mapColorInner(f, e)),
+  };
 }
 
 // Utils for converting types of values
@@ -217,161 +218,161 @@ function mapPalette<T, S>(f: (arg: T) => S, v: IPaletteV<T>): IPaletteV<S> {
 // Expects `f` to be a function between numeric types (e.g. number -> VarAD, VarAD -> number, AD var -> VarAD ...)
 // Coerces any non-numeric types
 export function mapValueNumeric<T, S>(f: (arg: T) => S, v: Value<T>): Value<S> {
-    const nonnumericValueTypes = [
-        "BoolV",
-        "StrV",
-        "ColorV",
-        "PaletteV",
-        "FileV",
-        "StyleV",
-        "IntV",
-    ];
+  const nonnumericValueTypes = [
+    "BoolV",
+    "StrV",
+    "ColorV",
+    "PaletteV",
+    "FileV",
+    "StyleV",
+    "IntV",
+  ];
 
-    if (v.tag === "FloatV") {
-        return mapFloat(f, v);
-    } else if (v.tag === "PtV") {
-        return mapPt(f, v);
-    } else if (v.tag === "PtListV") {
-        return mapPtList(f, v);
-    } else if (v.tag === "ListV") {
-        return mapList(f, v);
-    } else if (v.tag === "VectorV") {
-        return mapVector(f, v);
-    } else if (v.tag === "MatrixV") {
-        return mapMatrix(f, v);
-    } else if (v.tag === "TupV") {
-        return mapTup(f, v);
-    } else if (v.tag === "LListV") {
-        return mapLList(f, v);
-    } else if (v.tag === "HMatrixV") {
-        return mapHMatrix(f, v);
-    } else if (v.tag === "PolygonV") {
-        return mapPolygon(f, v);
-    } else if (v.tag === "ColorV") {
-        return mapColor(f, v);
-    } else if (v.tag === "PaletteV") {
-        return mapPalette(f, v);
-    } else if (v.tag === "PathDataV") {
-        return mapPathData(f, v);
-    } else if (nonnumericValueTypes.includes(v.tag)) {
-        return v as Value<S>;
-    } else {
-        throw Error(
-            `unimplemented conversion from autodiff types for numeric types for value type '${v.tag}'`
-        );
-    }
+  if (v.tag === "FloatV") {
+    return mapFloat(f, v);
+  } else if (v.tag === "PtV") {
+    return mapPt(f, v);
+  } else if (v.tag === "PtListV") {
+    return mapPtList(f, v);
+  } else if (v.tag === "ListV") {
+    return mapList(f, v);
+  } else if (v.tag === "VectorV") {
+    return mapVector(f, v);
+  } else if (v.tag === "MatrixV") {
+    return mapMatrix(f, v);
+  } else if (v.tag === "TupV") {
+    return mapTup(f, v);
+  } else if (v.tag === "LListV") {
+    return mapLList(f, v);
+  } else if (v.tag === "HMatrixV") {
+    return mapHMatrix(f, v);
+  } else if (v.tag === "PolygonV") {
+    return mapPolygon(f, v);
+  } else if (v.tag === "ColorV") {
+    return mapColor(f, v);
+  } else if (v.tag === "PaletteV") {
+    return mapPalette(f, v);
+  } else if (v.tag === "PathDataV") {
+    return mapPathData(f, v);
+  } else if (nonnumericValueTypes.includes(v.tag)) {
+    return v as Value<S>;
+  } else {
+    throw Error(
+      `unimplemented conversion from autodiff types for numeric types for value type '${v.tag}'`
+    );
+  }
 }
 
 export const valueAutodiffToNumber = (v: Value<VarAD>): Value<number> =>
-    mapValueNumeric(numOf, v);
+  mapValueNumeric(numOf, v);
 
 export const valueNumberToAutodiff = (v: Value<number>): Value<VarAD> =>
-    mapValueNumeric(varOf, v);
+  mapValueNumeric(varOf, v);
 
 export const valueNumberToAutodiffConst = (v: Value<number>): Value<VarAD> =>
-    mapValueNumeric(constOfIf, v); // COMBAK: Really this should be constOf... I don't know why some inputs are already converted to VarADs?
+  mapValueNumeric(constOfIf, v); // COMBAK: Really this should be constOf... I don't know why some inputs are already converted to VarADs?
 
 export const tagExprNumberToAutodiff = (v: TagExpr<number>): TagExpr<VarAD> =>
-    mapTagExpr(constOfIf, v);
+  mapTagExpr(constOfIf, v);
 
 // Walk translation to convert all TagExprs (tagged Done or Pending) in the state to VarADs
 // (This is because, when decoded from backend, it's not yet in VarAD form -- although this code could be phased out if the translation becomes completely generated in the frontend)
 
 export function mapTagExpr<T, S>(f: (arg: T) => S, e: TagExpr<T>): TagExpr<S> {
-    if (e.tag === "Done") {
-        return {
-            tag: "Done",
-            contents: mapValueNumeric(f, e.contents),
-        };
-    } else if (e.tag === "Pending") {
-        return {
-            tag: "Pending",
-            contents: mapValueNumeric(f, e.contents),
-        };
-    } else if (e.tag === "OptEval") {
-        // We don't convert expressions because any numbers encountered in them will be converted by the evaluator (to VarAD) as needed
-        // TODO: Need to convert expressions to numbers, or back to varying? I guess `varyingPaths` is the source of truth
-        return e;
-    } else {
-        throw Error("unrecognized tag");
-    }
+  if (e.tag === "Done") {
+    return {
+      tag: "Done",
+      contents: mapValueNumeric(f, e.contents),
+    };
+  } else if (e.tag === "Pending") {
+    return {
+      tag: "Pending",
+      contents: mapValueNumeric(f, e.contents),
+    };
+  } else if (e.tag === "OptEval") {
+    // We don't convert expressions because any numbers encountered in them will be converted by the evaluator (to VarAD) as needed
+    // TODO: Need to convert expressions to numbers, or back to varying? I guess `varyingPaths` is the source of truth
+    return e;
+  } else {
+    throw Error("unrecognized tag");
+  }
 }
 
 export function mapGPIExpr<T, S>(f: (arg: T) => S, e: GPIExpr<T>): GPIExpr<S> {
-    const propDict = Object.entries(e[1]).map(([prop, val]) => [
-        prop,
-        mapTagExpr(f, val),
-    ]);
+  const propDict = Object.entries(e[1]).map(([prop, val]) => [
+    prop,
+    mapTagExpr(f, val),
+  ]);
 
-    return [e[0], Object.fromEntries(propDict)];
+  return [e[0], Object.fromEntries(propDict)];
 }
 
 export function mapTranslation<T, S>(
-    f: (arg: T) => S,
-    trans: ITrans<T>
+  f: (arg: T) => S,
+  trans: ITrans<T>
 ): ITrans<S> {
-    const newTrMap = Object.entries(trans.trMap).map(([name, fdict]) => {
-        const fdict2 = Object.entries(fdict).map(([prop, val]) => {
-            if (val.tag === "FExpr") {
-                return [prop, { tag: "FExpr", contents: mapTagExpr(f, val.contents) }];
-            } else if (val.tag === "FGPI") {
-                return [prop, { tag: "FGPI", contents: mapGPIExpr(f, val.contents) }];
-            } else {
-                console.log(prop, val);
-                throw Error("unknown tag on field expr");
-            }
-        });
-
-        return [name, Object.fromEntries(fdict2)];
+  const newTrMap = Object.entries(trans.trMap).map(([name, fdict]) => {
+    const fdict2 = Object.entries(fdict).map(([prop, val]) => {
+      if (val.tag === "FExpr") {
+        return [prop, { tag: "FExpr", contents: mapTagExpr(f, val.contents) }];
+      } else if (val.tag === "FGPI") {
+        return [prop, { tag: "FGPI", contents: mapGPIExpr(f, val.contents) }];
+      } else {
+        console.log(prop, val);
+        throw Error("unknown tag on field expr");
+      }
     });
 
-    return {
-        ...trans,
-        trMap: Object.fromEntries(newTrMap),
-    };
+    return [name, Object.fromEntries(fdict2)];
+  });
+
+  return {
+    ...trans,
+    trMap: Object.fromEntries(newTrMap),
+  };
 }
 
 // TODO: Check the input type?
 export const makeTranslationDifferentiable = (trans: any): Translation => {
-    return mapTranslation(varOf, trans);
+  return mapTranslation(varOf, trans);
 };
 
 export const makeTranslationNumeric = (trans: Translation): ITrans<number> => {
-    return mapTranslation(numOf, trans);
+  return mapTranslation(numOf, trans);
 };
 
 //#region translation operations
 
 const dummySourceLoc = (): SourceLoc => {
-    return { line: -1, col: -1 };
+  return { line: -1, col: -1 };
 };
 
 const floatValToExpr = (e: Value<VarAD>): Expr => {
-    if (e.tag !== "FloatV") {
-        throw Error("expected to insert vector elem of type float");
-    }
-    return {
-        nodeType: "dummyExpr",
-        children: [],
-        start: dummySourceLoc(),
-        end: dummySourceLoc(),
-        tag: "Fix",
-        contents: e.contents.val,
-        // COMBAK: This apparently held a VarAD before the AFloat grammar change? Is doing ".val" going to break something?
-    };
+  if (e.tag !== "FloatV") {
+    throw Error("expected to insert vector elem of type float");
+  }
+  return {
+    nodeType: "dummyExpr",
+    children: [],
+    start: dummySourceLoc(),
+    end: dummySourceLoc(),
+    tag: "Fix",
+    contents: e.contents.val,
+    // COMBAK: This apparently held a VarAD before the AFloat grammar change? Is doing ".val" going to break something?
+  };
 };
 
 const mkPropertyDict = (
-    decls: PropertyDecl[]
+  decls: PropertyDecl[]
 ): { [k: string]: TagExpr<VarAD> } => {
-    const gpi = {};
+  const gpi = {};
 
-    for (const decl of decls) {
-        // TODO(error/warning): Warn if any of these properties are duplicated or do not exist in the shape constructor
-        gpi[decl.name.value] = { tag: "OptEval", contents: decl.value };
-    }
+  for (const decl of decls) {
+    // TODO(error/warning): Warn if any of these properties are duplicated or do not exist in the shape constructor
+    gpi[decl.name.value] = { tag: "OptEval", contents: decl.value };
+  }
 
-    return gpi;
+  return gpi;
 };
 
 /**
@@ -384,24 +385,24 @@ const mkPropertyDict = (
 
 // TODO: Test this
 export const insertGPI = (
-    path: Path,
-    gpi: IFGPI<VarAD>,
-    trans: Translation
+  path: Path,
+  gpi: IFGPI<VarAD>,
+  trans: Translation
 ): Translation => {
-    let name, field;
+  let name, field;
 
-    switch (path.tag) {
-        case "FieldPath": {
-            [name, field] = [path.name, path.field];
-            // TODO: warning / error here
-            trans.trMap[name.contents.value][field.value] = gpi;
-            return trans;
-        }
-
-        default: {
-            throw Error("expected GPI");
-        }
+  switch (path.tag) {
+    case "FieldPath": {
+      [name, field] = [path.name, path.field];
+      // TODO: warning / error here
+      trans.trMap[name.contents.value][field.value] = gpi;
+      return trans;
     }
+
+    default: {
+      throw Error("expected GPI");
+    }
+  }
 };
 
 // This function is a combination of `addField` and `addProperty` from `Style.hs`
@@ -409,359 +410,359 @@ export const insertGPI = (
 // TODO(error/warn): Improve these warning/error messages (especially for overrides) and distinguish the fatal ones
 // TODO(error): rewrite to use the same pattern as `findExprSafe`
 export const insertExpr = (
-    path: Path,
-    expr: TagExpr<VarAD>,
-    initTrans: Translation,
-    compiling = false,
-    override = false
+  path: Path,
+  expr: TagExpr<VarAD>,
+  initTrans: Translation,
+  compiling = false,
+  override = false
 ): Translation => {
-    let trans = initTrans;
-    let name, field, prop;
+  let trans = initTrans;
+  let name, field, prop;
 
-    switch (path.tag) {
-        case "FieldPath": {
-            [name, field] = [path.name, path.field];
+  switch (path.tag) {
+    case "FieldPath": {
+      [name, field] = [path.name, path.field];
 
-            // Initialize the field dict if it hasn't been initialized
-            if (!trans.trMap[name.contents.value]) {
-                trans.trMap[name.contents.value] = {};
-            }
+      // Initialize the field dict if it hasn't been initialized
+      if (!trans.trMap[name.contents.value]) {
+        trans.trMap[name.contents.value] = {};
+      }
 
-            let fexpr: FieldExpr<VarAD> = { tag: "FExpr", contents: expr };
+      let fexpr: FieldExpr<VarAD> = { tag: "FExpr", contents: expr };
 
-            // If it's a GPI, instantiate it (rule Line-Set-Ctor); otherwise put it in the translation as-is
-            if (expr.tag === "OptEval") {
-                const gpi: Expr = expr.contents;
-                if (gpi.tag === "GPIDecl") {
-                    const [nm, decls]: [Identifier, PropertyDecl[]] = [
-                        gpi.shapeName,
-                        gpi.properties,
-                    ];
+      // If it's a GPI, instantiate it (rule Line-Set-Ctor); otherwise put it in the translation as-is
+      if (expr.tag === "OptEval") {
+        const gpi: Expr = expr.contents;
+        if (gpi.tag === "GPIDecl") {
+          const [nm, decls]: [Identifier, PropertyDecl[]] = [
+            gpi.shapeName,
+            gpi.properties,
+          ];
 
-                    fexpr = {
-                        tag: "FGPI",
-                        contents: [nm.value, mkPropertyDict(decls)],
-                    };
-                }
-            }
+          fexpr = {
+            tag: "FGPI",
+            contents: [nm.value, mkPropertyDict(decls)],
+          };
+        }
+      }
 
-            // Check overrides before initialization
+      // Check overrides before initialization
+      if (
+        compiling &&
+        !override &&
+        trans.trMap[name.contents.value].hasOwnProperty(field.value)
+      ) {
+        trans = addWarn(trans, {
+          tag: "InsertedPathWithoutOverrideError",
+          path,
+        }); // TODO(error): Should this be an error?
+      }
+
+      // For any non-GPI thing, just put it in the translation
+      // NOTE: this will overwrite existing expressions
+      trans.trMap[name.contents.value][field.value] = fexpr;
+      return trans;
+    }
+
+    case "PropertyPath": {
+      [name, field, prop] = [path.name, path.field, path.property];
+
+      if (!trans.trMap[name.contents.value]) {
+        trans.trMap[name.contents.value] = {};
+      }
+
+      const fieldRes: FieldExpr<IVarAD> =
+        trans.trMap[name.contents.value][field.value];
+
+      // TODO(errors): Catch error if SubObj, etc don't exist -- but should these kinds of errors be caught by block statics rather than failing at runtime?
+      if (!fieldRes) {
+        // TODO(errors): Catch error if field doesn't exist
+        return addWarn(trans, {
+          tag: "InsertedPropWithNoFieldError",
+          subObj: name,
+          field,
+          property: prop,
+          path,
+        });
+      }
+
+      if (fieldRes.tag === "FExpr") {
+        // Deal with GPI aliasing (i.e. only happens if a GPI is aliased to another, and some operation is performed on the aliased GPI's property, it happens to the original)
+        // TODO: Test this
+        if (fieldRes.contents.tag === "OptEval") {
+          if (fieldRes.contents.contents.tag === "FieldPath") {
+            const p = fieldRes.contents.contents;
             if (
-                compiling &&
-                !override &&
-                trans.trMap[name.contents.value].hasOwnProperty(field.value)
+              p.name.contents.value === name.contents.value &&
+              p.field.value === field.value
             ) {
-                trans = addWarn(trans, {
-                    tag: "InsertedPathWithoutOverrideError",
-                    path,
-                }); // TODO(error): Should this be an error?
+              if (compiling) {
+                return addWarn(trans, { tag: "CircularPathAlias", path });
+              }
+              // TODO(errors): Use "showErrors" not these ad-hoc errors
+              const err = `path was aliased to itself`;
+              throw Error(err);
+            }
+            const newPath = clone(path);
+            return insertExpr(
+              {
+                ...newPath,
+                tag: "PropertyPath",
+                name: p.name, // Note use of alias
+                field: p.field, // Note use of alias
+                property: path.property,
+              },
+              expr,
+              trans
+            );
+          }
+        }
+
+        // TODO(error)
+        if (compiling) {
+          return addWarn(trans, {
+            tag: "InsertedPropWithNoGPIError",
+            subObj: name,
+            field,
+            property: prop,
+            path,
+          });
+        }
+        const err = `Err: Sub obj '${name.contents.value}' does not have GPI '${field.value}'; cannot add property '${prop.value}'`;
+        throw Error(err);
+      } else if (fieldRes.tag === "FGPI") {
+        const [, properties] = fieldRes.contents;
+
+        // TODO(error): check for field/property overrides of paths that don't already exist
+        // TODO(error): if there are multiple matches, override errors behave oddly...
+        if (compiling && !override && properties.hasOwnProperty(prop.value)) {
+          trans = addWarn(trans, {
+            tag: "InsertedPathWithoutOverrideError",
+            path,
+          });
+        }
+
+        properties[prop.value] = expr;
+        return trans;
+      } else {
+        throw Error("unexpected tag");
+      }
+    }
+
+    // TODO(error): deal with override for accesspaths? I don't know if you can currently write something like `override A.shape.center[0] = 5.` in Style
+    case "AccessPath": {
+      const [innerPath, indices] = [path.path, path.indices];
+
+      switch (innerPath.tag) {
+        case "FieldPath": {
+          // a.x[0] = e
+          [name, field] = [innerPath.name, innerPath.field];
+          const res = trans.trMap[name.contents.value][field.value];
+          if (res.tag !== "FExpr") {
+            if (compiling) {
+              return addWarn(
+                trans,
+                runtimeValueTypeError(path, "Float", "GPI")
+              );
+            }
+            const err = "did not expect GPI in vector access";
+            throw Error(err);
+          }
+          const res2: TagExpr<IVarAD> = res.contents;
+          // Deal with vector expressions
+          if (res2.tag === "OptEval") {
+            const res3: Expr = res2.contents;
+            if (res3.tag !== "Vector") {
+              if (compiling) {
+                return addWarn(
+                  trans,
+                  runtimeValueTypeError(path, "Vector", res3.tag)
+                );
+              }
+              const err = "expected Vector";
+              throw Error(err);
+            }
+            const res4: Expr[] = res3.contents;
+
+            if (expr.tag === "OptEval") {
+              res4[exprToNumber(indices[0])] = expr.contents;
+            } else if (expr.tag === "Done") {
+              res4[exprToNumber(indices[0])] = floatValToExpr(expr.contents);
+            } else {
+              if (compiling) {
+                return addWarn(
+                  trans,
+                  runtimeValueTypeError(path, "Float", "Pending float")
+                );
+              }
+              const err = "unexpected pending val";
+              throw Error(err);
             }
 
-            // For any non-GPI thing, just put it in the translation
-            // NOTE: this will overwrite existing expressions
-            trans.trMap[name.contents.value][field.value] = fexpr;
             return trans;
+          } else if (res2.tag === "Done") {
+            // Deal with vector values
+            const res3: Value<IVarAD> = res2.contents;
+            if (res3.tag !== "VectorV") {
+              const err = "expected Vector";
+              if (compiling) {
+                return addWarn(
+                  trans,
+                  runtimeValueTypeError(path, "Vector", "res3.tag")
+                );
+              }
+              throw Error(err);
+            }
+            const res4: IVarAD[] = res3.contents;
+
+            if (expr.tag === "Done" && expr.contents.tag === "FloatV") {
+              res4[exprToNumber(indices[0])] = expr.contents.contents;
+            } else {
+              if (compiling) {
+                return addWarn(
+                  trans,
+                  runtimeValueTypeError(path, "Float", expr.tag)
+                );
+              }
+              const err = "unexpected val";
+              throw Error(err);
+            }
+
+            return trans;
+          } else {
+            if (compiling) {
+              // TODO(errors): expected type?
+              return addWarn(
+                trans,
+                runtimeValueTypeError(path, "Float", res2.tag)
+              );
+            }
+            const err = "unexpected tag";
+            throw Error(err);
+          }
         }
 
         case "PropertyPath": {
-            [name, field, prop] = [path.name, path.field, path.property];
+          const ip = innerPath as IPropertyPath;
+          // a.x.y[0] = e
+          [name, field, prop] = [ip.name, ip.field, ip.property];
+          const gpi = trans.trMap[name.contents.value][
+            field.value
+          ] as IFGPI<VarAD>;
+          const [, properties] = gpi.contents;
+          const res = properties[prop.value];
 
-            if (!trans.trMap[name.contents.value]) {
-                trans.trMap[name.contents.value] = {};
+          if (res.tag === "OptEval") {
+            // Deal with vector expresions
+            const res2 = res.contents;
+            if (res2.tag !== "Vector") {
+              if (compiling) {
+                return addWarn(
+                  trans,
+                  runtimeValueTypeError(path, "Vector", res2.tag)
+                );
+              }
+              const err = "expected Vector";
+              throw Error(err);
             }
+            const res3 = res2.contents;
 
-            const fieldRes: FieldExpr<IVarAD> =
-                trans.trMap[name.contents.value][field.value];
-
-            // TODO(errors): Catch error if SubObj, etc don't exist -- but should these kinds of errors be caught by block statics rather than failing at runtime?
-            if (!fieldRes) {
-                // TODO(errors): Catch error if field doesn't exist
-                return addWarn(trans, {
-                    tag: "InsertedPropWithNoFieldError",
-                    subObj: name,
-                    field,
-                    property: prop,
-                    path,
-                });
-            }
-
-            if (fieldRes.tag === "FExpr") {
-                // Deal with GPI aliasing (i.e. only happens if a GPI is aliased to another, and some operation is performed on the aliased GPI's property, it happens to the original)
-                // TODO: Test this
-                if (fieldRes.contents.tag === "OptEval") {
-                    if (fieldRes.contents.contents.tag === "FieldPath") {
-                        const p = fieldRes.contents.contents;
-                        if (
-                            p.name.contents.value === name.contents.value &&
-                            p.field.value === field.value
-                        ) {
-                            if (compiling) {
-                                return addWarn(trans, { tag: "CircularPathAlias", path });
-                            }
-                            // TODO(errors): Use "showErrors" not these ad-hoc errors
-                            const err = `path was aliased to itself`;
-                            throw Error(err);
-                        }
-                        const newPath = clone(path);
-                        return insertExpr(
-                            {
-                                ...newPath,
-                                tag: "PropertyPath",
-                                name: p.name, // Note use of alias
-                                field: p.field, // Note use of alias
-                                property: path.property,
-                            },
-                            expr,
-                            trans
-                        );
-                    }
-                }
-
-                // TODO(error)
-                if (compiling) {
-                    return addWarn(trans, {
-                        tag: "InsertedPropWithNoGPIError",
-                        subObj: name,
-                        field,
-                        property: prop,
-                        path,
-                    });
-                }
-                const err = `Err: Sub obj '${name.contents.value}' does not have GPI '${field.value}'; cannot add property '${prop.value}'`;
-                throw Error(err);
-            } else if (fieldRes.tag === "FGPI") {
-                const [, properties] = fieldRes.contents;
-
-                // TODO(error): check for field/property overrides of paths that don't already exist
-                // TODO(error): if there are multiple matches, override errors behave oddly...
-                if (compiling && !override && properties.hasOwnProperty(prop.value)) {
-                    trans = addWarn(trans, {
-                        tag: "InsertedPathWithoutOverrideError",
-                        path,
-                    });
-                }
-
-                properties[prop.value] = expr;
-                return trans;
+            if (expr.tag === "OptEval") {
+              res3[exprToNumber(indices[0])] = expr.contents;
+            } else if (expr.tag === "Done") {
+              res3[exprToNumber(indices[0])] = floatValToExpr(expr.contents);
             } else {
-                throw Error("unexpected tag");
+              if (compiling) {
+                return addWarn(
+                  trans,
+                  runtimeValueTypeError(path, "Float", expr.tag)
+                );
+              }
+              const err = "unexpected pending val";
+              throw Error(err);
             }
+
+            return trans;
+          } else if (res.tag === "Done") {
+            // Deal with vector values
+            const res2 = res.contents;
+            if (res2.tag !== "VectorV") {
+              if (compiling) {
+                return addWarn(
+                  trans,
+                  runtimeValueTypeError(path, "Vector", res2.tag)
+                );
+              }
+              const err = "expected Vector";
+              throw Error(err);
+            }
+            const res3 = res2.contents;
+
+            if (expr.tag === "Done" && expr.contents.tag === "FloatV") {
+              res3[exprToNumber(indices[0])] = expr.contents.contents;
+            } else {
+              if (compiling) {
+                return addWarn(
+                  trans,
+                  runtimeValueTypeError(path, "Float", expr.tag)
+                );
+              }
+              const err = "unexpected val";
+              throw Error(err);
+            }
+
+            return trans;
+          } else {
+            throw Error("internal error: unexpected tag");
+          }
         }
 
-        // TODO(error): deal with override for accesspaths? I don't know if you can currently write something like `override A.shape.center[0] = 5.` in Style
-        case "AccessPath": {
-            const [innerPath, indices] = [path.path, path.indices];
-
-            switch (innerPath.tag) {
-                case "FieldPath": {
-                    // a.x[0] = e
-                    [name, field] = [innerPath.name, innerPath.field];
-                    const res = trans.trMap[name.contents.value][field.value];
-                    if (res.tag !== "FExpr") {
-                        if (compiling) {
-                            return addWarn(
-                                trans,
-                                runtimeValueTypeError(path, "Float", "GPI")
-                            );
-                        }
-                        const err = "did not expect GPI in vector access";
-                        throw Error(err);
-                    }
-                    const res2: TagExpr<IVarAD> = res.contents;
-                    // Deal with vector expressions
-                    if (res2.tag === "OptEval") {
-                        const res3: Expr = res2.contents;
-                        if (res3.tag !== "Vector") {
-                            if (compiling) {
-                                return addWarn(
-                                    trans,
-                                    runtimeValueTypeError(path, "Vector", res3.tag)
-                                );
-                            }
-                            const err = "expected Vector";
-                            throw Error(err);
-                        }
-                        const res4: Expr[] = res3.contents;
-
-                        if (expr.tag === "OptEval") {
-                            res4[exprToNumber(indices[0])] = expr.contents;
-                        } else if (expr.tag === "Done") {
-                            res4[exprToNumber(indices[0])] = floatValToExpr(expr.contents);
-                        } else {
-                            if (compiling) {
-                                return addWarn(
-                                    trans,
-                                    runtimeValueTypeError(path, "Float", "Pending float")
-                                );
-                            }
-                            const err = "unexpected pending val";
-                            throw Error(err);
-                        }
-
-                        return trans;
-                    } else if (res2.tag === "Done") {
-                        // Deal with vector values
-                        const res3: Value<IVarAD> = res2.contents;
-                        if (res3.tag !== "VectorV") {
-                            const err = "expected Vector";
-                            if (compiling) {
-                                return addWarn(
-                                    trans,
-                                    runtimeValueTypeError(path, "Vector", "res3.tag")
-                                );
-                            }
-                            throw Error(err);
-                        }
-                        const res4: IVarAD[] = res3.contents;
-
-                        if (expr.tag === "Done" && expr.contents.tag === "FloatV") {
-                            res4[exprToNumber(indices[0])] = expr.contents.contents;
-                        } else {
-                            if (compiling) {
-                                return addWarn(
-                                    trans,
-                                    runtimeValueTypeError(path, "Float", expr.tag)
-                                );
-                            }
-                            const err = "unexpected val";
-                            throw Error(err);
-                        }
-
-                        return trans;
-                    } else {
-                        if (compiling) {
-                            // TODO(errors): expected type?
-                            return addWarn(
-                                trans,
-                                runtimeValueTypeError(path, "Float", res2.tag)
-                            );
-                        }
-                        const err = "unexpected tag";
-                        throw Error(err);
-                    }
-                }
-
-                case "PropertyPath": {
-                    const ip = innerPath as IPropertyPath;
-                    // a.x.y[0] = e
-                    [name, field, prop] = [ip.name, ip.field, ip.property];
-                    const gpi = trans.trMap[name.contents.value][
-                        field.value
-                    ] as IFGPI<VarAD>;
-                    const [, properties] = gpi.contents;
-                    const res = properties[prop.value];
-
-                    if (res.tag === "OptEval") {
-                        // Deal with vector expresions
-                        const res2 = res.contents;
-                        if (res2.tag !== "Vector") {
-                            if (compiling) {
-                                return addWarn(
-                                    trans,
-                                    runtimeValueTypeError(path, "Vector", res2.tag)
-                                );
-                            }
-                            const err = "expected Vector";
-                            throw Error(err);
-                        }
-                        const res3 = res2.contents;
-
-                        if (expr.tag === "OptEval") {
-                            res3[exprToNumber(indices[0])] = expr.contents;
-                        } else if (expr.tag === "Done") {
-                            res3[exprToNumber(indices[0])] = floatValToExpr(expr.contents);
-                        } else {
-                            if (compiling) {
-                                return addWarn(
-                                    trans,
-                                    runtimeValueTypeError(path, "Float", expr.tag)
-                                );
-                            }
-                            const err = "unexpected pending val";
-                            throw Error(err);
-                        }
-
-                        return trans;
-                    } else if (res.tag === "Done") {
-                        // Deal with vector values
-                        const res2 = res.contents;
-                        if (res2.tag !== "VectorV") {
-                            if (compiling) {
-                                return addWarn(
-                                    trans,
-                                    runtimeValueTypeError(path, "Vector", res2.tag)
-                                );
-                            }
-                            const err = "expected Vector";
-                            throw Error(err);
-                        }
-                        const res3 = res2.contents;
-
-                        if (expr.tag === "Done" && expr.contents.tag === "FloatV") {
-                            res3[exprToNumber(indices[0])] = expr.contents.contents;
-                        } else {
-                            if (compiling) {
-                                return addWarn(
-                                    trans,
-                                    runtimeValueTypeError(path, "Float", expr.tag)
-                                );
-                            }
-                            const err = "unexpected val";
-                            throw Error(err);
-                        }
-
-                        return trans;
-                    } else {
-                        throw Error("internal error: unexpected tag");
-                    }
-                }
-
-                default:
-                    throw Error(
-                        "internal error: should not have nested AccessPath in AccessPath"
-                    );
-            }
-        }
+        default:
+          throw Error(
+            "internal error: should not have nested AccessPath in AccessPath"
+          );
+      }
     }
+  }
 
-    throw Error("internal error: unknown tag");
+  throw Error("internal error: unknown tag");
 };
 
 // Mutates translation
 export const insertExprs = (
-    ps: Path[],
-    es: TagExpr<VarAD>[],
-    tr: Translation
+  ps: Path[],
+  es: TagExpr<VarAD>[],
+  tr: Translation
 ): Translation => {
-    if (ps.length !== es.length) {
-        throw Error("length should be the same");
-    }
+  if (ps.length !== es.length) {
+    throw Error("length should be the same");
+  }
 
-    let tr2 = tr;
-    for (let i = 0; i < ps.length; i++) {
-        // Tr gets mutated
-        tr2 = insertExpr(ps[i], es[i], tr);
-    }
+  let tr2 = tr;
+  for (let i = 0; i < ps.length; i++) {
+    // Tr gets mutated
+    tr2 = insertExpr(ps[i], es[i], tr);
+  }
 
-    return tr2;
+  return tr2;
 };
 
 export const isTagExpr = (e: any): e is TagExpr<VarAD> => {
-    return e.tag === "OptEval" || e.tag === "Done" || e.tag === "Pending";
+  return e.tag === "OptEval" || e.tag === "Done" || e.tag === "Pending";
 };
 
 // Version of findExpr if you expect to not encounter any errors (e.g., if it's being used after the translation has already been checked)
 export const findExprSafe = (
-    trans: Translation,
-    path: Path
+  trans: Translation,
+  path: Path
 ): TagExpr<VarAD> | IFGPI<VarAD> => {
+  const res = findExpr(trans, path);
+  if (res.tag !== "FGPI" && !isTagExpr(res)) {
+    // Is an error
+    throw Error(showError(res));
+  }
 
-    const res = findExpr(trans, path);
-    if (res.tag !== "FGPI" && !isTagExpr(res)) { // Is an error
-        throw Error(showError(res));
-    }
-
-    return res;
+  return res;
 };
 
 /**
@@ -773,130 +774,134 @@ export const findExprSafe = (
  * TODO: the optional type here exist because GPI is not an expression in Style yet. It's not the most sustainable pattern w.r.t to our current way to typecasting the result using `as`.
  */
 export const findExpr = (
-    trans: Translation,
-    path: Path
+  trans: Translation,
+  path: Path
 ): TagExpr<VarAD> | IFGPI<VarAD> | StyleError => {
-    let name, field, prop;
+  let name, field, prop;
 
-    switch (path.tag) {
-        case "FieldPath": {
-            [name, field] = [path.name.contents.value, path.field.value];
-            const fields = trans.trMap[name];
-            if (!fields) {
-                return { tag: "NonexistentNameError", name: path.name.contents, path };
-            }
+  switch (path.tag) {
+    case "FieldPath": {
+      [name, field] = [path.name.contents.value, path.field.value];
+      const fields = trans.trMap[name];
+      if (!fields) {
+        return { tag: "NonexistentNameError", name: path.name.contents, path };
+      }
 
-            // Type cast to field expression
-            const fieldExpr = fields[field];
+      // Type cast to field expression
+      const fieldExpr = fields[field];
 
-            if (!fieldExpr) {
-                return { tag: "NonexistentFieldError", field: path.field, path };
-            }
+      if (!fieldExpr) {
+        return { tag: "NonexistentFieldError", field: path.field, path };
+      }
 
-            switch (fieldExpr.tag) {
-                case "FGPI":
-                    return fieldExpr;
-                case "FExpr":
-                    return fieldExpr.contents;
-            }
-        }
-
-        case "PropertyPath": {
-            [name, field, prop] = [
-                path.name.contents.value,
-                path.field.value,
-                path.property.value,
-            ];
-
-            const fieldsP = trans.trMap[name];
-            if (!fieldsP) {
-                return { tag: "NonexistentNameError", name: path.name.contents, path };
-            }
-
-            // Type cast to FGPI and get the properties
-            const gpi = fieldsP[field];
-
-            if (!gpi) {
-                return { tag: "NonexistentGPIError", gpi: path.field, path };
-            }
-
-            switch (gpi.tag) {
-                case "FExpr": {
-                    return { tag: "ExpectedGPIGotFieldError", field: path.field, path };
-                }
-                case "FGPI": {
-                    const [, propDict] = gpi.contents;
-                    const propRes = propDict[prop];
-                    if (!propRes) {
-                        return { tag: "NonexistentPropertyError", property: path.property, path };
-                    }
-                    return propRes;
-                }
-            }
-        }
-
-        case "AccessPath": {
-            // Have to look up AccessPaths first, since they make a recursive call, and are not invalid paths themselves
-            const res = findExpr(trans, path.path);
-            const i = exprToNumber(path.indices[0]); // COMBAK VECTORS: Currently only supports 1D vectors
-
-            if (res.tag === "OptEval") {
-                const res2: Expr = res.contents;
-
-                if (res2.tag === "Vector") {
-                    const inner: Expr = res2.contents[i];
-                    return { tag: "OptEval", contents: inner };
-                } else {
-                    return { tag: "InvalidAccessPathError", path };
-                }
-            } else if (res.tag === "Done") {
-                if (res.contents.tag === "VectorV") {
-                    const inner: VarAD = res.contents.contents[i];
-                    return { tag: "Done", contents: { tag: "FloatV", contents: inner } };
-                } else {
-                    return { tag: "InvalidAccessPathError", path };
-                }
-            } else {
-                return { tag: "InvalidAccessPathError", path };
-            }
-        }
+      switch (fieldExpr.tag) {
+        case "FGPI":
+          return fieldExpr;
+        case "FExpr":
+          return fieldExpr.contents;
+      }
     }
 
-    throw Error("internal error: unknown tag");
+    case "PropertyPath": {
+      [name, field, prop] = [
+        path.name.contents.value,
+        path.field.value,
+        path.property.value,
+      ];
+
+      const fieldsP = trans.trMap[name];
+      if (!fieldsP) {
+        return { tag: "NonexistentNameError", name: path.name.contents, path };
+      }
+
+      // Type cast to FGPI and get the properties
+      const gpi = fieldsP[field];
+
+      if (!gpi) {
+        return { tag: "NonexistentGPIError", gpi: path.field, path };
+      }
+
+      switch (gpi.tag) {
+        case "FExpr": {
+          return { tag: "ExpectedGPIGotFieldError", field: path.field, path };
+        }
+        case "FGPI": {
+          const [, propDict] = gpi.contents;
+          const propRes = propDict[prop];
+          if (!propRes) {
+            return {
+              tag: "NonexistentPropertyError",
+              property: path.property,
+              path,
+            };
+          }
+          return propRes;
+        }
+      }
+    }
+
+    case "AccessPath": {
+      // Have to look up AccessPaths first, since they make a recursive call, and are not invalid paths themselves
+      const res = findExpr(trans, path.path);
+      const i = exprToNumber(path.indices[0]); // COMBAK VECTORS: Currently only supports 1D vectors
+
+      if (res.tag === "OptEval") {
+        const res2: Expr = res.contents;
+
+        if (res2.tag === "Vector") {
+          const inner: Expr = res2.contents[i];
+          return { tag: "OptEval", contents: inner };
+        } else {
+          return { tag: "InvalidAccessPathError", path };
+        }
+      } else if (res.tag === "Done") {
+        if (res.contents.tag === "VectorV") {
+          const inner: VarAD = res.contents.contents[i];
+          return { tag: "Done", contents: { tag: "FloatV", contents: inner } };
+        } else {
+          return { tag: "InvalidAccessPathError", path };
+        }
+      } else {
+        return { tag: "InvalidAccessPathError", path };
+      }
+    }
+  }
+
+  throw Error("internal error: unknown tag");
 };
 
 //#endregion
 
 export const isPath = (expr: Expr): expr is Path => {
-    return ["FieldPath", "PropertyPath", "AccessPath", "LocalVar"].includes(
-        expr.tag
-    );
+  return ["FieldPath", "PropertyPath", "AccessPath", "LocalVar"].includes(
+    expr.tag
+  );
 };
 
 export const exprToNumber = (e: Expr): number => {
-    if (e.tag === "Fix") {
-        return e.contents;
-    }
-    throw Error("expecting expr to be number");
+  if (e.tag === "Fix") {
+    return e.contents;
+  }
+  throw Error("expecting expr to be number");
 };
 
 export const numToExpr = (n: number): Expr => {
-    return {
-        nodeType: "dummyExpr",
-        children: [],
-        start: dummySourceLoc(),
-        end: dummySourceLoc(),
-        tag: "Fix",
-        contents: n,
-    };
+  return {
+    nodeType: "dummyExpr",
+    children: [],
+    start: dummySourceLoc(),
+    end: dummySourceLoc(),
+    tag: "Fix",
+    contents: n,
+  };
 };
 
 // Add warning to the end of the existing list
 export const addWarn = (tr: Translation, warn: Warning): Translation => {
-    return {
-        ...tr,
-        warnings: tr.warnings.concat(warn),
-    };
+  return {
+    ...tr,
+    warnings: tr.warnings.concat(warn),
+  };
 };
 
 // COMBAK: consolidate prettyprinting code
@@ -909,12 +914,12 @@ export const initConstraintWeight = 10e-3;
 const defaultLbfgsMemSize = 17;
 
 export const defaultLbfgsParams: LbfgsParams = {
-    lastState: { tag: "Nothing" },
-    lastGrad: { tag: "Nothing" },
-    s_list: [],
-    y_list: [],
-    numUnconstrSteps: 0,
-    memSize: defaultLbfgsMemSize,
+  lastState: { tag: "Nothing" },
+  lastGrad: { tag: "Nothing" },
+  s_list: [],
+  y_list: [],
+  numUnconstrSteps: 0,
+  memSize: defaultLbfgsMemSize,
 };
 
 //#endregion

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,19 +1,20 @@
 import { checkDomain, compileDomain, Env, parseDomain } from "compiler/Domain";
 import { compileStyle } from "compiler/Style";
 import {
-    checkSubstance,
-    compileSubstance,
-    parseSubstance,
-    SubstanceEnv,
+  checkSubstance,
+  compileSubstance,
+  parseSubstance,
+  SubstanceEnv,
 } from "compiler/Substance";
 import { evalShapes } from "engine/Evaluator";
 import { initializeMat, step } from "engine/Optimizer";
 import { insertPending } from "engine/PropagateUpdate";
 import RenderStatic, {
-    RenderInteractive,
-    RenderShape,
+  RenderInteractive,
+  RenderShape,
 } from "renderer/Renderer";
 import { notEmptyLabel, resampleBest, sortShapes } from "renderer/ShapeDef";
+import { PenroseError } from "types/errors";
 import * as ShapeTypes from "types/shapeTypes";
 import { Shape } from "types/shapeTypes";
 import { collectLabels } from "utils/CollectLabels";
@@ -26,7 +27,7 @@ import { bBoxDims, toHex } from "utils/Util";
  * @param numSamples number of samples to choose from
  */
 export const resample = (state: State, numSamples: number): State => {
-    return resampleBest(state, numSamples);
+  return resampleBest(state, numSamples);
 };
 
 /**
@@ -35,7 +36,7 @@ export const resample = (state: State, numSamples: number): State => {
  * @param numSteps number of steps to take (default: 1)
  */
 export const stepState = (state: State, numSteps = 1): State => {
-    return step(state, numSteps);
+  return step(state, numSteps);
 };
 
 /**
@@ -43,11 +44,11 @@ export const stepState = (state: State, numSteps = 1): State => {
  * @param state current state
  */
 export const stepUntilConvergence = (state: State): State => {
-    const numSteps = 1;
-    let currentState = state;
-    while (!stateConverged(currentState))
-        currentState = step(currentState, numSteps);
-    return currentState;
+  const numSteps = 1;
+  let currentState = state;
+  while (!stateConverged(currentState))
+    currentState = step(currentState, numSteps);
+  return currentState;
 };
 
 /**
@@ -59,20 +60,20 @@ export const stepUntilConvergence = (state: State): State => {
  * @param node a node in the DOM tree
  */
 export const diagram = async (
-    domainProg: string,
-    subProg: string,
-    styProg: string,
-    node: HTMLElement
+  domainProg: string,
+  subProg: string,
+  styProg: string,
+  node: HTMLElement
 ): Promise<void> => {
-    const res = compileTrio(domainProg, subProg, styProg);
-    if (res.isOk()) {
-        const state: State = await prepareState(res.value);
-        const optimized = stepUntilConvergence(state);
-        node.appendChild(RenderStatic(optimized));
-    } else
-        throw Error(
-            `Error when generating Penrose diagram: ${showError(res.error)}`
-        );
+  const res = compileTrio(domainProg, subProg, styProg);
+  if (res.isOk()) {
+    const state: State = await prepareState(res.value);
+    const optimized = stepUntilConvergence(state);
+    node.appendChild(RenderStatic(optimized));
+  } else
+    throw Error(
+      `Error when generating Penrose diagram: ${showError(res.error)}`
+    );
 };
 
 /**
@@ -84,27 +85,27 @@ export const diagram = async (
  * @param node a node in the DOM tree
  */
 export const interactiveDiagram = async (
-    domainProg: string,
-    subProg: string,
-    styProg: string,
-    node: HTMLElement
+  domainProg: string,
+  subProg: string,
+  styProg: string,
+  node: HTMLElement
 ): Promise<void> => {
-    const updateData = (state: State) => {
-        const stepped = stepUntilConvergence(state);
-        node.replaceChild(
-            RenderInteractive(stepped, updateData),
-            node.firstChild as Node
-        );
-    };
-    const res = compileTrio(domainProg, subProg, styProg);
-    if (res.isOk()) {
-        const state: State = await prepareState(res.value);
-        const optimized = stepUntilConvergence(state);
-        node.appendChild(RenderInteractive(optimized, updateData));
-    } else
-        throw Error(
-            `Error when generating Penrose diagram: ${showError(res.error)}`
-        );
+  const updateData = (state: State) => {
+    const stepped = stepUntilConvergence(state);
+    node.replaceChild(
+      RenderInteractive(stepped, updateData),
+      node.firstChild as Node
+    );
+  };
+  const res = compileTrio(domainProg, subProg, styProg);
+  if (res.isOk()) {
+    const state: State = await prepareState(res.value);
+    const optimized = stepUntilConvergence(state);
+    node.appendChild(RenderInteractive(optimized, updateData));
+  } else
+    throw Error(
+      `Error when generating Penrose diagram: ${showError(res.error)}`
+    );
 };
 
 /**
@@ -114,23 +115,23 @@ export const interactiveDiagram = async (
  * @param styProg a Style program string
  */
 export const compileTrio = (
-    domainProg: string,
-    subProg: string,
-    styProg: string
+  domainProg: string,
+  subProg: string,
+  styProg: string
 ): Result<State, PenroseError> => {
-    const domainRes: Result<Env, PenroseError> = compileDomain(domainProg);
+  const domainRes: Result<Env, PenroseError> = compileDomain(domainProg);
 
-    const subRes: Result<[SubstanceEnv, Env], PenroseError> = andThen(
-        (env) => compileSubstance(subProg, env),
-        domainRes
-    );
+  const subRes: Result<[SubstanceEnv, Env], PenroseError> = andThen(
+    (env) => compileSubstance(subProg, env),
+    domainRes
+  );
 
-    const styRes: Result<State, PenroseError> = andThen(
-        (res) => compileStyle(styProg, ...res),
-        subRes
-    );
+  const styRes: Result<State, PenroseError> = andThen(
+    (res) => compileStyle(styProg, ...res),
+    subRes
+  );
 
-    return styRes;
+  return styRes;
 };
 
 /**
@@ -138,33 +139,33 @@ export const compileTrio = (
  * @param state an initial diagram state
  */
 export const prepareState = async (state: State): Promise<State> => {
-    await initializeMat();
-    // TODO:L errors
-    const stateAD = {
-        ...state,
-        originalTranslation: state.originalTranslation,
-    };
+  await initializeMat();
+  // TODO:L errors
+  const stateAD = {
+    ...state,
+    originalTranslation: state.originalTranslation,
+  };
 
-    // After the pending values load, they only use the evaluated shapes (all in terms of numbers)
-    // The results of the pending values are then stored back in the translation as autodiff types
-    const stateEvaled: State = evalShapes(stateAD);
+  // After the pending values load, they only use the evaluated shapes (all in terms of numbers)
+  // The results of the pending values are then stored back in the translation as autodiff types
+  const stateEvaled: State = evalShapes(stateAD);
 
-    const labelCache: LabelCache = await collectLabels(stateEvaled.shapes);
+  const labelCache: LabelCache = await collectLabels(stateEvaled.shapes);
 
-    const sortedShapes: Shape[] = sortShapes(
-        stateEvaled.shapes,
-        stateEvaled.shapeOrdering
-    );
+  const sortedShapes: Shape[] = sortShapes(
+    stateEvaled.shapes,
+    stateEvaled.shapeOrdering
+  );
 
-    const nonEmpties = sortedShapes.filter(notEmptyLabel);
+  const nonEmpties = sortedShapes.filter(notEmptyLabel);
 
-    const stateWithPendingProperties = insertPending({
-        ...stateEvaled,
-        labelCache,
-        shapes: nonEmpties,
-    });
+  const stateWithPendingProperties = insertPending({
+    ...stateEvaled,
+    labelCache,
+    shapes: nonEmpties,
+  });
 
-    return stateWithPendingProperties;
+  return stateWithPendingProperties;
 };
 
 /**
@@ -172,29 +173,31 @@ export const prepareState = async (state: State): Promise<State> => {
  * @param state current state
  */
 export const stateConverged = (state: State): boolean =>
-    state.params.optStatus.tag === "EPConverged";
+  state.params.optStatus.tag === "EPConverged";
 
 /**
  * Returns true if state is the initial frame
  * @param state current state
  */
 export const stateInitial = (state: State): boolean =>
-    state.params.optStatus.tag === "NewIter";
+  state.params.optStatus.tag === "NewIter";
 
 export type PenroseState = State;
 
+export type { PenroseError } from "./types/errors";
+
 export {
-    compileDomain,
-    compileSubstance,
-    checkDomain,
-    checkSubstance,
-    parseSubstance,
-    parseDomain,
-    RenderStatic,
-    RenderShape,
-    RenderInteractive,
-    ShapeTypes,
-    bBoxDims,
-    toHex,
-    showError
+  compileDomain,
+  compileSubstance,
+  checkDomain,
+  checkSubstance,
+  parseSubstance,
+  parseDomain,
+  RenderStatic,
+  RenderShape,
+  RenderInteractive,
+  ShapeTypes,
+  bBoxDims,
+  toHex,
+  showError,
 };

--- a/packages/core/src/renderer/Circle.ts
+++ b/packages/core/src/renderer/Circle.ts
@@ -14,7 +14,6 @@ const Circle = ({ shape, canvasSize }: ShapeProps) => {
   attrRadius(shape, elem);
   attrStroke(shape, elem);
   attrTitle(shape, elem);
-  console.log(elem);
 
   return elem;
 };

--- a/packages/core/src/types/errors.ts
+++ b/packages/core/src/types/errors.ts
@@ -4,13 +4,15 @@
 // type LanguageError = DomainError | SubstanceError | StyleError | PluginError;
 // type RuntimeError = OptimizerError | EvaluatorError;
 // type StyleError = StyleParseError | StyleCheckError | TranslationError;
-type PenroseError =
+export type PenroseError =
   | (DomainError & { errorType: "DomainError" })
   | (SubstanceError & { errorType: "SubstanceError" })
   | (StyleError & { errorType: "StyleError" });
 
+export type Warning = StyleError;
+
 // TODO: does type var ever appear in Substance? If not, can we encode that at the type level?
-type SubstanceError =
+export type SubstanceError =
   | ParseError
   | DuplicateName
   | TypeNotFound
@@ -23,7 +25,7 @@ type SubstanceError =
   | UnexpectedExprForNestedPred
   | FatalError; // TODO: resolve all fatal errors in the Substance module
 
-type DomainError =
+export type DomainError =
   | ParseError
   | TypeDeclared
   | TypeVarNotFound
@@ -33,59 +35,59 @@ type DomainError =
   | NotTypeConsInSubtype
   | NotTypeConsInPrelude;
 
-interface UnexpectedExprForNestedPred {
+export interface UnexpectedExprForNestedPred {
   tag: "UnexpectedExprForNestedPred";
   sourceType: TypeConstructor;
   sourceExpr: ASTNode;
   expectedExpr: ASTNode;
 }
 
-interface CyclicSubtypes {
+export interface CyclicSubtypes {
   tag: "CyclicSubtypes";
   cycles: string[][];
 }
-interface NotTypeConsInPrelude {
+export interface NotTypeConsInPrelude {
   tag: "NotTypeConsInPrelude";
   type: Prop | TypeVar;
 }
 
-interface NotTypeConsInSubtype {
+export interface NotTypeConsInSubtype {
   tag: "NotTypeConsInSubtype";
   type: Prop | TypeVar;
 }
-interface TypeDeclared {
+export interface TypeDeclared {
   tag: "TypeDeclared";
   typeName: Identifier;
 }
-interface DuplicateName {
+export interface DuplicateName {
   tag: "DuplicateName";
   name: Identifier;
   location: ASTNode;
   firstDefined: ASTNode;
 }
-interface TypeVarNotFound {
+export interface TypeVarNotFound {
   tag: "TypeVarNotFound";
   typeVar: TypeVar;
 }
-interface TypeNotFound {
+export interface TypeNotFound {
   tag: "TypeNotFound";
   typeName: Identifier;
   possibleTypes?: Identifier[];
 }
-interface VarNotFound {
+export interface VarNotFound {
   tag: "VarNotFound";
   variable: Identifier;
   possibleVars?: string[]; // TODO: use Identifier type, but need to store them in env
 }
 
-interface TypeMismatch {
+export interface TypeMismatch {
   tag: "TypeMismatch";
   sourceType: TypeConstructor;
   expectedType: TypeConstructor;
   sourceExpr: ASTNode;
   expectedExpr: ASTNode;
 }
-interface ArgLengthMismatch {
+export interface ArgLengthMismatch {
   tag: "ArgLengthMismatch";
   name: Identifier;
   argsGiven: SubExpr[];
@@ -94,7 +96,7 @@ interface ArgLengthMismatch {
   expectedExpr: ASTNode;
 }
 
-interface TypeArgLengthMismatch {
+export interface TypeArgLengthMismatch {
   tag: "TypeArgLengthMismatch";
   sourceType: TypeConstructor;
   expectedType: TypeConstructor;
@@ -102,25 +104,25 @@ interface TypeArgLengthMismatch {
   expectedExpr: ASTNode;
 }
 
-interface DeconstructNonconstructor {
+export interface DeconstructNonconstructor {
   tag: "DeconstructNonconstructor";
   deconstructor: Deconstructor;
 }
 
 // NOTE: for debugging purposes
-interface FatalError {
+export interface FatalError {
   tag: "Fatal";
   message: string;
 }
 
 // NOTE: aliased to ASTNode for now, can include more types for different errors
-type ErrorSource = ASTNode;
+export type ErrorSource = ASTNode;
 
 //#endregion
 
 //#region Style errors
 
-type StyleError =
+export type StyleError =
   // Misc errors
   | ParseError
   | GenericStyleError
@@ -158,89 +160,89 @@ type StyleError =
   // Runtime errors
   | RuntimeValueTypeError;
 
-type StyleWarning = IntOrFloat;
+export type StyleWarning = IntOrFloat;
 
-type StyleWarnings = StyleWarning[];
+export type StyleWarnings = StyleWarning[];
 
-interface StyleResults {
+export interface StyleResults {
   errors: StyleErrors;
   warnings: StyleWarnings;
 }
 
-interface IntOrFloat {
+export interface IntOrFloat {
   tag: "IntOrFloat";
   message: string;
 } // COMBAK: Use this in block checking
 
-interface GenericStyleError {
+export interface GenericStyleError {
   tag: "GenericStyleError";
   messages: string[];
 }
 
-interface StyleErrorList {
+export interface StyleErrorList {
   tag: "StyleErrorList";
   errors: StyleError[];
 }
 
-interface ParseError {
+export interface ParseError {
   tag: "ParseError";
   message: string;
 }
 
-interface SelectorDeclTypeError {
+export interface SelectorDeclTypeError {
   tag: "SelectorDeclTypeError";
-  typeName: identifier;
+  typeName: Identifier;
 }
 
-interface SelectorVarMultipleDecl {
+export interface SelectorVarMultipleDecl {
   tag: "SelectorVarMultipleDecl";
   varName: BindingForm;
 }
 
-interface SelectorDeclTypeMismatch {
+export interface SelectorDeclTypeMismatch {
   tag: "SelectorDeclTypeMismatch";
   subType: TypeConsApp;
   styType: TypeConsApp;
 }
 
-interface SelectorRelTypeMismatch {
+export interface SelectorRelTypeMismatch {
   tag: "SelectorRelTypeMismatch";
   varType: TypeConsApp;
   exprType: TypeConsApp;
 }
 
-interface TaggedSubstanceError {
+export interface TaggedSubstanceError {
   tag: "TaggedSubstanceError";
   error: SubstanceError;
 }
 
 //#region Block statics
 
-interface InvalidGPITypeError {
+export interface InvalidGPITypeError {
   tag: "InvalidGPITypeError";
   givenType: Identifier;
   // expectedType: string;
 }
 
-interface InvalidGPIPropertyError {
+export interface InvalidGPIPropertyError {
   tag: "InvalidGPIPropertyError";
   givenProperty: Identifier;
   expectedProperties: string[];
 }
 
-interface InvalidFunctionNameError {
+export interface InvalidFunctionNameError {
   tag: "InvalidFunctionNameError";
   givenName: Identifier;
   // expectedName: string;
 }
 
-interface InvalidObjectiveNameError {
+export interface InvalidObjectiveNameError {
   tag: "InvalidObjectiveNameError";
   givenName: Identifier;
   // expectedName: string;
 }
 
-interface InvalidConstraintNameError {
+export interface InvalidConstraintNameError {
   tag: "InvalidConstraintNameError";
   givenName: Identifier;
   // expectedName: string;
@@ -248,25 +250,25 @@ interface InvalidConstraintNameError {
 
 //#endregion Block statics
 
-interface DeletedPropWithNoSubObjError {
+export interface DeletedPropWithNoSubObjError {
   tag: "DeletedPropWithNoSubObjError";
   subObj: BindingForm;
   path: Path;
 }
 
-interface DeletedPropWithNoFieldError {
+export interface DeletedPropWithNoFieldError {
   tag: "DeletedPropWithNoFieldError";
   subObj: BindingForm;
   field: Identifier;
   path: Path;
 }
 
-interface CircularPathAlias {
+export interface CircularPathAlias {
   tag: "CircularPathAlias";
   path: Path;
 }
 
-interface DeletedPropWithNoGPIError {
+export interface DeletedPropWithNoGPIError {
   tag: "DeletedPropWithNoGPIError";
   subObj: BindingForm;
   field: Identifier;
@@ -274,24 +276,24 @@ interface DeletedPropWithNoGPIError {
   path: Path;
 }
 
-interface DeletedNonexistentFieldError {
+export interface DeletedNonexistentFieldError {
   tag: "DeletedNonexistentFieldError";
   subObj: BindingForm;
   field: Identifier;
   path: Path;
 }
 
-interface DeletedVectorElemError {
+export interface DeletedVectorElemError {
   tag: "DeletedVectorElemError";
   path: Path;
 }
 
-interface InsertedPathWithoutOverrideError {
+export interface InsertedPathWithoutOverrideError {
   tag: "InsertedPathWithoutOverrideError";
   path: Path;
 }
 
-interface InsertedPropWithNoFieldError {
+export interface InsertedPropWithNoFieldError {
   tag: "InsertedPropWithNoFieldError";
   subObj: BindingForm;
   field: Identifier;
@@ -299,7 +301,7 @@ interface InsertedPropWithNoFieldError {
   path: Path;
 }
 
-interface InsertedPropWithNoGPIError {
+export interface InsertedPropWithNoGPIError {
   tag: "InsertedPropWithNoGPIError";
   subObj: BindingForm;
   field: Identifier;
@@ -309,37 +311,37 @@ interface InsertedPropWithNoGPIError {
 
 //#region Translation validation errors
 
-interface NonexistentNameError {
+export interface NonexistentNameError {
   tag: "NonexistentNameError";
   name: Identifier;
   path: Path;
 }
 
-interface NonexistentFieldError {
+export interface NonexistentFieldError {
   tag: "NonexistentFieldError";
   field: Identifier;
   path: Path;
 }
 
-interface NonexistentGPIError {
+export interface NonexistentGPIError {
   tag: "NonexistentGPIError";
   gpi: Identifier;
   path: Path;
 }
 
-interface NonexistentPropertyError {
+export interface NonexistentPropertyError {
   tag: "NonexistentPropertyError";
   property: Identifier;
   path: Path;
 }
 
-interface ExpectedGPIGotFieldError {
+export interface ExpectedGPIGotFieldError {
   tag: "ExpectedGPIGotFieldError";
   field: Identifier;
   path: Path;
 }
 
-interface InvalidAccessPathError {
+export interface InvalidAccessPathError {
   tag: "InvalidAccessPathError";
   path: Path;
 }
@@ -347,7 +349,7 @@ interface InvalidAccessPathError {
 //#endregion Translation validation errors
 
 // TODO(errors): use identifiers here
-interface RuntimeValueTypeError {
+export interface RuntimeValueTypeError {
   tag: "RuntimeValueTypeError";
   path: Path;
   expectedType: string;

--- a/packages/core/src/types/types.d.ts
+++ b/packages/core/src/types/types.d.ts
@@ -1608,26 +1608,3 @@ interface Right<B> {
 type Either<A, B> = Left<A> | Right<B>;
 
 //#endregion
-
-//#region
-type PenroseError = LanguageError | RuntimeError;
-type LanguageError = DomainError | SubstanceError | StyleError | PluginError;
-type RuntimeError = OptimizerError | EvaluatorError;
-type StyleError = StyleParseError | StyleCheckError | TranslationError;
-
-interface LanguageError {
-  message: string;
-  sources: ErrorSource[];
-}
-
-interface StyleError {
-  sources: ErrorSource[];
-  message: FormatString; // Style match failed with Substance object $1 and select in Style $2
-}
-
-interface ErrorSource {
-  node: ASTNode;
-}
-
-type Warning = StyleError;
-//#endregion

--- a/packages/core/src/utils/Error.ts
+++ b/packages/core/src/utils/Error.ts
@@ -14,6 +14,25 @@ const {
 } = Result;
 
 import { ShapeDef, shapedefs } from "renderer/ShapeDef";
+import {
+  DomainError,
+  SubstanceError,
+  CyclicSubtypes,
+  NotTypeConsInPrelude,
+  NotTypeConsInSubtype,
+  DuplicateName,
+  TypeNotFound,
+  VarNotFound,
+  TypeMismatch,
+  UnexpectedExprForNestedPred,
+  ArgLengthMismatch,
+  TypeArgLengthMismatch,
+  DeconstructNonconstructor,
+  FatalError,
+  ParseError,
+  PenroseError,
+  StyleError,
+} from "types/errors";
 // #region error rendering and construction
 
 /**
@@ -331,6 +350,12 @@ export const showError = (
 
     case "Fatal": {
       return `FATAL: ${error.message}`;
+    }
+
+    default: {
+      return `Meta: Cannot render error with contents: ${JSON.stringify(
+        error
+      )}`;
     }
   }
 };


### PR DESCRIPTION
# Description

Related: #486 

* Adds `errors (1)` panel to inspector
* Shuffles error types around so that they can be exported by core

![image](https://user-images.githubusercontent.com/2660634/108458026-bf213f80-7241-11eb-9a10-ea34b5cf05c4.png)
