### PR TITLE
feat: opt tab for inspector; localStorage settings

### DIFF
--- a/packages/browser-ui/package.json
+++ b/packages/browser-ui/package.json
@@ -16,6 +16,7 @@
     "graphlib": "^2.1.8",
     "node-pre-gyp": "^0.14.0",
     "react": "^16.13.1",
+    "react-data-table-component": "^6.11.7",
     "react-dom": "^16.13.1",
     "react-fast-compare": "^2.0.4",
     "react-inspector": "^4.0.1",

--- a/packages/browser-ui/src/App.tsx
+++ b/packages/browser-ui/src/App.tsx
@@ -11,7 +11,7 @@ import {
   stateInitial,
   stepUntilConvergence,
   showError,
-  PenroseError,
+  PenroseError
 } from "@penrose/core";
 
 /**
@@ -24,7 +24,7 @@ export const DownloadSVG = (
   title = "illustration"
 ): void => {
   const blob = new Blob([svg.outerHTML], {
-    type: "image/svg+xml;charset=utf-8",
+    type: "image/svg+xml;charset=utf-8"
   });
   const url = URL.createObjectURL(blob);
   const downloadLink = document.createElement("a");
@@ -41,16 +41,22 @@ import SplitPane from "react-split-pane";
 import ButtonBar from "ui/ButtonBar";
 import { FileSocket, FileSocketResult } from "ui/FileSocket";
 
+const LOCALSTORAGE_SETTINGS = "browser-ui-settings-penrose";
+
+interface ISettings {
+  showInspector: boolean;
+  autostep: boolean;
+}
+
 interface ICanvasState {
   data: PenroseState | undefined; // NOTE: if the backend is not connected, data will be undefined, TODO: rename this field
   error: PenroseError | null;
-  autostep: boolean;
   processedInitial: boolean;
   penroseVersion: string;
   history: PenroseState[];
-  showInspector: boolean;
   files: FileSocketResult | null;
   connected: boolean;
+  settings: ISettings;
 }
 
 const socketAddress = "ws://localhost:9160";
@@ -59,12 +65,14 @@ class App extends React.Component<any, ICanvasState> {
     data: undefined,
     error: null,
     history: [],
-    autostep: true,
     processedInitial: false, // TODO: clarify the semantics of this flag
     penroseVersion: "",
-    showInspector: true,
     files: null,
     connected: false,
+    settings: {
+      autostep: false,
+      showInspector: true
+    }
   };
   public readonly buttons = React.createRef<ButtonBar>();
   public readonly canvasRef = React.createRef<HTMLDivElement>();
@@ -76,27 +84,28 @@ class App extends React.Component<any, ICanvasState> {
   // same as onCanvasState but doesn't alter timeline or involve optimization
   // used only in modshapes
   public modCanvas = async (canvasState: PenroseState) => {
-    await new Promise((r) => setTimeout(r, 1));
+    await new Promise(r => setTimeout(r, 1));
 
     this.setState({
       data: canvasState,
-      processedInitial: true,
+      processedInitial: true
     });
     this.renderCanvas(canvasState);
   };
+  // TODO: reset history on resample/got stuff
   public onCanvasState = async (canvasState: PenroseState) => {
     // HACK: this will enable the "animation" that we normally expect
-    await new Promise((r) => setTimeout(r, 1));
+    await new Promise(r => setTimeout(r, 1));
 
     this.setState({
       data: canvasState,
       history: [...this.state.history, canvasState],
       processedInitial: true,
-      error: null,
+      error: null
     });
     this.renderCanvas(canvasState);
-    const { autostep } = this.state;
-    if (autostep && !stateConverged(canvasState)) {
+    const { settings } = this.state;
+    if (settings.autostep && !stateConverged(canvasState)) {
       await this.step();
     }
   };
@@ -115,11 +124,11 @@ class App extends React.Component<any, ICanvasState> {
         xsVars: [],
         constrWeightNode: undefined,
         epWeightNode: undefined,
-        graphs: undefined,
+        graphs: undefined
       };
       const content = JSON.stringify({ ...state, params });
       const blob = new Blob([content], {
-        type: "text/json",
+        type: "text/json"
       });
       const url = URL.createObjectURL(blob);
       const downloadLink = document.createElement("a");
@@ -135,9 +144,16 @@ class App extends React.Component<any, ICanvasState> {
     }
   };
   public autoStepToggle = async () => {
-    this.setState({ autostep: !this.state.autostep });
-    if (this.state.autostep && this.state.processedInitial) {
-      await this.step();
+    const newSettings = {
+      ...this.state.settings,
+      autostep: !this.state.settings.autostep
+    };
+    this.setState({
+      settings: newSettings
+    });
+    localStorage.setItem(LOCALSTORAGE_SETTINGS, JSON.stringify(newSettings));
+    if (newSettings.autostep) {
+      await this.stepUntilConvergence();
     }
   };
 
@@ -164,7 +180,7 @@ class App extends React.Component<any, ICanvasState> {
   connectToSocket = () => {
     FileSocket(
       socketAddress,
-      async (files) => {
+      async files => {
         const { domain, substance, style } = files;
         this.setState({ files, connected: true });
 
@@ -189,12 +205,22 @@ class App extends React.Component<any, ICanvasState> {
   };
 
   public componentDidMount(): void {
+    const settings = localStorage.getItem(LOCALSTORAGE_SETTINGS);
+    if (!settings) {
+      localStorage.setItem(
+        LOCALSTORAGE_SETTINGS,
+        JSON.stringify({ autostep: false, showInspector: true })
+      );
+    } else {
+      const parsed = JSON.parse(settings);
+      this.setState({ settings: parsed });
+    }
     this.connectToSocket();
   }
 
   public updateData = async (data: PenroseState) => {
     this.setState({ data: { ...data } });
-    if (this.state.autostep) {
+    if (this.state.settings.autostep) {
       const stepped = stepState(data);
       this.onCanvasState(stepped);
     } else {
@@ -202,11 +228,12 @@ class App extends React.Component<any, ICanvasState> {
     }
   };
   public setInspector = async (showInspector: boolean) => {
-    this.setState({ showInspector });
-    // localStorage.setItem("showInspector", showInspector ? "true" : "false");
+    const newSettings = { ...this.state.settings, showInspector };
+    this.setState({ settings: newSettings });
+    localStorage.setItem(LOCALSTORAGE_SETTINGS, JSON.stringify(newSettings));
   };
   public toggleInspector = async () => {
-    await this.setInspector(!this.state.showInspector);
+    await this.setInspector(!this.state.settings.showInspector);
   };
   public hideInspector = async () => {
     await this.setInspector(false);
@@ -230,13 +257,12 @@ class App extends React.Component<any, ICanvasState> {
   private renderApp() {
     const {
       data,
-      autostep,
+      settings,
       penroseVersion,
-      showInspector,
       history,
       files,
       error,
-      connected,
+      connected
     } = this.state;
     return (
       <div
@@ -245,7 +271,7 @@ class App extends React.Component<any, ICanvasState> {
           height: "100%",
           display: "flex",
           flexFlow: "column",
-          overflow: "hidden",
+          overflow: "hidden"
         }}
       >
         <div style={{ flexShrink: 0 }}>
@@ -254,14 +280,14 @@ class App extends React.Component<any, ICanvasState> {
             downloadSVG={this.downloadSVG}
             downloadState={this.downloadState}
             stepUntilConvergence={this.stepUntilConvergence}
-            autostep={autostep}
+            autostep={settings.autostep}
             step={this.step}
             autoStepToggle={this.autoStepToggle}
             resample={this.resample}
             converged={data ? stateConverged(data) : false}
             initial={data ? stateInitial(data) : false}
             toggleInspector={this.toggleInspector}
-            showInspector={showInspector}
+            showInspector={settings.showInspector}
             files={files}
             ref={this.buttons}
             connected={connected}
@@ -273,7 +299,7 @@ class App extends React.Component<any, ICanvasState> {
             split="horizontal"
             defaultSize={400}
             style={{ position: "inherit" }}
-            className={this.state.showInspector ? "" : "soloPane1"}
+            className={this.state.settings.showInspector ? "" : "soloPane1"}
             pane2Style={{ overflow: "hidden" }}
           >
             <div style={{ width: "100%", height: "100%" }}>
@@ -285,13 +311,15 @@ class App extends React.Component<any, ICanvasState> {
               )}
               {error && <pre>errors encountered, check inspector</pre>}
             </div>
-            {showInspector && (
+            {settings.showInspector ? (
               <Inspector
                 history={history}
                 error={error}
                 onClose={this.toggleInspector}
                 modShapes={this.modShapes}
               />
+            ) : (
+              <div />
             )}
           </SplitPane>
         </div>

--- a/packages/browser-ui/src/inspector/views/Opt.tsx
+++ b/packages/browser-ui/src/inspector/views/Opt.tsx
@@ -40,7 +40,7 @@ const Opt: React.FC<IViewProps> = ({ frame, history }: IViewProps) => {
         highlightOnHover={true}
         striped={true}
         columns={[
-          { name: "Expression", sortable: true, selector: "name" },
+          { name: "Expression", selector: "name", sortable: true },
           { name: "Energy", selector: "energy", sortable: true },
           { name: "Type", selector: "type", sortable: true },
           { name: "Satisfied?", selector: "sat", sortable: true }

--- a/packages/browser-ui/src/inspector/views/Opt.tsx
+++ b/packages/browser-ui/src/inspector/views/Opt.tsx
@@ -14,11 +14,21 @@ const Opt: React.FC<IViewProps> = ({ frame, history }: IViewProps) => {
   const constrInfos = zip(
     frame.constrFns.map(prettyPrintFn),
     evalFns(frame.constrFns, frame)
-  ).map(([name, energy]) => ({ name, energy, type: "constraint" }));
+  ).map(([name, energy]) => ({
+    name,
+    energy,
+    type: "constraint",
+    sat: energy! <= 0 ? "yes" : "no"
+  }));
   const objInfos = zip(
     frame.objFns.map(prettyPrintFn),
     evalFns(frame.objFns, frame)
-  ).map(([name, energy]) => ({ name, energy, type: "objective" }));
+  ).map(([name, energy]) => ({
+    name,
+    energy,
+    type: "objective",
+    sat: energy! <= 0 ? "yes" : "no"
+  }));
 
   // TODO: hyperlink the shapes
   return (
@@ -32,7 +42,16 @@ const Opt: React.FC<IViewProps> = ({ frame, history }: IViewProps) => {
         columns={[
           { name: "Expression", sortable: true, selector: "name" },
           { name: "Energy", selector: "energy", sortable: true },
-          { name: "Type", selector: "type", sortable: true }
+          { name: "Type", selector: "type", sortable: true },
+          { name: "Satisfied?", selector: "sat", sortable: true }
+        ]}
+        conditionalRowStyles={[
+          {
+            when: row => row.sat === "yes",
+            style: {
+              backgroundColor: `#A2E5B2 !important`
+            }
+          }
         ]}
       />
     </div>

--- a/packages/browser-ui/src/inspector/views/Opt.tsx
+++ b/packages/browser-ui/src/inspector/views/Opt.tsx
@@ -47,9 +47,9 @@ const Opt: React.FC<IViewProps> = ({ frame, history }: IViewProps) => {
         ]}
         conditionalRowStyles={[
           {
-            when: row => row.sat === "yes",
+            when: row => row.sat === "no",
             style: {
-              backgroundColor: `#A2E5B2 !important`
+              backgroundColor: `#ffcabe !important`
             }
           }
         ]}

--- a/packages/browser-ui/src/inspector/views/Opt.tsx
+++ b/packages/browser-ui/src/inspector/views/Opt.tsx
@@ -1,0 +1,41 @@
+import * as React from "react";
+import IViewProps from "./IViewProps";
+import { prettyPrintFn, evalFns } from "@penrose/core";
+import { zip } from "lodash";
+import DataTable from "react-data-table-component";
+const Opt: React.FC<IViewProps> = ({ frame, history }: IViewProps) => {
+  if (!frame) {
+    return (
+      <div style={{ padding: "1em", fontSize: "1em", color: "#4f4f4f" }}>
+        no frame
+      </div>
+    );
+  }
+  const constrInfos = zip(
+    frame.constrFns.map(prettyPrintFn),
+    evalFns(frame.constrFns, frame)
+  ).map(([name, energy]) => ({ name, energy, type: "constraint" }));
+  const objInfos = zip(
+    frame.objFns.map(prettyPrintFn),
+    evalFns(frame.objFns, frame)
+  ).map(([name, energy]) => ({ name, energy, type: "objective" }));
+
+  // TODO: hyperlink the shapes
+  return (
+    <div>
+      <DataTable
+        data={[...constrInfos, ...objInfos]}
+        title={"Optimization"}
+        dense={true}
+        highlightOnHover={true}
+        striped={true}
+        columns={[
+          { name: "Expression", sortable: true, selector: "name" },
+          { name: "Energy", selector: "energy", sortable: true },
+          { name: "Type", selector: "type", sortable: true }
+        ]}
+      />
+    </div>
+  );
+};
+export default Opt;

--- a/packages/browser-ui/src/inspector/views/viewMap.tsx
+++ b/packages/browser-ui/src/inspector/views/viewMap.tsx
@@ -2,11 +2,13 @@ import Frames from "./Frames";
 import ShapeView from "./ShapeView";
 import Mod from "./Mod";
 import Errors from "inspector/views/Errors";
+import Opt from "./Opt";
 const viewMap = {
   frames: Frames,
   errors: Errors,
   // logs: LogView,
   shapes: ShapeView,
-  mod: Mod
+  mod: Mod,
+  opt: Opt
 };
 export default viewMap;

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -5,6 +5,7 @@ import {
   compileSubstance,
   parseSubstance,
 } from "compiler/Substance";
+import { prettyPrintFn } from "utils/OtherUtils";
 import { SubstanceEnv } from "types/substance";
 import consola, { LogLevel } from "consola";
 import { evalShapes } from "engine/Evaluator";
@@ -21,7 +22,6 @@ import * as ShapeTypes from "types/shape";
 import { State, LabelCache, Fn } from "types/state";
 import { collectLabels } from "utils/CollectLabels";
 import { andThen, Result, showError } from "utils/Error";
-import { prettyPrintFn } from "utils/OtherUtils";
 import { bBoxDims, toHex } from "utils/Util";
 
 const log = consola.create({ level: LogLevel.Warn }).withScope("Top Level");
@@ -284,4 +284,5 @@ export {
   initializeMat,
   showError,
   Result,
+  prettyPrintFn,
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -10353,6 +10353,11 @@ lodash.memoize@^4.1.2:
   resolved "https://registry.yarnpkg.com/lodash.memoize/-/lodash.memoize-4.1.2.tgz#bcc6c49a42a2840ed997f323eada5ecd182e0bfe"
   integrity sha1-vMbEmkKihA7Zl/Mj6tpezRguC/4=
 
+lodash.orderby@^4.6.0:
+  version "4.6.0"
+  resolved "https://registry.yarnpkg.com/lodash.orderby/-/lodash.orderby-4.6.0.tgz#e697f04ce5d78522f54d9338b32b81a3393e4eb3"
+  integrity sha1-5pfwTOXXhSL1TZM4syuBozk+TrM=
+
 lodash.set@^4.3.2:
   version "4.3.2"
   resolved "https://registry.yarnpkg.com/lodash.set/-/lodash.set-4.3.2.tgz#d8757b1da807dde24816b0d6a84bea1a76230b23"
@@ -11019,6 +11024,11 @@ nan@^2.12.1, nan@^2.14.0:
   version "2.14.2"
   resolved "https://registry.yarnpkg.com/nan/-/nan-2.14.2.tgz#f5376400695168f4cc694ac9393d0c9585eeea19"
   integrity sha512-M2ufzIiINKCuDfBSAUr1vWQ+vuVcA9kqx8JJUsbQi6yf1uGRyb7HfpdfUr5qLXf3B/t8dPvcjhKMmlfnP47EzQ==
+
+nanoid@^2.1.0:
+  version "2.1.11"
+  resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-2.1.11.tgz#ec24b8a758d591561531b4176a01e3ab4f0f0280"
+  integrity sha512-s/snB+WGm6uwi0WjsZdaVcuf3KJXlfGl2LcxgwkEwJF0D/BWzVWAZW/XY4bFaiR7s0Jk3FPvlnepg1H1b1UwlA==
 
 nanoid@^3.0.1, nanoid@^3.1.20:
   version "3.1.20"
@@ -13184,6 +13194,15 @@ react-app-polyfill@^2.0.0:
     regenerator-runtime "^0.13.7"
     whatwg-fetch "^3.4.1"
 
+react-data-table-component@^6.11.7:
+  version "6.11.7"
+  resolved "https://registry.yarnpkg.com/react-data-table-component/-/react-data-table-component-6.11.7.tgz#112761005ceb13ae09732e1c1125eeacbda9e21d"
+  integrity sha512-p+wdtaaKs2udJByL2tyvL9uj8EDFy5GtpVVtNGd6d5dT0KikVhgCKFMDyv0ef+azdBVS68BaxGQ8JArDr31nWw==
+  dependencies:
+    deepmerge "^4.2.2"
+    lodash.orderby "^4.6.0"
+    shortid "^2.2.16"
+
 react-dev-utils@^11.0.2:
   version "11.0.2"
   resolved "https://registry.yarnpkg.com/react-dev-utils/-/react-dev-utils-11.0.2.tgz#98aed16ef50f808ee17b32def75eb15f89655802"
@@ -14452,6 +14471,13 @@ shellwords@^0.1.1:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/shellwords/-/shellwords-0.1.1.tgz#d6b9181c1a48d397324c84871efbcfc73fc0654b"
   integrity sha512-vFwSUfQvqybiICwZY5+DAWIPLKsWO31Q91JSKl3UYv+K5c2QRPzn0qzec6QPu1Qc9eHYItiP3NdJqNVqetYAww==
+
+shortid@^2.2.16:
+  version "2.2.16"
+  resolved "https://registry.yarnpkg.com/shortid/-/shortid-2.2.16.tgz#b742b8f0cb96406fd391c76bfc18a67a57fe5608"
+  integrity sha512-Ugt+GIZqvGXCIItnsL+lvFJOiN7RYqlGy7QE41O3YC1xbNSeDGIRO7xg2JJXIAj1cAGnOeC1r7/T9pgrtQbv4g==
+  dependencies:
+    nanoid "^2.1.0"
 
 side-channel@^1.0.3, side-channel@^1.0.4:
   version "1.0.4"


### PR DESCRIPTION
*Autostep and show inspector are now togglable across refreshes via localStorage. By default autostep's off and inspector's on.

* We added a simple sortable table with energies of functions. More features to come

![image](https://user-images.githubusercontent.com/2660634/112891575-4ca84880-90a6-11eb-9515-04ffbf2a165e.png)
