### PR TITLE
feat: Split Optimization Status Tab Into Constraints and Objectives

### DIFF
--- a/packages/browser-ui/src/inspector/views/Opt.tsx
+++ b/packages/browser-ui/src/inspector/views/Opt.tsx
@@ -60,7 +60,7 @@ const Opt: React.FC<IViewProps> = ({ frame, history }: IViewProps) => {
           {
             when: (row) => row.sat === "no",
             style: {
-              backgroundColor: `rgb(255, 202, 190) !important`,
+              backgroundColor: `#ffcabe !important`,
             },
           },
         ]}

--- a/packages/browser-ui/src/inspector/views/Opt.tsx
+++ b/packages/browser-ui/src/inspector/views/Opt.tsx
@@ -45,7 +45,7 @@ const Opt: React.FC<IViewProps> = ({ frame, history }: IViewProps) => {
     <div style={{ boxSizing: "border-box" }}>
       <DataTable
         data={constrInfos}
-        title={"Constraint Status"}
+        title={"Constraints"}
         dense={true}
         highlightOnHover={true}
         striped={true}
@@ -65,7 +65,7 @@ const Opt: React.FC<IViewProps> = ({ frame, history }: IViewProps) => {
       />
       <DataTable
         data={objInfos}
-        title={"Objective Status"}
+        title={"Objectives"}
         dense={true}
         highlightOnHover={true}
         striped={true}

--- a/packages/browser-ui/src/inspector/views/Opt.tsx
+++ b/packages/browser-ui/src/inspector/views/Opt.tsx
@@ -1,7 +1,7 @@
 import * as React from "react";
 import IViewProps from "./IViewProps";
 import { prettyPrintFn, evalFns } from "@penrose/core";
-import { zip, sum } from "lodash";
+import { zipWith, sum } from "lodash";
 import DataTable from "react-data-table-component";
 
 export const EPS = 10e-3;
@@ -18,27 +18,29 @@ const Opt: React.FC<IViewProps> = ({ frame, history }: IViewProps) => {
       </div>
     );
   }
-  const constrInfos = zip(
+  const constrInfos = zipWith(
     frame.constrFns.map(prettyPrintFn),
-    evalFns(frame.constrFns, frame)
-  ).map(([name, fnEvaled]) => {
-    const energy = Math.max(fnEvaled?.f!, 0);
-    return {
-      name,
-      energy,
-      sat: energy <= EPS ? "yes" : "no",
-    };
-  });
-  const objInfos = zip(
+    evalFns(frame.constrFns, frame),
+    (name, fnEvaled) => {
+      const energy = Math.max(fnEvaled.f, 0);
+      return {
+        name,
+        energy,
+        sat: energy <= EPS ? "yes" : "no",
+      };
+    }
+  );
+  const objInfos = zipWith(
     frame.objFns.map(prettyPrintFn),
-    evalFns(frame.objFns, frame)
-  ).map(([name, fnEvaled]) => {
-    const gradientNorm = vnorm(fnEvaled?.gradf!);
-    return {
-      name,
-      gradientNorm,
-    };
-  });
+    evalFns(frame.objFns, frame),
+    (name, fnEvaled) => {
+      const gradientNorm = vnorm(fnEvaled.gradf);
+      return {
+        name,
+        gradientNorm,
+      };
+    }
+  );
 
   // TODO: hyperlink the shapes
   return (

--- a/packages/browser-ui/src/inspector/views/Opt.tsx
+++ b/packages/browser-ui/src/inspector/views/Opt.tsx
@@ -1,14 +1,10 @@
 import * as React from "react";
 import IViewProps from "./IViewProps";
-import { prettyPrintFn, evalFns } from "@penrose/core";
-import { zipWith, sum } from "lodash";
+import { prettyPrintFn, evalFns, ops } from "@penrose/core";
+import { zipWith } from "lodash";
 import DataTable from "react-data-table-component";
 
 export const EPS = 10e-3;
-
-const vnorm = (v: number[]): number => {
-  return Math.sqrt(sum(v.map((e) => e * e)));
-};
 
 const Opt: React.FC<IViewProps> = ({ frame, history }: IViewProps) => {
   if (!frame) {
@@ -34,7 +30,7 @@ const Opt: React.FC<IViewProps> = ({ frame, history }: IViewProps) => {
     frame.objFns.map(prettyPrintFn),
     evalFns(frame.objFns, frame),
     (name, fnEvaled) => {
-      const gradientNorm = vnorm(fnEvaled.gradf);
+      const gradientNorm = ops.vnorm(fnEvaled.gradf);
       return {
         name,
         gradientNorm,

--- a/packages/browser-ui/src/inspector/views/Opt.tsx
+++ b/packages/browser-ui/src/inspector/views/Opt.tsx
@@ -1,8 +1,15 @@
 import * as React from "react";
 import IViewProps from "./IViewProps";
 import { prettyPrintFn, evalFns } from "@penrose/core";
-import { zip } from "lodash";
+import { zip, sum } from "lodash";
 import DataTable from "react-data-table-component";
+
+export const EPS = 10e-3;
+
+const vnorm = (v: number[]): number => {
+  return Math.sqrt(sum(v.map((e) => e * e)));
+};
+
 const Opt: React.FC<IViewProps> = ({ frame, history }: IViewProps) => {
   if (!frame) {
     return (
@@ -14,44 +21,57 @@ const Opt: React.FC<IViewProps> = ({ frame, history }: IViewProps) => {
   const constrInfos = zip(
     frame.constrFns.map(prettyPrintFn),
     evalFns(frame.constrFns, frame)
-  ).map(([name, energy]) => ({
-    name,
-    energy,
-    type: "constraint",
-    sat: energy! <= 0 ? "yes" : "no",
-  }));
+  ).map(([name, fnEvaled]) => {
+    const energy = Math.max(fnEvaled?.f!, 0);
+    return {
+      name,
+      energy,
+      sat: energy <= EPS ? "yes" : "no",
+    };
+  });
   const objInfos = zip(
     frame.objFns.map(prettyPrintFn),
     evalFns(frame.objFns, frame)
-  ).map(([name, energy]) => ({
-    name,
-    energy,
-    type: "objective",
-    sat: energy! <= 0 ? "yes" : "no",
-  }));
+  ).map(([name, fnEvaled]) => {
+    const gradientNorm = vnorm(fnEvaled?.gradf!);
+    return {
+      name,
+      gradientNorm,
+    };
+  });
 
   // TODO: hyperlink the shapes
   return (
     <div style={{ boxSizing: "border-box" }}>
       <DataTable
-        data={[...constrInfos, ...objInfos]}
-        title={"Optimization"}
+        data={constrInfos}
+        title={"Constraint Status"}
         dense={true}
         highlightOnHover={true}
         striped={true}
         columns={[
           { name: "Expression", selector: "name", sortable: true },
           { name: "Energy", selector: "energy", sortable: true },
-          { name: "Type", selector: "type", sortable: true },
           { name: "Satisfied?", selector: "sat", sortable: true },
         ]}
         conditionalRowStyles={[
           {
             when: (row) => row.sat === "no",
             style: {
-              backgroundColor: `#ffcabe !important`,
+              backgroundColor: `rgb(255, 202, 190) !important`,
             },
           },
+        ]}
+      />
+      <DataTable
+        data={objInfos}
+        title={"Objective Status"}
+        dense={true}
+        highlightOnHover={true}
+        striped={true}
+        columns={[
+          { name: "Expression", selector: "name", sortable: true },
+          { name: "Gradient Norm", selector: "gradientNorm", sortable: true },
         ]}
       />
     </div>

--- a/packages/browser-ui/src/inspector/views/viewMap.tsx
+++ b/packages/browser-ui/src/inspector/views/viewMap.tsx
@@ -9,7 +9,7 @@ const viewMap = {
   errors: Errors,
   shapes: ShapeView,
   mod: Mod,
-  opt: Opt,
+  "optimization status": Opt,
   settings: Settings,
 };
 export default viewMap;

--- a/packages/core/src/__tests__/overall.test.ts
+++ b/packages/core/src/__tests__/overall.test.ts
@@ -137,8 +137,8 @@ describe("Run individual functions", () => {
 
       for (let i = 0; i < initEngsObj.length; i++) {
         // console.log("obj energies", initEngsObj[i], optedEngsObj[i]);
-        expect(initEngsObj[i]).toBeGreaterThanOrEqual(optedEngsObj[i]);
-        expect(optedEngsObj[i]).toBeLessThanOrEqual(EPS);
+        expect(initEngsObj[i].f).toBeGreaterThanOrEqual(optedEngsObj[i].f);
+        expect(optedEngsObj[i].f).toBeLessThanOrEqual(EPS);
       }
 
       // Test constraints
@@ -147,13 +147,15 @@ describe("Run individual functions", () => {
 
       for (let i = 0; i < initEngsConstr.length; i++) {
         // console.log("constr energies", initEngsConstr[i], optedEngsConstr[i]);
-        if (initEngsConstr[i] < 0 && optedEngsConstr[i] < 0) {
+        if (initEngsConstr[i].f < 0 && optedEngsConstr[i].f < 0) {
           // If it was already satisfied and stays satisfied, the magnitude of the constraint doesn't matter (i.e. both are negative)
           expect(true).toEqual(true);
         } else {
-          expect(initEngsConstr[i]).toBeGreaterThanOrEqual(optedEngsConstr[i]);
+          expect(initEngsConstr[i].f).toBeGreaterThanOrEqual(
+            optedEngsConstr[i].f
+          );
           // Check constraint satisfaction (< 0)
-          expect(optedEngsConstr[i]).toBeLessThanOrEqual(0);
+          expect(optedEngsConstr[i].f).toBeLessThanOrEqual(0);
         }
       }
     } else {

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -25,7 +25,7 @@ import { SubstanceEnv } from "types/substance";
 import { collectLabels } from "utils/CollectLabels";
 import { andThen, Result, showError } from "utils/Error";
 import { prettyPrintFn } from "utils/OtherUtils";
-import { bBoxDims, toHex } from "utils/Util";
+import { bBoxDims, toHex, ops } from "utils/Util";
 import { Canvas } from "renderer/ShapeDef";
 
 const log = consola.create({ level: LogLevel.Warn }).withScope("Top Level");
@@ -300,6 +300,7 @@ export {
   showError,
   Result,
   prettyPrintFn,
+  ops,
 };
 export type { PenroseError } from "./types/errors";
 export type { Registry, Trio };

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -233,13 +233,20 @@ export const evalEnergy = (s: State): number => {
   return objective(weight)(s.varyingValues);
 };
 
+export type FnEvaled = IFnEvaled;
+
+export interface IFnEvaled {
+  f: number;
+  gradf: number[];
+}
+
 /**
  * Evaluate a list of constraints/objectives: this will be useful if a user want to apply a subset of constrs/objs on a `State`. If the `State` doesn't have the constraints/objectives compiled, it will generate them first. Otherwise, it will evaluate the cached functions.
  * @param fns a list of constraints/objectives
  * @param s a state with or without its opt functions cached
- * @returns a list of scalar values of the energies of the requested functions, evaluated at the `varyingValues` in the `State`
+ * @returns a list of the energies and gradients of the requested functions, evaluated at the `varyingValues` in the `State`
  */
-export const evalFns = (fns: Fn[], s: State): number[] => {
+export const evalFns = (fns: Fn[], s: State): FnEvaled[] => {
   const { objFnCache, constrFnCache } = s.params;
 
   // NOTE: if `prepareState` hasn't been called before, log a warning message and generate a fresh optimization problem
@@ -265,7 +272,10 @@ export const evalFns = (fns: Fn[], s: State): number[] => {
       );
     }
     const cachedFnInfo = fnsCached[fnStr];
-    return cachedFnInfo.f(xs); // Could also return gradient if desired
+    return {
+      f: cachedFnInfo.f(xs),
+      gradf: cachedFnInfo.gradf(xs),
+    };
   });
 };
 

--- a/packages/core/src/utils/OtherUtils.ts
+++ b/packages/core/src/utils/OtherUtils.ts
@@ -112,8 +112,44 @@ export const prettyPrintExpr = (arg: Expr): string => {
     return [fnName, "(", ...fnArgs.map(prettyPrintExpr).join(", "), ")"].join(
       ""
     );
+  } else if (arg.tag === "UOp") {
+    let uOpName;
+    switch (arg.op) {
+      case "UMinus":
+        uOpName = "-";
+        break;
+    }
+    return "(" + uOpName + prettyPrintExpr(arg.arg) + ")";
+  } else if (arg.tag === "BinOp") {
+    let binOpName;
+    switch (arg.op) {
+      case "BPlus":
+        binOpName = "+";
+        break;
+      case "BMinus":
+        binOpName = "-";
+        break;
+      case "Multiply":
+        binOpName = "*";
+        break;
+      case "Divide":
+        binOpName = "/";
+        break;
+      case "Exp":
+        binOpName = "**";
+        break;
+    }
+    return (
+      "(" +
+      prettyPrintExpr(arg.left) +
+      " " +
+      binOpName +
+      " " +
+      prettyPrintExpr(arg.right) +
+      ")"
+    );
   } else {
-    // TODO: Finish writing pretty-printer for rest of expressions (UOp, BinOp)
+    // TODO: Finish writing pretty-printer for rest of expressions
     const res = JSON.stringify(arg);
     return res;
   }


### PR DESCRIPTION
# Description

Closes #593.
Closes #609.

The current optimization tab is misleading, because it groups constraints and objectives together even they they function differently. Constraints _must_ be 0 in a properly converged diagram. Objectives should be minimized, but neither their values nor their gradient norms are required to be 0.

This PR renames the optimization tab from `opt` to `optimization status` and separates the data into two tables with the following content:

Constraints:
- Expression
- Energy (now constrained to be non-negative)
- Satisfied? (now bounded by an epsilon)

Objectives:
- Expression
- Gradient Norm

Additionally, this PR improves pretty printing for UOp and BinOp nodes so they don't print as JSON.

<img width="1005" alt="Screen Shot 2021-07-07 at 11 27 47 PM" src="https://user-images.githubusercontent.com/2762356/124857832-fa1ada00-df7a-11eb-82ba-dea95e42f4b9.png">

# Implementation strategy and design decisions

- `evalFns` in `index.ts` now returns both the function value and its gradient.
- The table in `Opt.tsx` is split in two, and `frame.constrFns` and `frame.objFns` are dealt with differently.
- Added two new cases to `prettyPrintExpr` in `OtherUtils.ts` to support BinOp and UOp. These cases always use parentheses to avoid implementing operator precedence.

# Checklist

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] New and existing tests pass locally using `yarn test`
- [x] I ran `yarn docs` and there were no errors when generating the HTML site
- [x] My code follows the style guidelines of this project (e.g.: no ESLint warnings)
