### PR TITLE
chore: add a top-level `docs` script

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "clean": "lerna clean && lerna exec -- rimraf build",
     "start": "lerna run watch --stream --parallel --scope=@penrose/core --scope=@penrose/browser-ui",
     "test": "lerna run test --stream",
+    "docs": "lerna run docs --stream",
     "lerna": "lerna",
     "new-version": "lerna version --conventional-commits --create-release github -m \"chore(release): publish %s [ci skip]\"",
     "new-version:prerelease": "lerna version --conventional-prerelease",


### PR DESCRIPTION
# Description

Related issue/PR: #578 

The instruction in our PR template asks contributors to run `yarn docs`, but it's unclear where to run it. To be consistent with the instruction about `yarn test`, I added a convenience script at the top level. 
