### PR TITLE
refactor: shape property definitions and autodoc generate them

### DIFF
--- a/packages/browser-ui/src/inspector/views/mod/LabeledInput.tsx
+++ b/packages/browser-ui/src/inspector/views/mod/LabeledInput.tsx
@@ -22,7 +22,7 @@ type InputType =
 
 interface IInputProps {
   inputType: InputType;
-  showValue?: "true" | "false";
+  showValue?: boolean;
   min?: string;
   max?: string;
   minX?: string;
@@ -57,12 +57,12 @@ const toCanvas = (jsonVal: string): string => {
 
 class LabeledInput extends React.Component<IProps> {
   public readonly state = {
-    eValue: this.props.eValue,
+    eValue: this.props.eValue
   };
   public componentDidUpdate(prevProps: IProps) {
     if (this.props !== prevProps) {
       this.setState({
-        eValue: this.props.eValue,
+        eValue: this.props.eValue
       });
     }
   } // todo - will subpath<x> always have typeof x = number?
@@ -78,8 +78,8 @@ class LabeledInput extends React.Component<IProps> {
     const newstate = {
       eValue: {
         ...this.state.eValue,
-        contents: evalue,
-      },
+        contents: evalue
+      }
     };
     this.setState(newstate); // will update span values - could be phased out if spans are set manually
     this.props.modAttr(id, newstate.eValue as ShapeTypes.Value<any>);
@@ -145,7 +145,7 @@ class LabeledInput extends React.Component<IProps> {
     const hex = event.target.value;
     this.updateAttr(eattr, {
       tag: "RGBA",
-      contents: this.toRGBA(hex),
+      contents: this.toRGBA(hex)
     });
   };
   public handleOpacity = (
@@ -161,7 +161,7 @@ class LabeledInput extends React.Component<IProps> {
     colorobj[3] = +event.target.value / 100.0;
     this.updateAttr(eattr, {
       tag: "RGBA",
-      contents: colorobj,
+      contents: colorobj
     });
   };
   // https://stackoverflow.com/questions/21646738/convert-hex-to-rgba
@@ -183,7 +183,7 @@ class LabeledInput extends React.Component<IProps> {
       <input
         id={eAttr}
         type="range"
-        onChange={(e) => this.handleChange(eAttr, e)}
+        onChange={e => this.handleChange(eAttr, e)}
         min={toCanvas(inputProps.min!)}
         max={toCanvas(inputProps.max!)}
         value={round(this.props.eValue.contents)}
@@ -194,7 +194,7 @@ class LabeledInput extends React.Component<IProps> {
     id: string,
     spanval: string,
     ltxt: string,
-    showValue: boolean
+    showValue?: boolean
   ) => {
     if (showValue) {
       return (
@@ -229,7 +229,7 @@ class LabeledInput extends React.Component<IProps> {
                   index.toString(),
                   "x",
                   subindex.toString(),
-                  eAttr,
+                  eAttr
                 ].join("_");
                 const xltxt =
                   "S" + index.toString() + "x" + subindex.toString();
@@ -246,7 +246,7 @@ class LabeledInput extends React.Component<IProps> {
                   index.toString(),
                   "y",
                   subindex.toString(),
-                  eAttr,
+                  eAttr
                 ].join("_");
                 const yltxt =
                   "S" + index.toString() + "y" + subindex.toString();
@@ -259,7 +259,7 @@ class LabeledInput extends React.Component<IProps> {
                       <input
                         id={xid}
                         type="range"
-                        onChange={(e) =>
+                        onChange={e =>
                           this.handleMulPtRange(eAttr, index, subindex, 0, e)
                         }
                         min={toCanvas(inputProps.minX!)}
@@ -270,7 +270,7 @@ class LabeledInput extends React.Component<IProps> {
                         xid,
                         xspan,
                         xltxt,
-                        inputProps.showValue === "true"
+                        inputProps.showValue
                       )}
                     </div>
                     <div
@@ -280,7 +280,7 @@ class LabeledInput extends React.Component<IProps> {
                       <input
                         id={yid}
                         type="range"
-                        onChange={(e) =>
+                        onChange={e =>
                           this.handleMulPtRange(eAttr, index, subindex, 1, e)
                         }
                         min={toCanvas(inputProps.minY!)}
@@ -291,7 +291,7 @@ class LabeledInput extends React.Component<IProps> {
                         yid,
                         yspan,
                         yltxt,
-                        inputProps.showValue === "true"
+                        inputProps.showValue
                       )}
                     </div>
                   </React.Fragment>
@@ -319,14 +319,9 @@ class LabeledInput extends React.Component<IProps> {
             min={toCanvas(inputProps.minX!)}
             max={toCanvas(inputProps.maxX!)}
             value={round(pt[0] as number)}
-            onChange={(e) => this.handlePtRange(eAttr, 0, e)}
+            onChange={e => this.handlePtRange(eAttr, 0, e)}
           />
-          {this.makeSubLabel(
-            xid,
-            xspan,
-            eAttr + "X",
-            inputProps.showValue === "true"
-          )}
+          {this.makeSubLabel(xid, xspan, eAttr + "X", inputProps.showValue)}
         </div>
         <div className="sublabinput" style={{ display: "inline-block" }}>
           <input
@@ -335,14 +330,9 @@ class LabeledInput extends React.Component<IProps> {
             min={toCanvas(inputProps.minY!)}
             max={toCanvas(inputProps.maxY!)}
             value={round(pt[1] as number)}
-            onChange={(e) => this.handlePtRange(eAttr, 1, e)}
+            onChange={e => this.handlePtRange(eAttr, 1, e)}
           />
-          {this.makeSubLabel(
-            yid,
-            yspan,
-            eAttr + "Y",
-            inputProps.showValue === "true"
-          )}
+          {this.makeSubLabel(yid, yspan, eAttr + "Y", inputProps.showValue)}
         </div>
       </React.Fragment>
     );
@@ -358,7 +348,7 @@ class LabeledInput extends React.Component<IProps> {
         type="text"
         id={eAttr}
         defaultValue={this.props.eValue.contents}
-        onKeyDown={(e) => this.keyDown(eAttr, e)}
+        onKeyDown={e => this.keyDown(eAttr, e)}
       />
     );
   };
@@ -371,7 +361,7 @@ class LabeledInput extends React.Component<IProps> {
         type="url"
         id={eAttr}
         defaultValue={this.props.eValue.contents}
-        onKeyDown={(e) => this.keyDown(eAttr, e)}
+        onKeyDown={e => this.keyDown(eAttr, e)}
       />
     );
   };
@@ -381,7 +371,7 @@ class LabeledInput extends React.Component<IProps> {
       <input
         type="number"
         id={eAttr}
-        onChange={(e) => this.handleChange(eAttr, e)}
+        onChange={e => this.handleChange(eAttr, e)}
         min={inputProps.min ? toCanvas(inputProps.min) : ""}
         max={inputProps.max ? toCanvas(inputProps.max) : ""}
         value={this.props.eValue.contents}
@@ -395,7 +385,7 @@ class LabeledInput extends React.Component<IProps> {
         type="checkbox"
         id={eAttr}
         checked={this.props.eValue.contents}
-        onChange={(e) => this.handleCheck(eAttr, e)}
+        onChange={e => this.handleCheck(eAttr, e)}
       />
     );
   };
@@ -411,14 +401,9 @@ class LabeledInput extends React.Component<IProps> {
             type="color"
             id={cid}
             value={toHex(this.props.eValue.contents)}
-            onChange={(e) => this.handleColor(eAttr, e)}
+            onChange={e => this.handleColor(eAttr, e)}
           />
-          {this.makeSubLabel(
-            cid,
-            this.getSpan(),
-            eAttr,
-            inputProps.showValue === "true"
-          )}
+          {this.makeSubLabel(cid, this.getSpan(), eAttr, inputProps.showValue)}
         </div>
         <div className="sublabinput" style={{ display: "inline-block" }}>
           <input
@@ -428,7 +413,7 @@ class LabeledInput extends React.Component<IProps> {
             min="0"
             max="100"
             value={round(100 * this.props.eValue.contents.contents[3])}
-            onChange={(e) => this.handleOpacity(eAttr, e)}
+            onChange={e => this.handleOpacity(eAttr, e)}
           />
           {this.makeSubLabel(oid, this.getSpan(), "opacity", false)}
         </div>
@@ -440,7 +425,7 @@ class LabeledInput extends React.Component<IProps> {
     if (!inputProps.hasOwnProperty("options"))
       throw new Error("Select input type must have enumerated options.");
     return (
-      <select id={eAttr} onChange={(e) => this.handleChange(eAttr, e)}>
+      <select id={eAttr} onChange={e => this.handleChange(eAttr, e)}>
         {inputProps.options!.map((option: string) => (
           <option key={option} value={option}>
             {option}
@@ -472,7 +457,7 @@ class LabeledInput extends React.Component<IProps> {
     )
       return;
     // don't need to return anything b/c we need to make individual labels
-    else if (this.props.inputProps.showValue === "true")
+    else if (this.props.inputProps.showValue)
       return (
         <label htmlFor={this.props.eAttr}>
           {this.makeSpan()}

--- a/packages/core/src/engine/EngineUtils.ts
+++ b/packages/core/src/engine/EngineUtils.ts
@@ -739,13 +739,11 @@ export const insertExpr = (
             return addWarn(trans, {
               tag: "InvalidGPIPropertyError",
               givenProperty: prop,
-              expectedProperties: Object.entries(shapeDef.properties).map(
-                (e) => e[0]
-              ),
+              expectedProperties: Object.keys(shapeDef.properties),
             });
           }
 
-          if (shapeDef.properties[prop.value][0] !== "VectorV") {
+          if (shapeDef.properties[prop.value].propType !== "VectorV") {
             throw Error(
               "internal error: Cannot insert expression into an uninitialized non-vector. this feature is currently not supported."
             );

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -15,6 +15,7 @@ import RenderStatic, {
   RenderShape,
 } from "renderer/Renderer";
 import { resampleBest } from "renderer/Resample";
+import { shapedefs } from "renderer/ShapeDef";
 import { Synthesizer, SynthesizerSetting } from "synthesis/Synthesizer";
 import { Env } from "types/domain";
 import { PenroseError } from "types/errors";
@@ -282,6 +283,7 @@ export {
   Synthesizer,
   RenderInteractive,
   ShapeTypes,
+  shapedefs,
   bBoxDims,
   prettySubstance,
   toHex,

--- a/packages/core/src/renderer/Resample.ts
+++ b/packages/core/src/renderer/Resample.ts
@@ -74,7 +74,7 @@ const sampleProperty = (
 ): Value<number> => {
   const propModels: IPropModel = shapeDef.properties;
   const sampler = propModels[property];
-  if (sampler) return sampler[1]();
+  if (sampler) return sampler.sampler();
   else {
     throw new Error(
       `${property} is not a valid property to be sampled for shape ${shapeDef.shapeType}.`

--- a/packages/core/src/renderer/ShapeDef.ts
+++ b/packages/core/src/renderer/ShapeDef.ts
@@ -138,7 +138,37 @@ export type ShapeDef = IShapeDef;
 // type HasTag<T, N> = T extends { tag: N } ? T : never;
 
 export type PropType = Value<number>["tag"];
-export type IPropModel = { [k: string]: [PropType, Sampler] };
+
+export type InputType =
+  | "range"
+  | "mulptrange"
+  | "color"
+  | "select"
+  | "checkbox"
+  | "text"
+  | "number"
+  | "url"
+  | "ptrange";
+
+export interface IInputProps {
+  inputType: InputType;
+  showValue?: boolean;
+  min?: number;
+  max?: number;
+  minX?: number;
+  minY?: number;
+  maxX?: number;
+  maxY?: number;
+  options?: string[];
+}
+export interface IProp {
+  propType: PropType;
+  sampler: Sampler;
+  inspection?: IInputProps;
+  description?: string;
+}
+
+export type IPropModel = { [k: string]: IProp };
 
 export interface IShapeDef {
   shapeType: string;
@@ -151,15 +181,21 @@ export type Sampler = () => Value<number>;
 export const circleDef: ShapeDef = {
   shapeType: "Circle",
   properties: {
-    center: ["VectorV", vectorSampler],
-    r: ["FloatV", widthSampler],
-    pathLength: ["FloatV", pathLengthSampler], // part of svg spec
-    strokeWidth: ["FloatV", strokeSampler],
-    style: ["StrV", () => constValue("StrV", "filled")],
-    strokeStyle: ["StrV", () => constValue("StrV", "solid")],
-    strokeColor: ["ColorV", colorSampler],
-    color: ["ColorV", colorSampler],
-    name: ["StrV", () => constValue("StrV", "defaultCircle")],
+    center: { propType: "VectorV", sampler: vectorSampler },
+    r: { propType: "FloatV", sampler: widthSampler },
+    pathLength: { propType: "FloatV", sampler: pathLengthSampler }, // part of svg spec
+    strokeWidth: { propType: "FloatV", sampler: strokeSampler },
+    style: { propType: "StrV", sampler: () => constValue("StrV", "filled") },
+    strokeStyle: {
+      propType: "StrV",
+      sampler: () => constValue("StrV", "solid"),
+    },
+    strokeColor: { propType: "ColorV", sampler: colorSampler },
+    color: { propType: "ColorV", sampler: colorSampler },
+    name: {
+      propType: "StrV",
+      sampler: () => constValue("StrV", "defaultCircle"),
+    },
   },
   positionalProps: ["center"],
 };
@@ -167,17 +203,26 @@ export const circleDef: ShapeDef = {
 export const ellipseDef: ShapeDef = {
   shapeType: "Ellipse",
   properties: {
-    center: ["VectorV", vectorSampler],
-    rx: ["FloatV", widthSampler],
-    ry: ["FloatV", heightSampler],
-    pathLength: ["FloatV", pathLengthSampler], // part of svg spec
-    strokeWidth: ["FloatV", strokeSampler],
-    style: ["StrV", () => constValue("StrV", "filled")],
-    strokeStyle: ["StrV", () => constValue("StrV", "solid")],
-    strokeColor: ["ColorV", colorSampler],
-    strokeDashArray: ["StrV", () => constValue("StrV", "")],
-    color: ["ColorV", colorSampler],
-    name: ["StrV", () => constValue("StrV", "defaultCircle")],
+    center: { propType: "VectorV", sampler: vectorSampler },
+    rx: { propType: "FloatV", sampler: widthSampler },
+    ry: { propType: "FloatV", sampler: heightSampler },
+    pathLength: { propType: "FloatV", sampler: pathLengthSampler }, // part of svg spec
+    strokeWidth: { propType: "FloatV", sampler: strokeSampler },
+    style: { propType: "StrV", sampler: () => constValue("StrV", "filled") },
+    strokeStyle: {
+      propType: "StrV",
+      sampler: () => constValue("StrV", "solid"),
+    },
+    strokeColor: { propType: "ColorV", sampler: colorSampler },
+    strokeDashArray: {
+      propType: "StrV",
+      sampler: () => constValue("StrV", ""),
+    },
+    color: { propType: "ColorV", sampler: colorSampler },
+    name: {
+      propType: "StrV",
+      sampler: () => constValue("StrV", "defaultCircle"),
+    },
   },
   positionalProps: ["center"],
 };
@@ -185,17 +230,26 @@ export const ellipseDef: ShapeDef = {
 export const rectDef: ShapeDef = {
   shapeType: "Rectangle",
   properties: {
-    center: ["VectorV", vectorSampler],
-    w: ["FloatV", widthSampler],
-    h: ["FloatV", heightSampler],
-    rx: ["FloatV", zeroFloat],
-    strokeWidth: ["FloatV", strokeSampler],
-    style: ["StrV", () => constValue("StrV", "filled")],
-    strokeStyle: ["StrV", () => constValue("StrV", "solid")],
-    strokeColor: ["ColorV", colorSampler],
-    strokeDashArray: ["StrV", () => constValue("StrV", "")],
-    color: ["ColorV", colorSampler],
-    name: ["StrV", () => constValue("StrV", "defaultRect")],
+    center: { propType: "VectorV", sampler: vectorSampler },
+    w: { propType: "FloatV", sampler: widthSampler },
+    h: { propType: "FloatV", sampler: heightSampler },
+    rx: { propType: "FloatV", sampler: zeroFloat },
+    strokeWidth: { propType: "FloatV", sampler: strokeSampler },
+    style: { propType: "StrV", sampler: () => constValue("StrV", "filled") },
+    strokeStyle: {
+      propType: "StrV",
+      sampler: () => constValue("StrV", "solid"),
+    },
+    strokeColor: { propType: "ColorV", sampler: colorSampler },
+    strokeDashArray: {
+      propType: "StrV",
+      sampler: () => constValue("StrV", ""),
+    },
+    color: { propType: "ColorV", sampler: colorSampler },
+    name: {
+      propType: "StrV",
+      sampler: () => constValue("StrV", "defaultRect"),
+    },
   },
   positionalProps: ["center"],
 };
@@ -203,23 +257,29 @@ export const rectDef: ShapeDef = {
 export const polygonDef: ShapeDef = {
   shapeType: "Polygon",
   properties: {
-    strokeWidth: ["FloatV", strokeSampler],
-    style: ["StrV", () => constValue("StrV", "filled")],
-    strokeStyle: ["StrV", () => constValue("StrV", "solid")],
-    strokeColor: ["ColorV", colorSampler],
-    color: ["ColorV", colorSampler],
-    center: ["VectorV", vectorSampler],
-    scale: ["FloatV", () => constValue("FloatV", 1)],
-    name: ["StrV", () => constValue("StrV", "defaultPolygon")],
-    points: [
-      "PtListV",
-      () =>
+    strokeWidth: { propType: "FloatV", sampler: strokeSampler },
+    style: { propType: "StrV", sampler: () => constValue("StrV", "filled") },
+    strokeStyle: {
+      propType: "StrV",
+      sampler: () => constValue("StrV", "solid"),
+    },
+    strokeColor: { propType: "ColorV", sampler: colorSampler },
+    color: { propType: "ColorV", sampler: colorSampler },
+    center: { propType: "VectorV", sampler: vectorSampler },
+    scale: { propType: "FloatV", sampler: () => constValue("FloatV", 1) },
+    name: {
+      propType: "StrV",
+      sampler: () => constValue("StrV", "defaultPolygon"),
+    },
+    points: {
+      propType: "PtListV",
+      sampler: () =>
         constValue("PtListV", [
           [0, 0],
           [0, 10],
           [10, 0],
         ]),
-    ],
+    },
   },
   positionalProps: ["center"],
 };
@@ -227,21 +287,27 @@ export const polygonDef: ShapeDef = {
 export const freeformPolygonDef: ShapeDef = {
   shapeType: "FreeformPolygon",
   properties: {
-    strokeWidth: ["FloatV", strokeSampler],
-    style: ["StrV", () => constValue("StrV", "filled")],
-    strokeStyle: ["StrV", () => constValue("StrV", "solid")],
-    strokeColor: ["ColorV", colorSampler],
-    color: ["ColorV", colorSampler],
-    name: ["StrV", () => constValue("StrV", "defaultFreeformPolygon")],
-    points: [
-      "PtListV",
-      () =>
+    strokeWidth: { propType: "FloatV", sampler: strokeSampler },
+    style: { propType: "StrV", sampler: () => constValue("StrV", "filled") },
+    strokeStyle: {
+      propType: "StrV",
+      sampler: () => constValue("StrV", "solid"),
+    },
+    strokeColor: { propType: "ColorV", sampler: colorSampler },
+    color: { propType: "ColorV", sampler: colorSampler },
+    name: {
+      propType: "StrV",
+      sampler: () => constValue("StrV", "defaultFreeformPolygon"),
+    },
+    points: {
+      propType: "PtListV",
+      sampler: () =>
         constValue("PtListV", [
           [0, 0],
           [0, 10],
           [10, 0],
         ]),
-    ],
+    },
   },
   positionalProps: [],
 };
@@ -255,18 +321,30 @@ Q 10,60 10,30 z`;
 export const pathStringDef: ShapeDef = {
   shapeType: "PathString",
   properties: {
-    center: ["VectorV", vectorSampler],
-    w: ["FloatV", widthSampler],
-    h: ["FloatV", heightSampler],
-    rotation: ["FloatV", () => constValue("FloatV", 0)],
-    opacity: ["FloatV", () => constValue("FloatV", 1.0)],
-    strokeWidth: ["FloatV", strokeSampler],
-    strokeStyle: ["StrV", () => constValue("StrV", "solid")],
-    strokeColor: ["ColorV", colorSampler],
-    color: ["ColorV", colorSampler],
-    name: ["StrV", () => constValue("StrV", "defaultPolygon")],
-    data: ["StrV", () => constValue("StrV", DEFAULT_PATHSTR)],
-    viewBox: ["StrV", () => constValue("StrV", "0 0 100 100")],
+    center: { propType: "VectorV", sampler: vectorSampler },
+    w: { propType: "FloatV", sampler: widthSampler },
+    h: { propType: "FloatV", sampler: heightSampler },
+    rotation: { propType: "FloatV", sampler: () => constValue("FloatV", 0) },
+    opacity: { propType: "FloatV", sampler: () => constValue("FloatV", 1.0) },
+    strokeWidth: { propType: "FloatV", sampler: strokeSampler },
+    strokeStyle: {
+      propType: "StrV",
+      sampler: () => constValue("StrV", "solid"),
+    },
+    strokeColor: { propType: "ColorV", sampler: colorSampler },
+    color: { propType: "ColorV", sampler: colorSampler },
+    name: {
+      propType: "StrV",
+      sampler: () => constValue("StrV", "defaultPolygon"),
+    },
+    data: {
+      propType: "StrV",
+      sampler: () => constValue("StrV", DEFAULT_PATHSTR),
+    },
+    viewBox: {
+      propType: "StrV",
+      sampler: () => constValue("StrV", "0 0 100 100"),
+    },
   },
   positionalProps: ["center"],
 };
@@ -274,23 +352,29 @@ export const pathStringDef: ShapeDef = {
 export const polylineDef: ShapeDef = {
   shapeType: "Polyline",
   properties: {
-    strokeWidth: ["FloatV", strokeSampler],
-    center: ["VectorV", vectorSampler],
-    scale: ["FloatV", () => constValue("FloatV", 1)],
-    style: ["StrV", () => constValue("StrV", "filled")],
-    strokeStyle: ["StrV", () => constValue("StrV", "solid")],
-    strokeColor: ["ColorV", colorSampler],
-    color: ["ColorV", colorSampler],
-    name: ["StrV", () => constValue("StrV", "defaultPolygon")],
-    points: [
-      "PtListV",
-      () =>
+    strokeWidth: { propType: "FloatV", sampler: strokeSampler },
+    center: { propType: "VectorV", sampler: vectorSampler },
+    scale: { propType: "FloatV", sampler: () => constValue("FloatV", 1) },
+    style: { propType: "StrV", sampler: () => constValue("StrV", "filled") },
+    strokeStyle: {
+      propType: "StrV",
+      sampler: () => constValue("StrV", "solid"),
+    },
+    strokeColor: { propType: "ColorV", sampler: colorSampler },
+    color: { propType: "ColorV", sampler: colorSampler },
+    name: {
+      propType: "StrV",
+      sampler: () => constValue("StrV", "defaultPolygon"),
+    },
+    points: {
+      propType: "PtListV",
+      sampler: () =>
         constValue("PtListV", [
           [0, 0],
           [0, 10],
           [10, 0],
         ]),
-    ],
+    },
   },
   positionalProps: ["center"],
 };
@@ -298,15 +382,21 @@ export const polylineDef: ShapeDef = {
 export const imageDef: ShapeDef = {
   shapeType: "Image",
   properties: {
-    center: ["VectorV", vectorSampler],
-    w: ["FloatV", widthSampler],
-    h: ["FloatV", heightSampler],
-    rotation: ["FloatV", () => constValue("FloatV", 0)],
-    opacity: ["FloatV", () => constValue("FloatV", 1.0)],
-    style: ["StrV", () => constValue("StrV", "filled")],
-    stroke: ["StrV", () => constValue("StrV", "none")],
-    path: ["StrV", () => constValue("StrV", "missing image path")],
-    name: ["StrV", () => constValue("StrV", "defaultImage")],
+    center: { propType: "VectorV", sampler: vectorSampler },
+    w: { propType: "FloatV", sampler: widthSampler },
+    h: { propType: "FloatV", sampler: heightSampler },
+    rotation: { propType: "FloatV", sampler: () => constValue("FloatV", 0) },
+    opacity: { propType: "FloatV", sampler: () => constValue("FloatV", 1.0) },
+    style: { propType: "StrV", sampler: () => constValue("StrV", "filled") },
+    stroke: { propType: "StrV", sampler: () => constValue("StrV", "none") },
+    path: {
+      propType: "StrV",
+      sampler: () => constValue("StrV", "missing image path"),
+    },
+    name: {
+      propType: "StrV",
+      sampler: () => constValue("StrV", "defaultImage"),
+    },
   },
   positionalProps: ["center"],
 };
@@ -314,17 +404,26 @@ export const imageDef: ShapeDef = {
 export const squareDef: ShapeDef = {
   shapeType: "Square",
   properties: {
-    center: ["VectorV", vectorSampler],
-    side: ["FloatV", widthSampler],
-    rotation: ["FloatV", () => constValue("FloatV", 0)],
-    style: ["StrV", () => constValue("StrV", "none")],
-    rx: ["FloatV", zeroFloat],
-    strokeWidth: ["FloatV", strokeSampler],
-    strokeStyle: ["StrV", () => constValue("StrV", "solid")],
-    strokeColor: ["ColorV", colorSampler],
-    strokeDashArray: ["StrV", () => constValue("StrV", "")],
-    color: ["ColorV", colorSampler],
-    name: ["StrV", () => constValue("StrV", "defaultSquare")],
+    center: { propType: "VectorV", sampler: vectorSampler },
+    side: { propType: "FloatV", sampler: widthSampler },
+    rotation: { propType: "FloatV", sampler: () => constValue("FloatV", 0) },
+    style: { propType: "StrV", sampler: () => constValue("StrV", "none") },
+    rx: { propType: "FloatV", sampler: zeroFloat },
+    strokeWidth: { propType: "FloatV", sampler: strokeSampler },
+    strokeStyle: {
+      propType: "StrV",
+      sampler: () => constValue("StrV", "solid"),
+    },
+    strokeColor: { propType: "ColorV", sampler: colorSampler },
+    strokeDashArray: {
+      propType: "StrV",
+      sampler: () => constValue("StrV", ""),
+    },
+    color: { propType: "ColorV", sampler: colorSampler },
+    name: {
+      propType: "StrV",
+      sampler: () => constValue("StrV", "defaultSquare"),
+    },
   },
   positionalProps: ["center"],
 };
@@ -332,18 +431,24 @@ export const squareDef: ShapeDef = {
 export const textDef: ShapeDef = {
   shapeType: "Text",
   properties: {
-    center: ["VectorV", vectorSampler],
-    w: ["FloatV", () => constValue("FloatV", 0)],
-    h: ["FloatV", () => constValue("FloatV", 0)],
-    fontSize: ["StrV", () => constValue("StrV", "12pt")],
-    rotation: ["FloatV", () => constValue("FloatV", 0)],
-    style: ["StrV", () => constValue("StrV", "none")],
-    stroke: ["StrV", () => constValue("StrV", "none")],
-    color: ["ColorV", () => black],
-    name: ["StrV", () => constValue("StrV", "defaultText")],
-    string: ["StrV", () => constValue("StrV", "defaultLabelText")],
+    center: { propType: "VectorV", sampler: vectorSampler },
+    w: { propType: "FloatV", sampler: () => constValue("FloatV", 0) },
+    h: { propType: "FloatV", sampler: () => constValue("FloatV", 0) },
+    fontSize: { propType: "StrV", sampler: () => constValue("StrV", "12pt") },
+    rotation: { propType: "FloatV", sampler: () => constValue("FloatV", 0) },
+    style: { propType: "StrV", sampler: () => constValue("StrV", "none") },
+    stroke: { propType: "StrV", sampler: () => constValue("StrV", "none") },
+    color: { propType: "ColorV", sampler: () => black },
+    name: {
+      propType: "StrV",
+      sampler: () => constValue("StrV", "defaultText"),
+    },
+    string: {
+      propType: "StrV",
+      sampler: () => constValue("StrV", "defaultLabelText"),
+    },
     // HACK: typechecking is not passing due to Value mismatch. Not sure why
-    polygon: ["PolygonV", () => emptyPoly],
+    polygon: { propType: "PolygonV", sampler: () => emptyPoly },
   },
   positionalProps: ["center"],
 };
@@ -351,18 +456,36 @@ export const textDef: ShapeDef = {
 export const lineDef: ShapeDef = {
   shapeType: "Line",
   properties: {
-    start: ["VectorV", vectorSampler],
-    end: ["VectorV", vectorSampler],
-    thickness: ["FloatV", () => sampleFloatIn(5, 15)],
-    leftArrowhead: ["BoolV", () => constValue("BoolV", false)],
-    rightArrowhead: ["BoolV", () => constValue("BoolV", false)],
-    arrowheadStyle: ["StrV", () => constValue("StrV", "arrowhead-2")],
-    arrowheadSize: ["FloatV", () => constValue("FloatV", 1.0)],
-    color: ["ColorV", colorSampler],
-    style: ["StrV", () => constValue("StrV", "solid")],
-    stroke: ["StrV", () => constValue("StrV", "none")],
-    strokeDashArray: ["StrV", () => constValue("StrV", "")],
-    name: ["StrV", () => constValue("StrV", "defaultLine")],
+    start: { propType: "VectorV", sampler: vectorSampler },
+    end: { propType: "VectorV", sampler: vectorSampler },
+    thickness: { propType: "FloatV", sampler: () => sampleFloatIn(5, 15) },
+    leftArrowhead: {
+      propType: "BoolV",
+      sampler: () => constValue("BoolV", false),
+    },
+    rightArrowhead: {
+      propType: "BoolV",
+      sampler: () => constValue("BoolV", false),
+    },
+    arrowheadStyle: {
+      propType: "StrV",
+      sampler: () => constValue("StrV", "arrowhead-2"),
+    },
+    arrowheadSize: {
+      propType: "FloatV",
+      sampler: () => constValue("FloatV", 1.0),
+    },
+    color: { propType: "ColorV", sampler: colorSampler },
+    style: { propType: "StrV", sampler: () => constValue("StrV", "solid") },
+    stroke: { propType: "StrV", sampler: () => constValue("StrV", "none") },
+    strokeDashArray: {
+      propType: "StrV",
+      sampler: () => constValue("StrV", ""),
+    },
+    name: {
+      propType: "StrV",
+      sampler: () => constValue("StrV", "defaultLine"),
+    },
   },
   positionalProps: ["start", "end"],
 };
@@ -370,15 +493,27 @@ export const lineDef: ShapeDef = {
 export const arrowDef: ShapeDef = {
   shapeType: "Arrow",
   properties: {
-    start: ["VectorV", vectorSampler],
-    end: ["VectorV", vectorSampler],
-    thickness: ["FloatV", () => sampleFloatIn(5, 15)],
-    arrowheadStyle: ["StrV", () => constValue("StrV", "arrowhead-2")],
-    arrowheadSize: ["FloatV", () => constValue("FloatV", 1.0)],
-    style: ["StrV", () => constValue("StrV", "solid")],
-    color: ["ColorV", colorSampler],
-    name: ["StrV", () => constValue("StrV", "defaultArrow")],
-    strokeDashArray: ["StrV", () => constValue("StrV", "")],
+    start: { propType: "VectorV", sampler: vectorSampler },
+    end: { propType: "VectorV", sampler: vectorSampler },
+    thickness: { propType: "FloatV", sampler: () => sampleFloatIn(5, 15) },
+    arrowheadStyle: {
+      propType: "StrV",
+      sampler: () => constValue("StrV", "arrowhead-2"),
+    },
+    arrowheadSize: {
+      propType: "FloatV",
+      sampler: () => constValue("FloatV", 1.0),
+    },
+    style: { propType: "StrV", sampler: () => constValue("StrV", "solid") },
+    color: { propType: "ColorV", sampler: colorSampler },
+    name: {
+      propType: "StrV",
+      sampler: () => constValue("StrV", "defaultArrow"),
+    },
+    strokeDashArray: {
+      propType: "StrV",
+      sampler: () => constValue("StrV", ""),
+    },
   },
   positionalProps: ["start", "end"],
 };
@@ -386,21 +521,42 @@ export const arrowDef: ShapeDef = {
 export const curveDef: ShapeDef = {
   shapeType: "Path",
   properties: {
-    path: ["PtListV", () => constValue("PtListV", [])],
-    polyline: ["PtListV", () => constValue("PtListV", [])],
-    polygon: ["PolygonV", () => emptyPoly],
-    pathData: ["PathDataV", () => constValue("PathDataV", [])],
-    strokeWidth: ["FloatV", strokeSampler],
-    style: ["StrV", () => constValue("StrV", "solid")],
-    strokeDashArray: ["StrV", () => constValue("StrV", "")],
-    effect: ["StrV", () => constValue("StrV", "none")],
-    color: ["ColorV", colorSampler],
-    fill: ["ColorV", colorSampler],
-    leftArrowhead: ["BoolV", () => constValue("BoolV", false)],
-    rightArrowhead: ["BoolV", () => constValue("BoolV", false)],
-    arrowheadStyle: ["StrV", () => constValue("StrV", "arrowhead-2")],
-    arrowheadSize: ["FloatV", () => constValue("FloatV", 1.0)],
-    name: ["StrV", () => constValue("StrV", "defaultCurve")],
+    path: { propType: "PtListV", sampler: () => constValue("PtListV", []) },
+    polyline: { propType: "PtListV", sampler: () => constValue("PtListV", []) },
+    polygon: { propType: "PolygonV", sampler: () => emptyPoly },
+    pathData: {
+      propType: "PathDataV",
+      sampler: () => constValue("PathDataV", []),
+    },
+    strokeWidth: { propType: "FloatV", sampler: strokeSampler },
+    style: { propType: "StrV", sampler: () => constValue("StrV", "solid") },
+    strokeDashArray: {
+      propType: "StrV",
+      sampler: () => constValue("StrV", ""),
+    },
+    effect: { propType: "StrV", sampler: () => constValue("StrV", "none") },
+    color: { propType: "ColorV", sampler: colorSampler },
+    fill: { propType: "ColorV", sampler: colorSampler },
+    leftArrowhead: {
+      propType: "BoolV",
+      sampler: () => constValue("BoolV", false),
+    },
+    rightArrowhead: {
+      propType: "BoolV",
+      sampler: () => constValue("BoolV", false),
+    },
+    arrowheadStyle: {
+      propType: "StrV",
+      sampler: () => constValue("StrV", "arrowhead-2"),
+    },
+    arrowheadSize: {
+      propType: "FloatV",
+      sampler: () => constValue("FloatV", 1.0),
+    },
+    name: {
+      propType: "StrV",
+      sampler: () => constValue("StrV", "defaultCurve"),
+    },
   },
 };
 

--- a/packages/core/src/renderer/ShapeDef.ts
+++ b/packages/core/src/renderer/ShapeDef.ts
@@ -161,10 +161,23 @@ export interface IInputProps {
   maxY?: number;
   options?: string[];
 }
+
 export interface IProp {
+  /**
+   * The datatype of the property
+   */
   propType: PropType;
+  /**
+   * The sampling function to generate the property
+   */
   sampler: Sampler;
+  /**
+   * Optional parameters for the inspector to render the property
+   */
   inspection?: IInputProps;
+  /**
+   * Documentation of the property
+   */
   description?: string;
 }
 


### PR DESCRIPTION
closes #558, #570

- [x] Create new interface

```
export interface IProp {
  propType: PropType;
  sampler: Sampler;
  inspection?: IInputProps;
  description?: string;
}
```
- [ ] Port inspector `.json` properties
- [ ] Autodoc (need to find a good generator - maybe a gatsby or jekyll thing like https://pmarsceill.github.io/just-the-docs/ or https://github.com/rundocs/jekyll-rtd-theme or https://primer.style/doctocat/getting-started)

Note:

Typescript doesn't seem to catch the "old" way of accessing properties' samplers (eg `gpi[property][1]`), so runtime errors were thrown. I may have missed some old code paths where this is still the case - may need help finding them.