### PR TITLE
fix: type-change in synthesizer was adding improperly formed bind statements to AST

### DIFF
--- a/packages/core/src/analysis/SubstanceAnalysis.ts
+++ b/packages/core/src/analysis/SubstanceAnalysis.ts
@@ -1,4 +1,4 @@
-import { pullAt } from "lodash";
+import { pullAt, range } from "lodash";
 import { Identifier } from "types/ast";
 import { Map } from "immutable";
 import {
@@ -58,30 +58,6 @@ export const swapArgs = (
     ...stmt,
     args: swap(stmt.args, index1, index2),
   };
-};
-
-/**
- * Replace a Substance statement with another statement that takes the same arguments.
- * @param stmt a Substance statement
- * @param pick ArgStmtDecl chosen to replace stmt
- * @returns a new Substance statement
- */
-export const changeType = (
-  stmt: ApplyConstructor | ApplyPredicate | ApplyFunction | Func | Bind,
-  pick: ArgStmtDecl
-): ApplyConstructor | ApplyPredicate | ApplyFunction | Func | Bind => {
-  const s = stmt.tag === "Bind" ? stmt.expr : stmt;
-  if (pick.tag === "PredicateDecl") {
-    return applyPredicate(pick, (s as ApplyPredicate).args);
-  } else {
-    const castArgs = (s as ApplyConstructor).args;
-    const m =
-      pick.tag === "ConstructorDecl"
-        ? applyConstructor(pick, castArgs)
-        : applyFunction(pick, castArgs);
-    // make into a Bind if the pick returns something
-    return pick.output.variable ? applyBind(pick.output.variable, m) : m;
-  }
 };
 
 /**

--- a/packages/core/src/analysis/SubstanceAnalysis.ts
+++ b/packages/core/src/analysis/SubstanceAnalysis.ts
@@ -1,4 +1,4 @@
-import { pullAt, range } from "lodash";
+import { pullAt } from "lodash";
 import { Identifier } from "types/ast";
 import { Map } from "immutable";
 import {

--- a/packages/core/src/compiler/Substance.ts
+++ b/packages/core/src/compiler/Substance.ts
@@ -587,6 +587,8 @@ export const prettyStmt = (stmt: SubStmt): string => {
       return `${prettyExpr(stmt.left)} = ${prettyExpr(stmt.right)}`;
     case "EqualPredicates":
       return `${prettyPredicate(stmt.left)} <-> ${prettyPredicate(stmt.right)}`;
+    default:
+      throw new Error(`unsupported substance statement type`);
   }
 };
 


### PR DESCRIPTION
# Description
Fixes a bug where `typeChange` mutation in the synthesizer module was adding undefined statements to the AST, because the way new `Bind` statements were being created was improper. 

# Implementation strategy and design decisions
* Refactored `Synthesizer` code to use `generateConstructor`, `generateFunction` and `generatePredicate` functions.
  * Added option for each of these methods to take in a pre-selected declaration instead of randomly picking one (which will also help out with testing later on)
* Refactored so that `Add/Edit/Delete` mutation operations are added by the `Synthesizer` instead of by `SynthesizerContext`.

# Examples with steps to reproduce them
Validate correct functionality by running `yarn set-example` or `yarn tri-example` from `packages/synthesizer`
# Checklist
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] New and existing tests pass locally using `yarn test`
- [x] I ran `yarn docs` and there were no errors when generating the HTML site
- [x] My code follows the style guidelines of this project (e.g.: no ESLint warnings)

# Open questions

Questions that require more discussion or to be addressed in future development:
