### PR TITLE
chore: change typedoc build to gh-pages

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,31 +1,5 @@
 version: 2.1
 jobs:
-  docs-deploy:
-    docker:
-      - image: circleci/node:12.19.0
-    working_directory: ~/penrose/packages/core
-    steps:
-      - checkout:
-          path: ~/penrose
-      - run:
-          name: Install deps
-          command: |
-            sudo npm install -g --silent gh-pages
-            yarn
-            git config user.email "ci-build@penrose.ink"
-            git config user.name "ci-build"
-      - add_ssh_keys:
-          fingerprints:
-            - "e0:22:08:03:8f:eb:1c:b7:59:4e:48:00:6d:2d:a7:be"
-      - run:
-          name: Generate docs
-          command: yarn docs
-      - run:
-          name: Add nojekyll
-          command: touch docs/.nojekyll
-      - run:
-          name: Deploy to gh-pages
-          command: gh-pages --dotfiles --message "[skip ci] Updates" --dist docs/ -r https://github.com/penrose/penrose.git
   build:
     docker:
       - image: circleci/node:12.19.0
@@ -117,10 +91,6 @@ workflows:
 
   build_main_deploy:
     jobs:
-      - docs-deploy:
-          filters:
-            branches:
-              only: main
       - build:
           filters:
             branches:

--- a/.github/workflows/typedocs.yml
+++ b/.github/workflows/typedocs.yml
@@ -8,13 +8,22 @@ jobs:
   Install-And-Build:
     runs-on: ubuntu-latest
     steps:
-      - run: |
-          yarn
-          yarn docs
-      - run: touch docs/.nojekyll
-      - name: Deploy
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Install packages
+        run: yarn
+      - name: Build docs
+        run: yarn docs
+      - name: Deploy docs
         uses: JamesIves/github-pages-deploy-action@4.1.4
         with:
           branch: gh-pages
           folder: docs
           target-folder: typedoc
+      - name: Add .nojekyll
+        run: touch extra/.nojekyll
+      - name: Deploy .nojekyll
+        uses: JamesIves/github-pages-deploy-action@4.1.4
+        with:
+          branch: gh-pages
+          folder: extra

--- a/.github/workflows/typedocs.yml
+++ b/.github/workflows/typedocs.yml
@@ -28,7 +28,7 @@ jobs:
         uses: JamesIves/github-pages-deploy-action@4.1.4
         with:
           branch: gh-pages
-          folder: docs
+          folder: packages/core/docs
           target-folder: typedoc
       - name: Add .nojekyll
         run: |
@@ -38,4 +38,4 @@ jobs:
         uses: JamesIves/github-pages-deploy-action@4.1.4
         with:
           branch: gh-pages
-          folder: extra
+          folder: packages/core/extra

--- a/.github/workflows/typedocs.yml
+++ b/.github/workflows/typedocs.yml
@@ -8,8 +8,9 @@ jobs:
   Install-And-Build:
     runs-on: ubuntu-latest
     steps:
-      - run: yarn
-      - run: yarn docs
+      - run: |
+          yarn
+          yarn docs
       - run: touch docs/.nojekyll
       - name: Deploy
         uses: JamesIves/github-pages-deploy-action@4.1.4

--- a/.github/workflows/typedocs.yml
+++ b/.github/workflows/typedocs.yml
@@ -1,0 +1,18 @@
+name: Generate Typedocs
+on:
+  push:
+    branches:
+      - main
+jobs:
+  Install-And-Build:
+    runs-on: ubuntu-latest
+    steps:
+      - run: yarn
+      - run: yarn docs
+      - run: touch docs/.nojekyll
+      - name: Deploy
+        uses: JamesIves/github-pages-deploy-action@4.1.4
+        with:
+          branch: gh-pages
+          folder: docs
+          target-folder: typedoc

--- a/.github/workflows/typedocs.yml
+++ b/.github/workflows/typedocs.yml
@@ -3,6 +3,7 @@ on:
   push:
     branches:
       - main
+      - max/gh-actions
 jobs:
   Install-And-Build:
     runs-on: ubuntu-latest

--- a/.github/workflows/typedocs.yml
+++ b/.github/workflows/typedocs.yml
@@ -39,3 +39,4 @@ jobs:
         with:
           branch: gh-pages
           folder: packages/core/extra
+        clean: false

--- a/.github/workflows/typedocs.yml
+++ b/.github/workflows/typedocs.yml
@@ -39,4 +39,4 @@ jobs:
         with:
           branch: gh-pages
           folder: packages/core/extra
-        clean: false
+          clean: false

--- a/.github/workflows/typedocs.yml
+++ b/.github/workflows/typedocs.yml
@@ -3,7 +3,6 @@ on:
   push:
     branches:
       - main
-      - max/gh-actions
 defaults:
   run:
     working-directory: ./packages/core

--- a/.github/workflows/typedocs.yml
+++ b/.github/workflows/typedocs.yml
@@ -13,6 +13,13 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
+      - name: Restore lerna cache
+        uses: actions/cache@v2
+        with:
+          path: |
+            node_modules
+            */*/node_modules
+          key: ${{ runner.os }}-${{ hashFiles('**/yarn.lock') }}
       - name: Install packages
         run: yarn
       - name: Build docs
@@ -24,7 +31,9 @@ jobs:
           folder: docs
           target-folder: typedoc
       - name: Add .nojekyll
-        run: touch extra/.nojekyll
+        run: |
+          mkdir extra
+          touch extra/.nojekyll
       - name: Deploy .nojekyll
         uses: JamesIves/github-pages-deploy-action@4.1.4
         with:

--- a/.github/workflows/typedocs.yml
+++ b/.github/workflows/typedocs.yml
@@ -4,6 +4,9 @@ on:
     branches:
       - main
       - max/gh-actions
+defaults:
+  run:
+    working-directory: ./packages/core
 jobs:
   Install-And-Build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
In preparation for a more unified workflow, we'll no longer use circleci to build typedocs (and other docs).

**PLZ SQUASH. LOTS OF EMBARRASSING ERRORS IN MY COMMITS**

Also, the typedoc will be moved to https://penrose.github.io/penrose/typedoc