### PR TITLE
fix: add source loc to parser errors; report unexpected EOF

### DIFF
--- a/packages/core/src/compiler/Domain.ts
+++ b/packages/core/src/compiler/Domain.ts
@@ -3,7 +3,7 @@ import { Map } from "immutable";
 import { every, keyBy, zipWith } from "lodash";
 import nearley from "nearley";
 import domainGrammar from "parser/DomainParser";
-import { idOf } from "parser/ParserUtil";
+import { idOf, lastLocation } from "parser/ParserUtil";
 import {
   ParseError,
   DomainError,
@@ -33,10 +33,14 @@ export const parseDomain = (prog: string): Result<DomainProg, ParseError> => {
   );
   try {
     const { results } = parser.feed(prog).feed("\n"); // NOTE: extra newline to avoid trailing comments
-    const ast: DomainProg = results[0] as DomainProg;
-    return ok(ast);
+    if (results.length > 0) {
+      const ast: DomainProg = results[0] as DomainProg;
+      return ok(ast);
+    } else {
+      return err(parseError(`Unexpected end of input`, lastLocation(parser)));
+    }
   } catch (e) {
-    return err(parseError(e));
+    return err(parseError(e, lastLocation(parser)));
   }
 };
 

--- a/packages/core/src/compiler/Style.ts
+++ b/packages/core/src/compiler/Style.ts
@@ -21,7 +21,7 @@ import {
   isTagExpr,
 } from "engine/EngineUtils";
 import { alg, Graph } from "graphlib";
-import _ from "lodash";
+import _, { last, result } from "lodash";
 import nearley from "nearley";
 import styleGrammar from "parser/StyleParser";
 import {
@@ -51,6 +51,7 @@ import {
   PenroseError,
   StyleError,
 } from "types/errors";
+import { lastLocation } from "parser/ParserUtil";
 
 const log = consola
   .create({ level: LogLevel.Warn })
@@ -2809,10 +2810,14 @@ export const parseStyle = (p: string): Result<StyProg, ParseError> => {
   const parser = new nearley.Parser(nearley.Grammar.fromCompiled(styleGrammar));
   try {
     const { results } = parser.feed(p).feed("\n");
-    const ast: StyProg = results[0] as StyProg;
-    return ok(ast);
+    if (results.length > 0) {
+      const ast: StyProg = results[0] as StyProg;
+      return ok(ast);
+    } else {
+      return err(parseError(`Unexpected end of input`, lastLocation(parser)));
+    }
   } catch (e) {
-    return err(parseError(e));
+    return err(parseError(e, lastLocation(parser)));
   }
 };
 

--- a/packages/core/src/compiler/Substance.ts
+++ b/packages/core/src/compiler/Substance.ts
@@ -1,7 +1,7 @@
 import { Map } from "immutable";
 import { findIndex, zip } from "lodash";
 import nearley from "nearley";
-import { idOf } from "parser/ParserUtil";
+import { idOf, lastLocation } from "parser/ParserUtil";
 import substanceGrammar from "parser/SubstanceParser";
 import { ParseError, PenroseError, SubstanceError } from "types/errors";
 import {
@@ -35,10 +35,14 @@ export const parseSubstance = (prog: string): Result<SubProg, ParseError> => {
   );
   try {
     const { results } = parser.feed(prog).feed("\n"); // NOTE: extra newline to avoid trailing comments
-    const ast: SubProg = results[0] as SubProg;
-    return ok(ast);
+    if (results.length > 0) {
+      const ast: SubProg = results[0] as SubProg;
+      return ok(ast);
+    } else {
+      return err(parseError(`Unexpected end of input`, lastLocation(parser)));
+    }
   } catch (e) {
-    return err(parseError(e));
+    return err(parseError(e, lastLocation(parser)));
   }
 };
 

--- a/packages/core/src/parser/ParserUtil.ts
+++ b/packages/core/src/parser/ParserUtil.ts
@@ -172,3 +172,15 @@ export const idOf = (value: string, nodeType: string): Identifier => ({
   type: "identifier",
   value,
 });
+
+export const lastLocation = (parser: nearley.Parser): SourceLoc | undefined => {
+  const lexerState = parser.lexerState;
+  if (lexerState) {
+    return {
+      line: lexerState.line,
+      col: lexerState.col,
+    };
+  } else {
+    return undefined;
+  }
+};

--- a/packages/core/src/parser/StyleParser.test.ts
+++ b/packages/core/src/parser/StyleParser.test.ts
@@ -1,9 +1,9 @@
 // const grammar = require("./Style.ne");
-import * as nearley from "nearley";
-import grammar from "./StyleParser";
-import * as path from "path";
+import { parseStyle } from "compiler/Style";
 import * as fs from "fs";
-import { result } from "lodash";
+import * as nearley from "nearley";
+import * as path from "path";
+import grammar from "./StyleParser";
 
 const outputDir = "/tmp/asts";
 const saveASTs = false;
@@ -53,6 +53,14 @@ describe("Common", () => {
   test("empty program", () => {
     const { results } = parser.feed("");
     sameASTs(results);
+  });
+  test("unbalanced curly", () => {
+    const prog = `
+    forall Set x {
+      x.shape = Circle { 
+  }
+    `;
+    expect(parseStyle(prog).isErr()).toEqual(true);
   });
   test("type keyword check", () => {
     const prog = `

--- a/packages/core/src/types/errors.ts
+++ b/packages/core/src/types/errors.ts
@@ -187,6 +187,7 @@ export interface StyleErrorList {
 export interface ParseError {
   tag: "ParseError";
   message: string;
+  location?: SourceLoc;
 }
 
 export interface SelectorDeclTypeError {

--- a/packages/core/src/utils/Error.ts
+++ b/packages/core/src/utils/Error.ts
@@ -478,9 +478,13 @@ export const fatalError = (message: string): FatalError => ({
   message,
 });
 
-export const parseError = (message: string): ParseError => ({
+export const parseError = (
+  message: string,
+  location?: SourceLoc
+): ParseError => ({
   tag: "ParseError",
   message,
+  location,
 });
 
 // If there are multiple errors, just return the tag of the first one


### PR DESCRIPTION
# Description

Related issue/PR: #509 

Add `SourceLoc` to `ParserError` so the frontends can highlight the location. Also handle non-termination of parsers by checking `results`. See:  https://github.com/kach/nearley/issues/306

# Implementation strategy and design decisions

* new util function `lastLocation` that gets the last parsed location from `lexerState`
* refactored `ParserError`
* One new test case in `StyleParser.test`

