### PR TITLE
chore: add semantic commit message for release commits

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "start": "lerna run watch --stream --parallel --scope=@penrose/core --scope=@penrose/browser-ui",
     "test": "lerna run test --stream",
     "lerna": "lerna",
-    "new-version": "lerna version --conventional-commits --create-release github -m \"chore(release): publish %s\"",
+    "new-version": "lerna version --conventional-commits --create-release github -m \"chore(release): publish %s [ci skip]\"",
     "new-version:prerelease": "lerna version --conventional-prerelease",
     "graduate": "lerna version --conventional-commits --conventional-graduate",
     "publish:canary": "lerna publish --canary --dist-tag develop --force-publish",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "start": "lerna run watch --stream --parallel --scope=@penrose/core --scope=@penrose/browser-ui",
     "test": "lerna run test --stream",
     "lerna": "lerna",
-    "new-version": "lerna version --conventional-commits --create-release github",
+    "new-version": "lerna version --conventional-commits --create-release github -m \"chore(release): publish %s\"",
     "new-version:prerelease": "lerna version --conventional-prerelease",
     "graduate": "lerna version --conventional-commits --conventional-graduate",
     "publish:canary": "lerna publish --canary --dist-tag develop --force-publish",


### PR DESCRIPTION
# Description

Add `chore(release): %s [skip ci]` to every release message. 

In general, our canary releases have two problems:
* The commit SHA is _not_ included in the NPM versions: https://github.com/lerna/lerna/issues/1893#issuecomment-583124032
* As a result, we run into duplicate version numbers immediately after a `latest` release. 

To avoid the duplicate canary releases, I added `[skip ci]` in the release commit message. 
