### PR TITLE
feat: add right angle marker to euclidean style

### DIFF
--- a/packages/core/src/contrib/Constraints.ts
+++ b/packages/core/src/contrib/Constraints.ts
@@ -658,7 +658,7 @@ export const constrDict = {
   /**
    * Require that the `center`s of three shapes to be collinear. Does not enforce a specific ordering of points, instead it takes the arrangement of points that is most easily satisfiable.
    */
-  collinear_unordered: (
+  collinearUnordered: (
     [, p0]: [string, any],
     [, p1]: [string, any],
     [, p2]: [string, any]

--- a/packages/core/src/contrib/Constraints.ts
+++ b/packages/core/src/contrib/Constraints.ts
@@ -654,6 +654,36 @@ export const constrDict = {
       throw new Error("collinear: all input shapes need to have centers");
     }
   },
+
+  /**
+   * Require that the `center`s of three shapes to be collinear. Does not enforce a specific ordering of points, instead it takes the arrangement of points that is most easily satisfiable.
+   */
+  collinear_unordered: (
+    [, p0]: [string, any],
+    [, p1]: [string, any],
+    [, p2]: [string, any]
+  ) => {
+    if (every([p0, p1, p2].map((props) => props["center"]))) {
+      const c1 = fns.center(p0);
+      const c2 = fns.center(p1);
+      const c3 = fns.center(p2);
+
+      const v1 = ops.vnorm(ops.vsub(c1, c2));
+      const v2 = ops.vnorm(ops.vsub(c2, c3));
+      const v3 = ops.vnorm(ops.vsub(c1, c3));
+
+      // Use triangle inequality (v1 + v2 <= v3) to make sure v1, v2, and v3 don't form a triangle (and therefore must be collinear.)
+      return max(
+        constOf(0),
+        min(
+          min(sub(add(v1, v2), v3), sub(add(v1, v3), v2)),
+          sub(add(v2, v3), v1)
+        )
+      );
+    } else {
+      throw new Error("collinear: all input shapes need to have centers");
+    }
+  },
 };
 
 // -------- Helpers for writing objectives

--- a/packages/core/src/contrib/Functions.ts
+++ b/packages/core/src/contrib/Functions.ts
@@ -447,6 +447,9 @@ export const compDict = {
       throw Error("unsupported shape ${t1} in midpointOffset");
     }
   },
+  /**
+   * Return a point located at `padding` of a line `s1` offset by `padding` in its normal direction (for making right angle markers).
+   */
   innerPointOffset: (
     pt1: VarAD[],
     pt2: VarAD[],

--- a/packages/core/src/synthesis/Synthesizer.ts
+++ b/packages/core/src/synthesis/Synthesizer.ts
@@ -51,7 +51,7 @@ import {
 type RandomFunction = (min: number, max: number) => number;
 
 const log = consola
-  .create({ level: LogLevel.Debug })
+  .create({ level: LogLevel.Info })
   .withScope("Substance Synthesizer");
 
 //#region Synthesizer setting types
@@ -404,7 +404,6 @@ export class Synthesizer {
   mutateProgram = (): void => {
     const ops = ["add", "delete", "edit"];
     const op = this.choice(ops);
-    console.log(op);
     if (op === "add") this.addStmt();
     else if (op === "delete") this.deleteStmt();
     else if (op === "edit")
@@ -412,7 +411,6 @@ export class Synthesizer {
   };
 
   editStmt = (op: Modify["tag"]): void => {
-    console.log(op);
     this.cxt.findCandidates(this.env, this.setting.edit);
     const chosenType = this.choice(this.cxt.candidateTypes());
     const candidates = [...this.cxt.getCandidates(chosenType).keys()];
@@ -420,18 +418,18 @@ export class Synthesizer {
     const stmt = this.findStmt(chosenType, chosenName);
     if (stmt && (stmt.tag === "ApplyPredicate" || stmt.tag === "Bind")) {
       log.debug(`Editing statement: ${prettyStmt(stmt)}`);
-      console.log("editing", stmt);
       switch (op) {
         case "Swap": {
           const s = (stmt.tag === "Bind" ? stmt.expr : stmt) as ApplyPredicate;
           const indices = range(0, s.args.length);
           const idx1 = this.choice(indices);
           const idx2 = this.choice(without(indices, idx1));
-          const newStmt = idx1 && idx2 ? swapArgs(s, [idx1, idx2]) : stmt;
-          console.log(newStmt);
+          const newStmt =
+            idx1 !== undefined && idx2 !== undefined
+              ? swapArgs(s, [idx1, idx2])
+              : s;
           if (stmt.tag === "ApplyPredicate") {
             this.cxt.replaceStmt(stmt, newStmt as ApplyPredicate, op); // TODO: improve types to avoid casting
-            console.log("Replaced statement");
           } else {
             this.cxt.replaceStmt(
               stmt,

--- a/packages/core/src/synthesis/Synthesizer.ts
+++ b/packages/core/src/synthesis/Synthesizer.ts
@@ -51,7 +51,7 @@ import {
 type RandomFunction = (min: number, max: number) => number;
 
 const log = consola
-  .create({ level: LogLevel.Info })
+  .create({ level: LogLevel.Debug })
   .withScope("Substance Synthesizer");
 
 //#region Synthesizer setting types
@@ -404,6 +404,7 @@ export class Synthesizer {
   mutateProgram = (): void => {
     const ops = ["add", "delete", "edit"];
     const op = this.choice(ops);
+    console.log(op);
     if (op === "add") this.addStmt();
     else if (op === "delete") this.deleteStmt();
     else if (op === "edit")
@@ -411,6 +412,7 @@ export class Synthesizer {
   };
 
   editStmt = (op: Modify["tag"]): void => {
+    console.log(op);
     this.cxt.findCandidates(this.env, this.setting.edit);
     const chosenType = this.choice(this.cxt.candidateTypes());
     const candidates = [...this.cxt.getCandidates(chosenType).keys()];
@@ -418,15 +420,18 @@ export class Synthesizer {
     const stmt = this.findStmt(chosenType, chosenName);
     if (stmt && (stmt.tag === "ApplyPredicate" || stmt.tag === "Bind")) {
       log.debug(`Editing statement: ${prettyStmt(stmt)}`);
+      console.log("editing", stmt);
       switch (op) {
         case "Swap": {
           const s = (stmt.tag === "Bind" ? stmt.expr : stmt) as ApplyPredicate;
           const indices = range(0, s.args.length);
           const idx1 = this.choice(indices);
           const idx2 = this.choice(without(indices, idx1));
-          const newStmt = swapArgs(s, [idx1, idx2]);
+          const newStmt = idx1 && idx2 ? swapArgs(s, [idx1, idx2]) : stmt;
+          console.log(newStmt);
           if (stmt.tag === "ApplyPredicate") {
             this.cxt.replaceStmt(stmt, newStmt as ApplyPredicate, op); // TODO: improve types to avoid casting
+            console.log("Replaced statement");
           } else {
             this.cxt.replaceStmt(
               stmt,

--- a/packages/synthesizer/__tests__/c4p1.sub
+++ b/packages/synthesizer/__tests__/c4p1.sub
@@ -1,0 +1,22 @@
+Plane P
+Point A,B, C, D, E
+In(A, P)
+In(B, P)
+In(C, P)
+In(D, P)
+In(E, P)
+-- Rectangle p := MkRectangle(A, B, C, D)
+Segment s1 := MkSegment(A,E)
+Segment s2 := MkSegment(E,C)
+Segment s3 := MkSegment(A,B)
+Segment s4 := MkSegment(B,C)
+Segment s5 := MkSegment(C,D)
+Segment s6 := MkSegment(D,A)
+Segment s8 := MkSegment(E,D)
+Collinear(A,E,C)
+Collinear(B,E,D) 
+Angle r := InteriorAngle(B,E,C)
+EqualLength(s1, s2)
+EqualLengthMarker(s1, s2)
+RightMarked(r)
+AutoLabel All

--- a/packages/synthesizer/__tests__/congruent-settings.json
+++ b/packages/synthesizer/__tests__/congruent-settings.json
@@ -1,5 +1,5 @@
 {
-  "mutationCount": [1, 3],
+  "mutationCount": [1, 2],
   "argOption": "existing",
   "argReuse": "distinct",
   "weights": {

--- a/packages/synthesizer/__tests__/congruent-settings.json
+++ b/packages/synthesizer/__tests__/congruent-settings.json
@@ -1,0 +1,28 @@
+{
+  "mutationCount": [1, 3],
+  "argOption": "existing",
+  "argReuse": "distinct",
+  "weights": {
+    "type": 0.1,
+    "predicate": 0.3,
+    "constructor": 0.0
+  },
+  "add": {
+    "type": [],
+    "function": [],
+    "constructor": ["InteriorAngle"],
+    "predicate": ["EqualLength", "RightUnmarked"]
+  },
+  "delete": {
+    "type": [],
+    "function": [],
+    "constructor": [],
+    "predicate": ["RightMarked", "EqualLengthMarker", "EqualLength"]
+  },
+  "edit": {
+    "type": [],
+    "function": [],
+    "constructor": ["MkSegment"],
+    "predicate": ["RightMarked", "EqualLength", "EqualLengthMarker"]
+  }
+}

--- a/packages/synthesizer/__tests__/congruent-settings.json
+++ b/packages/synthesizer/__tests__/congruent-settings.json
@@ -5,7 +5,7 @@
   "weights": {
     "type": 0.1,
     "predicate": 0.3,
-    "constructor": 0.0
+    "constructor": 0.1
   },
   "add": {
     "type": [],

--- a/packages/synthesizer/__tests__/euclidean.sty
+++ b/packages/synthesizer/__tests__/euclidean.sty
@@ -185,13 +185,13 @@ where EqualAngleMarker1(a, b) {
   endB = ptOnLine(b.q, b.r, b.radius)
   sweepB = arcSweepFlag(b.q, startB, endB)
 
-  a.angleMark = Path {
+  override a.mark = Path {
     pathData : arc("open", startA, endA, (a.radius, a.radius), 0, 0, sweepA)
    strokeWidth : 2.0
     color : Colors.black
     fill: Colors.none
  }
-  b.angleMark = Path {
+  override b.mark = Path {
     pathData : arc("open", startB, endB, (b.radius, b.radius), 0, 0, sweepB)
     strokeWidth : 2.0
     color : Colors.black
@@ -209,13 +209,13 @@ where EqualAngleMarker2(a, b) {
   endB = ptOnLine(b.q, b.r, b.radius)
   sweepB = arcSweepFlag(b.q, startB, endB)
 
-  a.angleMark = Path {
+  override a.mark = Path {
     pathData : arc("open", startA, endA, (a.radius, a.radius), 0, 0, sweepA)
    strokeWidth : 2.0
     color : Colors.black
     fill: Colors.none
  }
-  b.angleMark = Path {
+  override b.mark = Path {
     pathData : arc("open", startB, endB, (b.radius, b.radius), 0, 0, sweepB)
     strokeWidth : 2.0
     color : Colors.black
@@ -229,13 +229,13 @@ where EqualAngleMarker2(a, b) {
   startBbig = ptOnLine(b.q, b.p, bigR)
   endBbig = ptOnLine(b.q, b.r, bigR)
 
-  a.angleMark2 = Path {
+  override a.mark2 = Path {
     pathData : arc("open", startAbig, endAbig, (bigR, bigR), 0, 0, sweepA)
     strokeWidth : 2.0
     color : Colors.black
     fill: Colors.none
  }
-  b.angleMark2 = Path { -- TODO: rename these to b.tick, b.tick2
+  override b.mark2 = Path {
     pathData : arc("open", startBbig, endBbig, (bigR, bigR), 0, 0, sweepB)
     strokeWidth : 2.0
     color : Colors.black
@@ -253,19 +253,19 @@ where EqualAngle(a, b) {
 
 Angle a
 where RightUnmarked(a) {
-  ensure equal(0, dot(normalize(a.p - a.q), normalize(a.r - a.q)))
+  ensure equal(dot(a.p - a.q, a.r - a.q), 0)
 }
 
 Angle a
 where RightMarked(a) {
   --render half square path of size a.radius
-  a.mark = Path {
+  override a.mark = Path {
     pathData : pathFromPoints("open", [ptOnLine(a.q, a.p, 20.), innerPointOffset(a.q, a.p, a.r, 20.), ptOnLine(a.q, a.r, 20.)])
     strokeWidth : 2.0
     color : Colors.black
     fill : Colors.none
   }
-  ensure equal(dot(normalize(a.p - a.q), normalize(a.r - a.q)), 0)
+  ensure equal(dot(a.p - a.q, a.r - a.q), 0)
 }
 
 Segment e; Plane p {

--- a/packages/synthesizer/__tests__/euclidean.sty
+++ b/packages/synthesizer/__tests__/euclidean.sty
@@ -141,8 +141,8 @@ with Point p; Point q {
      p.icon above e.icon
      q.icon above e.icon
 
-     encourage repel(e.icon, p.text, const.repelWeight)
-     encourage repel(e.icon, q.text, const.repelWeight)
+    --  encourage repel(e.icon, p.text, const.repelWeight)
+    --  encourage repel(e.icon, q.text, const.repelWeight)
 
     --  e.icon above const.plane
 }
@@ -177,21 +177,21 @@ where EqualLengthMarker(s, t) {
 Angle a, b
 where EqualAngleMarker1(a, b) {
   --find points from p->q, then q->r for each vector. draw vectors for each
-  startA = angleMarker(a.q, a.p, a.radius)
-  endA = angleMarker(a.q, a.r, a.radius)
+  startA = ptOnLine(a.q, a.p, a.radius)
+  endA = ptOnLine(a.q, a.r, a.radius)
   sweepA = arcSweepFlag(a.q, startA, endA)
 
-  startB = angleMarker(b.q, b.p, b.radius)
-  endB = angleMarker(b.q, b.r, b.radius)
+  startB = ptOnLine(b.q, b.p, b.radius)
+  endB = ptOnLine(b.q, b.r, b.radius)
   sweepB = arcSweepFlag(b.q, startB, endB)
 
-  override a.angleMark = Path {
+  a.angleMark = Path {
     pathData : arc("open", startA, endA, (a.radius, a.radius), 0, 0, sweepA)
    strokeWidth : 2.0
     color : Colors.black
     fill: Colors.none
  }
-  override b.angleMark = Path {
+  b.angleMark = Path {
     pathData : arc("open", startB, endB, (b.radius, b.radius), 0, 0, sweepB)
     strokeWidth : 2.0
     color : Colors.black
@@ -201,12 +201,12 @@ where EqualAngleMarker1(a, b) {
 
 Angle a, b
 where EqualAngleMarker2(a, b) {
-  startA = angleMarker(a.q, a.p, a.radius)
-  endA = angleMarker(a.q, a.r, a.radius)
+  startA = ptOnLine(a.q, a.p, a.radius)
+  endA = ptOnLine(a.q, a.r, a.radius)
   sweepA = arcSweepFlag(a.q, startA, endA)
 
-  startB = angleMarker(b.q, b.p, b.radius)
-  endB = angleMarker(b.q, b.r, b.radius)
+  startB = ptOnLine(b.q, b.p, b.radius)
+  endB = ptOnLine(b.q, b.r, b.radius)
   sweepB = arcSweepFlag(b.q, startB, endB)
 
   a.angleMark = Path {
@@ -223,11 +223,11 @@ where EqualAngleMarker2(a, b) {
  }
 
   bigR = const.bigThetaRadius
-  startAbig = angleMarker(a.q, a.p, bigR)
-  endAbig = angleMarker(a.q, a.r, bigR)
+  startAbig = ptOnLine(a.q, a.p, bigR)
+  endAbig = ptOnLine(a.q, a.r, bigR)
 
-  startBbig = angleMarker(b.q, b.p, bigR)
-  endBbig = angleMarker(b.q, b.r, bigR)
+  startBbig = ptOnLine(b.q, b.p, bigR)
+  endBbig = ptOnLine(b.q, b.r, bigR)
 
   a.angleMark2 = Path {
     pathData : arc("open", startAbig, endAbig, (bigR, bigR), 0, 0, sweepA)
@@ -235,7 +235,7 @@ where EqualAngleMarker2(a, b) {
     color : Colors.black
     fill: Colors.none
  }
-  b.angleMark2 = Path {
+  b.angleMark2 = Path { -- TODO: rename these to b.tick, b.tick2
     pathData : arc("open", startBbig, endBbig, (bigR, bigR), 0, 0, sweepB)
     strokeWidth : 2.0
     color : Colors.black
@@ -249,6 +249,23 @@ where EqualAngle(a, b) {
   dotA = dot(normalize(a.p - a.q), normalize(a.r - a.q))
   dotB = dot(normalize(b.p - b.q), normalize(b.r - b.q))
   ensure equal(dotA, dotB)
+}
+
+Angle a
+where RightUnmarked(a) {
+  ensure equal(0, dot(normalize(a.p - a.q), normalize(a.r - a.q)))
+}
+
+Angle a
+where RightMarked(a) {
+  --render half square path of size a.radius
+  a.mark = Path {
+    pathData : pathFromPoints("open", [ptOnLine(a.q, a.p, 20.), innerPointOffset(a.q, a.p, a.r, 20.), ptOnLine(a.q, a.r, 20.)])
+    strokeWidth : 2.0
+    color : Colors.black
+    fill : Colors.none
+  }
+  ensure equal(dot(normalize(a.p - a.q), normalize(a.r - a.q)), 0)
 }
 
 Segment e; Plane p {
@@ -323,7 +340,7 @@ with Point p; Point q; Point r {
   theta.p = p.vec
   theta.q = q.vec
   theta.r = r.vec
-  theta.color = setOpacity(Colors.darkpurple, 0.4)
+  theta.color = Colors.black
   theta.side1 = Line {
     start : p.icon.center
     end : q.icon.center

--- a/packages/synthesizer/__tests__/geometry.dsl
+++ b/packages/synthesizer/__tests__/geometry.dsl
@@ -49,7 +49,6 @@ constructor MkTriangle : Point p * Point q * Point r -> Triangle
 -- constructor MkSquareP : Point p * Point q * Point r * Point s -> Square
 -- constructor MkSquare : Point p * Point q * Point r * Point s -> Square -- Assuming the first two points are the segment of a triangle
 constructor MkRectangle : Point p * Point q * Point r * Point s -> Rectangle
-constructor MkArc : Point p * Point q -> Arc
 
 -- -- TODO: subtyping on the return types
 -- function Midpoint : Linelike -> Point
@@ -79,6 +78,8 @@ predicate EqualAngleMarker2 : Angle * Angle
 predicate EqualLengthMarker : Segment * Segment
 predicate EqualAngle : Angle * Angle
 predicate EqualLength : Segment * Segment 
+predicate RightMarked : Angle
+predicate RightUnmarked : Angle
 
 
 -- notation "{p, q}" ~ "MkSegment(p, q)"

--- a/packages/synthesizer/package.json
+++ b/packages/synthesizer/package.json
@@ -29,6 +29,7 @@
     "collinear-example": "yarn start __tests__/geometry.dsl --substance=__tests__/geo-template.sub  --style=__tests__/euclidean.sty --path=../automator/progs --synth-setting=__tests__/geo-settings.json --num-programs=30",
     "rect-example": "yarn start __tests__/geometry.dsl --substance=__tests__/rect.sub  --style=__tests__/euclidean.sty --path=../automator/progs --synth-setting=__tests__/rect-settings.json --num-programs=10",
     "tri-example": "yarn start __tests__/geometry.dsl --substance=__tests__/tri-template.sub  --style=__tests__/euclidean.sty --path=../automator/progs --synth-setting=__tests__/tri-settings.json --num-programs=30",
+    "congruent-example": "yarn start __tests__/geometry.dsl --substance=__tests__/c4p1.sub  --style=__tests__/euclidean.sty --path=../automator/progs --synth-setting=__tests__/congruent-settings.json --num-programs=30",
     "test": "echo \"no test specified for synthesizer\" && exit 0"
   },
   "bugs": {

--- a/packages/synthesizer/package.json
+++ b/packages/synthesizer/package.json
@@ -29,7 +29,7 @@
     "collinear-example": "yarn start __tests__/geometry.dsl --substance=__tests__/geo-template.sub  --style=__tests__/euclidean.sty --path=../automator/progs --synth-setting=__tests__/geo-settings.json --num-programs=30",
     "rect-example": "yarn start __tests__/geometry.dsl --substance=__tests__/rect.sub  --style=__tests__/euclidean.sty --path=../automator/progs --synth-setting=__tests__/rect-settings.json --num-programs=10",
     "tri-example": "yarn start __tests__/geometry.dsl --substance=__tests__/tri-template.sub  --style=__tests__/euclidean.sty --path=../automator/progs --synth-setting=__tests__/tri-settings.json --num-programs=30",
-    "congruent-example": "yarn start __tests__/geometry.dsl --substance=__tests__/c4p1.sub  --style=__tests__/euclidean.sty --path=../automator/progs --synth-setting=__tests__/congruent-settings.json --num-programs=30",
+    "congruent-example": "yarn start __tests__/geometry.dsl --substance=__tests__/congruent.sub  --style=__tests__/euclidean.sty --path=../automator/progs --synth-setting=__tests__/congruent-settings.json --num-programs=30",
     "test": "echo \"no test specified for synthesizer\" && exit 0"
   },
   "bugs": {


### PR DESCRIPTION
# Description
![Screenshot from 2021-06-22 14-44-23](https://user-images.githubusercontent.com/31522997/123177233-ba5fd880-d439-11eb-9016-8a98c7e64860.png)

* Added ability to render right angle markers for Euclidean angles, using `RightMarked(a)` predicate
* Added ability to make an angle appear as though it is a right angle, without the marker, using the `RightUnmarked(a)` predicate
* Fixed a bug in the `Synthesizer` that was caused by the `Swap` mutation attempting to swap arguments in functions/predicates/constructors that only have one argument
* Added an `unordered_collinear` constraint to `Constraints.ts` as an option to make points collinear without needing to specify their order in substance. for ex the relevant substance for this diagram was `Collinear(B,C,D)`:
![Screenshot from 2021-06-23 15-47-06](https://user-images.githubusercontent.com/31522997/123177670-8e912280-d43a-11eb-8c0e-fd4461532599.png)
With the `collinear` constraint function, the points would be ordered as `B,C,D`, with `C` in the middle. However, since I used `collinear_unordered`, the points are ordered as `C,B,D`. We are keeping both options because the original collinear produces reliable results, while the unordered version adds additional interesting challenges/mutations (esp. for program synthesis), and is more true to the geometric definition of collinear.

# Examples with steps to reproduce them
* `yarn start` from root
* View single example problem with `npx roger watch packages/synthesizer/__tests__/c4p1.sub packages/synthesizer/__tests__/euclidean.sty  packages/synthesizer/__tests__/geometry.dsl`
To run the synthesizer:
* `cd packages/synthesizer` and run `yarn congruent-example`
* `cd packages/automator` and run `yarn generate-site`
* view `packages/automator/browser/index.html` in your browser 
# Checklist

- [x ] I have commented my code, particularly in hard-to-understand areas
- [x ] My changes generate no new warnings
- [x ] New and existing tests pass locally using `yarn test`
- [x ] I ran `yarn docs` and there were no errors when generating the HTML site
- [x ] My code follows the style guidelines of this project (e.g.: no ESLint warnings)

# Open questions

Questions that require more discussion or to be addressed in future development:
