### PR TITLE
feat: process prelude values in substance checker

### DIFF
--- a/packages/core/src/compiler/Style.ts
+++ b/packages/core/src/compiler/Style.ts
@@ -8,6 +8,8 @@ import {
   addWarn,
   defaultLbfgsParams,
   dummyASTNode,
+  dummyIdentifier,
+  dummySourceLoc,
   findExpr,
   findExprSafe,
   initConstraintWeight,
@@ -292,24 +294,6 @@ const initSelEnv = (): SelEnv => {
     header: { tag: "Nothing" },
     warnings: [],
     errors: [],
-  };
-};
-
-const dummySourceLoc = (): SourceLoc => {
-  return { line: -1, col: -1 };
-};
-
-// COMBAK: Make fake identifier from string (e.g. if we don't have a source loc, make fake source loc)
-const dummyIdentifier = (name: string): Identifier => {
-  return {
-    // COMBAK: Is this ok?
-    nodeType: "dummyNode",
-    children: [],
-    type: "value",
-    value: name,
-    tag: "Identifier",
-    start: dummySourceLoc(),
-    end: dummySourceLoc(),
   };
 };
 

--- a/packages/core/src/compiler/Substance.test.ts
+++ b/packages/core/src/compiler/Substance.test.ts
@@ -24,6 +24,13 @@ const subPaths = [
   // "mesh-set-domain/DomainInterop.sub",
 ];
 
+const hasVars = (env: Env, vars: [string, string][]) => {
+  vars.map(([name, type]: [string, string]) => {
+    expect(env.vars.has(name)).toBe(true);
+    expect(showType(env.vars.get(name)!)).toEqual(type);
+  });
+};
+
 const domainProg = `
 type Set
 type OpenSet
@@ -43,6 +50,7 @@ predicate Both : Prop p1 * Prop p2
 predicate Empty : Set s
 predicate Intersecting : Set s1 * Set s2
 predicate IsSubset : Set s1 * Set s2
+value X: Set
 `;
 
 const envOrError = (prog: string): Env => {
@@ -84,6 +92,24 @@ Set D
     const res = compileSubstance(prog, env);
     expect(res.isOk()).toBe(true);
   });
+  test("preludes", () => {
+    const env = envOrError(domainProg);
+    const prog = `
+Set A, B, C
+List(Set) l
+OpenSet D
+A := D
+    `;
+    const res = compileSubstance(prog, env);
+    expect(res.isOk()).toBe(true);
+    if (res.isOk()) {
+      hasVars(res.value[1], [
+        ["A", "Set"],
+        ["X", "Set"], // defined in prelude
+        ["l", "List(Set)"],
+      ]);
+    }
+  });
 });
 
 describe("Postprocess", () => {
@@ -116,12 +142,6 @@ NoLabel D, E
 });
 
 describe("Check statements", () => {
-  const hasVars = (env: Env, vars: [string, string][]) => {
-    vars.map(([name, type]: [string, string]) => {
-      expect(env.vars.has(name)).toBe(true);
-      expect(showType(env.vars.get(name)!)).toEqual(type);
-    });
-  };
   test("decls", () => {
     const env = envOrError(domainProg);
     const prog = `

--- a/packages/core/src/engine/EngineUtils.ts
+++ b/packages/core/src/engine/EngineUtils.ts
@@ -375,7 +375,7 @@ export const makeTranslationNumeric = (trans: Translation): ITrans<number> => {
 
 //#region translation operations
 
-const dummySourceLoc = (): SourceLoc => {
+export const dummySourceLoc = (): SourceLoc => {
   return { line: -1, col: -1 };
 };
 
@@ -386,6 +386,20 @@ export const dummyASTNode = (o: any): ASTNode => {
     end: dummySourceLoc(),
     nodeType: "dummyASTNode", // COMBAK: Is this ok?
     children: [],
+  };
+};
+
+// COMBAK: Make fake identifier from string (e.g. if we don't have a source loc, make fake source loc)
+export const dummyIdentifier = (name: string): Identifier => {
+  return {
+    // COMBAK: Is this ok?
+    nodeType: "dummyNode",
+    children: [],
+    type: "value",
+    value: name,
+    tag: "Identifier",
+    start: dummySourceLoc(),
+    end: dummySourceLoc(),
   };
 };
 


### PR DESCRIPTION
# Description

Related issue/PR: N/A

Currently, the system would parse prelude values, but doesn't really include them in the rest of the compilation pipeline. This PR adds support for processing prelude values with nullary types in the Substance checker.

# Implementation strategy and design decisions

* Prelude declarations are retrieved from the Domain environment and translated to Substance statements by `toSubDecl``
* In `compileSubstance`, prelude values are appended to the parsed AST _before_ the checker runs (so that the checker can include metadata like varying mappings in the Substance environment)
* We do _not_ handle prelude values with dependent types for now.

# Examples with steps to reproduce them

* In `Substance.test.ts`, I added `value X: Set` to the common Domain program, and a test checks for prelude values.

# Checklist

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] New and existing tests pass locally using `yarn test`
- [x] I ran `yarn docs` and there were no errors when generating the HTML site
- [x] My code follows the style guidelines of this project (e.g.: no ESLint warnings)

# Open questions

- [ ] Error locations in Domain/Substance with prelude line added (see [comment](https://github.com/penrose/penrose/pull/533#issuecomment-815133150))