### PR TITLE
feat: [layout] add `evalFns` for individual opt fns, and compile each opt function

### DIFF
--- a/packages/core/src/__tests__/overall.test.ts
+++ b/packages/core/src/__tests__/overall.test.ts
@@ -159,22 +159,4 @@ describe("Run individual functions", () => {
       console.log(showError(res.error));
     }
   });
-
-  // test("filtered constraints", async () => {
-  //   const twoSubsets = `Set A, B\nIsSubset(B, A)\nAutoLabel All`;
-  //   const res = compileTrio(setDomain, twoSubsets, vennStyle);
-
-  //   if (res.isOk()) {
-  //     // NOTE: delibrately not cache the overall objective and re-generate for original and filtered states
-  //     const state = res.value;
-  //     const smallerThanFns = state.constrFns.filter(
-  //       (c) => c.fname === "smallerThan"
-  //     );
-  //     const stateFiltered = { ...state, constrFns: smallerThanFns };
-  //     expect(evalEnergy(state)).toBeGreaterThan(evalEnergy(stateFiltered));
-
-  //   } else {
-  //     console.log(showError(res.error));
-  //   }
-  // });
 });

--- a/packages/core/src/__tests__/overall.test.ts
+++ b/packages/core/src/__tests__/overall.test.ts
@@ -4,6 +4,7 @@ import seedrandom from "seedrandom";
 import {
   compileTrio,
   evalEnergy,
+  evalFns,
   prepareState,
   readRegistry,
   RenderStatic,
@@ -112,4 +113,68 @@ describe("Cross-instance energy eval", () => {
       fail("compilation failed");
     }
   });
+});
+
+describe("Run individual functions", () => {
+  // TODO: Test evalFns vs overall objective? Also, test individual functions more thoroughly
+  const EPS = 1e-3; // Minimized objectives should be close to 0
+
+  test("Check each individual function is minimized/satisfied", async () => {
+    const twoSubsets = `Set A, B\nIsSubset(B, A)\nAutoLabel All`;
+    const res = compileTrio(setDomain, twoSubsets, vennStyle);
+
+    if (res.isOk()) {
+      const stateEvaled = await prepareState(res.value);
+      const stateOptimized = stepUntilConvergence(stateEvaled);
+
+      // console.log("# objectives", stateEvaled.objFns.length);
+      // console.log("# constraints", stateEvaled.constrFns.length);
+
+      // Test objectives
+      const initEngsObj = evalFns(stateEvaled.objFns, stateEvaled);
+      const optedEngsObj = evalFns(stateEvaled.objFns, stateOptimized);
+
+      for (let i = 0; i < initEngsObj.length; i++) {
+        // console.log("obj energies", initEngsObj[i], optedEngsObj[i]);
+        expect(initEngsObj[i]).toBeGreaterThanOrEqual(optedEngsObj[i]);
+        expect(optedEngsObj[i]).toBeLessThanOrEqual(EPS);
+      }
+
+      // Test constraints
+      const initEngsConstr = evalFns(stateEvaled.constrFns, stateEvaled);
+      const optedEngsConstr = evalFns(stateEvaled.constrFns, stateOptimized);
+
+      for (let i = 0; i < initEngsConstr.length; i++) {
+        // console.log("constr energies", initEngsConstr[i], optedEngsConstr[i]);
+        if (initEngsConstr[i] < 0 && optedEngsConstr[i] < 0) {
+          // If it was already satisfied and stays satisfied, the magnitude of the constraint doesn't matter (i.e. both are negative)
+          expect(true).toEqual(true);
+        } else {
+          expect(initEngsConstr[i]).toBeGreaterThanOrEqual(optedEngsConstr[i]);
+          // Check constraint satisfaction (< 0)
+          expect(optedEngsConstr[i]).toBeLessThanOrEqual(0);
+        }
+      }
+    } else {
+      console.log(showError(res.error));
+    }
+  });
+
+  // test("filtered constraints", async () => {
+  //   const twoSubsets = `Set A, B\nIsSubset(B, A)\nAutoLabel All`;
+  //   const res = compileTrio(setDomain, twoSubsets, vennStyle);
+
+  //   if (res.isOk()) {
+  //     // NOTE: delibrately not cache the overall objective and re-generate for original and filtered states
+  //     const state = res.value;
+  //     const smallerThanFns = state.constrFns.filter(
+  //       (c) => c.fname === "smallerThan"
+  //     );
+  //     const stateFiltered = { ...state, constrFns: smallerThanFns };
+  //     expect(evalEnergy(state)).toBeGreaterThan(evalEnergy(stateFiltered));
+
+  //   } else {
+  //     console.log(showError(res.error));
+  //   }
+  // });
 });

--- a/packages/core/src/engine/Autodiff.ts
+++ b/packages/core/src/engine/Autodiff.ts
@@ -1549,7 +1549,7 @@ export const energyAndGradCompiled = (
   xs: number[],
   xsVars: VarAD[],
   energyGraph: VarAD,
-  weightInfo: WeightInfo,
+  weightInfo: MaybeVal<WeightInfo>,
   debug = false
 ) => {
   // Zero xsvars vals, gradients, and caching setting
@@ -1557,7 +1557,9 @@ export const energyAndGradCompiled = (
   clearVisitedNodesOutput(energyGraph);
 
   // Set the weight nodes to have the right weight values (may have been updated at some point during the opt)
-  setWeights(weightInfo);
+  if (weightInfo.tag === "Just") {
+    setWeights(weightInfo.contents);
+  }
 
   // Set the leaves of the graph to have the new input values
   setInputs(xsVars, xs);
@@ -1566,11 +1568,16 @@ export const energyAndGradCompiled = (
   // Note that this does NOT include the weight (i.e. is called on `xsVars`, not `xsVarsWithWeight`! Because the EP weight is not a degree of freedom)
   const gradGraph = gradAllSymbolic(energyGraph, xsVars);
 
+  const epWeightNode: MaybeVal<VarAD> =
+    weightInfo.tag === "Just"
+      ? just(weightInfo.contents.epWeightNode)
+      : { tag: "Nothing" }; // Generate energy and gradient without weight
+
   const graphs: GradGraphs = {
     inputs: xsVars,
     energyOutput: energyGraph,
     gradOutputs: gradGraph,
-    weight: { tag: "Just", contents: weightInfo.epWeightNode },
+    weight: epWeightNode,
   };
 
   // Synthesize energy and gradient code

--- a/packages/core/src/engine/Evaluator.ts
+++ b/packages/core/src/engine/Evaluator.ts
@@ -166,7 +166,7 @@ export const evalFns = (
   varyingMap: VaryMap<VarAD>
 ): FnDone<VarAD>[] => fns.map((f) => evalFn(f, trans, varyingMap));
 
-const evalFn = (
+export const evalFn = (
   fn: Fn,
   trans: Translation,
   varyingMap: VaryMap<VarAD>

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -207,9 +207,9 @@ export const readRegistry = (registry: Registry): Trio[] => {
 };
 
 /**
- * Evaluate the overall energy of a `State`. If the `State` already has an optimization problem initialized (i.e. it has a defined `objective` field), this function will call `genOptProblem`. Otherwise, it will evaluate the cached objective function.
+ * Evaluate the overall energy of a `State`. If the `State` does not have an optimization problem initialized (i.e. it doesn't have a defined `objective` field), this function will call `genOptProblem` to initialize it. Otherwise, it will evaluate the cached objective function.
  * @param s a state with or without an optimization problem initialized
- * @returns a scaler value of the current energy
+ * @returns a scalar value of the current energy
  */
 export const evalEnergy = (s: State): number => {
   const { objective, weight } = s.params;
@@ -226,9 +226,10 @@ export const evalEnergy = (s: State): number => {
 };
 
 /**
- * Evaluate a list of constraints/objectives: this will be useful if a user want to apply a subset of constrs/objs on a `State`
- * TODO: comment this properly
- * NOTE: The type has to be passed in because otherwise we can't distinguish between the kinds of functions
+ * Evaluate a list of constraints/objectives: this will be useful if a user want to apply a subset of constrs/objs on a `State`. If the `State` doesn't have the constraints/objectives compiled, it will generate them first. Otherwise, it will evaluate the cached functions.
+ * @param fns a list of constraints/objectives
+ * @param s a state with or without its opt functions cached
+ * @returns a list of scalar values of the energies of the requested functions, evaluated at the `varyingValues` in the `State`
  */
 export const evalFns = (fns: Fn[], s: State): number[] => {
   const { objFnCache, constrFnCache } = s.params;

--- a/packages/core/src/types/types.d.ts
+++ b/packages/core/src/types/types.d.ts
@@ -625,6 +625,18 @@ interface IParams {
   energyGraph: VarAD; // This is the top of the energy graph (parent node)
   constrWeightNode: VarAD; // Handle to node for constraint weight (so it can be set as the weight changes)
   epWeightNode: VarAD; // similar to constrWeightNode
+
+  // Cached versions of compiling each objective and constraint into a function and gradient
+  objFnCache: { [k: string]: FnCached }; // Key is the serialized function name, e.g. `contains(A.shape, B.shape)`
+  constrFnCache: { [k: string]: FnCached }; // This is kept separate from objfns because objs/constrs may have the same names (=> clashing keys if in same dict)
+}
+
+type FnCached = IFnCached;
+
+// Just the compiled function and its grad, with no weights for EP/constraints/penalties, etc.
+interface IFnCached {
+  f(xs: number[]): number;
+  gradf(xs: number[]): number[];
 }
 
 type WeightInfo = IWeightInfo;


### PR DESCRIPTION
# Description

Related issue/PR: #511 #512

We need more granular codegen + evaluation for improving our solver, and for other uses like diagram generation.

Changes: Add a new API function `evalFns` to evaluate individual functions on the state (with no weights). Also, precompile each obj/constrfn and cache its energy and gradient in the state in `prepareState`.

# Implementation strategy and design decisions

- add a new API function for `evalFns`
- add `genFn` based on `genOptProblem`
  - write a new version of `evalEnergyOnCustom` without the weight node stuff, and only on a single objective or constraint
  - change existing `energyAndGradCompiled` so it accepts `MaybeVal<WeightInfo>`
- write a `genFns` wrapper that looks at all opt functions in the state and caches their info in the state, in an `{ fnName(args) => { energy, gradient } }` map
- write `evalFns` on multiple functions (and their gradients) that uses the cache if it exists
- add a test that verifies that running `evalFns` on a simple triple's state before and after optimization yields minimized objective energies and satisfied constraints

# Examples with steps to reproduce them

In `__tests__`, run `npm test -- -t "Run individual functions"`.

# Checklist

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] New and existing tests pass locally using `yarn test`
- [x] I ran `yarn docs` and there were no errors when generating the HTML site
- [x] My code follows the style guidelines of this project (e.g.: no ESLint warnings)

# Open questions

Questions that require more discussion or to be addressed in future development:

- I didn't test that each individual generated function is actually correct (that is, I didn't inspect the generated code). The tests give a pretty high degree of assurance that it's overall correct, but there could still be bugs.
- Return individual gradients, for use in more sophisticated layout algorithms.