### PR TITLE
fix: K&R style braces in GPI exprs #543

### DIFF
--- a/packages/core/src/parser/Style.ne
+++ b/packages/core/src/parser/Style.ne
@@ -588,7 +588,7 @@ expr_list
   -> _ {% d => [] %}
   |  _ sepBy1[expr, ","] _ {% nth(1) %}
 
-gpi_decl -> identifier _ "{" property_decl_list "}" {%
+gpi_decl -> identifier _ml "{" property_decl_list "}" {%
   ([shapeName, , , properties, rbrace]): GPIDecl => ({
     ...nodeData([shapeName, ...properties]),
     ...rangeBetween(shapeName, rbrace),

--- a/packages/core/src/parser/StyleParser.test.ts
+++ b/packages/core/src/parser/StyleParser.test.ts
@@ -327,7 +327,8 @@ const {
     const prog = `
 const {
   -- literals
-  A.circle = Circle { -- comment begin
+  A.circle = Circle -- C-style braces
+  { -- comment begin
     strokeStyle: "dashed"
     -- comment between lines
     beautiful: true --comment inline


### PR DESCRIPTION
# Description

Related issue/PR: #543 

# Implementation strategy and design decisions

Parse comments and newlines after the GPI name in the Style parser


