### PR TITLE
fix: handle Text GPIs with empty strings #294

### DIFF
--- a/packages/core/src/engine/Evaluator.ts
+++ b/packages/core/src/engine/Evaluator.ts
@@ -130,11 +130,11 @@ export const evalShapes = (s: State): State => {
       shapesEvaled.find(({ properties }) => sameName(properties.name, name))!
   );
 
-  const nonEmpties = sortedShapesEvaled.filter(notEmptyLabel);
+  // const nonEmpties = sortedShapesEvaled.filter(notEmptyLabel);
 
   // Update the state with the new list of shapes
   // (This is a shallow copy of the state btw, not a deep copy)
-  return { ...s, shapes: nonEmpties };
+  return { ...s, shapes: sortedShapesEvaled };
 };
 
 const sameName = (given: Value<number>, expected: string): boolean => {

--- a/packages/core/src/renderer/Label.ts
+++ b/packages/core/src/renderer/Label.ts
@@ -8,8 +8,9 @@ const Label = ({ shape, canvasSize, labels }: ShapeProps) => {
   attrTransformCoords(shape, canvasSize, elem);
   attrTitle(shape, elem);
   const name = shape.properties.name as IStrV<string>;
-  if (retrieveLabel(name.contents, labels) !== undefined) {
-    const renderedLabel = retrieveLabel(name.contents, labels)!.rendered;
+  const retrievedLabel = retrieveLabel(name.contents, labels);
+  if (retrievedLabel && retrievedLabel.rendered) {
+    const renderedLabel = retrievedLabel.rendered;
     attrFill(shape, renderedLabel.getElementsByTagName("g")[0]);
     attrWH(shape, renderedLabel as any);
     renderedLabel.getElementsByTagName("g")[0].setAttribute("stroke", "none");

--- a/packages/core/src/renderer/ShapeDef.ts
+++ b/packages/core/src/renderer/ShapeDef.ts
@@ -51,11 +51,6 @@ export const sortShapes = (shapes: Shape[], ordering: string[]): Shape[] => {
  * @param shape a `Text` shape
  */
 export const notEmptyLabel = (shape: Shape): boolean => {
-  if (!shape) {
-    // COMBAK: temp hack, revert when labels are generated
-    console.error("Skipping undefined shape");
-    return true;
-  }
   const { shapeType, properties } = shape;
   return shapeType === "Text" ? !(properties.string.contents === "") : true;
 };


### PR DESCRIPTION
# Description

Related issue/PR: #294 

When the user `override` the `string` property of `Text` GPIs, the system reports an error in retrieving the label data. Our old code in `tex2svg` returns `undefined` whenever `string === ""`. Now that we have actual use cases from the domain expert study to "remove" a label, especially when `delete` is not straightforward.   

# Implementation strategy and design decisions

* Allow empty strings in `Text` and remove all the hacks in the system to handle them
* In `tex2svg`, check for `Infinity` to prevent `NaN` blow-up

# Examples with steps to reproduce them

https://panes.penrose.ink/gist/faf5f3cc108199b08c78c6da24a51531
