### PR TITLE
fix: Unify BBox Computation in `Constraints.ts` and Make `Square` Rect-Like

### DIFF
--- a/examples/graph-domain/disjoint-rect-line-horiz.sty
+++ b/examples/graph-domain/disjoint-rect-line-horiz.sty
@@ -95,5 +95,5 @@ Vertex v1; Vertex v2 {
 }
 
 Vertex v; Edge e {
-       ensure disjointRectLineAAHoriz(v.shape, e.shape)
+       ensure disjointRectLineAA(v.shape, e.shape)
 }

--- a/examples/graph-domain/disjoint-rect-line-vert.sty
+++ b/examples/graph-domain/disjoint-rect-line-vert.sty
@@ -95,5 +95,5 @@ Vertex v1; Vertex v2 {
 }
 
 Vertex v; Edge e {
-       ensure disjointRectLineAAVert(v.shape, e.shape)
+       ensure disjointRectLineAA(v.shape, e.shape)
 }

--- a/examples/monoidal-category-domain/monoidal-test.sty
+++ b/examples/monoidal-category-domain/monoidal-test.sty
@@ -159,7 +159,7 @@ where m := join(a, b) {
 
 Object o; Morphism m
 where NotChildOf(o, m) {
-       ensure disjointRectLineAAHoriz(m.shape, o.shape)
+       ensure disjointRectLineAA(m.shape, o.shape)
 }
 
 Morphism m1; Morphism m2 {

--- a/packages/core/src/contrib/Constraints.ts
+++ b/packages/core/src/contrib/Constraints.ts
@@ -941,6 +941,9 @@ export const areDisjointBoxes = (a: BBox, b: BBox): VarAD => {
 };
 
 /**
+ * Preconditions:
+ *   If the input is line-like, it must be axis-aligned.
+ *   Assumes line-like shapes are longer than they are thick.
  * Input: A rect- or line-like shape.
  * Output: A new BBox
  * Errors: Throws an error if the input shape is not rect- or line-like.
@@ -957,7 +960,10 @@ export const bboxFromShape = (t: string, s: any): BBox => {
   if (t == "Square") {
     w = s.side.contents;
   } else if (isLinelike(t)) {
-    w = max(absVal(sub(s.start.contents[0], s.end.contents[0])), constOf(2));
+    w = max(
+      absVal(sub(s.start.contents[0], s.end.contents[0])),
+      s.thickness.contents
+    );
   } else {
     w = s.w.contents;
   }
@@ -966,7 +972,10 @@ export const bboxFromShape = (t: string, s: any): BBox => {
   if (t == "Square") {
     h = s.side.contents;
   } else if (isLinelike(t)) {
-    h = max(absVal(sub(s.start.contents[1], s.end.contents[1])), constOf(2));
+    h = max(
+      absVal(sub(s.start.contents[1], s.end.contents[1])),
+      s.thickness.contents
+    );
   } else {
     h = s.h.contents;
   }

--- a/packages/core/src/contrib/Constraints.ts
+++ b/packages/core/src/contrib/Constraints.ts
@@ -421,11 +421,7 @@ export const constrDict = {
     const overlapY = overlap1D(box.yRange, line.yRange);
 
     // Push away in both X and Y directions
-    return ifCond(
-      areDisjointBoxes(box, line),
-      constOf(0),
-      mul(overlapX, overlapY)
-    );
+    return mul(overlapX, overlapY);
   },
 
   /**
@@ -458,11 +454,7 @@ export const constrDict = {
       const overlapY = overlap1D(inflatedBox1.yRange, box2.yRange);
 
       // Push away in both X and Y directions, and account for padding
-      return ifCond(
-        areDisjointBoxes(inflatedBox1, box2),
-        constOf(0),
-        mul(overlapX, overlapY)
-      );
+      return mul(overlapX, overlapY);
     } else {
       // TODO (new case): I guess we might need Rectangle disjoint from polyline? Unless they repel each other?
       throw new Error(`${[t1, t2]} not supported for disjoint`);

--- a/packages/core/src/contrib/Constraints.ts
+++ b/packages/core/src/contrib/Constraints.ts
@@ -424,7 +424,7 @@ export const constrDict = {
     return ifCond(
       areDisjointBoxes(box, line),
       constOf(0),
-      add(overlapX, overlapY)
+      mul(overlapX, overlapY)
     );
   },
 
@@ -450,14 +450,9 @@ export const constrDict = {
       return sub(add(lenApprox, constOfIf(offset)), ops.vdist(centerT, cp));
     } else if (isRectlike(t1) && isRectlike(t2)) {
       // Assuming AABB (they are axis-aligned [bounding] boxes)
-      // TODO: Write this to use the area of rectangle overlap, as this can currently only move in horiz/vert directions (i.e. results in worse local minima sometimes)
       const box1 = bboxFromShape(t1, s1);
       const box2 = bboxFromShape(t2, s2);
       const inflatedBox1 = BBox.inflate(box1, constOfIf(offset));
-      //   const _iminX = debug(inflatedBox1.minX, "inflated minX");
-      //   const _imaxX = debug(inflatedBox1.maxX, "inflated maxX");
-      //   const _minX = debug(box2.minX, "minX");
-      //   const _maxX = debug(box2.maxX, "maxX");
 
       const overlapX = overlap1D(inflatedBox1.xRange, box2.xRange);
       const overlapY = overlap1D(inflatedBox1.yRange, box2.yRange);
@@ -466,7 +461,7 @@ export const constrDict = {
       return ifCond(
         areDisjointBoxes(inflatedBox1, box2),
         constOf(0),
-        add(overlapX, overlapY)
+        mul(overlapX, overlapY)
       );
     } else {
       // TODO (new case): I guess we might need Rectangle disjoint from polyline? Unless they repel each other?

--- a/packages/core/src/contrib/Constraints.ts
+++ b/packages/core/src/contrib/Constraints.ts
@@ -119,19 +119,19 @@ export const objDict = {
    */
   centerArrow: (
     [t1, arr]: [string, any],
-    [t2, text1]: [string, any],
-    [t3, text2]: [string, any]
+    [t2, s2]: [string, any],
+    [t3, s3]: [string, any]
   ): VarAD => {
     const spacing = varOf(1.1); // arbitrary
 
     if (isLinelike(t1) && isRectlike(t2) && isRectlike(t3)) {
-      const text1BB = bboxFromShape(t2, text1);
-      const text2BB = bboxFromShape(t3, text2);
+      const s2BB = bboxFromShape(t2, s2);
+      const s3BB = bboxFromShape(t3, s3);
       // HACK: Arbitrarily pick the height of the text
       // [spacing * getNum text1 "h", negate $ 2 * spacing * getNum text2 "h"]
-      return centerArrow2(arr, text1BB.center, text2BB.center, [
-        mul(spacing, text1BB.h),
-        neg(mul(text2BB.h, spacing)),
+      return centerArrow2(arr, s2BB.center, s3BB.center, [
+        mul(spacing, s2BB.h),
+        neg(mul(s3BB.h, spacing)),
       ]);
     } else throw new Error(`${[t1, t2, t3]} not supported for centerArrow`);
   },

--- a/packages/core/src/contrib/Constraints.ts
+++ b/packages/core/src/contrib/Constraints.ts
@@ -27,9 +27,8 @@ import {
 import * as _ from "lodash";
 import { linePts } from "utils/OtherUtils";
 import { canvasSize } from "renderer/ShapeDef";
-import { VarAD, VecAD } from "types/ad";
+import { VarAD, VecAD, BBox, Pt2 } from "types/ad";
 import { every } from "lodash";
-import { IVarAD } from "../../build/dist/types/ad";
 
 // Kinds of shapes
 /**
@@ -936,21 +935,11 @@ export const overlap1D = (
   );
 };
 
-export interface IBBox {
-  minX: IVarAD;
-  maxX: IVarAD;
-  minY: IVarAD;
-  maxY: IVarAD;
-  center: [IVarAD, IVarAD];
-  w: IVarAD;
-  h: IVarAD;
-}
-
 /**
  * Input: A rect-like shape.
  * Output: A bbox corresponding to the rect.
  */
-export const bbox = ([t, s]: [string, any]): IBBox => {
+export const bbox = ([t, s]: [string, any]): BBox => {
   if (!(isRectlike(t) || isLinelike(t))) {
     throw new Error(
       `Bbox expected a rect-like or line-like shape, but got ${t}`
@@ -980,7 +969,7 @@ export const bbox = ([t, s]: [string, any]): IBBox => {
   const halfHeight = div(h, constOf(2.0));
   const nhalfWidth = neg(halfWidth);
   const nhalfHeight = neg(halfHeight);
-  const pts = [
+  const pts = <Pt2[]>[
     [halfWidth, halfHeight],
     [nhalfWidth, halfHeight],
     [nhalfWidth, nhalfHeight],
@@ -999,42 +988,13 @@ export const bbox = ([t, s]: [string, any]): IBBox => {
     maxX: corners.bottomRight[0],
     minY: corners.bottomRight[1],
     maxY: corners.topLeft[1],
+    top: <[Pt2, Pt2]>[corners.topLeft, corners.topRight],
+    bot: <[Pt2, Pt2]>[corners.bottomLeft, corners.bottomRight],
+    left: <[Pt2, Pt2]>[corners.bottomLeft, corners.topLeft],
+    right: <[Pt2, Pt2]>[corners.bottomRight, corners.topRight],
     center,
     w,
     h,
-  };
-
-  return rect;
-};
-
-/**
- * Return the bounding box (as 4 segments) of an axis-aligned box-like shape given by `center`, width `w`, height `h` as an object with `top, bot, left, right`.
- */
-export const bboxSegs = (center: VecAD, w: VarAD, h: VarAD): any => {
-  const halfWidth = div(w, constOf(2.0));
-  const halfHeight = div(h, constOf(2.0));
-  const nhalfWidth = neg(halfWidth);
-  const nhalfHeight = neg(halfHeight);
-  // CCW: TR, TL, BL, BR
-  const pts = [
-    [halfWidth, halfHeight],
-    [nhalfWidth, halfHeight],
-    [nhalfWidth, nhalfHeight],
-    [halfWidth, nhalfHeight],
-  ].map((p) => ops.vadd(center, p));
-
-  const corners = {
-    topRight: pts[0],
-    topLeft: pts[1],
-    bottomLeft: pts[2],
-    bottomRight: pts[3],
-  };
-
-  const rect = {
-    top: [corners.topLeft, corners.topRight],
-    bot: [corners.bottomLeft, corners.bottomRight],
-    left: [corners.bottomLeft, corners.topLeft],
-    right: [corners.bottomRight, corners.topRight],
   };
 
   return rect;

--- a/packages/core/src/contrib/Constraints.ts
+++ b/packages/core/src/contrib/Constraints.ts
@@ -320,8 +320,7 @@ export const constrDict = {
       //    in dist (getX r, getY r) (getX c, getY c) - diff + padding
 
       // TODO: `rL` is probably a hack for dimensions
-      const s1BBox = bbox([t1, s1]);
-      const rL = div(min(s1BBox.w, s1BBox.h), varOf(2.0));
+      const rL = div(min(s1.w.contents, s1.h.contents), varOf(2.0));
       const diff = sub(rL, s2.r.contents);
       const d = ops.vdist(fns.center(s1), fns.center(s2));
       return add(sub(d, diff), offset);
@@ -446,7 +445,7 @@ export const constrDict = {
       const o = [s1.r.contents, s2.r.contents, varOf(10.0)];
       return sub(addN(o), d);
     } else if (isRectlike(t1) && isLinelike(t2)) {
-      const [text, seg] = [s1, s2];
+      const seg = s2;
       const textBB = bbox([t1, s1]);
       const centerT = textBB.center;
       const endpts = linePts(seg);

--- a/packages/core/src/contrib/Constraints.ts
+++ b/packages/core/src/contrib/Constraints.ts
@@ -947,6 +947,8 @@ export const bbox = ([t, s]: [string, any]): BBox => {
   }
 
   // TODO: Compute the bbox of the line in a nicer way
+
+  // initialize center, w, and h depending on whether the input shape is line-like or rect/square-like
   const center = isLinelike(t)
     ? ops.vdiv(ops.vadd(s.start.contents, s.end.contents), constOf(2))
     : s.center.contents;

--- a/packages/core/src/contrib/Constraints.ts
+++ b/packages/core/src/contrib/Constraints.ts
@@ -992,7 +992,7 @@ export const bbox = ([t, s]: [string, any]): BBox => {
   } else if (isLinelike(t)) {
     w = max(absVal(sub(s.start.contents[0], s.end.contents[0])), constOf(2));
   } else {
-    w = s.h.contents;
+    w = s.w.contents;
   }
 
   let h;

--- a/packages/core/src/contrib/Constraints.ts
+++ b/packages/core/src/contrib/Constraints.ts
@@ -986,24 +986,31 @@ export const bbox = ([t, s]: [string, any]): BBox => {
   }
 
   // initialize w, h, and center depending on whether the input shape is line-like or rect/square-like
-  const w =
-    t === "Square"
-      ? s.side.contents
-      : isLinelike(t)
-      ? max(absVal(sub(s.start.contents[0], s.end.contents[0])), constOf(2))
-      : s.w.contents;
+  let w;
+  if (t == "Square") {
+    w = s.side.contents;
+  } else if (isLinelike(t)) {
+    w = max(absVal(sub(s.start.contents[0], s.end.contents[0])), constOf(2));
+  } else {
+    w = s.h.contents;
+  }
 
-  const h =
-    t === "Square"
-      ? s.side.contents
-      : isLinelike(t)
-      ? max(absVal(sub(s.start.contents[1], s.end.contents[1])), constOf(2))
-      : s.h.contents;
+  let h;
+  if (t == "Square") {
+    h = s.side.contents;
+  } else if (isLinelike(t)) {
+    h = max(absVal(sub(s.start.contents[1], s.end.contents[1])), constOf(2));
+  } else {
+    h = s.h.contents;
+  }
 
-  // TODO: Compute the bbox of the line in a nicer way
-  const center = isLinelike(t)
-    ? ops.vdiv(ops.vadd(s.start.contents, s.end.contents), constOf(2))
-    : s.center.contents;
+  let center;
+  if (isLinelike(t)) {
+    // TODO: Compute the bbox of the line in a nicer way
+    center = ops.vdiv(ops.vadd(s.start.contents, s.end.contents), constOf(2));
+  } else {
+    center = s.center.contents;
+  }
 
   return bboxFromWHC(w, h, center);
 };

--- a/packages/core/src/contrib/Functions.ts
+++ b/packages/core/src/contrib/Functions.ts
@@ -1,6 +1,5 @@
 import {
   bbox,
-  bboxSegs,
   intersectsSegSeg,
   intersectionSegSeg,
   inRange,

--- a/packages/core/src/contrib/Functions.ts
+++ b/packages/core/src/contrib/Functions.ts
@@ -4,6 +4,7 @@ import {
   intersectsSegSeg,
   intersectionSegSeg,
   inRange,
+  isRectlike,
 } from "contrib/Constraints"; // TODO move this into graphics utils?
 import {
   absVal,
@@ -358,13 +359,12 @@ export const compDict = {
     [t1, s1]: [string, any]
   ): IFloatV<VarAD> => {
     // if (s1.rotation.contents) { throw Error("assumed AABB"); }
-    if (t1 !== "Rectangle" && t1 !== "Text") {
-      throw Error("expected box-like shape");
+    if (!isRectlike(t1)) {
+      throw Error("expected rect-like shape");
     }
 
-    const [w, h] = [s1.w.contents, s1.h.contents];
     // TODO: Deal with start and end disjoint from rect, or start and end subset of rect
-    const rect = bbox(s1.center.contents, w, h);
+    const rect = bbox([t1, s1]);
 
     // Intersects top or bottom => return w
     // i.e. endX \in [minX, maxX] -- if not this, the other must be true
@@ -379,7 +379,7 @@ export const compDict = {
     // Find some other way to calculate what side intersects the ray between the points
     // Check if this works better WRT new disjoint rectangles, rect-line etc.
 
-    const dim = ifCond(inRange(end[0], rect.minX, rect.maxX), h, w);
+    const dim = ifCond(inRange(end[0], rect.minX, rect.maxX), rect.h, rect.w);
     return { tag: "FloatV", contents: dim };
   },
 

--- a/packages/core/src/contrib/Functions.ts
+++ b/packages/core/src/contrib/Functions.ts
@@ -1,5 +1,4 @@
 import {
-  bbox,
   intersectsSegSeg,
   intersectionSegSeg,
   inRange,
@@ -37,6 +36,7 @@ import {
 } from "types/value";
 import { getStart, linePts } from "utils/OtherUtils";
 import { randFloat } from "utils/Util";
+import { bboxFromShape } from "./Constraints";
 
 /**
  * Static dictionary of computation functions
@@ -363,7 +363,7 @@ export const compDict = {
     }
 
     // TODO: Deal with start and end disjoint from rect, or start and end subset of rect
-    const rect = bbox([t1, s1]);
+    const rect = bboxFromShape(t1, s1);
 
     // Intersects top or bottom => return w
     // i.e. endX \in [minX, maxX] -- if not this, the other must be true

--- a/packages/core/src/contrib/Functions.ts
+++ b/packages/core/src/contrib/Functions.ts
@@ -3,6 +3,7 @@ import {
   intersectionSegSeg,
   inRange,
   isRectlike,
+  bboxFromShape,
 } from "contrib/Constraints"; // TODO move this into graphics utils?
 import {
   absVal,
@@ -36,7 +37,7 @@ import {
 } from "types/value";
 import { getStart, linePts } from "utils/OtherUtils";
 import { randFloat } from "utils/Util";
-import { bboxFromShape } from "./Constraints";
+import * as BBox from "engine/BBox";
 
 /**
  * Static dictionary of computation functions
@@ -378,7 +379,11 @@ export const compDict = {
     // Find some other way to calculate what side intersects the ray between the points
     // Check if this works better WRT new disjoint rectangles, rect-line etc.
 
-    const dim = ifCond(inRange(end[0], rect.minX, rect.maxX), rect.h, rect.w);
+    const dim = ifCond(
+      inRange(end[0], BBox.minX(rect), BBox.maxX(rect)),
+      rect.h,
+      rect.w
+    );
     return { tag: "FloatV", contents: dim };
   },
 

--- a/packages/core/src/engine/BBox.ts
+++ b/packages/core/src/engine/BBox.ts
@@ -1,0 +1,142 @@
+import { Pt2, VarAD } from "types/ad";
+import { add, constOf, div, neg, ops } from "./Autodiff";
+
+export class BBox {
+  public readonly w: VarAD;
+  public readonly h: VarAD;
+  public readonly center: Pt2;
+  private _corners?: BBox.Corners;
+
+  /**
+   * Input: A width, height, and center.
+   * Constructs a new BBox
+   */
+  constructor(w: VarAD, h: VarAD, center: Pt2) {
+    this.w = w;
+    this.h = h;
+    this.center = center;
+  }
+
+  /**
+   * Input: A BBox and an inflation parameter delta.
+   * Output: A new BBox inflated on all sides by delta.
+   */
+  static inflate(b: BBox, delta: VarAD): BBox {
+    return new this(
+      add(b.w, add(delta, delta)),
+      add(b.h, add(delta, delta)),
+      b.center
+    );
+  }
+
+  /**
+   * The four corners of the BBox.
+   */
+  get corners(): BBox.Corners {
+    //   lazily create corners
+    if (typeof this._corners === "undefined") {
+      const halfWidth = div(this.w, constOf(2.0));
+      const halfHeight = div(this.h, constOf(2.0));
+      const nhalfWidth = neg(halfWidth);
+      const nhalfHeight = neg(halfHeight);
+      const pts = <Pt2[]>[
+        [halfWidth, halfHeight],
+        [nhalfWidth, halfHeight],
+        [nhalfWidth, nhalfHeight],
+        [halfWidth, nhalfHeight],
+      ].map((p) => ops.vadd(this.center, p));
+
+      this._corners = {
+        topRight: pts[0],
+        topLeft: pts[1],
+        bottomLeft: pts[2],
+        bottomRight: pts[3],
+      };
+    }
+
+    return this._corners;
+  }
+
+  /**
+   * The min X of the BBox.
+   */
+  get minX(): VarAD {
+    return this.corners.topLeft[0];
+  }
+
+  /**
+   * The max X of the BBox.
+   */
+  get maxX(): VarAD {
+    return this.corners.bottomRight[0];
+  }
+
+  /**
+   * The min Y of the BBox.
+   */
+  get minY(): VarAD {
+    return this.corners.bottomRight[1];
+  }
+
+  /**
+   * The max Y of the BBox.
+   */
+  get maxY(): VarAD {
+    return this.corners.topLeft[1];
+  }
+
+  /**
+   * The x interval of the BBox.
+   */
+  get xRange(): [VarAD, VarAD] {
+    return [this.minX, this.maxX];
+  }
+
+  /**
+   * The y interval of the BBox.
+   */
+  get yRange(): [VarAD, VarAD] {
+    return [this.minY, this.maxY];
+  }
+
+  /**
+   * The four edges of the BBox.
+   */
+  get edges(): BBox.Edges {
+    const corners = this.corners;
+
+    return {
+      top: <[Pt2, Pt2]>[corners.topLeft, corners.topRight],
+      bot: <[Pt2, Pt2]>[corners.bottomLeft, corners.bottomRight],
+      left: <[Pt2, Pt2]>[corners.bottomLeft, corners.topLeft],
+      right: <[Pt2, Pt2]>[corners.bottomRight, corners.topRight],
+    };
+  }
+}
+
+interface ICorners {
+  topRight: Pt2;
+  topLeft: Pt2;
+  bottomLeft: Pt2;
+  bottomRight: Pt2;
+}
+
+interface IIntervals {
+  xRange: [VarAD, VarAD];
+  yRange: [VarAD, VarAD];
+}
+
+interface IEdges {
+  top: [Pt2, Pt2];
+  bot: [Pt2, Pt2];
+  left: [Pt2, Pt2];
+  right: [Pt2, Pt2];
+}
+
+module BBox {
+  export type Corners = ICorners;
+
+  export type Intervals = IIntervals;
+
+  export type Edges = IEdges;
+}

--- a/packages/core/src/engine/BBox.ts
+++ b/packages/core/src/engine/BBox.ts
@@ -1,117 +1,10 @@
 import { Pt2, VarAD } from "types/ad";
 import { add, constOf, div, neg, ops } from "./Autodiff";
 
-export class BBox {
-  public readonly w: VarAD;
-  public readonly h: VarAD;
-  public readonly center: Pt2;
-  private _corners?: BBox.Corners;
-
-  /**
-   * Input: A width, height, and center.
-   * Constructs a new BBox
-   */
-  constructor(w: VarAD, h: VarAD, center: Pt2) {
-    this.w = w;
-    this.h = h;
-    this.center = center;
-  }
-
-  /**
-   * Input: A BBox and an inflation parameter delta.
-   * Output: A new BBox inflated on all sides by delta.
-   */
-  static inflate(b: BBox, delta: VarAD): BBox {
-    return new this(
-      add(b.w, add(delta, delta)),
-      add(b.h, add(delta, delta)),
-      b.center
-    );
-  }
-
-  /**
-   * The four corners of the BBox.
-   */
-  get corners(): BBox.Corners {
-    //   lazily create corners
-    if (typeof this._corners === "undefined") {
-      const halfWidth = div(this.w, constOf(2.0));
-      const halfHeight = div(this.h, constOf(2.0));
-      const nhalfWidth = neg(halfWidth);
-      const nhalfHeight = neg(halfHeight);
-      const pts = <Pt2[]>[
-        [halfWidth, halfHeight],
-        [nhalfWidth, halfHeight],
-        [nhalfWidth, nhalfHeight],
-        [halfWidth, nhalfHeight],
-      ].map((p) => ops.vadd(this.center, p));
-
-      this._corners = {
-        topRight: pts[0],
-        topLeft: pts[1],
-        bottomLeft: pts[2],
-        bottomRight: pts[3],
-      };
-    }
-
-    return this._corners;
-  }
-
-  /**
-   * The min X of the BBox.
-   */
-  get minX(): VarAD {
-    return this.corners.topLeft[0];
-  }
-
-  /**
-   * The max X of the BBox.
-   */
-  get maxX(): VarAD {
-    return this.corners.bottomRight[0];
-  }
-
-  /**
-   * The min Y of the BBox.
-   */
-  get minY(): VarAD {
-    return this.corners.bottomRight[1];
-  }
-
-  /**
-   * The max Y of the BBox.
-   */
-  get maxY(): VarAD {
-    return this.corners.topLeft[1];
-  }
-
-  /**
-   * The x interval of the BBox.
-   */
-  get xRange(): [VarAD, VarAD] {
-    return [this.minX, this.maxX];
-  }
-
-  /**
-   * The y interval of the BBox.
-   */
-  get yRange(): [VarAD, VarAD] {
-    return [this.minY, this.maxY];
-  }
-
-  /**
-   * The four edges of the BBox.
-   */
-  get edges(): BBox.Edges {
-    const corners = this.corners;
-
-    return {
-      top: <[Pt2, Pt2]>[corners.topLeft, corners.topRight],
-      bot: <[Pt2, Pt2]>[corners.bottomLeft, corners.bottomRight],
-      left: <[Pt2, Pt2]>[corners.bottomLeft, corners.topLeft],
-      right: <[Pt2, Pt2]>[corners.bottomRight, corners.topRight],
-    };
-  }
+interface IBBox {
+  w: VarAD;
+  h: VarAD;
+  center: Pt2;
 }
 
 interface ICorners {
@@ -133,10 +26,115 @@ interface IEdges {
   right: [Pt2, Pt2];
 }
 
-module BBox {
-  export type Corners = ICorners;
+export type BBox = IBBox;
 
-  export type Intervals = IIntervals;
+export type Corners = ICorners;
 
-  export type Edges = IEdges;
-}
+export type Intervals = IIntervals;
+
+export type Edges = IEdges;
+
+/**
+ * Input: A width, height, and center.
+ * Output: A new BBox.
+ */
+export const bbox = (w: VarAD, h: VarAD, center: Pt2): BBox => {
+  return {
+    w,
+    h,
+    center,
+  };
+};
+
+export const corners = (b: BBox): Corners => {
+  const halfWidth = div(b.w, constOf(2.0));
+  const halfHeight = div(b.h, constOf(2.0));
+  const nhalfWidth = neg(halfWidth);
+  const nhalfHeight = neg(halfHeight);
+  const pts = <Pt2[]>[
+    [halfWidth, halfHeight],
+    [nhalfWidth, halfHeight],
+    [nhalfWidth, nhalfHeight],
+    [halfWidth, nhalfHeight],
+  ].map((p) => ops.vadd(b.center, p));
+
+  return {
+    topRight: pts[0],
+    topLeft: pts[1],
+    bottomLeft: pts[2],
+    bottomRight: pts[3],
+  };
+};
+
+/**
+ * Input: A BBox and an inflation parameter delta.
+ * Output: A BBox inflated on all sides by delta.
+ */
+export const inflate = (b: BBox, delta: VarAD): BBox => {
+  return bbox(
+    add(b.w, add(delta, delta)),
+    add(b.h, add(delta, delta)),
+    b.center
+  );
+};
+
+/**
+ * Input: A BBox.
+ * Output: The min X of the BBox.
+ */
+export const minX = (b: BBox): VarAD => {
+  return corners(b).topLeft[0];
+};
+
+/**
+ * Input: A BBox.
+ * Output: The max X of the BBox.
+ */
+export const maxX = (b: BBox): VarAD => {
+  return corners(b).bottomRight[0];
+};
+
+/**
+ * Input: A BBox.
+ * Output: The min Y of the BBox.
+ */
+export const minY = (b: BBox): VarAD => {
+  return corners(b).bottomRight[1];
+};
+
+/**
+ * Input: A BBox.
+ * Output: The max Y of the BBox.
+ */
+export const maxY = (b: BBox): VarAD => {
+  return corners(b).topLeft[1];
+};
+
+/**
+ * Input: A BBox.
+ * Output: The X interval of the BBox.
+ */
+export const xRange = (b: BBox): [VarAD, VarAD] => {
+  return [minX(b), maxX(b)];
+};
+
+/**
+ * Input: A BBox.
+ * Output: The Y interval of the BBox.
+ */
+export const yRange = (b: BBox): [VarAD, VarAD] => {
+  return [minY(b), maxY(b)];
+};
+
+/**
+ * Input: A BBox.
+ * The four edges of the BBox.
+ */
+export const edges = (b: BBox): Edges => {
+  return {
+    top: <[Pt2, Pt2]>[corners(b).topLeft, corners(b).topRight],
+    bot: <[Pt2, Pt2]>[corners(b).bottomLeft, corners(b).bottomRight],
+    left: <[Pt2, Pt2]>[corners(b).bottomLeft, corners(b).topLeft],
+    right: <[Pt2, Pt2]>[corners(b).bottomRight, corners(b).topRight],
+  };
+};

--- a/packages/core/src/types/ad.ts
+++ b/packages/core/src/types/ad.ts
@@ -61,22 +61,6 @@ export type VecAD = VarAD[];
 
 export type Pt2 = [VarAD, VarAD];
 
-export interface IBBox {
-  minX: VarAD;
-  maxX: VarAD;
-  minY: VarAD;
-  maxY: VarAD;
-  top: [Pt2, Pt2];
-  bot: [Pt2, Pt2];
-  left: [Pt2, Pt2];
-  right: [Pt2, Pt2];
-  center: Pt2;
-  w: VarAD;
-  h: VarAD;
-}
-
-export type BBox = IBBox;
-
 export type GradGraphs = IGradGraphs;
 
 export interface IGradGraphs {

--- a/packages/core/src/types/ad.ts
+++ b/packages/core/src/types/ad.ts
@@ -61,6 +61,22 @@ export type VecAD = VarAD[];
 
 export type Pt2 = [VarAD, VarAD];
 
+export interface IBBox {
+  minX: VarAD;
+  maxX: VarAD;
+  minY: VarAD;
+  maxY: VarAD;
+  top: [Pt2, Pt2];
+  bot: [Pt2, Pt2];
+  left: [Pt2, Pt2];
+  right: [Pt2, Pt2];
+  center: Pt2;
+  w: VarAD;
+  h: VarAD;
+}
+
+export type BBox = IBBox;
+
 export type GradGraphs = IGradGraphs;
 
 export interface IGradGraphs {


### PR DESCRIPTION
# Description

Though `Square` is a rect-like shape, it does not expose the same interface of `w` and `h` like other rect-likes, which causes many constraint implementations to fail on squares.

This PR enhances the `bbox` function to compute `w`, `h`, and `center`.

Additionally, this PR moves the implementation of line-like bboxes into `bbox`. This also consolidates `disjointRectLineAAVert` and `disjointRectLineAAHoriz` into one constraint `disjointRectLineAA`.

# Implementation strategy and design decisions

Include a high-level summary of the implementation strategy and list important design decisions made, if any.

# Checklist

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] New and existing tests pass locally using `yarn test`
- [x] I ran `yarn docs` and there were no errors when generating the HTML site
- [x] My code follows the style guidelines of this project (e.g.: no ESLint warnings)
