### PR TITLE
fix: style path validation code or remove unsupported style program features so LA example works

### DIFF
--- a/examples/linear-algebra-domain/linear-algebra-paper-simple.sty
+++ b/examples/linear-algebra-domain/linear-algebra-paper-simple.sty
@@ -16,7 +16,8 @@ C { -- 1
     color black = rgba(0.,0.,0.,1.)
     white = rgba(1., 1., 1., 1.)
     lightBlue = rgba(1e-1, 0.1, 0.9, 1.0)
-    darkBlue = rgba(lightBlue.r / 2., lightBlue.g / 2., lightBlue.b / 2., 0.5)
+    -- Note: we don't currently support color accessors r,g,b
+    -- darkBlue = rgba(lightBlue.r / 2., lightBlue.g / 2., lightBlue.b / 2., 0.5)
     darkGray = rgba(0.4, 0.4, 0.4, 1.)
     gray = rgba(0.6, 0.6, 0.6, 1.)
     green = rgba(0., 0.8, 0., 1.)
@@ -36,6 +37,7 @@ testing { -- 2
         v = (a + (2., 900.))  / (4.0 + 3.)
         -- z = Colors.black.g
         asum = a[1] + a[0]
+        -- Currently not supported: indexing a vector or list by a variable
         -- c = 0
         -- b = 1
         -- msum = m[1][0] + m[c][b]

--- a/packages/browser-ui/src/App.tsx
+++ b/packages/browser-ui/src/App.tsx
@@ -173,6 +173,12 @@ class App extends React.Component<any, ICanvasState> {
           const initState: PenroseState = await prepareState(compileRes.value);
           void this.onCanvasState(initState);
         } else {
+          void console.error(
+            "Failed to compile with errors:",
+            compileRes.error,
+            compileRes.error.errors.map(showError)
+          );
+
           this.setState({ error: compileRes.error, data: undefined });
         }
       },

--- a/packages/core/src/compiler/Style.ts
+++ b/packages/core/src/compiler/Style.ts
@@ -2946,7 +2946,7 @@ const checkTranslation = (trans: Translation): StyleErrors => {
   // Look up all paths used anywhere in the translation's expressions and verify they exist in the translation
   const allPaths: Path[] = foldSubObjs(findPathsField, trans);
   const allPathsUniq: Path[] = _.uniqBy(allPaths, prettyPrintPath);
-  const exprs = allPaths.map((p) => findExpr(trans, p));
+  const exprs = allPathsUniq.map((p) => findExpr(trans, p));
   const errs = exprs.filter(isStyErr);
   return errs as StyleErrors; // Should be true due to the filter above, though you can't use booleans and the `res is StyleError` assertion together.
 };

--- a/packages/core/src/engine/EngineUtils.ts
+++ b/packages/core/src/engine/EngineUtils.ts
@@ -851,6 +851,9 @@ export const findExpr = (
         if (res2.tag === "Vector") {
           const inner: Expr = res2.contents[i];
           return { tag: "OptEval", contents: inner };
+        } else if (res2.tag === "List") {
+          const inner: Expr = res2.contents[i];
+          return { tag: "OptEval", contents: inner };
         } else if (res2.tag === "PropertyPath" || res2.tag === "FieldPath") {
           // COMBAK: This deals with accessing elements of path aliases. Maybe there is a nicer way to do it.
           return findExpr(trans, { ...path, path: res2 });


### PR DESCRIPTION
# Description

Minor fixes in Style checking so LA example works.

Related issue/PR: #489 

# Implementation strategy and design decisions

* Style does not support variables as indices for now, e.g. `a = 3; myMatrix[a][1]` is not allowed
* `findExpr` deals correctly with list lookups
* Style does not support color accessors, e.g. `color.r`, `color.g`, `color.b`, `color.a`

# Examples with steps to reproduce them

`roger watch linear-algebra-domain/twoVectorsPerp-unsugared.sub linear-algebra-domain/linear-algebra-paper-simple.sty linear-algebra-domain/linear-algebra.dsl`

# Checklist

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] New and existing tests pass locally using `yarn test`
- [x] I ran `yarn docs` and there were no errors when generating the HTML site
- [x] My code follows the style guidelines of this project (e.g.: no ESLint warnings)

# Open questions

Questions that require more discussion or to be addressed in future development:

Maybe add Style support for those minor unsupported language features in the future.