### PR TITLE
feat: Add basic graph domain and more standard library functions for Style

### DIFF
--- a/examples/graph-domain/graph-theory-extended.dsl
+++ b/examples/graph-domain/graph-theory-extended.dsl
@@ -1,0 +1,52 @@
+type List ('X)
+vconstructor Cons ['X] (head : 'X, tail : List('X)) : List('X)
+vconstructor Nil ['X] : List('X)
+
+-- Main types
+type Vertex
+type Edge
+type Graph
+
+-- Subtypes
+type UndirectedEdge
+type DirectedEdge
+type UndirectedGraph
+type DirectedGraph
+type Tree
+type BinaryTree
+type Face
+type Path
+type Cycle
+
+UndirectedEdge <: Edge
+DirectedEdge <: Edge
+UndirectedGraph <: Graph
+DirectedGraph <: Graph
+Tree <: Graph
+BinaryTree <: Tree
+Face <: Graph
+Path <: Graph
+Cycle <: Graph
+
+constructor MkGraph : List(Vertex) vertices * List(Edge) edges -> Graph
+constructor MkEdge : Vertex from * Vertex to -> Edge
+constructor MkUndirectedEdge : Vertex from * Vertex to -> UndirectedEdge
+constructor MkDirectedEdge : Vertex from * Vertex to -> DirectedEdge 
+
+operator Union : Graph G1 * Graph G2 -> Graph
+operator Product : Graph G1 * Graph G2 -> Graph
+operator Neighbors : Vertex v -> List(Vertex)
+operator FindFace : Graph G -> Face
+operator FindVertex : Graph G -> Vertex
+
+predicate SelectedV : Vertex v
+predicate SelectedE : Edge e
+predicate Colored : Graph G
+predicate FullyConnected : Graph G
+predicate Bipartite : Graph G
+predicate SmallerDegree : Vertex v1 * Vertex v2
+predicate InV : Vertex v * Graph G
+predicate InE : Edge e * Graph G
+predicate InF : Face f * Graph G
+
+-- TODO syntactic sugar

--- a/examples/graph-domain/graph-theory.dsl
+++ b/examples/graph-domain/graph-theory.dsl
@@ -1,0 +1,28 @@
+type Vertex
+type Edge
+type Graph
+
+-- Subtypes
+type Face
+type Path
+
+Face <: Graph
+Path <: Graph
+
+constructor MkEdge : Vertex from * Vertex to -> Edge
+
+-- COMBAK: Add lists
+-- constructor MkGraph : List(Vertex) vertices * List(Edge) edges -> Graph
+-- operator Neighbors : Vertex v -> List(Vertex)
+
+predicate Directed : Edge e
+predicate Undirected : Edge e
+
+predicate SelectedV : Vertex v
+predicate SelectedE : Edge e
+
+-- predicate InV : Vertex v * Graph G
+-- predicate InE : Edge e * Graph G
+-- predicate InF : Face f * Graph G
+
+-- TODO syntactic sugar

--- a/examples/graph-domain/graph-theory.sty
+++ b/examples/graph-domain/graph-theory.sty
@@ -1,0 +1,68 @@
+Colors {
+    Colors.black = rgba(0.0, 0.0, 0.0, 1.0)
+    Colors.darkgray = rgba(0.1, 0.1, 0.1, 1.0)
+    Colors.gray = rgba(0.8, 0.8, 0.8, 1.0)
+    Colors.red = rgba(1.0, 0.0, 0.0, 1.0)
+    Colors.pink = rgba(1.0, 0.4, 0.7, 1.0)
+    Colors.yellow = rgba(1.0, 1.0, 0.0, 1.0)
+    Colors.orange = rgba(1.0, 0.6, 0.0, 1.0)
+    Colors.lightorange = rgba(1.0, 0.6, 0.0, 0.25)
+    Colors.green = rgba(0.0, 1.0, 0.0, 1.0)
+    Colors.blue = rgba(0.0, 0.0, 1.0, 1.0)
+    Colors.sky = rgba(0.325, 0.718, 0.769, 1.0)
+    Colors.lightsky = rgba(0.325, 0.718, 0.769, 0.25)
+    Colors.lightblue = rgba(0.0, 0.0, 1.0, 0.25)
+    Colors.cyan = rgba(0.0, 1.0, 1.0, 1.0)
+    Colors.purple = rgba(0.5, 0.0, 0.5, 1.0)
+    Colors.white = rgba(1.0, 1.0, 1.0, 1.0)
+    Colors.none = rgba(0.0, 0.0, 0.0, 0.0)
+    Colors.bluegreen = rgba(0.44, 0.68, 0.60, 1.0)
+}
+
+global {
+    global.padding = 20.0
+    global.stroke = 2.0
+}
+
+Vertex V {
+       V.shape = Circle { 
+         r : 6.0
+	 color : Colors.black	 
+	 strokeWidth : 0.0
+       }
+
+       V.text = Text {
+	 center: V.shape.center + (global.padding, global.padding)
+	 string : V.label
+	 rotation : 0.0
+	 color : V.shape.color
+       }
+
+-- TODO: make the vertices be labels
+
+-- TODO: Improve labels
+}
+
+Edge E
+where E := MkEdge(v1, v2)
+with Vertex v1; Vertex v2 {
+     E.shape = Line { 
+     	     start : v1.shape.center
+     	     end : v2.shape.center
+	     color : Colors.black
+	     thickness : 3.0
+     }
+
+     E.text = Text {
+     -- If you refer to a nonexistent shape property, bad crash
+     -- Unhandled Rejection (TypeError): Cannot read property 'tag' of undefined
+       -- center : average(E.shape.center) + (global.padding, global.padding)
+
+       center : (E.shape.start + E.shape.end) / 2. + (global.padding, global.padding)
+       string : E.label
+       rotation : 0.0
+     }
+
+     v1.shape above E.shape
+     v2.shape above E.shape
+}

--- a/examples/graph-domain/graph-theory.sty
+++ b/examples/graph-domain/graph-theory.sty
@@ -25,21 +25,18 @@ global {
 }
 
 Vertex V {
-       V.shape = Circle { 
-         r : 6.0
-	 color : Colors.black	 
-	 strokeWidth : 0.0
+       V.shape = Rectangle { 
+         -- r : 10.0
+	 -- color : Colors.black	 
+	 strokeWidth : 1.
        }
 
        V.text = Text {
-	 center: V.shape.center + (global.padding, global.padding)
+	 center: V.shape.center
 	 string : V.label
 	 rotation : 0.0
-	 color : V.shape.color
+	 color : Colors.black
        }
-
--- TODO: make the vertices be labels
-
 -- TODO: Improve labels
 }
 
@@ -51,6 +48,7 @@ with Vertex v1; Vertex v2 {
      	     end : v2.shape.center
 	     color : Colors.black
 	     thickness : 3.0
+             leftArrowhead: true
      }
 
      E.text = Text {

--- a/examples/graph-domain/graph-theory.sty
+++ b/examples/graph-domain/graph-theory.sty
@@ -29,6 +29,8 @@ global {
                color: Colors.none
                strokeColor: Colors.black
     }
+
+-- TODO: Can we have a "below everything" directive? or something broader than pairwise
 }
 
 Vertex V {
@@ -49,26 +51,36 @@ Vertex V {
 	 color : Colors.black
        }
 
-       -- ensure contains(V.shape, V.text)
-       V.text above V.shape
-
--- TODO: Make this work WRT rectangle dimensions
+-- TODO: Make this work WRT rectangle dimensions (right now it's overapproximated w/ squares)
        ensure contains(global.box, V.shape)
+
+       V.text above V.shape
+       V.shape above global.box
 }
 
 Edge E
 where E := MkEdge(v1, v2)
 with Vertex v1; Vertex v2 {
 
-     dir = normalize(v2.shape.center - v1.shape.center)
-     padding = 10.
+     vec2 dir = normalize(v2.shape.center - v1.shape.center)
+     scalar padding = 20.
+     scalar arrowheadSize = 10. -- Guess
 
 -- TODO: Figure out the line offset factor (would be the distance from center to shape border, plus some offset in that direction)
 
+-- Figure out which side of the rectangle the v1->v2 edge between their centers is hitting
+-- TODO: This locks up the opt / works very poorly....
+   -- scalar startSideDim = intersectingSideSize(v1.shape.center, v2.shape.center, v1.shape)
+   -- scalar endSideDim = intersectingSideSize(v2.shape.center, v1.shape.center, v2.shape)
+
+   scalar startSideDim = v1.shape.w
+   scalar endSideDim = v2.shape.w
+
      E.shape = Line { 
      -- TODO(errors): If you do v * c, then the type fails? very badly
-     	     start : v1.shape.center + (v1.shape.w / 2.) * dir
-     	     end : v2.shape.center - (v2.shape.h / 2.) * dir
+     -- If you accidentally do a scalar when a vector was expected, also bad
+     	     start : v1.shape.center + (startSideDim / 2. + padding) * dir
+     	     end : v2.shape.center - (endSideDim / 2. + arrowheadSize + padding) * dir
 	     color : Colors.black
 	     thickness : 2.0
              rightArrowhead: true
@@ -87,29 +99,42 @@ with Vertex v1; Vertex v2 {
 
 -- TODO: Make this work WRT rectangle dimensions
      encourage centerLabel(E.shape, E.text, 5.0)
+     -- Also, it should really have two local minima (on either side of the line), which it currently doesn't, resulting in weird labels
+
+     ensure disjoint(E.text, E.shape) -- TODO: Indeed, this doesn't use the dimensions... so the layout looks weird
+     ensure contains(global.box, E.text)
 
 -- TODO: encourage edge to be horizontal
 -- Um... but if it's calculated I guess you want to encourage the nodes to be horizontal
-   -- encourage equal(v1.shape.center[1], v2.shape.center[1]) -- encourage horizontal (same y-coord)
+   encourage equal(v1.shape.center[1], v2.shape.center[1]) -- encourage horizontal (same y-coord)
    ensure lessThan(v1.shape.center[0], v2.shape.center[0]) -- ensure arrows are left-to-right
    -- The problem is now that they're horizontal, but don't respect directionality...
    -- TODO: Add lessThan, equal..
 
+   ensure minSize(E.shape)
+
      v1.shape above E.shape
      v2.shape above E.shape
+     E.text above global.box
+     E.shape above global.box
 }
 
 Vertex v1; Vertex v2 {
 -- TODO: Make this work WRT rectangle dimensions
        ensure disjoint(v1.shape, v2.shape, 10.)
+       encourage repel(v1.shape, v2.shape)
 }
 
 Edge e1; Edge e2 {
 -- TODO: Minimize edge crossings
 -- I guess an alternative is that no line intersects a box
+   ensure disjoint(e1.text, e2.text)
    ensure notCrossing(e1.shape, e2.shape)
 }
 
 Vertex v; Edge e {
        ensure disjoint(v.shape, e.shape)
+       ensure disjoint(v.shape, e.text)
 }
+
+-- TODO: It's hard to select the thing to drag when shapes are overlapping, which is exactly when you want to drag, to make them not overlap

--- a/examples/graph-domain/graph-theory.sty
+++ b/examples/graph-domain/graph-theory.sty
@@ -45,13 +45,13 @@ Vertex V {
        }
 
        V.text = Text {
-       -- ERROR: You get the divide by 0 from `contains` if the text center is set... How to detect these conflicts? the divide by 0 was due to a hardcoded distance of 0?
+       -- ERROR: You get the divide by 0 from `contains` if the text center is set. How to detect these conflicts? the divide by 0 was due to a hardcoded distance of 0?
 	 center: V.shape.center
 	 string : V.label
 	 color : Colors.black
        }
 
--- TODO: Make this work WRT rectangle dimensions (right now it's overapproximated w/ squares)
+       -- TODO: Make this work WRT rectangle dimensions (right now it's overapproximated w/ squares)
        ensure contains(global.box, V.shape)
 
        V.text above V.shape
@@ -66,10 +66,10 @@ with Vertex v1; Vertex v2 {
      scalar padding = 20.
      scalar arrowheadSize = 10. -- Guess
 
--- TODO: Figure out the line offset factor (would be the distance from center to shape border, plus some offset in that direction)
+     -- TODO: Figure out the line offset factor (would be the distance from center to shape border, plus some offset in that direction)
 
--- Figure out which side of the rectangle the v1->v2 edge between their centers is hitting
--- TODO: This locks up the opt / works very poorly....
+     -- Figure out which side of the rectangle the v1->v2 edge between their centers is hitting
+     -- TODO: This locks up the opt / works very poorly....
    -- scalar startSideDim = intersectingSideSize(v1.shape.center, v2.shape.center, v1.shape)
    -- scalar endSideDim = intersectingSideSize(v2.shape.center, v1.shape.center, v2.shape)
 
@@ -77,7 +77,7 @@ with Vertex v1; Vertex v2 {
    scalar endSideDim = v2.shape.w
 
      E.shape = Line { 
-     -- TODO(errors): If you do v * c, then the type fails? very badly
+     -- TODO(errors): If you do v * c, then the type fails very badly
      -- If you accidentally do a scalar when a vector was expected, also bad
      	     start : v1.shape.center + (startSideDim / 2. + padding) * dir
      	     end : v2.shape.center - (endSideDim / 2. + arrowheadSize + padding) * dir
@@ -88,29 +88,21 @@ with Vertex v1; Vertex v2 {
      }
 
      E.text = Text {
-     -- If you refer to a nonexistent shape property, bad crash
-     -- Unhandled Rejection (TypeError): Cannot read property 'tag' of undefined
-       -- center : average(E.shape.center) + (global.padding, global.padding)
-
-       -- center : (E.shape.start + E.shape.end) / 2. + (global.padding, global.padding)
        string : E.label
        rotation : 0.0
      }
 
--- TODO: Make this work WRT rectangle dimensions
-     encourage centerLabel(E.shape, E.text, 5.0)
-     -- Also, it should really have two local minima (on either side of the line), which it currently doesn't, resulting in weird labels
+     -- TODO(errors): If you refer to a nonexistent shape property, bad crash
+     -- Unhandled Rejection (TypeError): Cannot read property 'tag' of undefined
 
-     ensure disjoint(E.text, E.shape) -- TODO: Indeed, this doesn't use the dimensions... so the layout looks weird
+     -- TODO: Make this work WRT rectangle dimensions
+     encourage centerLabel(E.shape, E.text, 5.0)
+     ensure disjoint(E.text, E.shape) -- TODO: fix this to use bbox dimensions
      ensure contains(global.box, E.text)
 
--- TODO: encourage edge to be horizontal
--- Um... but if it's calculated I guess you want to encourage the nodes to be horizontal
+     -- TODO: encourage edge to be horizontal
    encourage equal(v1.shape.center[1], v2.shape.center[1]) -- encourage horizontal (same y-coord)
    ensure lessThan(v1.shape.center[0], v2.shape.center[0]) -- ensure arrows are left-to-right
-   -- The problem is now that they're horizontal, but don't respect directionality...
-   -- TODO: Add lessThan, equal..
-
    ensure minSize(E.shape)
 
      v1.shape above E.shape
@@ -120,14 +112,14 @@ with Vertex v1; Vertex v2 {
 }
 
 Vertex v1; Vertex v2 {
--- TODO: Make this work WRT rectangle dimensions
+       -- TODO: Make this work WRT rectangle dimensions
        ensure disjoint(v1.shape, v2.shape, 10.)
        encourage repel(v1.shape, v2.shape)
 }
 
 Edge e1; Edge e2 {
--- TODO: Minimize edge crossings
--- I guess an alternative is that no line intersects a box
+     -- TODO: Minimize edge crossings
+     -- I guess an alternative is that no line intersects a box
    ensure disjoint(e1.text, e2.text)
    ensure notCrossing(e1.shape, e2.shape)
 }

--- a/examples/graph-domain/graph-theory.sty
+++ b/examples/graph-domain/graph-theory.sty
@@ -22,33 +22,57 @@ Colors {
 global {
     global.padding = 20.0
     global.stroke = 2.0
+    global.box = Rectangle {
+               center: (0., 0.)
+               w: 700.
+               h: 500.
+               color: Colors.none
+               strokeColor: Colors.black
+    }
 }
 
 Vertex V {
+       -- TODO: Can we have boxes with rounded corners
        V.shape = Rectangle { 
+         w: V.text.w + global.padding
+         h: V.text.h + global.padding
          -- r : 10.0
-	 -- color : Colors.black	 
-	 strokeWidth : 1.
+	 color : Colors.none
+	 strokeWidth : 2.
+         strokeColor: Colors.black
        }
 
        V.text = Text {
+       -- ERROR: You get the divide by 0 from `contains` if the text center is set... How to detect these conflicts? the divide by 0 was due to a hardcoded distance of 0?
 	 center: V.shape.center
 	 string : V.label
-	 rotation : 0.0
 	 color : Colors.black
        }
--- TODO: Improve labels
+
+       -- ensure contains(V.shape, V.text)
+       V.text above V.shape
+
+-- TODO: Make this work WRT rectangle dimensions
+       ensure contains(global.box, V.shape)
 }
 
 Edge E
 where E := MkEdge(v1, v2)
 with Vertex v1; Vertex v2 {
+
+     dir = normalize(v2.shape.center - v1.shape.center)
+     padding = 10.
+
+-- TODO: Figure out the line offset factor (would be the distance from center to shape border, plus some offset in that direction)
+
      E.shape = Line { 
-     	     start : v1.shape.center
-     	     end : v2.shape.center
+     -- TODO(errors): If you do v * c, then the type fails? very badly
+     	     start : v1.shape.center + (v1.shape.w / 2.) * dir
+     	     end : v2.shape.center - (v2.shape.h / 2.) * dir
 	     color : Colors.black
-	     thickness : 3.0
-             leftArrowhead: true
+	     thickness : 2.0
+             rightArrowhead: true
+             arrowheadSize: 0.7
      }
 
      E.text = Text {
@@ -56,11 +80,36 @@ with Vertex v1; Vertex v2 {
      -- Unhandled Rejection (TypeError): Cannot read property 'tag' of undefined
        -- center : average(E.shape.center) + (global.padding, global.padding)
 
-       center : (E.shape.start + E.shape.end) / 2. + (global.padding, global.padding)
+       -- center : (E.shape.start + E.shape.end) / 2. + (global.padding, global.padding)
        string : E.label
        rotation : 0.0
      }
 
+-- TODO: Make this work WRT rectangle dimensions
+     encourage centerLabel(E.shape, E.text, 5.0)
+
+-- TODO: encourage edge to be horizontal
+-- Um... but if it's calculated I guess you want to encourage the nodes to be horizontal
+   -- encourage equal(v1.shape.center[1], v2.shape.center[1]) -- encourage horizontal (same y-coord)
+   ensure lessThan(v1.shape.center[0], v2.shape.center[0]) -- ensure arrows are left-to-right
+   -- The problem is now that they're horizontal, but don't respect directionality...
+   -- TODO: Add lessThan, equal..
+
      v1.shape above E.shape
      v2.shape above E.shape
+}
+
+Vertex v1; Vertex v2 {
+-- TODO: Make this work WRT rectangle dimensions
+       ensure disjoint(v1.shape, v2.shape, 10.)
+}
+
+Edge e1; Edge e2 {
+-- TODO: Minimize edge crossings
+-- I guess an alternative is that no line intersects a box
+   ensure notCrossing(e1.shape, e2.shape)
+}
+
+Vertex v; Edge e {
+       ensure disjoint(v.shape, e.shape)
 }

--- a/examples/graph-domain/graph1-extended.sub
+++ b/examples/graph-domain/graph1-extended.sub
@@ -1,0 +1,67 @@
+Graph G1
+Vertex v1, v2, v3, v4
+
+Edge e1
+e1 := MkEdge(v1, v2)
+
+Edge e2
+e2 := MkEdge(v1, v3)
+
+Edge e3
+e3 := MkEdge(v3, v4)
+
+Edge e4
+e4 := MkEdge(v3, v2)
+
+InV(v1, G1)
+InV(v2, G1)
+InE(e1, G1)
+
+Graph G2
+Face f1
+f1 := FindFace(G2)
+
+Vertex vf1
+vf1 := FindVertex(f1)
+
+Vertex vf2
+vf2 := FindVertex(G2)
+
+Edge ef12
+ef12 := MkEdge(vf1, vf2)
+SelectedE(ef12)
+
+AutoLabel All
+
+-- TODO: rest of In predicates (if we need them?)
+
+-- Style fails on parametric type; Substance fails on Nil constructor and on Cons constructor
+-- List(Vertex) temp
+-- temp := Nil()
+
+-- List(Vertex) V
+-- V := Cons(v1, Cons(v2, temp))
+
+/*
+-- Make a concrete graph
+Vertex v1, v2, v3, v4
+List(Vertex) V := [v1, v2, v3, v4]
+Edge e1 := MkEdge(v1, v2)
+Edge e2 := MkEdge(v2, v3)
+Edge e3 := MkEdge(v3, v4)
+List(Edge) E := [e1, e2, e3]
+Graph G1 := MakeGraph(V, E)
+
+-- Make abstract graphs that satisfy some properties and operate on them
+Graph G2
+FullyConnected(G2)
+
+Tree T
+
+Graph G3 := Product(G2, T)
+
+-- Highlight subparts of each graph (if possible)
+Path p1 := FindPath(G1)
+Graph G4 := Subgraph(G3)
+Selected(e2)
+*/

--- a/examples/graph-domain/graph1.sub
+++ b/examples/graph-domain/graph1.sub
@@ -18,3 +18,12 @@ Edge e4 := MkEdge(v3, v2)
 -- SelectedE(ef12)
 
 AutoLabel All
+Label v1 $\text{lemon pie}$
+Label v2 $\int_0^\infty x^2$
+Label v3 $\text{this is a tall} \\ \text{label with many} \\ \text{lines}$
+-- TODO: Parbox doesn't work
+-- $\parbox{15em}{I have discovered a truly marvelous proof of this,\\which this margin is too narrow to contain.}$
+
+Label e1 $\text{this is a really long label}$
+-- Label e2 $\frac{1}{e^x^2}$
+Label e2 $\frac{1}{e^x}$

--- a/examples/graph-domain/graph1.sub
+++ b/examples/graph-domain/graph1.sub
@@ -4,15 +4,19 @@ Vertex v1, v2, v3, v4
 Edge e1 := MkEdge(v1, v2)
 Edge e2 := MkEdge(v1, v3)
 Edge e3 := MkEdge(v3, v4)
-Edge e4 := MkEdge(v3, v2)
+-- Edge e4 := MkEdge(v3, v2) -- No cycle
+Edge e4 := MkEdge(v2, v3) -- Cycle
 
 AutoLabel All
-Label v1 $\text{this is another long label}$
+-- Label v1 $\text{this is another long label}$
+-- TODO: The longer labels won't work until the arrow positioning is fixed
+Label v1 $\text{another label}$
 Label v2 $\int_0^\infty x^2$
-Label v3 $\text{this is}\\\text{a tall label}\\\text{with many lines}$
+Label v3 $\text{this is}\\\text{a tall label}\\\text{with many lines}\\\text{so many}$
 Label v4 $v_4$
 
-Label e1 $\text{this is a really long label}$
+-- Label e1 $\text{this is a really long label}$
+Label e1 $\text{it's a label}$
 Label e2 $\frac{1}{e^x}$
-Label e3 $e_3$
+Label e3 $\text{another} \\ \text{very tall} \\ \text{label here}$
 Label e4 $e_4$

--- a/examples/graph-domain/graph1.sub
+++ b/examples/graph-domain/graph1.sub
@@ -1,0 +1,20 @@
+Graph G1
+Vertex v1, v2, v3, v4
+
+Edge e1 := MkEdge(v1, v2)
+Edge e2 := MkEdge(v1, v3)
+Edge e3 := MkEdge(v3, v4)
+Edge e4 := MkEdge(v3, v2)
+
+-- InV(v1, G1)
+-- InV(v2, G1)
+-- InE(e1, G1)
+
+-- Graph G2
+-- Face f1 := FindFace(G2)
+-- Vertex vf1 := FindVertex(f1)
+-- Vertex vf2 := FindVertex(G2)
+-- Edge ef12 := MkEdge(vf1, vf2)
+-- SelectedE(ef12)
+
+AutoLabel All

--- a/examples/graph-domain/graph1.sub
+++ b/examples/graph-domain/graph1.sub
@@ -6,24 +6,13 @@ Edge e2 := MkEdge(v1, v3)
 Edge e3 := MkEdge(v3, v4)
 Edge e4 := MkEdge(v3, v2)
 
--- InV(v1, G1)
--- InV(v2, G1)
--- InE(e1, G1)
-
--- Graph G2
--- Face f1 := FindFace(G2)
--- Vertex vf1 := FindVertex(f1)
--- Vertex vf2 := FindVertex(G2)
--- Edge ef12 := MkEdge(vf1, vf2)
--- SelectedE(ef12)
-
 AutoLabel All
-Label v1 $\text{lemon pie}$
+Label v1 $\text{this is another long label}$
 Label v2 $\int_0^\infty x^2$
-Label v3 $\text{this is a tall} \\ \text{label with many} \\ \text{lines}$
--- TODO: Parbox doesn't work
--- $\parbox{15em}{I have discovered a truly marvelous proof of this,\\which this margin is too narrow to contain.}$
+Label v3 $\text{this is}\\\text{a tall label}\\\text{with many lines}$
+Label v4 $v_4$
 
 Label e1 $\text{this is a really long label}$
--- Label e2 $\frac{1}{e^x^2}$
 Label e2 $\frac{1}{e^x}$
+Label e3 $e_3$
+Label e4 $e_4$

--- a/examples/graph-domain/notes.md
+++ b/examples/graph-domain/notes.md
@@ -1,0 +1,4 @@
+2/10/21/
+
+- What is the new syntax for parametric types in Domain? Do we have an example of that?
+- Can we autolabel substance objects with the right TeX?

--- a/examples/set-theory-domain/continuousmap.sty
+++ b/examples/set-theory-domain/continuousmap.sty
@@ -57,7 +57,7 @@ with Set X; Set Y; Set R1; Set R2 {
       -- rotation : 0.0
     }
 
-    encourage centerLabel(f.icon, f.text, 5.0)
+    encourage centerLabelAbove(f.icon, f.text, 5.0)
 
     -- Unused?
     -- f.centerFn = encourage centerArrow(f.icon, R1.icon, R2.icon)

--- a/packages/core/src/contrib/Constraints.ts
+++ b/packages/core/src/contrib/Constraints.ts
@@ -1,26 +1,26 @@
 import {
-  absVal,
-  add,
-  addN,
-  constOf,
-  constOfIf,
-  div,
-  EPS_DENOM,
-  fns,
-  gt,
-  inverse,
-  max,
-  min,
-  mul,
-  neg,
-  ops,
-  squared,
-  sub,
-  varOf,
-  ifCond,
-  lt,
-  eq,
-  and,
+    absVal,
+    add,
+    addN,
+    constOf,
+    constOfIf,
+    div,
+    EPS_DENOM,
+    fns,
+    gt,
+    inverse,
+    max,
+    min,
+    mul,
+    neg,
+    ops,
+    squared,
+    sub,
+    varOf,
+    ifCond,
+    lt,
+    eq,
+    and,
 } from "engine/Autodiff";
 import * as _ from "lodash";
 import { linePts } from "utils/OtherUtils";
@@ -31,491 +31,497 @@ import { canvasSize } from "renderer/ShapeDef";
  * Takes a `shapeType`, returns whether it's rectlike. (excluding squares)
  */
 export const isRectlike = (shapeType: string): boolean => {
-  return (
-    shapeType == "Rectangle" || shapeType == "Image" || shapeType == "Text"
-  );
+    return (
+        shapeType == "Rectangle" || shapeType == "Image" || shapeType == "Text"
+    );
 };
 
 /**
  * Takes a `shapeType`, returns whether it's linelike. (TODO: Account for arrowhead size)
  */
 export const isLinelike = (shapeType: string): boolean => {
-  return shapeType == "Line" || shapeType == "Arrow";
+    return shapeType == "Line" || shapeType == "Arrow";
 };
 
 export const objDict = {
-  /**
-   * Encourage the inputs to have the same value: `(x - y)^2`
-   */
-  equal: (x: VarAD, y: VarAD) => squared(sub(x, y)),
+    /**
+     * Encourage the inputs to have the same value: `(x - y)^2`
+     */
+    equal: (x: VarAD, y: VarAD) => squared(sub(x, y)),
 
-  /**
-   * Encourage shape `top` to be above shape `bottom`. Only works for shapes with property `center`.
-   */
-  above: (
-    [t1, top]: [string, any],
-    [t2, bottom]: [string, any],
-    offset = 100
-  ) =>
-    // (getY top - getY bottom - offset) ^ 2
-    squared(
-      sub(sub(top.center.contents[1], bottom.center.contents[1]), varOf(offset))
-    ),
+    /**
+     * Encourage shape `top` to be above shape `bottom`. Only works for shapes with property `center`.
+     */
+    above: (
+        [t1, top]: [string, any],
+        [t2, bottom]: [string, any],
+        offset = 100
+    ) =>
+        // (getY top - getY bottom - offset) ^ 2
+        squared(
+            sub(sub(top.center.contents[1], bottom.center.contents[1]), varOf(offset))
+        ),
 
-  /**
-   * Encourage shape `s1` to have the same center position as shape `s2`. Only works for shapes with property `center`.
-   */
-  sameCenter: ([t1, s1]: [string, any], [t2, s2]: [string, any]) =>
-    ops.vdistsq(fns.center(s1), fns.center(s2)),
+    /**
+     * Encourage shape `s1` to have the same center position as shape `s2`. Only works for shapes with property `center`.
+     */
+    sameCenter: ([t1, s1]: [string, any], [t2, s2]: [string, any]) =>
+        ops.vdistsq(fns.center(s1), fns.center(s2)),
 
-  /**
-   * Try to repel shapes `s1` and `s2` with some weight.
-   */
-  repel: ([t1, s1]: [string, any], [t2, s2]: [string, any], weight = 10.0) => {
-    // HACK: `repel` typically needs to have a weight multiplied since its magnitude is small
-    // TODO: find this out programmatically
-    const repelWeight = 10e6;
+    /**
+     * Try to repel shapes `s1` and `s2` with some weight.
+     */
+    repel: ([t1, s1]: [string, any], [t2, s2]: [string, any], weight = 10.0) => {
+        // HACK: `repel` typically needs to have a weight multiplied since its magnitude is small
+        // TODO: find this out programmatically
+        const repelWeight = 10e6;
 
-    let res;
+        let res;
 
-    // Repel a line `s1` from another shape `s2` with a center.
-    if (isLinelike(t1)) {
-      const line = s1;
-      const c2 = fns.center(s2);
-      const lineSamplePts = sampleSeg(linePts(line));
-      const allForces = addN(
-        lineSamplePts.map((p) => repelPt(constOfIf(weight), c2, p))
-      );
-      res = mul(constOfIf(weight), allForces);
-    } else {
-      // Repel any two shapes with a center.
-      // 1 / (d^2(cx, cy) + eps)
-      res = inverse(ops.vdistsq(fns.center(s1), fns.center(s2)));
-    }
+        // Repel a line `s1` from another shape `s2` with a center.
+        if (isLinelike(t1)) {
+            const line = s1;
+            const c2 = fns.center(s2);
+            const lineSamplePts = sampleSeg(linePts(line));
+            const allForces = addN(
+                lineSamplePts.map((p) => repelPt(constOfIf(weight), c2, p))
+            );
+            res = mul(constOfIf(weight), allForces);
+        } else {
+            // Repel any two shapes with a center.
+            // 1 / (d^2(cx, cy) + eps)
+            res = inverse(ops.vdistsq(fns.center(s1), fns.center(s2)));
+        }
 
-    return mul(res, constOf(repelWeight));
-  },
+        return mul(res, constOf(repelWeight));
+    },
 
-  /**
-   * Try to center the arrow `arr` between the shapes `s2` and `s3` (they can also be any shapes with a center).
-   */
-  centerArrow: (
-    [t1, arr]: [string, any],
-    [t2, text1]: [string, any],
-    [t3, text2]: [string, any]
-  ): VarAD => {
-    const spacing = varOf(1.1); // arbitrary
+    /**
+     * Try to center the arrow `arr` between the shapes `s2` and `s3` (they can also be any shapes with a center).
+     */
+    centerArrow: (
+        [t1, arr]: [string, any],
+        [t2, text1]: [string, any],
+        [t3, text2]: [string, any]
+    ): VarAD => {
+        const spacing = varOf(1.1); // arbitrary
 
-    if (isLinelike(t1) && isRectlike(t2) && isRectlike(t3)) {
-      // HACK: Arbitrarily pick the height of the text
-      // [spacing * getNum text1 "h", negate $ 2 * spacing * getNum text2 "h"]
-      return centerArrow2(arr, fns.center(text1), fns.center(text2), [
-        mul(spacing, text1.h.contents),
-        neg(mul(text2.h.contents, spacing)),
-      ]);
-    } else throw new Error(`${[t1, t2, t3]} not supported for centerArrow`);
-  },
+        if (isLinelike(t1) && isRectlike(t2) && isRectlike(t3)) {
+            // HACK: Arbitrarily pick the height of the text
+            // [spacing * getNum text1 "h", negate $ 2 * spacing * getNum text2 "h"]
+            return centerArrow2(arr, fns.center(text1), fns.center(text2), [
+                mul(spacing, text1.h.contents),
+                neg(mul(text2.h.contents, spacing)),
+            ]);
+        } else throw new Error(`${[t1, t2, t3]} not supported for centerArrow`);
+    },
 
-  /**
-   * Encourage shape `bottom` to be below shape `top`. Only works for shapes with property `center`.
-   */
-  below: (
-    [t1, bottom]: [string, any],
-    [t2, top]: [string, any],
-    offset = 100
-  ) =>
-    // TODO: can this be made more efficient (code-wise) by calling "above" and swapping arguments?
-    squared(
-      sub(
-        sub(top.center.contents[1], bottom.center.contents[1]),
-        constOfIf(offset)
-      )
-    ),
+    /**
+     * Encourage shape `bottom` to be below shape `top`. Only works for shapes with property `center`.
+     */
+    below: (
+        [t1, bottom]: [string, any],
+        [t2, top]: [string, any],
+        offset = 100
+    ) =>
+        // TODO: can this be made more efficient (code-wise) by calling "above" and swapping arguments?
+        squared(
+            sub(
+                sub(top.center.contents[1], bottom.center.contents[1]),
+                constOfIf(offset)
+            )
+        ),
 
-  /**
-   * Try to center a label `s2` with respect to some shape `s1`.
-   */
-  centerLabel: (
-    [t1, s1]: [string, any],
-    [t2, s2]: [string, any],
-    w: number
-  ): VarAD => {
-    if (isLinelike(t1) && isRectlike(t2)) {
-      const [arr, text] = [s1, s2];
-      const midpt = ops.vdiv(
-        ops.vadd(arr.start.contents, arr.end.contents),
-        constOf(2.0)
-      );
-      // The distance between the midpoint of the arrow and the center of the text should be approx. the label's "radius" plus some padding
-      const padding = constOf(10);
-      // is (x-y)^2 = x^2-2xy+y^2 better? or x^2 - y^2?
-      return add(
-        sub(ops.vdistsq(midpt, text.center.contents), squared(text.w.contents)),
-        squared(padding)
-      );
+    centerLabelAbove: (
+        [t1, s1]: [string, any],
+        [t2, s2]: [string, any],
+        w: number
+    ): VarAD => {
+        if (isLinelike(t1) && isRectlike(t2)) {
+            const [arr, text] = [s1, s2];
+            const mx = div(
+                add(arr.start.contents[0], arr.end.contents[0]),
+                constOf(2.0)
+            );
+            const my = div(
+                add(arr.start.contents[1], arr.end.contents[1]),
+                constOf(2.0)
+            );
 
-      // Old code, to adapt or remove (TODO)
-      // const mx = div(
-      //     add(arr.start.contents[0], arr.end.contents[0]),
-      //     constOf(2.0)
-      // );
-      // const my = div(
-      //     add(arr.start.contents[1], arr.end.contents[1]),
-      //     constOf(2.0)
-      // );
+            // entire equation is (mx - lx) ^ 2 + (my + 1.1 * text.h - ly) ^ 2 from Functions.hs - split it into two halves below for readability
+            const lh = squared(sub(mx, text.center.contents[0]));
+            const rh = squared(
+                sub(
+                    add(my, mul(text.h.contents, constOf(1.1))),
+                    text.center.contents[1]
+                )
+            );
+            return mul(add(lh, rh), constOfIf(w));
+        } else throw Error("unsupported shapes");
+    },
 
-      // // entire equation is (mx - lx) ^ 2 + (my + 1.1 * text.h - ly) ^ 2 from Functions.hs - split it into two halves below for readability
-      // const lh = squared(sub(mx, text.center.contents[0]));
-      // const rh = squared(
-      //     sub(
-      //         add(my, mul(text.h.contents, constOf(1.1))),
-      //         text.center.contents[1]
-      //     )
-      // );
-      // return mul(add(lh, rh), constOfIf(w));
-    } else if (isRectlike(t1) && isRectlike(t2)) {
-      // Try to center label in the rectangle
-      // TODO: This should be applied generically on any two GPIs with a center
-      return objDict.sameCenter([t1, s1], [t2, s2]);
-    } else throw new Error(`${[t1, t2]} not supported for centerLabel`);
-  },
+    /**
+     * Try to center a label `s2` with respect to some shape `s1`.
+     */
+    centerLabel: (
+        [t1, s1]: [string, any],
+        [t2, s2]: [string, any],
+        w: number
+    ): VarAD => {
+        if (isLinelike(t1) && isRectlike(t2)) {
+            // The distance between the midpoint of the arrow and the center of the text should be approx. the label's "radius" plus some padding
+            const [arr, text] = [s1, s2];
+            const midpt = ops.vdiv(
+                ops.vadd(arr.start.contents, arr.end.contents),
+                constOf(2.0)
+            );
+            const padding = constOf(10);
+            // is (x-y)^2 = x^2-2xy+y^2 better? or x^2 - y^2?
+            return add(
+                sub(ops.vdistsq(midpt, text.center.contents), squared(text.w.contents)),
+                squared(padding)
+            );
+        } else if (isRectlike(t1) && isRectlike(t2)) {
+            // Try to center label in the rectangle
+            // TODO: This should be applied generically on any two GPIs with a center
+            return objDict.sameCenter([t1, s1], [t2, s2]);
+        } else throw new Error(`${[t1, t2]} not supported for centerLabel`);
+    },
 
-  /**
-   * Try to place shape `s1` near shape `s2` (putting their centers at the same place).
-   */
-  near: ([t1, s1]: [string, any], [t2, s2]: [string, any], offset = 10.0) => {
-    // This only works for two objects with centers (x,y)
-    const res = absVal(ops.vdistsq(fns.center(s1), fns.center(s2)));
-    return sub(res, squared(constOfIf(offset)));
-  },
+    /**
+     * Try to place shape `s1` near shape `s2` (putting their centers at the same place).
+     */
+    near: ([t1, s1]: [string, any], [t2, s2]: [string, any], offset = 10.0) => {
+        // This only works for two objects with centers (x,y)
+        const res = absVal(ops.vdistsq(fns.center(s1), fns.center(s2)));
+        return sub(res, squared(constOfIf(offset)));
+    },
 
-  /**
-   * Try to place shape `s1` near a location `(x, y)`.
-   */
-  nearPt: ([t1, s1]: [string, any], x: any, y: any) => {
-    return ops.vdistsq(fns.center(s1), [constOfIf(x), constOfIf(y)]);
-  },
+    /**
+     * Try to place shape `s1` near a location `(x, y)`.
+     */
+    nearPt: ([t1, s1]: [string, any], x: any, y: any) => {
+        return ops.vdistsq(fns.center(s1), [constOfIf(x), constOfIf(y)]);
+    },
 };
 
 export const constrDict = {
-  /**
-   * Require that a shape have a size less than some constant maximum, based on the type of the shape.
-   */
-  maxSize: ([shapeType, props]: [string, any]) => {
-    const limit = Math.max(...canvasSize);
-    switch (shapeType) {
-      case "Circle":
-        return sub(props.r.contents, constOf(limit / 6.0));
-      case "Square":
-        return sub(props.side.contents, constOf(limit / 3.0));
-      default:
-        // HACK: report errors systematically
-        throw new Error(`${shapeType} doesn't have a maxSize`);
-    }
-  },
+    /**
+     * Require that a shape have a size less than some constant maximum, based on the type of the shape.
+     */
+    maxSize: ([shapeType, props]: [string, any]) => {
+        const limit = Math.max(...canvasSize);
+        switch (shapeType) {
+            case "Circle":
+                return sub(props.r.contents, constOf(limit / 6.0));
+            case "Square":
+                return sub(props.side.contents, constOf(limit / 3.0));
+            default:
+                // HACK: report errors systematically
+                throw new Error(`${shapeType} doesn't have a maxSize`);
+        }
+    },
 
-  /**
-   * Require that a shape have a size greater than some constant minimum, based on the type of the shape.
-   */
-  minSize: ([shapeType, props]: [string, any]) => {
-    const limit = 20;
+    /**
+     * Require that a shape have a size greater than some constant minimum, based on the type of the shape.
+     */
+    minSize: ([shapeType, props]: [string, any]) => {
+        const limit = 20;
 
-    if (isLinelike(shapeType)) {
-      const minLen = 50;
-      const vec = ops.vsub(props.end.contents, props.start.contents);
-      return sub(constOf(minLen), ops.vnorm(vec));
-    }
+        if (isLinelike(shapeType)) {
+            const minLen = 50;
+            const vec = ops.vsub(props.end.contents, props.start.contents);
+            return sub(constOf(minLen), ops.vnorm(vec));
+        }
 
-    switch (shapeType) {
-      case "Circle":
-        return sub(constOf(limit), props.r.contents);
-      case "Square":
-        return sub(constOf(limit), props.side.contents);
-      default:
-        // HACK: report errors systematically
-        throw new Error(`${shapeType} doesn't have a minSize`);
-    }
-  },
+        switch (shapeType) {
+            case "Circle":
+                return sub(constOf(limit), props.r.contents);
+            case "Square":
+                return sub(constOf(limit), props.side.contents);
+            default:
+                // HACK: report errors systematically
+                throw new Error(`${shapeType} doesn't have a minSize`);
+        }
+    },
 
-  /**
-   * Require that a shape `s1` contains another shape `s2`, based on the type of the shape, and with an optional `offset` between the sizes of the shapes (e.g. if `s1` should contain `s2` with margin `offset`).
-   */
-  contains: (
-    [t1, s1]: [string, any],
-    [t2, s2]: [string, any],
-    offset: VarAD
-  ) => {
-    if (t1 === "Circle" && t2 === "Circle") {
-      const d = ops.vdist(fns.center(s1), fns.center(s2));
-      const o = offset
-        ? sub(sub(s1.r.contents, s2.r.contents), offset)
-        : sub(s1.r.contents, s2.r.contents);
-      const res = sub(d, o);
-      return res;
-    } else if (t1 === "Circle" && isRectlike(t2)) {
-      const d = ops.vdist(fns.center(s1), fns.center(s2));
-      const textR = max(s2.w.contents, s2.h.contents);
-      return add(sub(d, s1.r.contents), textR);
-    } else if (isRectlike(t1) && t2 === "Circle") {
-      // contains [GPI r@("Rectangle", _), GPI c@("Circle", _), Val (FloatV padding)] =
-      // -- HACK: reusing test impl, revert later
-      //    let r_l = min (getNum r "w") (getNum r "h") / 2
-      //        diff = r_l - getNum c "r"
-      //    in dist (getX r, getY r) (getX c, getY c) - diff + padding
+    /**
+     * Require that a shape `s1` contains another shape `s2`, based on the type of the shape, and with an optional `offset` between the sizes of the shapes (e.g. if `s1` should contain `s2` with margin `offset`).
+     */
+    contains: (
+        [t1, s1]: [string, any],
+        [t2, s2]: [string, any],
+        offset: VarAD
+    ) => {
+        if (t1 === "Circle" && t2 === "Circle") {
+            const d = ops.vdist(fns.center(s1), fns.center(s2));
+            const o = offset
+                ? sub(sub(s1.r.contents, s2.r.contents), offset)
+                : sub(s1.r.contents, s2.r.contents);
+            const res = sub(d, o);
+            return res;
+        } else if (t1 === "Circle" && isRectlike(t2)) {
+            const d = ops.vdist(fns.center(s1), fns.center(s2));
+            const textR = max(s2.w.contents, s2.h.contents);
+            return add(sub(d, s1.r.contents), textR);
+        } else if (isRectlike(t1) && t2 === "Circle") {
+            // contains [GPI r@("Rectangle", _), GPI c@("Circle", _), Val (FloatV padding)] =
+            // -- HACK: reusing test impl, revert later
+            //    let r_l = min (getNum r "w") (getNum r "h") / 2
+            //        diff = r_l - getNum c "r"
+            //    in dist (getX r, getY r) (getX c, getY c) - diff + padding
 
-      // TODO: `rL` is probably a hack for dimensions
-      const rL = div(min(s1.w.contents, s1.h.contents), varOf(2.0));
-      const diff = sub(rL, s2.r.contents);
-      const d = ops.vdist(fns.center(s1), fns.center(s2));
-      return add(sub(d, diff), offset);
-    } else if (t1 === "Square" && t2 === "Circle") {
-      // dist (outerx, outery) (innerx, innery) - (0.5 * outer.side - inner.radius)
-      const sq = s1.center.contents;
-      const d = ops.vdist(sq, fns.center(s2));
-      return sub(d, sub(mul(constOf(0.5), s1.side.contents), s2.r.contents));
-    } else if (isRectlike(t1) && isRectlike(t2)) {
-      // contains [GPI r@("Rectangle", _), GPI l@("Text", _), Val (FloatV padding)] =
-      // TODO: implement precisely, max (w, h)? How about diagonal case?
-      // dist (getX l, getY l) (getX r, getY r) - getNum r "w" / 2 +
-      //   getNum l "w" / 2 + padding
+            // TODO: `rL` is probably a hack for dimensions
+            const rL = div(min(s1.w.contents, s1.h.contents), varOf(2.0));
+            const diff = sub(rL, s2.r.contents);
+            const d = ops.vdist(fns.center(s1), fns.center(s2));
+            return add(sub(d, diff), offset);
+        } else if (t1 === "Square" && t2 === "Circle") {
+            // dist (outerx, outery) (innerx, innery) - (0.5 * outer.side - inner.radius)
+            const sq = s1.center.contents;
+            const d = ops.vdist(sq, fns.center(s2));
+            return sub(d, sub(mul(constOf(0.5), s1.side.contents), s2.r.contents));
+        } else if (isRectlike(t1) && isRectlike(t2)) {
+            // contains [GPI r@("Rectangle", _), GPI l@("Text", _), Val (FloatV padding)] =
+            // TODO: implement precisely, max (w, h)? How about diagonal case?
+            // dist (getX l, getY l) (getX r, getY r) - getNum r "w" / 2 +
+            //   getNum l "w" / 2 + padding
 
-      // TODO: This uses an approximation of each rect:
-      // Containee overapproximation: square of its max (w,h)^2
-      // Container underapproximation: square of its min (w,h)^2
-      // s1 `contains` s2
-      // (Is `max` bad for opt bc discontinuous?)
-      const a1 = ops.vdist(fns.center(s1), fns.center(s2));
-      const a2 = div(min(s1.h.contents, s1.w.contents), constOf(2.0));
-      const a3 = div(max(s2.h.contents, s2.w.contents), constOf(2.0));
-      const c = offset ? offset : constOf(0.0);
-      return add(add(sub(a1, a2), a3), c);
-    } else if (t1 === "Square" && isRectlike(t2)) {
-      const a1 = ops.vdist(fns.center(s1), fns.center(s2));
-      const a2 = div(s1.side.contents, constOf(2.0));
-      const a3 = div(s2.w.contents, constOf(2.0)); // TODO: Implement w/ exact text dims
-      const c = offset ? offset : constOf(0.0);
-      return add(add(sub(a1, a2), a3), c);
-    } else if (t1 === "Square" && isLinelike(t2)) {
-      const [[startX, startY], [endX, endY]] = linePts(s2);
-      const [x, y] = fns.center(s1);
+            // TODO: This uses an approximation of each rect:
+            // Containee overapproximation: square of its max (w,h)^2
+            // Container underapproximation: square of its min (w,h)^2
+            // s1 `contains` s2
+            // (Is `max` bad for opt bc discontinuous?)
+            const a1 = ops.vdist(fns.center(s1), fns.center(s2));
+            const a2 = div(min(s1.h.contents, s1.w.contents), constOf(2.0));
+            const a3 = div(max(s2.h.contents, s2.w.contents), constOf(2.0));
+            const c = offset ? offset : constOf(0.0);
+            return add(add(sub(a1, a2), a3), c);
+        } else if (t1 === "Square" && isRectlike(t2)) {
+            const a1 = ops.vdist(fns.center(s1), fns.center(s2));
+            const a2 = div(s1.side.contents, constOf(2.0));
+            const a3 = div(s2.w.contents, constOf(2.0)); // TODO: Implement w/ exact text dims
+            const c = offset ? offset : constOf(0.0);
+            return add(add(sub(a1, a2), a3), c);
+        } else if (t1 === "Square" && isLinelike(t2)) {
+            const [[startX, startY], [endX, endY]] = linePts(s2);
+            const [x, y] = fns.center(s1);
 
-      const r = div(s1.side.contents, constOf(2.0));
-      const f = constOf(0.75); // 0.25 padding
-      //     (lx, ly) = ((x - side / 2) * 0.75, (y - side / 2) * 0.75)
-      //     (rx, ry) = ((x + side / 2) * 0.75, (y + side / 2) * 0.75)
-      // in inRange startX lx rx + inRange startY ly ry + inRange endX lx rx +
-      //    inRange endY ly ry
-      const [lx, ly] = [mul(sub(x, r), f), mul(sub(y, r), f)];
-      const [rx, ry] = [mul(add(x, r), f), mul(add(y, r), f)];
-      return addN([
-        constrDict.inRange(startX, lx, rx),
-        constrDict.inRange(startY, ly, ry),
-        constrDict.inRange(endX, lx, rx),
-        constrDict.inRange(endY, ly, ry),
-      ]);
-    } else throw new Error(`${[t1, t2]} not supported for contains`);
-  },
+            const r = div(s1.side.contents, constOf(2.0));
+            const f = constOf(0.75); // 0.25 padding
+            //     (lx, ly) = ((x - side / 2) * 0.75, (y - side / 2) * 0.75)
+            //     (rx, ry) = ((x + side / 2) * 0.75, (y + side / 2) * 0.75)
+            // in inRange startX lx rx + inRange startY ly ry + inRange endX lx rx +
+            //    inRange endY ly ry
+            const [lx, ly] = [mul(sub(x, r), f), mul(sub(y, r), f)];
+            const [rx, ry] = [mul(add(x, r), f), mul(add(y, r), f)];
+            return addN([
+                constrDict.inRange(startX, lx, rx),
+                constrDict.inRange(startY, ly, ry),
+                constrDict.inRange(endX, lx, rx),
+                constrDict.inRange(endY, ly, ry),
+            ]);
+        } else throw new Error(`${[t1, t2]} not supported for contains`);
+    },
 
-  /**
-   * Require that a shape `s1` is disjoint from shape `s2`, based on the type of the shape, and with an optional `offset` between them (e.g. if `s1` should be disjoint from `s2` with margin `offset`).
-   */
-  disjoint: (
-    [t1, s1]: [string, any],
-    [t2, s2]: [string, any],
-    offset = 5.0
-  ) => {
-    if (t1 === "Circle" && t2 === "Circle") {
-      const d = ops.vdist(fns.center(s1), fns.center(s2));
-      const o = [s1.r.contents, s2.r.contents, varOf(10.0)];
-      return sub(addN(o), d);
-    } else if (isRectlike(t1) && isLinelike(t2)) {
-      const [text, seg] = [s1, s2];
-      const centerT = fns.center(text);
-      const endpts = linePts(seg);
-      const cp = closestPt_PtSeg(centerT, endpts);
-      const lenApprox = div(text.w.contents, constOf(2.0));
-      return sub(add(lenApprox, constOfIf(offset)), ops.vdist(centerT, cp));
-    } else if (isRectlike(t1) && isRectlike(t2)) {
-      // Arbitrarily using x size, TODO: fix this to work more generally
-      // TODO generalize the shape types
-      // TODO: Should this be min or max...?
-      const r1 = mul(constOf(0.5), min(s1.w.contents, s1.h.contents));
-      const r2 = mul(constOf(0.5), min(s2.w.contents, s2.h.contents));
-      return noIntersect(s1.center.contents, r1, s2.center.contents, r2);
-    } else {
-      // TODO (new case): I guess we might need Rectangle disjoint from polyline? Unless they repel each other?
-      throw new Error(`${[t1, t2]} not supported for disjoint`);
-    }
-  },
+    /**
+     * Require that a shape `s1` is disjoint from shape `s2`, based on the type of the shape, and with an optional `offset` between them (e.g. if `s1` should be disjoint from `s2` with margin `offset`).
+     */
+    disjoint: (
+        [t1, s1]: [string, any],
+        [t2, s2]: [string, any],
+        offset = 5.0
+    ) => {
+        if (t1 === "Circle" && t2 === "Circle") {
+            const d = ops.vdist(fns.center(s1), fns.center(s2));
+            const o = [s1.r.contents, s2.r.contents, varOf(10.0)];
+            return sub(addN(o), d);
+        } else if (isRectlike(t1) && isLinelike(t2)) {
+            const [text, seg] = [s1, s2];
+            const centerT = fns.center(text);
+            const endpts = linePts(seg);
+            const cp = closestPt_PtSeg(centerT, endpts);
+            const lenApprox = div(text.w.contents, constOf(2.0));
+            return sub(add(lenApprox, constOfIf(offset)), ops.vdist(centerT, cp));
+        } else if (isRectlike(t1) && isRectlike(t2)) {
+            // Arbitrarily using x size, TODO: fix this to work more generally
+            const r1 = mul(constOf(0.5), min(s1.w.contents, s1.h.contents));
+            const r2 = mul(constOf(0.5), min(s2.w.contents, s2.h.contents));
+            return noIntersect(s1.center.contents, r1, s2.center.contents, r2);
+        } else {
+            // TODO (new case): I guess we might need Rectangle disjoint from polyline? Unless they repel each other?
+            throw new Error(`${[t1, t2]} not supported for disjoint`);
+        }
+    },
 
-  /**
-   * Require that two linelike shapes `l1` and `l2` are not crossing (with optional offset `offset` -- TODO: currently not accounted for).
-   */
-  notCrossing: (
-    [t1, s1]: [string, any],
-    [t2, s2]: [string, any],
-    offset = 5.0
-  ) => {
-    if (isLinelike(t1) && isLinelike(t2)) {
-      // If the lines intersect, return the smallest distance squared between their endpoints (assuming the starts and ends "correspond" -- but not geometrically necessary.) TODO -- Try every pair of distances? (end -> start)
-      // Else, return 0.
-      // The idea is to minimize the distance between the 'crossing' endpoints, so the lines uncross. Though I guess taking the min may make this discontinuous?
+    /**
+     * Require that two linelike shapes `l1` and `l2` are not crossing (with optional offset `offset` -- TODO: currently not accounted for).
+     */
+    notCrossing: (
+        [t1, s1]: [string, any],
+        [t2, s2]: [string, any],
+        offset = 5.0
+    ) => {
+        if (isLinelike(t1) && isLinelike(t2)) {
+            // If the lines intersect, return the smallest distance squared between their endpoints (assuming the starts and ends "correspond" -- but not geometrically necessary.) TODO -- Try every pair of distances? (end -> start)
+            // Else, return 0.
+            // The idea is to minimize the distance between the 'crossing' endpoints, so the lines uncross. Though I guess taking the min may make this discontinuous?
 
-      return ifCond(
-        intersects(
-          s1.start.contents,
-          s1.end.contents,
-          s2.start.contents,
-          s2.end.contents
-        ),
-        min(
-          ops.vdistsq(s1.start.contents, s2.start.contents),
-          ops.vdistsq(s1.start.contents, s2.start.contents)
-        ),
-        constOf(0)
-      );
-    } else {
-      throw new Error(`${[t1, t2]} not supported for notCrossing`);
-    }
-  },
-  /**
-   * Require that shape `s1` is smaller than `s2` with some offset `offset`.
-   */
-  smallerThan: ([t1, s1]: [string, any], [t2, s2]: [string, any]) => {
-    // s1 is smaller than s2
-    const offset = mul(varOf(0.4), s2.r.contents);
-    return sub(sub(s1.r.contents, s2.r.contents), offset);
-  },
+            return ifCond(
+                intersects(
+                    s1.start.contents,
+                    s1.end.contents,
+                    s2.start.contents,
+                    s2.end.contents
+                ),
+                min(
+                    ops.vdistsq(s1.start.contents, s2.start.contents),
+                    ops.vdistsq(s1.start.contents, s2.start.contents)
+                ),
+                constOf(0)
+            );
+        } else {
+            throw new Error(`${[t1, t2]} not supported for notCrossing`);
+        }
+    },
+    /**
+     * Require that shape `s1` is smaller than `s2` with some offset `offset`.
+     */
+    smallerThan: ([t1, s1]: [string, any], [t2, s2]: [string, any]) => {
+        // s1 is smaller than s2
+        const offset = mul(varOf(0.4), s2.r.contents);
+        return sub(sub(s1.r.contents, s2.r.contents), offset);
+    },
 
-  /**
-   * Require that shape `s1` outside of `s2` with some offset `padding`.
-   */
-  outsideOf: (
-    [t1, s1]: [string, any],
-    [t2, s2]: [string, any],
-    padding = 10
-  ) => {
-    if (isRectlike(t1) && t2 === "Circle") {
-      const textR = max(s1.w.contents, s1.h.contents);
-      const d = ops.vdist(fns.center(s1), fns.center(s2));
-      return sub(add(add(s2.r.contents, textR), constOfIf(padding)), d);
-    } else throw new Error(`${[t1, t2]} not supported for outsideOf`);
-  },
+    /**
+     * Require that shape `s1` outside of `s2` with some offset `padding`.
+     */
+    outsideOf: (
+        [t1, s1]: [string, any],
+        [t2, s2]: [string, any],
+        padding = 10
+    ) => {
+        if (isRectlike(t1) && t2 === "Circle") {
+            const textR = max(s1.w.contents, s1.h.contents);
+            const d = ops.vdist(fns.center(s1), fns.center(s2));
+            return sub(add(add(s2.r.contents, textR), constOfIf(padding)), d);
+        } else throw new Error(`${[t1, t2]} not supported for outsideOf`);
+    },
 
-  /**
-   * Require that shape `s1` overlaps shape `s2` with some offset `padding`.
-   */
-  overlapping: (
-    [t1, s1]: [string, any],
-    [t2, s2]: [string, any],
-    padding = 10
-  ) => {
-    if (t1 === "Circle" && t2 === "Circle") {
-      return looseIntersect(
-        fns.center(s1),
-        s1.r.contents,
-        fns.center(s2),
-        s2.r.contents,
-        constOfIf(padding)
-      );
-    } else throw new Error(`${[t1, t2]} not supported for overlapping`);
-  },
+    /**
+     * Require that shape `s1` overlaps shape `s2` with some offset `padding`.
+     */
+    overlapping: (
+        [t1, s1]: [string, any],
+        [t2, s2]: [string, any],
+        padding = 10
+    ) => {
+        if (t1 === "Circle" && t2 === "Circle") {
+            return looseIntersect(
+                fns.center(s1),
+                s1.r.contents,
+                fns.center(s2),
+                s2.r.contents,
+                constOfIf(padding)
+            );
+        } else throw new Error(`${[t1, t2]} not supported for overlapping`);
+    },
 
-  /**
-   * Require that shape `s1` is tangent to shape `s2`.
-   */
-  tangentTo: ([t1, s1]: [string, any], [t2, s2]: [string, any]) => {
-    if (t1 === "Circle" && t2 === "Circle") {
-      const d = ops.vdist(fns.center(s1), fns.center(s2));
-      const r1 = s1.r.contents;
-      const r2 = s2.r.contents;
-      // Since we want equality
-      return absVal(sub(d, sub(r1, r2)));
-    } else throw new Error(`${[t1, t2]} not supported for tangentTo`);
-  },
+    /**
+     * Require that shape `s1` is tangent to shape `s2`.
+     */
+    tangentTo: ([t1, s1]: [string, any], [t2, s2]: [string, any]) => {
+        if (t1 === "Circle" && t2 === "Circle") {
+            const d = ops.vdist(fns.center(s1), fns.center(s2));
+            const r1 = s1.r.contents;
+            const r2 = s2.r.contents;
+            // Since we want equality
+            return absVal(sub(d, sub(r1, r2)));
+        } else throw new Error(`${[t1, t2]} not supported for tangentTo`);
+    },
 
-  /**
-   * Require that label `s2` is at a distance of `offset` from a point-like shape `s1`.
-   */
-  atDist: ([t1, s1]: [string, any], [t2, s2]: [string, any], offset: VarAD) => {
-    // TODO: Account for the size/radius of the initial point, rather than just the center
+    /**
+     * Require that label `s2` is at a distance of `offset` from a point-like shape `s1`.
+     */
+    atDist: ([t1, s1]: [string, any], [t2, s2]: [string, any], offset: VarAD) => {
+        // TODO: Account for the size/radius of the initial point, rather than just the center
 
-    if (isRectlike(t2)) {
-      let pt;
-      if (isLinelike(t1)) {
-        // Position label close to the arrow's end
-        pt = { x: s1.end.contents[0], y: s1.end.contents[1] };
-      } else {
-        // Only assume shape1 has a center
-        pt = { x: s1.center.contents[0], y: s1.center.contents[1] };
-      }
+        if (isRectlike(t2)) {
+            let pt;
+            if (isLinelike(t1)) {
+                // Position label close to the arrow's end
+                pt = { x: s1.end.contents[0], y: s1.end.contents[1] };
+            } else {
+                // Only assume shape1 has a center
+                pt = { x: s1.center.contents[0], y: s1.center.contents[1] };
+            }
 
-      // Get polygon of text (box)
-      // TODO: Make this a GPI property
-      // TODO: Do this properly; Port the matrix stuff in `textPolygonFn` / `textPolygonFn2` in Shapes.hs
-      // I wrote a version simplified to work for rectangles
-      const text = s2;
-      const textCenter = fns.center(text);
-      const rect = bbox(textCenter, text.w.contents, text.h.contents);
+            // Get polygon of text (box)
+            // TODO: Make this a GPI property
+            // TODO: Do this properly; Port the matrix stuff in `textPolygonFn` / `textPolygonFn2` in Shapes.hs
+            // I wrote a version simplified to work for rectangles
+            const text = s2;
+            const textCenter = fns.center(text);
+            const rect = bbox(textCenter, text.w.contents, text.h.contents);
 
-      // TODO: Rewrite this with `ifCond`
-      // If the point is inside the box, push it outside w/ `noIntersect`
-      if (pointInBox(pt, rect)) {
-        return noIntersect(
-          textCenter,
-          text.w.contents,
-          fns.center(s1),
-          constOf(2.0)
-        );
-      } else {
-        // If the point is outside the box, try to get the distance from the point to equal the desired distance
-        const dsqRes = dsqBP(pt, rect);
-        const WEIGHT = 1;
-        return mul(constOf(WEIGHT), equalHard(dsqRes, squared(offset)));
-      }
-    } else {
-      throw Error(`unsupported shapes for 'atDist': ${t1}, ${t2}`);
-    }
-  },
+            // TODO: Rewrite this with `ifCond`
+            // If the point is inside the box, push it outside w/ `noIntersect`
+            if (pointInBox(pt, rect)) {
+                return noIntersect(
+                    textCenter,
+                    text.w.contents,
+                    fns.center(s1),
+                    constOf(2.0)
+                );
+            } else {
+                // If the point is outside the box, try to get the distance from the point to equal the desired distance
+                const dsqRes = dsqBP(pt, rect);
+                const WEIGHT = 1;
+                return mul(constOf(WEIGHT), equalHard(dsqRes, squared(offset)));
+            }
+        } else {
+            throw Error(`unsupported shapes for 'atDist': ${t1}, ${t2}`);
+        }
+    },
 
-  /**
-   * Require that the vector defined by `(q, p)` is perpendicular from the vector defined by `(r, p)`.
-   */
-  perpendicular: (q: VarAD[], p: VarAD[], r: VarAD[]): VarAD => {
-    const v1 = ops.vsub(q, p);
-    const v2 = ops.vsub(r, p);
-    const dotProd = ops.vdot(v1, v2);
-    return equalHard(dotProd, constOf(0.0));
-  },
+    /**
+     * Require that the vector defined by `(q, p)` is perpendicular from the vector defined by `(r, p)`.
+     */
+    perpendicular: (q: VarAD[], p: VarAD[], r: VarAD[]): VarAD => {
+        const v1 = ops.vsub(q, p);
+        const v2 = ops.vsub(r, p);
+        const dotProd = ops.vdot(v1, v2);
+        return equalHard(dotProd, constOf(0.0));
+    },
 
-  /**
-   * Require that the value `x` is in the range defined by `[x0, x1]`.
-   */
-  inRange: (x: VarAD, x0: VarAD, x1: VarAD) => {
-    return mul(sub(x, x0), sub(x, x1));
-  },
+    /**
+     * Require that the value `x` is in the range defined by `[x0, x1]`.
+     */
+    inRange: (x: VarAD, x0: VarAD, x1: VarAD) => {
+        return mul(sub(x, x0), sub(x, x1));
+    },
 
-  /**
-   * Require that the value `x` is less than the value `y`
-   */
-  equal: (x: VarAD, y: VarAD) => {
-    return equalHard(x, y);
-  },
+    /**
+     * Require that the value `x` is less than the value `y`
+     */
+    equal: (x: VarAD, y: VarAD) => {
+        return equalHard(x, y);
+    },
 
-  /**
-   * Require that the value `x` is less than the value `y` with optional offset `padding`
-   */
-  lessThan: (x: VarAD, y: VarAD, padding = 0) => {
-    return add(sub(x, y), constOfIf(padding));
-  },
+    /**
+     * Require that the value `x` is less than the value `y` with optional offset `padding`
+     */
+    lessThan: (x: VarAD, y: VarAD, padding = 0) => {
+        return add(sub(x, y), constOfIf(padding));
+    },
 
-  /**
-   * Require that the value `x` is less than the value `y`, with steeper penalty
-   */
-  lessThanSq: (x: VarAD, y: VarAD) => {
-    // if x < y then 0 else (x - y)^2
-    return ifCond(lt(x, y), constOf(0), squared(sub(x, y)));
-  },
+    /**
+     * Require that the value `x` is less than the value `y`, with steeper penalty
+     */
+    lessThanSq: (x: VarAD, y: VarAD) => {
+        // if x < y then 0 else (x - y)^2
+        return ifCond(lt(x, y), constOf(0), squared(sub(x, y)));
+    },
 };
 
 // -------- Helpers for writing objectives
@@ -524,8 +530,8 @@ export const constrDict = {
  * Check that the `inputs` list equals the `expected` list.
  */
 const typesAre = (inputs: string[], expected: string[]): boolean =>
-  inputs.length === expected.length &&
-  _.every(_.zip(inputs, expected).map(([i, e]) => i === e));
+    inputs.length === expected.length &&
+    _.every(_.zip(inputs, expected).map(([i, e]) => i === e));
 
 // -------- (Hidden) helpers for objective/constraints/computations
 
@@ -533,77 +539,77 @@ const typesAre = (inputs: string[], expected: string[]): boolean =>
  * Require that `x` equals `y`.
  */
 const equalHard = (x: VarAD, y: VarAD) => {
-  // This is an equality constraint (x = c) via two inequality constraints (x <= c and x >= c)
-  const valMax = max(x, y);
-  const valMin = min(x, y);
-  // TODO: I guess you could also use an absolute value?
-  return sub(valMax, valMin);
+    // This is an equality constraint (x = c) via two inequality constraints (x <= c and x >= c)
+    const valMax = max(x, y);
+    const valMin = min(x, y);
+    // TODO: I guess you could also use an absolute value?
+    return sub(valMax, valMin);
 };
 
 /**
  * Require that a shape at `center1` with radius `r1` not intersect a shape at `center2` with radius `r2` with optional padding `padding`. (For a non-circle shape, its radius should be half of the shape's general "width")
  */
 const noIntersect = (
-  center1: VarAD[],
-  r1: VarAD,
-  center2: VarAD[],
-  r2: VarAD,
-  padding = 10
+    center1: VarAD[],
+    r1: VarAD,
+    center2: VarAD[],
+    r2: VarAD,
+    padding = 10
 ): VarAD => {
-  // noIntersect [[x1, y1, s1], [x2, y2, s2]] = - dist (x1, y1) (x2, y2) + (s1 + s2 + 10)
-  const res = add(add(r1, r2), constOfIf(padding));
-  return sub(res, ops.vdist(center1, center2));
+    // noIntersect [[x1, y1, s1], [x2, y2, s2]] = - dist (x1, y1) (x2, y2) + (s1 + s2 + 10)
+    const res = add(add(r1, r2), constOfIf(padding));
+    return sub(res, ops.vdist(center1, center2));
 };
 
 /**
  * Require that a shape at `center1` with radius `r1` intersect a shape at `center2` with radius `r2`, with overlap amount `padding`.
  */
 const looseIntersect = (
-  center1: VarAD[],
-  r1: VarAD,
-  center2: VarAD[],
-  r2: VarAD,
-  padding: VarAD
+    center1: VarAD[],
+    r1: VarAD,
+    center2: VarAD[],
+    r2: VarAD,
+    padding: VarAD
 ): VarAD => {
-  // looseIntersect [[x1, y1, s1], [x2, y2, s2]] = dist (x1, y1) (x2, y2) - (s1 + s2 - 10)
-  const res = sub(add(r1, r2), padding);
-  return sub(ops.vdist(center1, center2), res);
+    // looseIntersect [[x1, y1, s1], [x2, y2, s2]] = dist (x1, y1) (x2, y2) - (s1 + s2 - 10)
+    const res = sub(add(r1, r2), padding);
+    return sub(ops.vdist(center1, center2), res);
 };
 
 /**
  * Encourage that an arrow `arr` be centered between two shapes with centers `center1` and `center2`, and text size (?) `[o1, o2]`.
  */
 const centerArrow2 = (
-  arr: any,
-  center1: VarAD[],
-  center2: VarAD[],
-  [o1, o2]: VarAD[]
+    arr: any,
+    center1: VarAD[],
+    center2: VarAD[],
+    [o1, o2]: VarAD[]
 ): VarAD => {
-  const vec = ops.vsub(center2, center1); // direction the arrow should point to
-  const dir = ops.vnormalize(vec);
+    const vec = ops.vsub(center2, center1); // direction the arrow should point to
+    const dir = ops.vnormalize(vec);
 
-  let start = center1;
-  let end = center2;
+    let start = center1;
+    let end = center2;
 
-  // TODO: take in spacing, use the right text dimension/distance?, note on arrow directionality
+    // TODO: take in spacing, use the right text dimension/distance?, note on arrow directionality
 
-  // TODO: add abs
-  if (gt(ops.vnorm(vec), add(o1, absVal(o2)))) {
-    start = ops.vadd(center1, ops.vmul(o1, dir));
-    end = ops.vadd(center2, ops.vmul(o2, dir));
-  }
+    // TODO: add abs
+    if (gt(ops.vnorm(vec), add(o1, absVal(o2)))) {
+        start = ops.vadd(center1, ops.vmul(o1, dir));
+        end = ops.vadd(center2, ops.vmul(o2, dir));
+    }
 
-  const fromPt = arr.start.contents;
-  const toPt = arr.end.contents;
+    const fromPt = arr.start.contents;
+    const toPt = arr.end.contents;
 
-  return add(ops.vdistsq(fromPt, start), ops.vdistsq(toPt, end));
+    return add(ops.vdistsq(fromPt, start), ops.vdistsq(toPt, end));
 };
 
 /**
  * Repel a vector `a` from a vector `b` with weight `c`.
  */
 const repelPt = (c: VarAD, a: VarAD[], b: VarAD[]) =>
-  div(c, add(ops.vdistsq(a, b), constOf(EPS_DENOM)));
+    div(c, add(ops.vdistsq(a, b), constOf(EPS_DENOM)));
 
 // ------- Polygon-related helpers
 
@@ -611,9 +617,9 @@ const repelPt = (c: VarAD, a: VarAD[], b: VarAD[]) =>
  * Return true iff `p` is in rect `b`, assuming `rect` is an axis-aligned bounding box (AABB) with properties `minX, maxX, minY, maxY`.
  */
 const pointInBox = (p: any, rect: any): boolean => {
-  return (
-    p.x > rect.minX && p.x < rect.maxX && p.y > rect.minY && p.y < rect.maxY
-  );
+    return (
+        p.x > rect.minX && p.x < rect.maxX && p.y > rect.minY && p.y < rect.maxY
+    );
 };
 
 /**
@@ -622,139 +628,139 @@ const pointInBox = (p: any, rect: any): boolean => {
  * https://stackoverflow.com/questions/5254838/calculating-distance-between-a-point-and-a-rectangular-box-nearest-point
  */
 const dsqBP = (p: any, rect: any): VarAD => {
-  const dx = max(max(sub(rect.minX, p.x), constOf(0.0)), sub(p.x, rect.maxX));
-  const dy = max(max(sub(rect.minY, p.y), constOf(0.0)), sub(p.y, rect.maxY));
-  return add(squared(dx), squared(dy));
+    const dx = max(max(sub(rect.minX, p.x), constOf(0.0)), sub(p.x, rect.maxX));
+    const dy = max(max(sub(rect.minY, p.y), constOf(0.0)), sub(p.y, rect.maxY));
+    return add(squared(dx), squared(dy));
 };
 
 /**
  * Linearly interpolate between left `l` and right `r` endpoints, at fraction `k` of interpolation.
  */
 const lerp = (l: VarAD, r: VarAD, k: VarAD): VarAD => {
-  // TODO: Rewrite the lerp code to be more concise
-  return add(mul(l, sub(constOf(1.0), k)), mul(r, k));
+    // TODO: Rewrite the lerp code to be more concise
+    return add(mul(l, sub(constOf(1.0), k)), mul(r, k));
 };
 
 /**
  * Linearly interpolate between vector `l` and vector `r` endpoints, at fraction `k` of interpolation.
  */
 const lerp2 = (l: VarAD[], r: VarAD[], k: VarAD): [VarAD, VarAD] => {
-  return [lerp(l[0], r[0], k), lerp(l[1], r[1], k)];
+    return [lerp(l[0], r[0], k), lerp(l[1], r[1], k)];
 };
 
 /**
  * Sample a line `line` at `NUM_SAMPLES` points uniformly.
  */
 const sampleSeg = (line: VarAD[][]) => {
-  const NUM_SAMPLES = 15;
-  const NUM_SAMPLES2 = constOf(1 + NUM_SAMPLES);
-  // TODO: Check that this covers the whole line, i.e. no off-by-one error
-  const samples = _.range(1 + NUM_SAMPLES).map((i) => {
-    const k = div(constOf(i), NUM_SAMPLES2);
-    return lerp2(line[0], line[1], k);
-  });
+    const NUM_SAMPLES = 15;
+    const NUM_SAMPLES2 = constOf(1 + NUM_SAMPLES);
+    // TODO: Check that this covers the whole line, i.e. no off-by-one error
+    const samples = _.range(1 + NUM_SAMPLES).map((i) => {
+        const k = div(constOf(i), NUM_SAMPLES2);
+        return lerp2(line[0], line[1], k);
+    });
 
-  return samples;
+    return samples;
 };
 
 /**
  * Return the closest point on segment `[start, end]` to point `pt`.
  */
 const closestPt_PtSeg = (pt: VarAD[], [start, end]: VarAD[][]): VarAD[] => {
-  const EPS0 = varOf(10e-3);
-  const lensq = max(ops.vdistsq(start, end), EPS0); // Avoid a divide-by-0 if the line is too small
+    const EPS0 = varOf(10e-3);
+    const lensq = max(ops.vdistsq(start, end), EPS0); // Avoid a divide-by-0 if the line is too small
 
-  // If line seg looks like a point, the calculation just returns (something close to) `v`
-  const dir = ops.vsub(end, start);
-  // t = ((p -: v) `dotv` dir) / lensq -- project vector onto line seg and normalize
-  const t = div(
-    ops.vdot(ops.vsub(pt, start), dir),
-    add(lensq, constOf(EPS_DENOM))
-  );
-  const t1 = clamp([0.0, 1.0], t);
+    // If line seg looks like a point, the calculation just returns (something close to) `v`
+    const dir = ops.vsub(end, start);
+    // t = ((p -: v) `dotv` dir) / lensq -- project vector onto line seg and normalize
+    const t = div(
+        ops.vdot(ops.vsub(pt, start), dir),
+        add(lensq, constOf(EPS_DENOM))
+    );
+    const t1 = clamp([0.0, 1.0], t);
 
-  // v +: (t' *: dir) -- walk along vector of line seg
-  return ops.vadd(start, ops.vmul(t1, dir));
+    // v +: (t' *: dir) -- walk along vector of line seg
+    return ops.vadd(start, ops.vmul(t1, dir));
 };
 
 /**
  * Clamp `x` in range `[l, r]`.
  */
 const clamp = ([l, r]: number[], x: VarAD): VarAD => {
-  return max(constOf(l), min(constOf(r), x));
+    return max(constOf(l), min(constOf(r), x));
 };
 
 /**
  * returns true iff the line from `(a,b)` -> `(c,d)` intersects with `(p,q)` -> `(r,s)`
  */
 // https://stackoverflow.com/questions/9043805/test-if-two-lines-intersect-javascript-function
-// TODO < Check this function
+// TODO: Check this function more thoroughly (seems to work fine in Style, though)
 const intersects = (
-  l1_p1: VarAD[],
-  l1_p2: VarAD[],
-  l2_p1: VarAD[],
-  l2_p2: VarAD[]
+    l1_p1: VarAD[],
+    l1_p2: VarAD[],
+    l2_p1: VarAD[],
+    l2_p2: VarAD[]
 ) => {
-  const [[a, b], [c, d]] = [l1_p1, l1_p2];
-  const [[p, q], [r, s]] = [l2_p1, l2_p2];
+    const [[a, b], [c, d]] = [l1_p1, l1_p2];
+    const [[p, q], [r, s]] = [l2_p1, l2_p2];
 
-  // const det = (c - a) * (s - q) - (r - p) * (d - b);
-  const det = sub(mul(sub(c, a), sub(s, q)), mul(sub(r, p), sub(d, b)));
-  // const lambda = ((s - q) * (r - a) + (p - r) * (s - b)) / det;
-  // const gamma = ((b - d) * (r - a) + (c - a) * (s - b)) / det;
-  const lambda = div(
-    add(mul(sub(s, q), sub(r, a)), mul(sub(p, r), sub(s, b))),
-    det
-  );
-  const gamma = div(
-    add(mul(sub(b, d), sub(r, a)), mul(sub(c, a), sub(s, b))),
-    det
-  );
-  const o = constOf(0);
-  const l = constOf(1);
-  const fals = constOf(0);
+    // const det = (c - a) * (s - q) - (r - p) * (d - b);
+    const det = sub(mul(sub(c, a), sub(s, q)), mul(sub(r, p), sub(d, b)));
+    // const lambda = ((s - q) * (r - a) + (p - r) * (s - b)) / det;
+    // const gamma = ((b - d) * (r - a) + (c - a) * (s - b)) / det;
+    const lambda = div(
+        add(mul(sub(s, q), sub(r, a)), mul(sub(p, r), sub(s, b))),
+        det
+    );
+    const gamma = div(
+        add(mul(sub(b, d), sub(r, a)), mul(sub(c, a), sub(s, b))),
+        det
+    );
+    const o = constOf(0);
+    const l = constOf(1);
+    const fals = constOf(0);
 
-  // if (det === 0) { return false; }
-  // return (0 < lambda && lambda < 1) && (0 < gamma && gamma < 1);
-  return ifCond(
-    eq(det, o),
-    fals,
-    and(and(lt(o, lambda), lt(lambda, l)), and(lt(o, gamma), lt(gamma, l)))
-  );
+    // if (det === 0) { return false; }
+    // return (0 < lambda && lambda < 1) && (0 < gamma && gamma < 1);
+    return ifCond(
+        eq(det, o),
+        fals,
+        and(and(lt(o, lambda), lt(lambda, l)), and(lt(o, gamma), lt(gamma, l)))
+    );
 };
 
 /**
  * Return the bounding box of an axis-aligned box-like shape given by `center`, width `w`, height `h` as an object with `minX, maxX, minY, maxY`.
  */
 export const bbox = (center: VecAD, w: VarAD, h: VarAD): any => {
-  const halfWidth = div(w, constOf(2.0));
-  const halfHeight = div(h, constOf(2.0));
-  const nhalfWidth = neg(halfWidth);
-  const nhalfHeight = neg(halfHeight);
-  // CCW: TR, TL, BL, BR
-  const pts = [
-    [halfWidth, halfHeight],
-    [nhalfWidth, halfHeight],
-    [nhalfWidth, nhalfHeight],
-    [halfWidth, nhalfHeight],
-  ].map((p) => ops.vadd(center, p));
+    const halfWidth = div(w, constOf(2.0));
+    const halfHeight = div(h, constOf(2.0));
+    const nhalfWidth = neg(halfWidth);
+    const nhalfHeight = neg(halfHeight);
+    // CCW: TR, TL, BL, BR
+    const pts = [
+        [halfWidth, halfHeight],
+        [nhalfWidth, halfHeight],
+        [nhalfWidth, nhalfHeight],
+        [halfWidth, nhalfHeight],
+    ].map((p) => ops.vadd(center, p));
 
-  const rect = {
-    minX: pts[1][0],
-    maxX: pts[0][0],
-    minY: pts[2][1],
-    maxY: pts[0][1],
-  };
+    const rect = {
+        minX: pts[1][0],
+        maxX: pts[0][0],
+        minY: pts[2][1],
+        maxY: pts[0][1],
+    };
 
-  return rect;
+    return rect;
 };
 
 /**
  * Return numerically-encoded boolean indicating whether `x \in [l, r]`.
  */
 export const inRange = (x: VarAD, l: VarAD, r: VarAD): VarAD => {
-  if (l.val > r.val) throw Error("invalid range"); // TODO do this range check better
-  const fals = constOf(0);
-  const tru = constOf(1);
-  return ifCond(and(gt(x, l), lt(x, r)), tru, fals);
+    if (l.val > r.val) throw Error("invalid range"); // TODO do this range check better
+    const fals = constOf(0);
+    const tru = constOf(1);
+    return ifCond(and(gt(x, l), lt(x, r)), tru, fals);
 };

--- a/packages/core/src/contrib/Functions.ts
+++ b/packages/core/src/contrib/Functions.ts
@@ -11,11 +11,14 @@ import {
   add,
   addN,
   max,
+  min,
   div,
   mul,
   cos,
   sin,
   neg,
+  sqrt,
+  absVal,
 } from "engine/Autodiff";
 import { Elem, SubPath } from "types/shapeTypes";
 
@@ -431,6 +434,77 @@ export const compDict = {
       tag: "VectorV",
       contents: m.map((row) => ops.vdot(row, v)),
     };
+  },
+
+  // ------ Utility functions
+
+  /**
+   * Return the square root of the number `x`. (NOTE: if `x < 0`, you may get `NaN`s)
+   */
+  sqrt: (x: VarAD): IFloatV<VarAD> => {
+    return { tag: "FloatV", contents: sqrt(x) };
+  },
+
+  /**
+   * Return the max of the numbers `x`, `y`.
+   */
+  max: (x: VarAD, y: VarAD): IFloatV<VarAD> => {
+    return { tag: "FloatV", contents: max(x, y) };
+  },
+
+  /**
+   * Return the min of the numbers `x`, `y`.
+   */
+  min: (x: VarAD, y: VarAD): IFloatV<VarAD> => {
+    return { tag: "FloatV", contents: min(x, y) };
+  },
+
+  /**
+   * Return the absolute value of the number `x`.
+   */
+  abs: (x: VarAD): IFloatV<VarAD> => {
+    return { tag: "FloatV", contents: absVal(x) };
+  },
+
+  /**
+   * Return the Euclidean norm of the vector `v`.
+   */
+  norm: (v: VarAD[]): IFloatV<VarAD> => {
+    return { tag: "FloatV", contents: ops.vnorm(v) };
+  },
+
+  /**
+   * Return the Euclidean norm squared of the vector `v`.
+   */
+  normsq: (v: VarAD[]): IFloatV<VarAD> => {
+    return { tag: "FloatV", contents: ops.vnormsq(v) };
+  },
+
+  /**
+   * Return the Euclidean distance between the vectors `v` and `w`.
+   */
+  vdist: (v: VarAD[], w: VarAD[]): IFloatV<VarAD> => {
+    return { tag: "FloatV", contents: ops.vdist(v, w) };
+  },
+
+  /**
+   * Return the Euclidean distance squared between the vectors `v` and `w`.
+   */
+  vdistsq: (v: VarAD[], w: VarAD[]): IFloatV<VarAD> => {
+    return { tag: "FloatV", contents: ops.vdistsq(v, w) };
+  },
+
+  // ------ Geometry/graphics utils
+
+  /**
+   * Rotate a 2D vector `v` by 90 degrees clockwise.
+   */
+  rot90: (v: VarAD[]) => {
+    if (v.length !== 2) {
+      throw Error("expected 2D vector in `rot90`");
+    }
+    const [x, y] = v;
+    return { tag: "VectorV", contents: [neg(y), x] };
   },
 };
 

--- a/packages/core/src/engine/Autodiff.ts
+++ b/packages/core/src/engine/Autodiff.ts
@@ -681,6 +681,80 @@ export const lt = (v: VarAD, w: VarAD, isCompNode = true): VarAD => {
 };
 
 /**
+ * Return a conditional `v == w`. (TODO: Maybe check if they are equal up to a tolerance?)
+ * Note, the 1.0, 0.0 stuff is irrelevant, in the codegen they are boolean
+ */
+export const eq = (v: VarAD, w: VarAD, isCompNode = true): VarAD => {
+  // returns a boolean, which is converted to number
+  const z = variableAD(v.val === w.val ? 1.0 : 0.0, "eq");
+  z.isCompNode = isCompNode;
+
+  if (isCompNode) {
+    z.children.push({ node: v, sensitivityNode: just(noGrad) });
+    z.children.push({ node: w, sensitivityNode: just(noGrad) });
+
+    v.parents.push({ node: z, sensitivityNode: just(noGrad) });
+    w.parents.push({ node: z, sensitivityNode: just(noGrad) });
+  } else {
+    z.childrenGrad.push({ node: v, sensitivityNode: none });
+    z.childrenGrad.push({ node: w, sensitivityNode: none });
+
+    v.parentsGrad.push({ node: z, sensitivityNode: none });
+    w.parentsGrad.push({ node: z, sensitivityNode: none });
+  }
+
+  return z;
+};
+
+/**
+ * Return a boolean (number) `v && w` -- TODO: Is this derivative right?
+ */
+export const and = (v: VarAD, w: VarAD, isCompNode = true): VarAD => {
+  const z = variableAD(v.val * w.val, "and");
+  z.isCompNode = isCompNode;
+
+  if (isCompNode) {
+    z.children.push({ node: v, sensitivityNode: just(noGrad) });
+    z.children.push({ node: w, sensitivityNode: just(noGrad) });
+
+    v.parents.push({ node: z, sensitivityNode: just(noGrad) });
+    w.parents.push({ node: z, sensitivityNode: just(noGrad) });
+  } else {
+    z.childrenGrad.push({ node: v, sensitivityNode: none });
+    z.childrenGrad.push({ node: w, sensitivityNode: none });
+
+    v.parentsGrad.push({ node: z, sensitivityNode: none });
+    w.parentsGrad.push({ node: z, sensitivityNode: none });
+  }
+
+  return z;
+};
+
+/**
+ * Return a boolean (number) `v || w` -- TODO: Is this derivative right?
+ */
+export const or = (v: VarAD, w: VarAD, isCompNode = true): VarAD => {
+  const z = variableAD(v.val + w.val, "or");
+  z.isCompNode = isCompNode;
+
+  if (isCompNode) {
+    z.children.push({ node: v, sensitivityNode: just(noGrad) });
+    z.children.push({ node: w, sensitivityNode: just(noGrad) });
+
+    v.parents.push({ node: z, sensitivityNode: just(noGrad) });
+    w.parents.push({ node: z, sensitivityNode: just(noGrad) });
+  } else {
+    z.childrenGrad.push({ node: v, sensitivityNode: none });
+    z.childrenGrad.push({ node: w, sensitivityNode: none });
+
+    v.parentsGrad.push({ node: z, sensitivityNode: none });
+    w.parentsGrad.push({ node: z, sensitivityNode: none });
+  }
+
+  return z;
+};
+
+/**
  * Return a conditional `if(cond) then v else w`.
  */
 export const ifCond = (
@@ -689,19 +763,22 @@ export const ifCond = (
   w: VarAD,
   isCompNode = true
 ): VarAD => {
-  // When the computation graph is evaluated, depending on whether cond is nonnegative, either v or w is evaluated (and returned?)
+  // When the computation graph is evaluated, either v or w is evaluated and returned, depending on the boolean value cond in the generated gradient
 
-  const z = variableAD(0.0, "ifCond"); // No value?
+  const z = variableAD(cond.val ? v.val : w.val, "ifCond"); // No value?
   z.isCompNode = isCompNode;
 
   if (isCompNode) {
+    const vNode = ifCond(cond, gvarOf(1.0), gvarOf(0.0), false);
+    const wNode = ifCond(cond, gvarOf(0.0), gvarOf(1.0), false);
+
     z.children.push({ node: cond, sensitivityNode: just(noGrad) });
-    z.children.push({ node: v, sensitivityNode: just(noGrad) });
-    z.children.push({ node: w, sensitivityNode: just(noGrad) });
+    z.children.push({ node: v, sensitivityNode: just(vNode) });
+    z.children.push({ node: w, sensitivityNode: just(wNode) });
 
     cond.parents.push({ node: z, sensitivityNode: just(noGrad) });
-    v.parents.push({ node: z, sensitivityNode: just(noGrad) });
-    w.parents.push({ node: z, sensitivityNode: just(noGrad) });
+    v.parents.push({ node: z, sensitivityNode: just(vNode) });
+    w.parents.push({ node: z, sensitivityNode: just(wNode) });
   } else {
     z.childrenGrad.push({ node: cond, sensitivityNode: none });
     z.childrenGrad.push({ node: v, sensitivityNode: none });
@@ -1265,6 +1342,12 @@ const traverseGraph = (i: number, z: IVarAD, setting: string): any => {
       stmt = `const ${parName} = ${childName0} > ${childName1};`;
     } else if (z.op === "lt") {
       stmt = `const ${parName} = ${childName0} < ${childName1};`;
+    } else if (z.op === "and") {
+      stmt = `const ${parName} = ${childName0} && ${childName1};`;
+    } else if (z.op === "or") {
+      stmt = `const ${parName} = ${childName0} || ${childName1};`;
+    } else if (z.op === "eq") {
+      stmt = `const ${parName} = ${childName0} === ${childName1};`;
     } else if (z.op === "+ list") {
       stmt = `const ${parName} = ${childName0} + ${childName1};`;
     } else if (z.op === "div") {

--- a/packages/core/src/engine/Autodiff.ts
+++ b/packages/core/src/engine/Autodiff.ts
@@ -707,7 +707,7 @@ export const eq = (v: VarAD, w: VarAD, isCompNode = true): VarAD => {
 };
 
 /**
- * Return a boolean (number) `v && w` -- TODO: Is this derivative right?
+ * Return a boolean (number) `v && w`
  */
 export const and = (v: VarAD, w: VarAD, isCompNode = true): VarAD => {
   const z = variableAD(v.val * w.val, "and");
@@ -731,7 +731,7 @@ export const and = (v: VarAD, w: VarAD, isCompNode = true): VarAD => {
 };
 
 /**
- * Return a boolean (number) `v || w` -- TODO: Is this derivative right?
+ * Return a boolean (number) `v || w`
  */
 export const or = (v: VarAD, w: VarAD, isCompNode = true): VarAD => {
   const z = variableAD(v.val + w.val, "or");

--- a/packages/core/src/engine/Evaluator.ts
+++ b/packages/core/src/engine/Evaluator.ts
@@ -628,7 +628,7 @@ export const evalExpr = (
           tag: "Val",
           contents: compDict[fnName](
             optDebugInfo as OptDebugInfo,
-            JSON.stringify(p) // COMBAK: Test that derivatives still work. Might break due to JSON.stringify(p) changing?
+            prettyPrintPath(p) // COMBAK: Test that derivatives still work
           ),
         };
       }
@@ -668,7 +668,7 @@ export const resolvePath = (
   optDebugInfo?: OptDebugInfo
 ): ArgVal<VarAD> => {
   // HACK: this is a temporary way to consistently compare paths. We will need to make varymap much more efficient
-  let varyingVal = varyingMap?.get(JSON.stringify(path));
+  let varyingVal = varyingMap?.get(prettyPrintPath(path));
 
   if (varyingVal) {
     return floatVal(varyingVal);
@@ -747,7 +747,7 @@ export const resolvePath = (
             return val;
           } else {
             // Look up in varyingMap to see if there is a fresh value
-            varyingVal = varyingMap?.get(JSON.stringify(propertyPath));
+            varyingVal = varyingMap?.get(prettyPrintPath(propertyPath));
             if (varyingVal) {
               return { tag: "FloatV", contents: varyingVal };
             } else {
@@ -1063,7 +1063,7 @@ export function genPathMap<T>(
     );
   }
   const res = new Map();
-  paths.forEach((path, index) => res.set(JSON.stringify(path), vals[index]));
+  paths.forEach((path, index) => res.set(prettyPrintPath(path), vals[index]));
 
   // console.log("gen path map", res);
   // throw Error("TODO");

--- a/packages/core/src/engine/Optimizer.ts
+++ b/packages/core/src/engine/Optimizer.ts
@@ -277,7 +277,7 @@ export const step = (state: State, steps: number, evaluate = true) => {
         state.params.currObjective,
         state.params.currGradient,
         state.params.lbfgsInfo,
-        state.varyingPaths.map((p) => JSON.stringify(p))
+        state.varyingPaths.map((p) => prettyPrintPath(p))
       );
       xs = res.xs;
 


### PR DESCRIPTION
# Description

Related issue/PR: #434 #367 #319 #120

This PR adds a basic graph domain (with pure Penrose layout) and more standard library functions for Style (incl. functions, constraints, objectives, autodiff primitives). 

This reasons are to pilot the user study [e.g. building stdlib, reporting errors], to have a more complicated layout test case, and because it’s just a useful domain to have, since we've been wanting to build it since last summer.

# Implementation strategy and design decisions

For further documentation, see 2/25/21 meeting notes.

# Examples with steps to reproduce them

in `graph-domain`, run `roger watch graph1.sub graph-theory.sty graph-theory.dsl`

![image](https://user-images.githubusercontent.com/2762356/109240978-84218d80-77a6-11eb-9c97-c2dbc6f2c74a.png)

Added to the working examples page.

# Checklist

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] New and existing tests pass locally using `yarn test`
- [x] I ran `yarn docs` and there were no errors when generating the HTML site
- [x] My code follows the style guidelines of this project (e.g.: no ESLint warnings)

Also,
- [x] All prior Penrose diagrams (as documented on the wiki page) work

# Open questions

- Improve the graph layout; see TODOs in the Style file
  - Especially address incorporating bbox dimensions (and why it slows down the opt a lot)
- Add more shapes: curved "connector" shapes, rounded boxes, line breaks
- File issues about the misleading errors documented in the Style file