### PR TITLE
fix: repel objective on segments causes slow optimization time

### DIFF
--- a/examples/geometry-domain/euclidean-simple.sty
+++ b/examples/geometry-domain/euclidean-simple.sty
@@ -150,8 +150,8 @@ with Point p; Point q {
      p.icon above e.icon
      q.icon above e.icon
 
-     encourage closestPtToSeg(e.icon, p.text.center, 30.)
-     encourage closestPtToSeg(e.icon, q.text.center, 30.)
+     encourage pointAtDistFromClosestPt(e.icon, p.text.center, 30.)
+     encourage pointAtDistFromClosestPt(e.icon, q.text.center, 30.)
 
      e.icon above const.plane
 }

--- a/examples/geometry-domain/euclidean-simple.sty
+++ b/examples/geometry-domain/euclidean-simple.sty
@@ -150,8 +150,8 @@ with Point p; Point q {
      p.icon above e.icon
      q.icon above e.icon
 
-     encourage pointLineDist(e.icon, p.text.center, 30.)
-     encourage pointLineDist(e.icon, q.text.center, 30.)
+     encourage pointLineDist(p.text.center, e.icon, 30.)
+     encourage pointLineDist(q.text.center, e.icon, 30.)
 
      e.icon above const.plane
 }

--- a/examples/geometry-domain/euclidean-simple.sty
+++ b/examples/geometry-domain/euclidean-simple.sty
@@ -150,8 +150,8 @@ with Point p; Point q {
      p.icon above e.icon
      q.icon above e.icon
 
-     encourage repel(e.icon, p.text, const.repelWeight)
-     encourage repel(e.icon, q.text, const.repelWeight)
+    encourage closestPtToSeg(e.icon, p.text.center, 30.)
+    encourage closestPtToSeg(e.icon, q.text.center, 30.)
 
      e.icon above const.plane
 }

--- a/examples/geometry-domain/euclidean-simple.sty
+++ b/examples/geometry-domain/euclidean-simple.sty
@@ -150,8 +150,8 @@ with Point p; Point q {
      p.icon above e.icon
      q.icon above e.icon
 
-     encourage pointAtDistFromClosestPt(e.icon, p.text.center, 30.)
-     encourage pointAtDistFromClosestPt(e.icon, q.text.center, 30.)
+     encourage pointLineDist(e.icon, p.text.center, 30.)
+     encourage pointLineDist(e.icon, q.text.center, 30.)
 
      e.icon above const.plane
 }

--- a/examples/geometry-domain/euclidean-simple.sty
+++ b/examples/geometry-domain/euclidean-simple.sty
@@ -150,8 +150,8 @@ with Point p; Point q {
      p.icon above e.icon
      q.icon above e.icon
 
-    encourage closestPtToSeg(e.icon, p.text.center, 30.)
-    encourage closestPtToSeg(e.icon, q.text.center, 30.)
+     encourage closestPtToSeg(e.icon, p.text.center, 30.)
+     encourage closestPtToSeg(e.icon, q.text.center, 30.)
 
      e.icon above const.plane
 }

--- a/packages/core/src/contrib/Constraints.ts
+++ b/packages/core/src/contrib/Constraints.ts
@@ -229,6 +229,45 @@ export const objDict = {
   nearScalar: (c: any, goal: any) => {
     return squared(sub(constOfIf(c), constOfIf(goal)));
   },
+  /**
+   * try to make distance between a point and a segment `s1` = padding.
+   */
+  closestPtToSeg: ([, s1]: [string, any], point: VarAD[], padding: VarAD) => {
+    return equalHard(
+      ops.vdist(
+        closestPt_PtSeg(point, [s1.start.contents, s1.end.contents]),
+        point
+      ),
+      padding
+    );
+  },
+  /**
+   * Repel the angle between the p1-p0 and p1-p2 away from 0 and 180 degrees.
+   */
+  nonDegenerateAngle: (
+    [, p0]: [string, any],
+    [, p1]: [string, any],
+    [, p2]: [string, any],
+    strength = 20
+  ) => {
+    if (every([p0, p1, p2].map((props) => props["center"]))) {
+      const c0 = fns.center(p0);
+      const c1 = fns.center(p1);
+      const c2 = fns.center(p2);
+
+      const l1 = ops.vsub(c0, c1);
+      const l2 = ops.vsub(c2, c1);
+
+      const force = mul(
+        constOfIf(strength),
+        div(squared(ops.vdot(l1, l2)), mul(ops.vnormsq(l1), ops.vnormsq(l2)))
+      );
+
+      return force;
+    } else {
+      throw new Error("collinear: all input shapes need to have centers");
+    }
+  },
 };
 
 export const constrDict = {

--- a/packages/core/src/contrib/Constraints.ts
+++ b/packages/core/src/contrib/Constraints.ts
@@ -264,7 +264,10 @@ export const objDict = {
   /**
    * try to make distance between a point and a segment `s1` = padding.
    */
-  pointLineDist: ([, s1]: [string, any], point: VarAD[], padding: VarAD) => {
+  pointLineDist: (point: VarAD[], [t1, s1]: [string, any], padding: VarAD) => {
+    if (!isLinelike(t1)) {
+      throw new Error(`pointLineDist: expected a point and a line, got ${t1}`);
+    }
     return squared(
       equalHard(
         ops.vdist(

--- a/packages/core/src/contrib/Constraints.ts
+++ b/packages/core/src/contrib/Constraints.ts
@@ -242,7 +242,7 @@ export const objDict = {
     );
   },
   /**
-   * Repel the angle between the p1-p0 and p1-p2 away from 0 and 180 degrees.
+   * Repel the angle between the p1-p0 and p1-p2 away from 0 and 180 degrees. NOTE: angles between 10 and 170 degrees are considered satisfied.
    */
   nonDegenerateAngle: (
     [, p0]: [string, any],
@@ -258,14 +258,22 @@ export const objDict = {
       const l1 = ops.vsub(c0, c1);
       const l2 = ops.vsub(c2, c1);
 
-      const force = mul(
-        constOfIf(strength),
-        div(squared(ops.vdot(l1, l2)), mul(ops.vnormsq(l1), ops.vnormsq(l2)))
+      // angles between 10 and 170 degrees do not need to be pushed
+      return ifCond(
+        lt(
+          absVal(ops.vdot(ops.vnormalize(l1), ops.vnormalize(l2))),
+          varOf(0.985) // cos10 deg = .9848, abs(cos170) = .9848
+        ),
+        varOf(0),
+        mul(
+          constOfIf(strength),
+          div(squared(ops.vdot(l1, l2)), mul(ops.vnormsq(l1), ops.vnormsq(l2)))
+        )
       );
-
-      return force;
     } else {
-      throw new Error("collinear: all input shapes need to have centers");
+      throw new Error(
+        "nonDegenerateAngle: all input shapes need to have centers"
+      );
     }
   },
 };

--- a/packages/core/src/contrib/Constraints.ts
+++ b/packages/core/src/contrib/Constraints.ts
@@ -258,17 +258,12 @@ export const objDict = {
       const l1 = ops.vsub(c0, c1);
       const l2 = ops.vsub(c2, c1);
 
+      const cosine = absVal(ops.vdot(ops.vnormalize(l1), ops.vnormalize(l2)));
       // angles between 10 and 170 degrees do not need to be pushed
       return ifCond(
-        lt(
-          absVal(ops.vdot(ops.vnormalize(l1), ops.vnormalize(l2))),
-          varOf(0.985) // cos10 deg = .9848, abs(cos170) = .9848
-        ),
+        lt(cosine, varOf(0.985)), // cos10 deg = .9848, abs(cos170) = .9848
         varOf(0),
-        mul(
-          constOfIf(strength),
-          div(squared(ops.vdot(l1, l2)), mul(ops.vnormsq(l1), ops.vnormsq(l2)))
-        )
+        mul(constOfIf(strength), cosine)
       );
     } else {
       throw new Error(

--- a/packages/core/src/contrib/Constraints.ts
+++ b/packages/core/src/contrib/Constraints.ts
@@ -230,18 +230,6 @@ export const objDict = {
     return squared(sub(constOfIf(c), constOfIf(goal)));
   },
   /**
-   * try to make distance between a point and a segment `s1` = padding.
-   */
-  closestPtToSeg: ([, s1]: [string, any], point: VarAD[], padding: VarAD) => {
-    return equalHard(
-      ops.vdist(
-        closestPt_PtSeg(point, [s1.start.contents, s1.end.contents]),
-        point
-      ),
-      padding
-    );
-  },
-  /**
    * Repel the angle between the p1-p0 and p1-p2 away from 0 and 180 degrees. NOTE: angles between 10 and 170 degrees are considered satisfied.
    */
   nonDegenerateAngle: (
@@ -270,6 +258,24 @@ export const objDict = {
         "nonDegenerateAngle: all input shapes need to have centers"
       );
     }
+  },
+  /**
+   * try to make distance between a point and a segment `s1` = padding.
+   */
+  pointAtDistFromClosestPt: (
+    [, s1]: [string, any],
+    point: VarAD[],
+    padding: VarAD
+  ) => {
+    return squared(
+      equalHard(
+        ops.vdist(
+          closestPt_PtSeg(point, [s1.start.contents, s1.end.contents]),
+          point
+        ),
+        padding
+      )
+    );
   },
 };
 

--- a/packages/synthesizer/__tests__/euclidean.sty
+++ b/packages/synthesizer/__tests__/euclidean.sty
@@ -141,8 +141,8 @@ with Point p; Point q {
      p.icon above e.icon
      q.icon above e.icon
 
-     encourage pointLineDist(e.icon, p.text.center, 30.)
-     encourage pointLineDist(e.icon, q.text.center, 30.)
+     encourage pointLineDist(p.text.center, e.icon, 30.)
+     encourage pointLineDist(q.text.center, e.icon, 30.)
 
     --  e.icon above const.plane
 }

--- a/packages/synthesizer/__tests__/euclidean.sty
+++ b/packages/synthesizer/__tests__/euclidean.sty
@@ -141,8 +141,8 @@ with Point p; Point q {
      p.icon above e.icon
      q.icon above e.icon
 
-     encourage closestPtToSeg(e.icon, p.text.center, 30.)
-     encourage closestPtToSeg(e.icon, q.text.center, 30.)
+     encourage pointAtDistFromClosestPt(e.icon, p.text.center, 30.)
+     encourage pointAtDistFromClosestPt(e.icon, q.text.center, 30.)
 
     --  e.icon above const.plane
 }

--- a/packages/synthesizer/__tests__/euclidean.sty
+++ b/packages/synthesizer/__tests__/euclidean.sty
@@ -141,8 +141,8 @@ with Point p; Point q {
      p.icon above e.icon
      q.icon above e.icon
 
-    encourage closestPtToSeg(e.icon, p.text.center, 30.)
-    encourage closestPtToSeg(e.icon, q.text.center, 30.)
+     encourage closestPtToSeg(e.icon, p.text.center, 30.)
+     encourage closestPtToSeg(e.icon, q.text.center, 30.)
 
     --  e.icon above const.plane
 }

--- a/packages/synthesizer/__tests__/euclidean.sty
+++ b/packages/synthesizer/__tests__/euclidean.sty
@@ -141,8 +141,8 @@ with Point p; Point q {
      p.icon above e.icon
      q.icon above e.icon
 
-     encourage repel(e.icon, p.text, const.repelWeight)
-     encourage repel(e.icon, q.text, const.repelWeight)
+    encourage closestPtToSeg(e.icon, p.text.center, 30.)
+    encourage closestPtToSeg(e.icon, q.text.center, 30.)
 
     --  e.icon above const.plane
 }
@@ -341,6 +341,7 @@ with Point p; Point q; Point r {
     style : "solid"
   }
   theta.radius = const.thetaRadius
+  encourage nonDegenerateAngle(p.icon, q.icon, r.icon)
 }
  --    theta.radius = const.thetaRadius
 --     -- TODO: always take the acute angle, not the obtuse angle

--- a/packages/synthesizer/__tests__/euclidean.sty
+++ b/packages/synthesizer/__tests__/euclidean.sty
@@ -141,8 +141,8 @@ with Point p; Point q {
      p.icon above e.icon
      q.icon above e.icon
 
-     encourage pointAtDistFromClosestPt(e.icon, p.text.center, 30.)
-     encourage pointAtDistFromClosestPt(e.icon, q.text.center, 30.)
+     encourage pointLineDist(e.icon, p.text.center, 30.)
+     encourage pointLineDist(e.icon, q.text.center, 30.)
 
     --  e.icon above const.plane
 }


### PR DESCRIPTION
# Description
Using `repel` to ensure that text labels are a certain distance from a segment causes optimization times of between 10-15 seconds. Based on the discussion in related issue #607, implemented 2 changes:
* Added a constraint `closestPtToSeg` that ensures a given point is a certain distance away from the **nearest point on a given segment**. As @hypotext mentions in the issue, this is faster because it does not involve sampling the distance at multiple points of the segment. After implementing this objective, the resample time drops from 10-15 seconds to 2-6 seconds.
* Per @joshpoll suggestions, added a constraint `nonDegenerateAngle` to push angles to be within a reasonable range (avoid 0 and 180-degree angles). At the moment, this is implemented with a cutoff, so any angles between 10 and 170 degrees have automatically satisfied this objective.

# Examples with steps to reproduce them
1. `yarn start`
2. Run `npx roger watch packages/synthesizer/__tests__/congruent.sub packages/synthesizer/__tests__/euclidean.sty  packages/synthesizer/__tests__/geometry.dsl` from penrose root.
# Checklist

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] New and existing tests pass locally using `yarn test`
- [x] I ran `yarn docs` and there were no errors when generating the HTML site
- [x] My code follows the style guidelines of this project (e.g.: no ESLint warnings)

# Open questions
This was my first time writing a new constraint, and though everything appears to be working properly I'd definitely appreciate feedback on the implementation.
Questions that require more discussion or to be addressed in future development:
