### PR TITLE
chore: add registry.json

### DIFF
--- a/examples/registry.json
+++ b/examples/registry.json
@@ -1,0 +1,43 @@
+{
+  "root": "https://raw.githubusercontent.com/penrose/penrose/main/examples/",
+  "domains": {
+    "set-theory": {
+      "name": "Set Theory",
+      "URI": "set-theory-domain/setTheory.dsl"
+    }
+  },
+  "styles": {
+    "venn": {
+      "domain": "set-theory",
+      "name": "Venn",
+      "URI": "set-theory-domain/venn.sty"
+    },
+    "tree": {
+      "domain": "set-theory",
+      "name": "Tree",
+      "URI": "set-theory-domain/tree.sty"
+    },
+    "continuousmap": {
+      "domain": "set-theory",
+      "name": "Continuous Map",
+      "URI": "set-theory-domain/continuousmap.sty"
+    },
+    "venn-3d": {
+      "domain": "set-theory",
+      "name": "Venn 3D",
+      "URI": "set-theory-domain/venn-3d.sty"
+    }
+  },
+  "substances": {
+    "nested": {
+      "domain": "set-theory",
+      "name": "Nested",
+      "URI": "set-theory-domain/nested.sub"
+    }
+  },
+  "tree": {
+    "domain": "set-theory",
+    "name": "Tree",
+    "URI": "set-theory-domain/tree.sub"
+  }
+}

--- a/examples/registry.json
+++ b/examples/registry.json
@@ -1,9 +1,40 @@
 {
   "root": "https://raw.githubusercontent.com/penrose/penrose/main/examples/",
+  "trios": [
+    {
+      "substance": "tree",
+      "style": "venn",
+      "domain": "set-theory"
+    },
+    {
+      "substance": "tree",
+      "style": "tree",
+      "domain": "set-theory"
+    },
+    {
+      "substance": "tree",
+      "style": "venn-3d",
+      "domain": "set-theory"
+    },
+    {
+      "substance": "continuousmap",
+      "style": "continuousmap",
+      "domain": "set-theory"
+    },
+    {
+      "substance": "two-vectors-perp",
+      "style": "linear-algebra-simple",
+      "domain": "linear-algebra"
+    }
+  ],
   "domains": {
     "set-theory": {
       "name": "Set Theory",
       "URI": "set-theory-domain/setTheory.dsl"
+    },
+    "linear-algebra": {
+      "name": "Linear Algebra",
+      "URI": "linear-algebra-domain/linear-algebra.dsl"
     }
   },
   "styles": {
@@ -26,18 +57,28 @@
       "domain": "set-theory",
       "name": "Venn 3D",
       "URI": "set-theory-domain/venn-3d.sty"
+    },
+    "linear-algebra-simple": {
+      "domain": "linear-algebra",
+      "name": "Linear Algebra 2D",
+      "URI": "linear-algebra-domain/linear-algebra-paper-simple.sty"
     }
   },
   "substances": {
+    "two-vectors-perp": {
+      "domain": "linear-algebra",
+      "name": "Two Perpendicular Vectors",
+      "URI": "linear-algebra-domain/twoVectorsPerp-unsugared.sub"
+    },
     "nested": {
       "domain": "set-theory",
       "name": "Nested",
       "URI": "set-theory-domain/nested.sub"
+    },
+    "tree": {
+      "domain": "set-theory",
+      "name": "Tree",
+      "URI": "set-theory-domain/tree.sub"
     }
-  },
-  "tree": {
-    "domain": "set-theory",
-    "name": "Tree",
-    "URI": "set-theory-domain/tree.sub"
   }
 }


### PR DESCRIPTION
We have a new `examples/registry.json` which is more human readable than the existing `styleLibrary.json` etc.

It has set theory stuff but needs more domains supported.