### PR TITLE
fix: arrowheads incorporated in the path length

### DIFF
--- a/packages/core/src/contrib/Constraints.ts
+++ b/packages/core/src/contrib/Constraints.ts
@@ -41,7 +41,7 @@ export const isRectlike = (shapeType: string): boolean => {
 };
 
 /**
- * Takes a `shapeType`, returns whether it's linelike. (TODO: Account for arrowhead size)
+ * Takes a `shapeType`, returns whether it's linelike.
  */
 export const isLinelike = (shapeType: string): boolean => {
   return shapeType == "Line" || shapeType == "Arrow";

--- a/packages/core/src/renderer/Arrow.ts
+++ b/packages/core/src/renderer/Arrow.ts
@@ -1,3 +1,4 @@
+import { Shape } from "types/shape";
 import { IFloatV, IStrV, IColorV, IVectorV } from "types/value";
 import { arrowheads, round2, toHex, toScreen } from "utils/Util";
 import { attrFill, attrTitle, DASH_ARRAY } from "./AttrHelper";
@@ -31,6 +32,55 @@ export const arrowHead = (
   return marker;
 };
 
+export const makeRoomForArrows = (shape: Shape) => {
+  const [lineSX, lineSY] = (shape.properties.start as IVectorV<number>)
+    .contents as [number, number];
+  const [lineEX, lineEY] = (shape.properties.end as IVectorV<number>)
+    .contents as [number, number];
+
+  const arrowheadStyle = (shape.properties.arrowheadStyle as IStrV).contents;
+  const arrowheadSize = (shape.properties.arrowheadSize as IFloatV<number>)
+    .contents;
+  const thickness = (shape.properties.thickness as IFloatV<number>).contents;
+
+  // height * size = Penrose computed arrow size
+  // multiplied by thickness since the arrow size uses markerUnits, which is strokeWidth by default:
+  // https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/markerUnits
+  const arrowHeight =
+    arrowheads[arrowheadStyle].height * arrowheadSize * thickness;
+  const length = Math.sqrt((lineSX - lineEX) ** 2 + (lineSY - lineEY) ** 2);
+
+  // Subtract off the arrowHeight from each side.
+  // See https://math.stackexchange.com/a/2045181 for a derivation.
+  let arrowSX, arrowSY;
+  if (shape.shapeType === "Line" && shape.properties.leftArrowhead.contents) {
+    [arrowSX, arrowSY] = [
+      lineSX - (arrowHeight / length) * (lineSX - lineEX),
+      lineSY - (arrowHeight / length) * (lineSY - lineEY),
+    ];
+  } else {
+    [arrowSX, arrowSY] = [lineSX, lineSY];
+  }
+
+  let arrowEX, arrowEY;
+  if (
+    shape.shapeType === "Arrow" ||
+    (shape.shapeType === "Line" && shape.properties.rightArrowhead.contents)
+  ) {
+    [arrowEX, arrowEY] = [
+      lineEX - (arrowHeight / length) * (lineEX - lineSX),
+      lineEY - (arrowHeight / length) * (lineEY - lineSY),
+    ];
+  } else {
+    [arrowEX, arrowEY] = [lineEX, lineEY];
+  }
+
+  return [
+    [arrowSX, arrowSY],
+    [arrowEX, arrowEY],
+  ];
+};
+
 const Arrow = ({ shape, canvasSize }: ShapeProps) => {
   const elem = document.createElementNS("http://www.w3.org/2000/svg", "g");
   elem.setAttribute("pointer-events", "bounding-box");
@@ -43,29 +93,11 @@ const Arrow = ({ shape, canvasSize }: ShapeProps) => {
     .contents[3];
   elem.appendChild(arrowHead(id, color, alpha, arrowheadStyle, arrowheadSize));
   const path = document.createElementNS("http://www.w3.org/2000/svg", "path");
-  const [sx, sy] = toScreen(
-    ((shape.properties.start as IVectorV<number>) as any).contents,
-    canvasSize
-  );
-  const [ex, ey] = toScreen(
-    ((shape.properties.end as IVectorV<number>) as any).contents,
-    canvasSize
-  );
+  const [[arrowSX, arrowSY], [arrowEX, arrowEY]] = makeRoomForArrows(shape);
+  const [sx, sy] = toScreen([arrowSX, arrowSY], canvasSize);
+  const [ex, ey] = toScreen([arrowEX, arrowEY], canvasSize);
 
-  const strokeWidth = (shape.properties.thickness as IFloatV<number>).contents;
-  // HACK: scale path down a bit to accommodate arrow length
-  const { width, refX } = arrowheads[arrowheadStyle];
-  const slope = Math.atan2(ey - sy, ex - sx);
-  const [offsetX, offsetY] = [
-    Math.cos(slope) * (width - refX) * strokeWidth * arrowheadSize,
-    Math.sin(slope) * (width - refX) * strokeWidth * arrowheadSize,
-  ];
-  path.setAttribute(
-    "d",
-    `M${sx} ${sy} L${
-      Math.abs(offsetX) < Math.abs(ex - sx) ? ex - offsetX : ex
-    } ${Math.abs(offsetY) < Math.abs(ey - sy) ? ey - offsetY : ey}`
-  );
+  path.setAttribute("d", `M ${sx} ${sy} L ${ex} ${ey}`);
   path.setAttribute("marker-end", `url(#${id})`);
   attrFill(shape, path);
   path.setAttribute("stroke", color);

--- a/packages/core/src/renderer/Line.ts
+++ b/packages/core/src/renderer/Line.ts
@@ -1,48 +1,8 @@
-import { IVectorV, IFloatV, IColorV, IStrV } from "types/value";
-import { arrowheads, toHex, toScreen } from "utils/Util";
-import { arrowHead } from "./Arrow";
+import { IFloatV, IColorV, IStrV } from "types/value";
+import { toHex, toScreen } from "utils/Util";
+import { arrowHead, makeRoomForArrows } from "./Arrow";
 import { attrTitle, DASH_ARRAY } from "./AttrHelper";
 import { ShapeProps } from "./Renderer";
-import { Shape } from "types/shape";
-
-const makeRoomForArrows = (shape: Shape) => {
-  const [lineSX, lineSY] = (shape.properties.start as IVectorV<number>)
-    .contents as [number, number];
-  const [lineEX, lineEY] = (shape.properties.end as IVectorV<number>)
-    .contents as [number, number];
-
-  const arrowheadStyle = (shape.properties.arrowheadStyle as IStrV).contents;
-  const arrowheadSize = (shape.properties.arrowheadSize as IFloatV<number>)
-    .contents;
-  const thickness = (shape.properties.thickness as IFloatV<number>).contents;
-
-  // height * size = Penrose computed arrow size
-  // multiplied by thickness since the arrow size uses markerUnits, which is strokeWidth by default:
-  // https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/markerUnits
-  const arrowHeight =
-    arrowheads[arrowheadStyle].height * arrowheadSize * thickness;
-  const length = Math.sqrt((lineSX - lineEX) ** 2 + (lineSY - lineEY) ** 2);
-
-  // Subtract off the arrowHeight from each side.
-  // See https://math.stackexchange.com/a/2045181 for a derivation.
-  const [arrowSX, arrowSY] = shape.properties.leftArrowhead.contents
-    ? [
-        lineSX - (arrowHeight / length) * (lineSX - lineEX),
-        lineSY - (arrowHeight / length) * (lineSY - lineEY),
-      ]
-    : [lineSX, lineSY];
-  const [arrowEX, arrowEY] = shape.properties.rightArrowhead.contents
-    ? [
-        lineEX - (arrowHeight / length) * (lineEX - lineSX),
-        lineEY - (arrowHeight / length) * (lineEY - lineSY),
-      ]
-    : [lineEX, lineEY];
-
-  return [
-    [arrowSX, arrowSY],
-    [arrowEX, arrowEY],
-  ];
-};
 
 const Line = ({ shape, canvasSize }: ShapeProps) => {
   const style = shape.properties.style.contents;

--- a/packages/core/src/renderer/Line.ts
+++ b/packages/core/src/renderer/Line.ts
@@ -23,9 +23,8 @@ const makeRoomForArrows = (shape: Shape) => {
     arrowheads[arrowheadStyle].height * arrowheadSize * thickness;
   const length = Math.sqrt((lineSX - lineEX) ** 2 + (lineSY - lineEY) ** 2);
 
-  //   TODO: these should only happen if there is actually an arrow on that side
-  // subtract off a the arrowHeight from each side
-
+  // Subtract off the arrowHeight from each side.
+  // See https://math.stackexchange.com/a/2045181 for a derivation.
   const [arrowSX, arrowSY] = shape.properties.leftArrowhead.contents
     ? [
         lineSX - (arrowHeight / length) * (lineSX - lineEX),


### PR DESCRIPTION
# Description

Closes #586.

# Implementation strategy and design decisions

I extended the Line renderer in `renderer/Line.ts` to compute the heights of the arrowheads and shrink the main path accordingly. To compute the height of the arrowhead, you multiply the arrowhead style's height by the size specified in Penrose. This value controls the `markerHeight` of the arrowhead. You then have to multiply by the unit for the markerHeight, which is the `stroke-width` of the line. See https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/markerUnits for details.

To compute the amount of distance to shave off the ends of the path I used the formula in this Math Stack Exchange post: https://math.stackexchange.com/a/2045181. It is fairly straightforward: Compute the vector of the difference between the points, then shave off a fraction of that vector from each endpoint as needed.

# Examples with steps to reproduce them

I used the monoidal category domain with the following files to generate the before and after screenshots.

`monoidal-category-domain/test.sub`
`monoidal-category-domain/monoidal-test.sty`
`monoidal-category-domain/monoidal-test.dsl`

Before:
<img width="506" alt="Screen Shot 2021-06-10 at 5 00 44 PM" src="https://user-images.githubusercontent.com/21694516/121599577-3d803800-ca11-11eb-80a7-08cf59a11514.png">

After:
<img width="585" alt="Screen Shot 2021-06-10 at 5 28 47 PM" src="https://user-images.githubusercontent.com/21694516/121599640-5983d980-ca11-11eb-89ad-ad239b7f4271.png">

Notice that arrowheads no longer intersect components!

# Checklist

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] New and existing tests pass locally using `yarn test`
- [x] I ran `yarn docs` and there were no errors when generating the HTML site
- [x] My code follows the style guidelines of this project (e.g.: no ESLint warnings)