### PR TITLE
fix(#597): invalid URL during docs deploy workflow

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -25,7 +25,7 @@ jobs:
           command: touch docs/.nojekyll
       - run:
           name: Deploy to gh-pages
-          command: gh-pages --dotfiles --message "[skip ci] Updates" --dist docs/
+          command: gh-pages --dotfiles --message "[skip ci] Updates" --dist docs/ -r https://github.com/penrose/penrose.git
   build:
     docker:
       - image: circleci/node:12.19.0


### PR DESCRIPTION
# Description

Related issue/PR: #597 

Instead of using the default `remote origin`, explicitly specify the repo URL when publishing docs via `gh-pages`. The default is no longer valid for unknown reasons. 




