### PR TITLE
fix: Catch errors thrown in `core` in `browser-ui`

### DIFF
--- a/packages/browser-ui/package.json
+++ b/packages/browser-ui/package.json
@@ -11,7 +11,7 @@
     "@reach/tabs": "^0.9.0",
     "consola": "^2.15.0",
     "console-feed": "^2.8.11",
-    "cytoscape": "^3.18.2",
+    "cytoscape": "^3.19.0",
     "cytoscape-dagre": "^2.3.2",
     "debug": "^4.1.1",
     "fast-memoize": "^2.5.2",

--- a/packages/browser-ui/src/App.tsx
+++ b/packages/browser-ui/src/App.tsx
@@ -161,16 +161,35 @@ class App extends React.Component<any, ICanvasState> {
   };
 
   public step = (): void => {
-    const stepped = stepState(this.state.data, 1);
-    void this.onCanvasState(stepped);
+    try {
+      const stepped = stepState(this.state.data, 1);
+      void this.onCanvasState(stepped);
+    } catch (e) {
+        const error: PenroseError = {
+          errorType: "RuntimeError", tag: "RuntimeError", message: `Runtime error encountered: '${e}' Check console for more information.`
+        };
+
+      const errorWrapper = { error, data: undefined };
+      this.setState(errorWrapper);
+      throw e;
+    }
   };
 
   public stepUntilConvergence = (): void => {
-    const stepped = stepUntilConvergence(
-      this.state.data,
-      this.state.settings.autoStepSize
-    );
-    void this.onCanvasState(stepped);
+    try {
+      const stepped = stepUntilConvergence(
+        this.state.data,
+        this.state.settings.autoStepSize
+      );
+      void this.onCanvasState(stepped);
+    } catch (e) {
+        const error: PenroseError = {
+          errorType: "RuntimeError", tag: "RuntimeError", message: `Runtime error encountered: '${e}' Check console for more information.`
+        };
+      const errorWrapper = { error, data: undefined };
+      this.setState(errorWrapper);
+      throw e;
+    }
   };
 
   public resample = async () => {
@@ -198,8 +217,18 @@ class App extends React.Component<any, ICanvasState> {
           style.contents
         );
         if (compileRes.isOk()) {
-          const initState: PenroseState = await prepareState(compileRes.value);
-          void this.onCanvasState(initState);
+          try {
+            const initState: PenroseState = await prepareState(compileRes.value);
+            void this.onCanvasState(initState);
+          } catch (e) {
+              const error: PenroseError = {
+                errorType: "RuntimeError", tag: "RuntimeError", message: `Runtime error encountered: '${e}' Check console for more information.`
+              };
+
+            const errorWrapper = { error, data: undefined };
+            this.setState(errorWrapper);
+            throw e;
+          }
         } else {
           this.setState({ error: compileRes.error, data: undefined });
         }
@@ -333,8 +362,8 @@ class App extends React.Component<any, ICanvasState> {
                 setSettings={this.setSettings}
               />
             ) : (
-              <div />
-            )}
+                <div />
+              )}
           </SplitPane>
         </div>
       </div>

--- a/packages/core/src/engine/Optimizer.ts
+++ b/packages/core/src/engine/Optimizer.ts
@@ -2,56 +2,56 @@ import consola, { LogLevel } from "consola";
 import { constrDict, objDict } from "contrib/Constraints";
 import eig from "eigen";
 import {
-  add,
-  differentiable,
-  energyAndGradCompiled,
-  fns,
-  makeADInputVars,
-  markInput,
-  mul,
-  ops,
-  varOf,
+    add,
+    differentiable,
+    energyAndGradCompiled,
+    fns,
+    makeADInputVars,
+    markInput,
+    mul,
+    ops,
+    varOf,
 } from "engine/Autodiff";
 import {
-  defaultLbfgsParams,
-  initConstraintWeight,
-  makeTranslationDifferentiable,
-  makeTranslationNumeric,
+    defaultLbfgsParams,
+    initConstraintWeight,
+    makeTranslationDifferentiable,
+    makeTranslationNumeric,
 } from "engine/EngineUtils";
 import {
-  argValue,
-  evalFn,
-  evalFns,
-  evalShapes,
-  genPathMap,
-  insertVaryings,
+    argValue,
+    evalFn,
+    evalFns,
+    evalShapes,
+    genPathMap,
+    insertVaryings,
 } from "engine/Evaluator";
 import * as _ from "lodash";
 import rfdc from "rfdc";
 import { OptInfo, VarAD } from "types/ad";
 import { MaybeVal } from "types/common";
 import {
-  Fn,
-  FnCached,
-  FnDone,
-  LbfgsParams,
-  Params,
-  State,
-  VaryMap,
-  WeightInfo,
+    Fn,
+    FnCached,
+    FnDone,
+    LbfgsParams,
+    Params,
+    State,
+    VaryMap,
+    WeightInfo,
 } from "types/state";
 import { Path } from "types/style";
 import {
-  addv,
-  dot,
-  negv,
-  normList,
-  prettyPrintFn,
-  prettyPrintFns,
-  prettyPrintPath,
-  repeat,
-  scalev,
-  subv,
+    addv,
+    dot,
+    negv,
+    normList,
+    prettyPrintFn,
+    prettyPrintFns,
+    prettyPrintPath,
+    repeat,
+    scalev,
+    subv,
 } from "utils/OtherUtils";
 
 // NOTE: to view logs, change `level` below to `LogLevel.Info`, otherwise it should be `LogLevel.Warn`
@@ -100,39 +100,39 @@ const EPS = uoStop;
 ////////////////////////////////////////////////////////////////////////////////
 
 const unconstrainedConverged2 = (normGrad: number): boolean => {
-  if (DEBUG_GRAD_DESCENT) {
-    log.info("UO convergence check: ||grad f(x)||", normGrad);
-  }
-  return normGrad < uoStop;
+    if (DEBUG_GRAD_DESCENT) {
+        log.info("UO convergence check: ||grad f(x)||", normGrad);
+    }
+    return normGrad < uoStop;
 };
 
 const epConverged2 = (
-  xs0: number[],
-  xs1: number[],
-  fxs0: number,
-  fxs1: number
+    xs0: number[],
+    xs1: number[],
+    fxs0: number,
+    fxs1: number
 ): boolean => {
-  // TODO: These dx and dfx should really be scaled to account for magnitudes
-  const stateChange = normList(subv(xs1, xs0));
-  const energyChange = Math.abs(fxs1 - fxs0);
-  log.info(
-    "epConverged?: stateChange: ",
-    stateChange,
-    " | energyChange: ",
-    energyChange
-  );
+    // TODO: These dx and dfx should really be scaled to account for magnitudes
+    const stateChange = normList(subv(xs1, xs0));
+    const energyChange = Math.abs(fxs1 - fxs0);
+    log.info(
+        "epConverged?: stateChange: ",
+        stateChange,
+        " | energyChange: ",
+        energyChange
+    );
 
-  return stateChange < epStop || energyChange < epStop;
+    return stateChange < epStop || energyChange < epStop;
 };
 
 const applyFn = (f: FnDone<VarAD>, dict: any) => {
-  if (dict[f.name]) {
-    return dict[f.name](...f.args.map(argValue));
-  } else {
-    throw new Error(
-      `constraint or objective ${f.name} not found in dirctionary`
-    );
-  }
+    if (dict[f.name]) {
+        return dict[f.name](...f.args.map(argValue));
+    } else {
+        throw new Error(
+            `constraint or objective ${f.name} not found in dirctionary`
+        );
+    }
 };
 
 /**
@@ -153,7 +153,7 @@ const applyFn = (f: FnDone<VarAD>, dict: any) => {
 // 2) fix initial value of the penalty parameter so that the magnitude of the penalty term is not much smaller than the magnitude of objective function
 
 export const initializeMat = async () => {
-  await eig.ready;
+    await eig.ready;
 };
 
 /**
@@ -163,380 +163,380 @@ export const initializeMat = async () => {
  * @param evaluate
  */
 export const step = (state: State, steps: number, evaluate = true) => {
-  const { optStatus, weight } = state.params;
-  let newState = { ...state };
-  const optParams = newState.params; // this is just a reference, so updating this will update newState as well
-  let xs: number[] = state.varyingValues;
+    const { optStatus, weight } = state.params;
+    let newState = { ...state };
+    const optParams = newState.params; // this is just a reference, so updating this will update newState as well
+    let xs: number[] = state.varyingValues;
 
-  log.info("===============");
-  log.info(
-    "step | weight: ",
-    weight,
-    "| EP round: ",
-    optParams.EPround,
-    " | UO round: ",
-    optParams.UOround
-  );
-  log.info("params: ", optParams);
-  // log.info("state: ", state);
-  log.info("fns: ", prettyPrintFns(state));
-  log.info(
-    "variables: ",
-    state.varyingPaths.map((p: Path): string => prettyPrintPath(p))
-  );
-
-  switch (optStatus) {
-    case "NewIter": {
-      log.trace("step newIter, xs", xs);
-
-      // if (!state.params.functionsCompiled) {
-      // TODO: Doesn't reuse compiled function for now (since caching function in App currently does not work)
-      if (true) {
-        const { objective, gradient } = state.params;
-        if (!objective || !gradient) {
-          return genOptProblem(state);
-        } else {
-          return {
-            ...state,
-            params: {
-              ...state.params,
-              weight: initConstraintWeight,
-              UOround: 0,
-              EPround: 0,
-              optStatus: "UnconstrainedRunning" as const,
-              lbfgsInfo: defaultLbfgsParams,
-            },
-          };
-        }
-      } else {
-        // Reuse compiled functions for resample; set other initialization params accordingly
-        // The computational graph gets destroyed in resample (just for now, because it can't get serialized)
-        // But it's not needed for the optimization
-        log.info("Reusing compiled objective and gradients");
-        const params = state.params;
-
-        const newParams: Params = {
-          ...params,
-          lastGradient: repeat(xs.length, 0),
-          lastGradientPreconditioned: repeat(xs.length, 0),
-          currObjective: params.objective(initConstraintWeight),
-          currGradient: params.gradient(initConstraintWeight),
-          weight: initConstraintWeight,
-          UOround: 0,
-          EPround: 0,
-          optStatus: "UnconstrainedRunning",
-          lbfgsInfo: defaultLbfgsParams,
-        };
-
-        return { ...state, params: newParams };
-      }
-    }
-
-    case "UnconstrainedRunning": {
-      // NOTE: use cached varying values
-      log.info("step step, xs", xs);
-
-      const res = minimize(
-        xs,
-        state.params.currObjective,
-        state.params.currGradient,
-        state.params.lbfgsInfo,
-        state.varyingPaths.map((p) => prettyPrintPath(p)),
-        steps
-      );
-      xs = res.xs;
-
-      // the new `xs` is put into the `newState`, which is returned at end of function
-      // we don't need the updated xsVars and energyGraph as they are always cleared on evaluation; only their structure matters
-      const {
-        energyVal,
-        normGrad,
-        newLbfgsInfo,
-        gradient,
-        gradientPreconditioned,
-      } = res;
-
-      optParams.lastUOstate = xs;
-      optParams.lastUOenergy = energyVal;
-      optParams.UOround = optParams.UOround + 1;
-      optParams.lbfgsInfo = newLbfgsInfo;
-      optParams.lastGradient = gradient;
-      optParams.lastGradientPreconditioned = gradientPreconditioned;
-
-      // NOTE: `varyingValues` is updated in `state` after each step by putting it into `newState` and passing it to `evalTranslation`, which returns another state
-
-      // TODO. In the original optimizer, we cheat by using the EP cond here, because the UO cond is sometimes too strong.
-      if (unconstrainedConverged2(normGrad)) {
-        optParams.optStatus = "UnconstrainedConverged";
-        eig.GC.flush(); // Clear allocated matrix, vector objects in L-BFGS params
-        optParams.lbfgsInfo = defaultLbfgsParams;
-        log.info(
-          "Unconstrained converged with energy",
-          energyVal,
-          "gradient norm",
-          normGrad
-        );
-      } else {
-        optParams.optStatus = "UnconstrainedRunning";
-        // Note that lbfgs prams have already been updated
-        log.info(
-          `Took ${steps} steps. Current energy`,
-          energyVal,
-          "gradient norm",
-          normGrad
-        );
-      }
-
-      break;
-    }
-
-    case "UnconstrainedConverged": {
-      // No minimization step should be taken. Just figure out if we should start another UO round with higher EP weight.
-      // We are using the last UO state and energy because they serve as the current EP state and energy, and comparing it to the last EP stuff.
-
-      // Do EP convergence check on the last EP state (and its energy), and curr EP state (and its energy)
-      // (There is no EP state or energy on the first round)
-      // Note that lbfgs params have already been reset to default
-
-      // TODO. Make a diagram to clarify vocabulary
-      log.info("step: unconstrained converged", optParams);
-
-      // We force EP to run at least two rounds (State 0 -> State 1 -> State 2; the first check is only between States 1 and 2)
-      if (
-        optParams.EPround > 1 &&
-        epConverged2(
-          optParams.lastEPstate,
-          optParams.lastUOstate,
-          optParams.lastEPenergy,
-          optParams.lastUOenergy
-        )
-      ) {
-        optParams.optStatus = "EPConverged";
-        log.info("EP converged with energy", optParams.lastUOenergy);
-      } else {
-        // If EP has not converged, increase weight and continue.
-        // The point is that, for the next round, the last converged UO state becomes both the last EP state and the initial state for the next round--starting with a harsher penalty.
-        log.info(
-          "step: UO converged but EP did not converge; starting next round"
-        );
-        optParams.optStatus = "UnconstrainedRunning";
-
-        optParams.weight = weightGrowthFactor * weight;
-        optParams.EPround = optParams.EPround + 1;
-        optParams.UOround = 0;
-
-        optParams.currObjective = optParams.objective(optParams.weight);
-        optParams.currGradient = optParams.gradient(optParams.weight);
-
-        log.info(
-          "increased EP weight to",
-          optParams.weight,
-          "in compiled energy and gradient"
-        );
-      }
-
-      // Done with EP check, so save the curr EP state as the last EP state for the future.
-      optParams.lastEPstate = optParams.lastUOstate;
-      optParams.lastEPenergy = optParams.lastUOenergy;
-
-      break;
-    }
-
-    case "EPConverged": {
-      // do nothing if converged
-      log.info("step: EP converged");
-      return state;
-    }
-  }
-
-  // return the state with a new set of shapes
-  if (evaluate) {
-    const varyingValues = xs;
-    // log.info("evaluating state with varying values", varyingValues);
-    // log.info("varyingMap", zip(state.varyingPaths, varyingValues) as [Path, number][]);
-
-    newState.translation = insertVaryings(
-      state.translation,
-      _.zip(state.varyingPaths, varyingValues.map(differentiable)) as [
-        Path,
-        VarAD
-      ][]
+    log.info("===============");
+    log.info(
+        "step | weight: ",
+        weight,
+        "| EP round: ",
+        optParams.EPround,
+        " | UO round: ",
+        optParams.UOround
+    );
+    log.info("params: ", optParams);
+    // log.info("state: ", state);
+    log.info("fns: ", prettyPrintFns(state));
+    log.info(
+        "variables: ",
+        state.varyingPaths.map((p: Path): string => prettyPrintPath(p))
     );
 
-    newState.varyingValues = varyingValues;
-    newState = evalShapes(newState);
-  }
+    switch (optStatus) {
+        case "NewIter": {
+            log.trace("step newIter, xs", xs);
 
-  return newState;
+            // if (!state.params.functionsCompiled) {
+            // TODO: Doesn't reuse compiled function for now (since caching function in App currently does not work)
+            if (true) {
+                const { objective, gradient } = state.params;
+                if (!objective || !gradient) {
+                    return genOptProblem(state);
+                } else {
+                    return {
+                        ...state,
+                        params: {
+                            ...state.params,
+                            weight: initConstraintWeight,
+                            UOround: 0,
+                            EPround: 0,
+                            optStatus: "UnconstrainedRunning" as const,
+                            lbfgsInfo: defaultLbfgsParams,
+                        },
+                    };
+                }
+            } else {
+                // Reuse compiled functions for resample; set other initialization params accordingly
+                // The computational graph gets destroyed in resample (just for now, because it can't get serialized)
+                // But it's not needed for the optimization
+                log.info("Reusing compiled objective and gradients");
+                const params = state.params;
+
+                const newParams: Params = {
+                    ...params,
+                    lastGradient: repeat(xs.length, 0),
+                    lastGradientPreconditioned: repeat(xs.length, 0),
+                    currObjective: params.objective(initConstraintWeight),
+                    currGradient: params.gradient(initConstraintWeight),
+                    weight: initConstraintWeight,
+                    UOround: 0,
+                    EPround: 0,
+                    optStatus: "UnconstrainedRunning",
+                    lbfgsInfo: defaultLbfgsParams,
+                };
+
+                return { ...state, params: newParams };
+            }
+        }
+
+        case "UnconstrainedRunning": {
+            // NOTE: use cached varying values
+            log.info("step step, xs", xs);
+
+            const res = minimize(
+                xs,
+                state.params.currObjective,
+                state.params.currGradient,
+                state.params.lbfgsInfo,
+                state.varyingPaths.map((p) => prettyPrintPath(p)),
+                steps
+            );
+            xs = res.xs;
+
+            // the new `xs` is put into the `newState`, which is returned at end of function
+            // we don't need the updated xsVars and energyGraph as they are always cleared on evaluation; only their structure matters
+            const {
+                energyVal,
+                normGrad,
+                newLbfgsInfo,
+                gradient,
+                gradientPreconditioned,
+            } = res;
+
+            optParams.lastUOstate = xs;
+            optParams.lastUOenergy = energyVal;
+            optParams.UOround = optParams.UOround + 1;
+            optParams.lbfgsInfo = newLbfgsInfo;
+            optParams.lastGradient = gradient;
+            optParams.lastGradientPreconditioned = gradientPreconditioned;
+
+            // NOTE: `varyingValues` is updated in `state` after each step by putting it into `newState` and passing it to `evalTranslation`, which returns another state
+
+            // TODO. In the original optimizer, we cheat by using the EP cond here, because the UO cond is sometimes too strong.
+            if (unconstrainedConverged2(normGrad)) {
+                optParams.optStatus = "UnconstrainedConverged";
+                eig.GC.flush(); // Clear allocated matrix, vector objects in L-BFGS params
+                optParams.lbfgsInfo = defaultLbfgsParams;
+                log.info(
+                    "Unconstrained converged with energy",
+                    energyVal,
+                    "gradient norm",
+                    normGrad
+                );
+            } else {
+                optParams.optStatus = "UnconstrainedRunning";
+                // Note that lbfgs prams have already been updated
+                log.info(
+                    `Took ${steps} steps. Current energy`,
+                    energyVal,
+                    "gradient norm",
+                    normGrad
+                );
+            }
+
+            break;
+        }
+
+        case "UnconstrainedConverged": {
+            // No minimization step should be taken. Just figure out if we should start another UO round with higher EP weight.
+            // We are using the last UO state and energy because they serve as the current EP state and energy, and comparing it to the last EP stuff.
+
+            // Do EP convergence check on the last EP state (and its energy), and curr EP state (and its energy)
+            // (There is no EP state or energy on the first round)
+            // Note that lbfgs params have already been reset to default
+
+            // TODO. Make a diagram to clarify vocabulary
+            log.info("step: unconstrained converged", optParams);
+
+            // We force EP to run at least two rounds (State 0 -> State 1 -> State 2; the first check is only between States 1 and 2)
+            if (
+                optParams.EPround > 1 &&
+                epConverged2(
+                    optParams.lastEPstate,
+                    optParams.lastUOstate,
+                    optParams.lastEPenergy,
+                    optParams.lastUOenergy
+                )
+            ) {
+                optParams.optStatus = "EPConverged";
+                log.info("EP converged with energy", optParams.lastUOenergy);
+            } else {
+                // If EP has not converged, increase weight and continue.
+                // The point is that, for the next round, the last converged UO state becomes both the last EP state and the initial state for the next round--starting with a harsher penalty.
+                log.info(
+                    "step: UO converged but EP did not converge; starting next round"
+                );
+                optParams.optStatus = "UnconstrainedRunning";
+
+                optParams.weight = weightGrowthFactor * weight;
+                optParams.EPround = optParams.EPround + 1;
+                optParams.UOround = 0;
+
+                optParams.currObjective = optParams.objective(optParams.weight);
+                optParams.currGradient = optParams.gradient(optParams.weight);
+
+                log.info(
+                    "increased EP weight to",
+                    optParams.weight,
+                    "in compiled energy and gradient"
+                );
+            }
+
+            // Done with EP check, so save the curr EP state as the last EP state for the future.
+            optParams.lastEPstate = optParams.lastUOstate;
+            optParams.lastEPenergy = optParams.lastUOenergy;
+
+            break;
+        }
+
+        case "EPConverged": {
+            // do nothing if converged
+            log.info("step: EP converged");
+            return state;
+        }
+    }
+
+    // return the state with a new set of shapes
+    if (evaluate) {
+        const varyingValues = xs;
+        // log.info("evaluating state with varying values", varyingValues);
+        // log.info("varyingMap", zip(state.varyingPaths, varyingValues) as [Path, number][]);
+
+        newState.translation = insertVaryings(
+            state.translation,
+            _.zip(state.varyingPaths, varyingValues.map(differentiable)) as [
+                Path,
+                VarAD
+            ][]
+        );
+
+        newState.varyingValues = varyingValues;
+        newState = evalShapes(newState);
+    }
+
+    return newState;
 };
 
 // Note: line search seems to be quite sensitive to the maxSteps parameter; with maxSteps=25, the line search might
 
 const awLineSearch2 = (
-  xs0: number[],
-  f: (zs: number[]) => number,
-  gradf: (zs: number[]) => number[],
+    xs0: number[],
+    f: (zs: number[]) => number,
+    gradf: (zs: number[]) => number[],
 
-  gradfxs0: number[],
-  fxs0: number,
-  maxSteps = 10
+    gradfxs0: number[],
+    fxs0: number,
+    maxSteps = 10
 ) => {
-  const descentDir = negv(gradfxs0); // This is preconditioned by L-BFGS
+    const descentDir = negv(gradfxs0); // This is preconditioned by L-BFGS
 
-  const duf = (u: number[]) => {
-    return (zs: number[]) => {
-      return dot(u, gradf(zs));
+    const duf = (u: number[]) => {
+        return (zs: number[]) => {
+            return dot(u, gradf(zs));
+        };
     };
-  };
 
-  const dufDescent = duf(descentDir);
-  const dufAtx0 = dufDescent(xs0);
-  const minInterval = 10e-10;
+    const dufDescent = duf(descentDir);
+    const dufAtx0 = dufDescent(xs0);
+    const minInterval = 10e-10;
 
-  // HS (Haskell?): duf, TS: dufDescent
-  // HS: x0, TS: xs
+    // HS (Haskell?): duf, TS: dufDescent
+    // HS: x0, TS: xs
 
-  // Hyperparameters
-  const c1 = 0.001; // Armijo
-  const c2 = 0.9; // Wolfe
+    // Hyperparameters
+    const c1 = 0.001; // Armijo
+    const c2 = 0.9; // Wolfe
 
-  // Armijo condition
-  // f(x0 + t * descentDir) <= (f(x0) + c1 * t * <grad(f)(x0), x0>)
-  const armijo = (ti: number): boolean => {
-    const cond1 = f(addv(xs0, scalev(ti, descentDir)));
-    const cond2 = fxs0 + c1 * ti * dufAtx0;
-    return cond1 <= cond2;
-  };
+    // Armijo condition
+    // f(x0 + t * descentDir) <= (f(x0) + c1 * t * <grad(f)(x0), x0>)
+    const armijo = (ti: number): boolean => {
+        const cond1 = f(addv(xs0, scalev(ti, descentDir)));
+        const cond2 = fxs0 + c1 * ti * dufAtx0;
+        return cond1 <= cond2;
+    };
 
-  // D(u) := <grad f, u>
-  // D(u, f, x) = <grad f(x), u>
-  // u is the descentDir (i.e. -grad(f)(x))
+    // D(u) := <grad f, u>
+    // D(u, f, x) = <grad f(x), u>
+    // u is the descentDir (i.e. -grad(f)(x))
 
-  // Strong Wolfe condition
-  // |<grad(f)(x0 + t * descentDir), u>| <= c2 * |<grad f(x0), u>|
-  const strongWolfe = (ti: number) => {
-    const cond1 = Math.abs(dufDescent(addv(xs0, scalev(ti, descentDir))));
-    const cond2 = c2 * Math.abs(dufAtx0);
-    return cond1 <= cond2;
-  };
+    // Strong Wolfe condition
+    // |<grad(f)(x0 + t * descentDir), u>| <= c2 * |<grad f(x0), u>|
+    const strongWolfe = (ti: number) => {
+        const cond1 = Math.abs(dufDescent(addv(xs0, scalev(ti, descentDir))));
+        const cond2 = c2 * Math.abs(dufAtx0);
+        return cond1 <= cond2;
+    };
 
-  // Weak Wolfe condition
-  // <grad(f)(x0 + t * descentDir), u> >= c2 * <grad f(x0), u>
-  const weakWolfe = (ti: number) => {
-    const cond1 = dufDescent(addv(xs0, scalev(ti, descentDir)));
-    const cond2 = c2 * dufAtx0;
-    return cond1 >= cond2;
-  };
+    // Weak Wolfe condition
+    // <grad(f)(x0 + t * descentDir), u> >= c2 * <grad f(x0), u>
+    const weakWolfe = (ti: number) => {
+        const cond1 = dufDescent(addv(xs0, scalev(ti, descentDir)));
+        const cond2 = c2 * dufAtx0;
+        return cond1 >= cond2;
+    };
 
-  const wolfe = weakWolfe; // Set this if using strongWolfe instead
+    const wolfe = weakWolfe; // Set this if using strongWolfe instead
 
-  // Interval check
-  const shouldStop = (numUpdates: number, ai: number, bi: number) => {
-    const intervalTooSmall = Math.abs(bi - ai) < minInterval;
-    const tooManySteps = numUpdates > maxSteps;
+    // Interval check
+    const shouldStop = (numUpdates: number, ai: number, bi: number) => {
+        const intervalTooSmall = Math.abs(bi - ai) < minInterval;
+        const tooManySteps = numUpdates > maxSteps;
 
-    if (intervalTooSmall && DEBUG_LINE_SEARCH) {
-      log.info("line search stopping: interval too small");
-    }
-    if (tooManySteps && DEBUG_LINE_SEARCH) {
-      log.info("line search stopping: step count exceeded");
-    }
+        if (intervalTooSmall && DEBUG_LINE_SEARCH) {
+            log.info("line search stopping: interval too small");
+        }
+        if (tooManySteps && DEBUG_LINE_SEARCH) {
+            log.info("line search stopping: step count exceeded");
+        }
 
-    return intervalTooSmall || tooManySteps;
-  };
+        return intervalTooSmall || tooManySteps;
+    };
 
-  // Consts / initial values
-  // TODO: port comments from original
+    // Consts / initial values
+    // TODO: port comments from original
 
-  // const t = 0.002; // for venn_simple.sty
-  // const t = 0.1; // for tree.sty
+    // const t = 0.002; // for venn_simple.sty
+    // const t = 0.1; // for tree.sty
 
-  let a = 0;
-  let b = Infinity;
-  let t = 1.0;
-  let i = 0;
-  const DEBUG_LINE_SEARCH = false;
+    let a = 0;
+    let b = Infinity;
+    let t = 1.0;
+    let i = 0;
+    const DEBUG_LINE_SEARCH = false;
 
-  if (DEBUG_LINE_SEARCH) {
-    log.info("line search", xs0, gradfxs0, duf(xs0)(xs0));
-  }
-
-  // Main loop + update check
-  while (true) {
-    const needToStop = shouldStop(i, a, b);
-
-    if (needToStop) {
-      if (DEBUG_LINE_SEARCH) {
-        log.info("stopping early: (i, a, b, t) = ", i, a, b, t);
-      }
-      break;
-    }
-
-    const isArmijo = armijo(t);
-    const isWolfe = wolfe(t);
     if (DEBUG_LINE_SEARCH) {
-      log.info("(i, a, b, t), armijo, wolfe", i, a, b, t, isArmijo, isWolfe);
+        log.info("line search", xs0, gradfxs0, duf(xs0)(xs0));
     }
 
-    if (!isArmijo) {
-      if (DEBUG_LINE_SEARCH) {
-        log.info("not armijo");
-      }
-      b = t;
-    } else if (!isWolfe) {
-      if (DEBUG_LINE_SEARCH) {
-        log.info("not wolfe");
-      }
-      a = t;
-    } else {
-      if (DEBUG_LINE_SEARCH) {
-        log.info("found good interval");
-        log.info("stopping: (i, a, b, t) = ", i, a, b, t);
-      }
-      break;
+    // Main loop + update check
+    while (true) {
+        const needToStop = shouldStop(i, a, b);
+
+        if (needToStop) {
+            if (DEBUG_LINE_SEARCH) {
+                log.info("stopping early: (i, a, b, t) = ", i, a, b, t);
+            }
+            break;
+        }
+
+        const isArmijo = armijo(t);
+        const isWolfe = wolfe(t);
+        if (DEBUG_LINE_SEARCH) {
+            log.info("(i, a, b, t), armijo, wolfe", i, a, b, t, isArmijo, isWolfe);
+        }
+
+        if (!isArmijo) {
+            if (DEBUG_LINE_SEARCH) {
+                log.info("not armijo");
+            }
+            b = t;
+        } else if (!isWolfe) {
+            if (DEBUG_LINE_SEARCH) {
+                log.info("not wolfe");
+            }
+            a = t;
+        } else {
+            if (DEBUG_LINE_SEARCH) {
+                log.info("found good interval");
+                log.info("stopping: (i, a, b, t) = ", i, a, b, t);
+            }
+            break;
+        }
+
+        if (b < Infinity) {
+            if (DEBUG_LINE_SEARCH) {
+                log.info("already found armijo");
+            }
+            t = (a + b) / 2.0;
+        } else {
+            if (DEBUG_LINE_SEARCH) {
+                log.info("did not find armijo");
+            }
+            t = 2.0 * a;
+        }
+
+        i++;
     }
 
-    if (b < Infinity) {
-      if (DEBUG_LINE_SEARCH) {
-        log.info("already found armijo");
-      }
-      t = (a + b) / 2.0;
-    } else {
-      if (DEBUG_LINE_SEARCH) {
-        log.info("did not find armijo");
-      }
-      t = 2.0 * a;
-    }
-
-    i++;
-  }
-
-  return t;
+    return t;
 };
 
 const vecList = (xs: any): number[] => {
-  // Prints a col vector (nx1)
-  const res = [];
-  for (let i = 0; i < xs.rows(); i++) {
-    res.push(xs.get(i, 0));
-  }
-  return res;
+    // Prints a col vector (nx1)
+    const res = [];
+    for (let i = 0; i < xs.rows(); i++) {
+        res.push(xs.get(i, 0));
+    }
+    return res;
 };
 
 const printVec = (xs: any) => {
-  // Prints a col vector (nx1)
-  log.info("xs (matrix)", vecList(xs));
+    // Prints a col vector (nx1)
+    log.info("xs (matrix)", vecList(xs));
 };
 
 const colVec = (xs: number[]): any => {
-  // Return a col vector (nx1)
-  // TODO: What is the performance of this?
-  const m = eig.Matrix.constant(xs.length, 1, 0); // rows x cols
-  xs.forEach((e, i) => m.set(i, 0, e));
+    // Return a col vector (nx1)
+    // TODO: What is the performance of this?
+    const m = eig.Matrix.constant(xs.length, 1, 0); // rows x cols
+    xs.forEach((e, i) => m.set(i, 0, e));
 
-  // log.info("original xs", xs);
-  // printVec(m);
-  return m;
+    // log.info("original xs", xs);
+    // printVec(m);
+    return m;
 };
 
 // v is a col vec, w is a col vec, they need to be the same size, returns v dot w (removed from its container)
@@ -548,300 +548,300 @@ const dotVec = (v: any, w: any): number => v.transpose().matMul(w).get(0, 0);
 
 // `any` here is a column vector type
 const lbfgsInner = (grad_fx_k: any, ss: any[], ys: any[]): any => {
-  // TODO: See if using the mutation methods in linear-algebra-js (instead of the return-a-new-matrix ones) yield any speedup
-  // Also see if rewriting outside the functional style yields speedup (e.g. less copying of matrix objects -> less garbage collection)
+    // TODO: See if using the mutation methods in linear-algebra-js (instead of the return-a-new-matrix ones) yield any speedup
+    // Also see if rewriting outside the functional style yields speedup (e.g. less copying of matrix objects -> less garbage collection)
 
-  // Helper functions
-  const calculate_rho = (s: any, y: any): number => {
-    return 1.0 / (dotVec(y, s) + EPSD);
-  };
+    // Helper functions
+    const calculate_rho = (s: any, y: any): number => {
+        return 1.0 / (dotVec(y, s) + EPSD);
+    };
 
-  // `any` = column vec
-  const pull_q_back = (
-    acc: [any, number[]],
-    curr: [number, any, any]
-  ): [any, number[]] => {
-    const [q_i_plus_1, alphas2] = acc; // alphas2 is the same stuff as alphas, just renamed to avoid shadowing
-    const [rho_i, s_i, y_i] = curr;
+    // `any` = column vec
+    const pull_q_back = (
+        acc: [any, number[]],
+        curr: [number, any, any]
+    ): [any, number[]] => {
+        const [q_i_plus_1, alphas2] = acc; // alphas2 is the same stuff as alphas, just renamed to avoid shadowing
+        const [rho_i, s_i, y_i] = curr;
 
-    const alpha_i: number = rho_i * dotVec(s_i, q_i_plus_1);
-    const q_i: any = q_i_plus_1.matSub(y_i.mul(alpha_i));
+        const alpha_i: number = rho_i * dotVec(s_i, q_i_plus_1);
+        const q_i: any = q_i_plus_1.matSub(y_i.mul(alpha_i));
 
-    return [q_i, alphas2.concat([alpha_i])]; // alphas, left to right
-  };
+        return [q_i, alphas2.concat([alpha_i])]; // alphas, left to right
+    };
 
-  // takes two column vectors (nx1), returns a square matrix (nxn)
-  const estimate_hess = (y_km1: any, s_km1: any): any => {
-    const gamma_k = dotVec(s_km1, y_km1) / (dotVec(y_km1, y_km1) + EPSD);
-    const n = y_km1.rows();
-    return eig.Matrix.identity(n, n).mul(gamma_k);
-  };
+    // takes two column vectors (nx1), returns a square matrix (nxn)
+    const estimate_hess = (y_km1: any, s_km1: any): any => {
+        const gamma_k = dotVec(s_km1, y_km1) / (dotVec(y_km1, y_km1) + EPSD);
+        const n = y_km1.rows();
+        return eig.Matrix.identity(n, n).mul(gamma_k);
+    };
 
-  // `any` = column vec
-  const push_r_forward = (
-    r_i: any,
-    curr: [[number, number], [any, any]]
-  ): any => {
-    const [[rho_i, alpha_i], [s_i, y_i]] = curr;
-    const beta_i: number = rho_i * dotVec(y_i, r_i);
-    const r_i_plus_1 = r_i.matAdd(s_i.mul(alpha_i - beta_i));
-    return r_i_plus_1;
-  };
+    // `any` = column vec
+    const push_r_forward = (
+        r_i: any,
+        curr: [[number, number], [any, any]]
+    ): any => {
+        const [[rho_i, alpha_i], [s_i, y_i]] = curr;
+        const beta_i: number = rho_i * dotVec(y_i, r_i);
+        const r_i_plus_1 = r_i.matAdd(s_i.mul(alpha_i - beta_i));
+        return r_i_plus_1;
+    };
 
-  // BACKWARD: for i = k-1 ... k-m
-  // The length of any list should be the number of stored vectors
-  const rhos = _.zip(ss, ys).map(([s, y]) => calculate_rho(s, y));
-  const q_k = grad_fx_k;
-  // Note the order of alphas will be from k-1 through k-m for the push_r_forward loop
-  // (Note that `reduce` is a left fold)
-  const [q_k_minus_m, alphas] = (_.zip(rhos, ss, ys) as any).reduce(
-    pull_q_back,
-    [q_k, []]
-  );
+    // BACKWARD: for i = k-1 ... k-m
+    // The length of any list should be the number of stored vectors
+    const rhos = _.zip(ss, ys).map(([s, y]) => calculate_rho(s, y));
+    const q_k = grad_fx_k;
+    // Note the order of alphas will be from k-1 through k-m for the push_r_forward loop
+    // (Note that `reduce` is a left fold)
+    const [q_k_minus_m, alphas] = (_.zip(rhos, ss, ys) as any).reduce(
+        pull_q_back,
+        [q_k, []]
+    );
 
-  const h_0_k = estimate_hess(ys[0], ss[0]); // nxn matrix, according to Nocedal p226, eqn 9.6
+    const h_0_k = estimate_hess(ys[0], ss[0]); // nxn matrix, according to Nocedal p226, eqn 9.6
 
-  // FORWARD: for i = k-m .. k-1
-  // below: [nxn matrix * nx1 (col) vec] -> nx1 (col) vec
-  const r_k_minus_m = h_0_k.matMul(q_k_minus_m);
-  // Note that rhos, alphas, ss, and ys are all in order from `k-1` to `k-m` so we just reverse all of them together to go from `k-m` to `k-1`
-  // NOTE: `reverse` mutates the array in-place, which is fine because we don't need it later
-  const inputs = _.zip(_.zip(rhos, alphas), _.zip(ss, ys)).reverse() as any;
-  const r_k = inputs.reduce(push_r_forward, r_k_minus_m);
+    // FORWARD: for i = k-m .. k-1
+    // below: [nxn matrix * nx1 (col) vec] -> nx1 (col) vec
+    const r_k_minus_m = h_0_k.matMul(q_k_minus_m);
+    // Note that rhos, alphas, ss, and ys are all in order from `k-1` to `k-m` so we just reverse all of them together to go from `k-m` to `k-1`
+    // NOTE: `reverse` mutates the array in-place, which is fine because we don't need it later
+    const inputs = _.zip(_.zip(rhos, alphas), _.zip(ss, ys)).reverse() as any;
+    const r_k = inputs.reduce(push_r_forward, r_k_minus_m);
 
-  // result r_k is H_k * grad f(x_k)
-  return r_k;
+    // result r_k is H_k * grad f(x_k)
+    return r_k;
 };
 
 // Outer loop of lbfgs
 // See Optimizer.hs for any add'l comments
 const lbfgs = (xs: number[], gradfxs: number[], lbfgsInfo: LbfgsParams) => {
-  // Comments for normal BFGS:
-  // For x_{k+1}, to compute H_k, we need the (k-1) info
-  // Our convention is that we are always working "at" k to compute k+1
-  // x_0 doesn't require any H; x_1 (the first step) with k = 0 requires H_0
-  // x_2 (the NEXT step) with k=1 requires H_1. For example>
-  // x_2 = x_1 - alpha_1 H_1 grad f(x_1)   [GD step]
-  // H_1 = V_0 H_0 V_0 + rho_0 s_0 s_0^T   [This is confusing because the book adds an extra +1 to the H index]
-  // V_0 = I - rho_0 y_0 s_0^T
-  // rho_0 = 1 / y_0^T s_0
-  // s_0 = x_1 - x_0
-  // y_0 = grad f(x_1) - grad f(x_0)
+    // Comments for normal BFGS:
+    // For x_{k+1}, to compute H_k, we need the (k-1) info
+    // Our convention is that we are always working "at" k to compute k+1
+    // x_0 doesn't require any H; x_1 (the first step) with k = 0 requires H_0
+    // x_2 (the NEXT step) with k=1 requires H_1. For example>
+    // x_2 = x_1 - alpha_1 H_1 grad f(x_1)   [GD step]
+    // H_1 = V_0 H_0 V_0 + rho_0 s_0 s_0^T   [This is confusing because the book adds an extra +1 to the H index]
+    // V_0 = I - rho_0 y_0 s_0^T
+    // rho_0 = 1 / y_0^T s_0
+    // s_0 = x_1 - x_0
+    // y_0 = grad f(x_1) - grad f(x_0)
 
-  if (DEBUG_LBFGS) {
-    log.info(
-      "Starting lbfgs calculation with xs",
-      xs,
-      "gradfxs",
-      gradfxs,
-      "lbfgs params",
-      lbfgsInfo
-    );
-  }
-
-  if (lbfgsInfo.numUnconstrSteps === 0) {
-    // Initialize state
-    // Perform normal gradient descent on first step
-    // Store x_k, grad f(x_k) so we can compute s_k, y_k on next step
-
-    return {
-      gradfxsPreconditioned: gradfxs,
-      updatedLbfgsInfo: {
-        ...lbfgsInfo,
-        lastState: { tag: "Just" as const, contents: colVec(xs) },
-        lastGrad: { tag: "Just" as const, contents: colVec(gradfxs) },
-        s_list: [],
-        y_list: [],
-        numUnconstrSteps: 1,
-      },
-    };
-  } else if (
-    lbfgsInfo.lastState.tag === "Just" &&
-    lbfgsInfo.lastGrad.tag === "Just"
-  ) {
-    // Our current step is k; the last step is km1 (k_minus_1)
-    const x_k = colVec(xs);
-    const grad_fx_k = colVec(gradfxs);
-
-    const km1 = lbfgsInfo.numUnconstrSteps;
-    const x_km1 = lbfgsInfo.lastState.contents;
-    const grad_fx_km1 = lbfgsInfo.lastGrad.contents;
-    const ss_km2 = lbfgsInfo.s_list;
-    const ys_km2 = lbfgsInfo.y_list;
-
-    // Compute s_{k-1} = x_k - x_{k-1} and y_{k-1} = (analogous with grads)
-    // Unlike Nocedal, compute the difference vectors first instead of last (same result, just a loop rewrite)
-    // Use the updated {s_i} and {y_i}. (If k < m, this reduces to normal BFGS, i.e. we use all the vectors so far)
-    // Newest vectors added to front
-
-    const s_km1 = x_k.matSub(x_km1);
-    const y_km1 = grad_fx_k.matSub(grad_fx_km1);
-
-    // The limited-memory part: drop stale vectors
-    // Haskell `ss` -> JS `ss_km2`; Haskell `ss'` -> JS `ss_km1`
-    const ss_km1 = _.take([s_km1].concat(ss_km2), lbfgsInfo.memSize);
-    const ys_km1 = _.take([y_km1].concat(ys_km2), lbfgsInfo.memSize);
-    const gradPreconditioned = lbfgsInner(grad_fx_k, ss_km1, ys_km1);
-
-    // Reset L-BFGS if the result is not a descent direction, and use steepest descent direction
-    // https://github.com/JuliaNLSolvers/Optim.jl/issues/143
-    // https://github.com/JuliaNLSolvers/Optim.jl/pull/144
-    // A descent direction is a vector p s.t. <p `dot` grad_fx_k> < 0
-    // If P is a positive definite matrix, then p = -P grad f(x) is a descent dir at x
-    const descentDirCheck = -1.0 * dotVec(gradPreconditioned, grad_fx_k);
-
-    if (descentDirCheck > 0.0) {
-      log.info(
-        "L-BFGS did not find a descent direction. Resetting correction vectors.",
-        lbfgsInfo
-      );
-      return {
-        gradfxsPreconditioned: gradfxs,
-        updatedLbfgsInfo: {
-          ...lbfgsInfo,
-          lastState: { tag: "Just" as const, contents: x_k },
-          lastGrad: { tag: "Just" as const, contents: grad_fx_k },
-          s_list: [],
-          y_list: [],
-          numUnconstrSteps: 1,
-        },
-      };
-    }
-
-    // Found a direction; update the state
-    // TODO: check the curvature condition y_k^T s_k > 0 (8.7) (Nocedal 201)
-    // https://github.com/JuliaNLSolvers/Optim.jl/issues/26
     if (DEBUG_LBFGS) {
-      log.info("Descent direction found.", vecList(gradPreconditioned));
+        log.info(
+            "Starting lbfgs calculation with xs",
+            xs,
+            "gradfxs",
+            gradfxs,
+            "lbfgs params",
+            lbfgsInfo
+        );
     }
 
-    return {
-      gradfxsPreconditioned: vecList(gradPreconditioned),
-      updatedLbfgsInfo: {
-        ...lbfgsInfo,
-        lastState: { tag: "Just" as const, contents: x_k },
-        lastGrad: { tag: "Just" as const, contents: grad_fx_k },
-        s_list: ss_km1,
-        y_list: ys_km1,
-        numUnconstrSteps: km1 + 1,
-      },
-    };
-  } else {
-    log.info("State:", lbfgsInfo);
-    throw Error("Invalid L-BFGS state");
-  }
+    if (lbfgsInfo.numUnconstrSteps === 0) {
+        // Initialize state
+        // Perform normal gradient descent on first step
+        // Store x_k, grad f(x_k) so we can compute s_k, y_k on next step
+
+        return {
+            gradfxsPreconditioned: gradfxs,
+            updatedLbfgsInfo: {
+                ...lbfgsInfo,
+                lastState: { tag: "Just" as const, contents: colVec(xs) },
+                lastGrad: { tag: "Just" as const, contents: colVec(gradfxs) },
+                s_list: [],
+                y_list: [],
+                numUnconstrSteps: 1,
+            },
+        };
+    } else if (
+        lbfgsInfo.lastState.tag === "Just" &&
+        lbfgsInfo.lastGrad.tag === "Just"
+    ) {
+        // Our current step is k; the last step is km1 (k_minus_1)
+        const x_k = colVec(xs);
+        const grad_fx_k = colVec(gradfxs);
+
+        const km1 = lbfgsInfo.numUnconstrSteps;
+        const x_km1 = lbfgsInfo.lastState.contents;
+        const grad_fx_km1 = lbfgsInfo.lastGrad.contents;
+        const ss_km2 = lbfgsInfo.s_list;
+        const ys_km2 = lbfgsInfo.y_list;
+
+        // Compute s_{k-1} = x_k - x_{k-1} and y_{k-1} = (analogous with grads)
+        // Unlike Nocedal, compute the difference vectors first instead of last (same result, just a loop rewrite)
+        // Use the updated {s_i} and {y_i}. (If k < m, this reduces to normal BFGS, i.e. we use all the vectors so far)
+        // Newest vectors added to front
+
+        const s_km1 = x_k.matSub(x_km1);
+        const y_km1 = grad_fx_k.matSub(grad_fx_km1);
+
+        // The limited-memory part: drop stale vectors
+        // Haskell `ss` -> JS `ss_km2`; Haskell `ss'` -> JS `ss_km1`
+        const ss_km1 = _.take([s_km1].concat(ss_km2), lbfgsInfo.memSize);
+        const ys_km1 = _.take([y_km1].concat(ys_km2), lbfgsInfo.memSize);
+        const gradPreconditioned = lbfgsInner(grad_fx_k, ss_km1, ys_km1);
+
+        // Reset L-BFGS if the result is not a descent direction, and use steepest descent direction
+        // https://github.com/JuliaNLSolvers/Optim.jl/issues/143
+        // https://github.com/JuliaNLSolvers/Optim.jl/pull/144
+        // A descent direction is a vector p s.t. <p `dot` grad_fx_k> < 0
+        // If P is a positive definite matrix, then p = -P grad f(x) is a descent dir at x
+        const descentDirCheck = -1.0 * dotVec(gradPreconditioned, grad_fx_k);
+
+        if (descentDirCheck > 0.0) {
+            log.info(
+                "L-BFGS did not find a descent direction. Resetting correction vectors.",
+                lbfgsInfo
+            );
+            return {
+                gradfxsPreconditioned: gradfxs,
+                updatedLbfgsInfo: {
+                    ...lbfgsInfo,
+                    lastState: { tag: "Just" as const, contents: x_k },
+                    lastGrad: { tag: "Just" as const, contents: grad_fx_k },
+                    s_list: [],
+                    y_list: [],
+                    numUnconstrSteps: 1,
+                },
+            };
+        }
+
+        // Found a direction; update the state
+        // TODO: check the curvature condition y_k^T s_k > 0 (8.7) (Nocedal 201)
+        // https://github.com/JuliaNLSolvers/Optim.jl/issues/26
+        if (DEBUG_LBFGS) {
+            log.info("Descent direction found.", vecList(gradPreconditioned));
+        }
+
+        return {
+            gradfxsPreconditioned: vecList(gradPreconditioned),
+            updatedLbfgsInfo: {
+                ...lbfgsInfo,
+                lastState: { tag: "Just" as const, contents: x_k },
+                lastGrad: { tag: "Just" as const, contents: grad_fx_k },
+                s_list: ss_km1,
+                y_list: ys_km1,
+                numUnconstrSteps: km1 + 1,
+            },
+        };
+    } else {
+        log.info("State:", lbfgsInfo);
+        throw Error("Invalid L-BFGS state");
+    }
 };
 
 const minimize = (
-  xs0: number[],
-  f: (zs: number[]) => number,
-  gradf: (zs: number[]) => number[],
-  lbfgsInfo: LbfgsParams,
-  varyingPaths: string[],
-  numSteps: number
+    xs0: number[],
+    f: (zs: number[]) => number,
+    gradf: (zs: number[]) => number[],
+    lbfgsInfo: LbfgsParams,
+    varyingPaths: string[],
+    numSteps: number
 ): OptInfo => {
-  // TODO: Do a UO convergence check here? Since the EP check is tied to the render cycle...
+    // TODO: Do a UO convergence check here? Since the EP check is tied to the render cycle...
 
-  log.info("-------------------------------------");
-  log.info("minimize, num steps", numSteps);
+    log.info("-------------------------------------");
+    log.info("minimize, num steps", numSteps);
 
-  // (10,000 steps / 100ms) * (10 ms / s) (???) = 100k steps/s (on this simple problem (just `sameCenter` or just `contains`, with no line search, and not sure about mem use)
-  // this is just a factor of 5 slowdown over the compiled energy function
+    // (10,000 steps / 100ms) * (10 ms / s) (???) = 100k steps/s (on this simple problem (just `sameCenter` or just `contains`, with no line search, and not sure about mem use)
+    // this is just a factor of 5 slowdown over the compiled energy function
 
-  let xs = [...xs0]; // Don't use xs
-  let fxs = 0.0;
-  let gradfxs = repeat(xs0.length, 0);
-  let gradientPreconditioned = [...gradfxs];
-  let normGradfxs = 0.0;
-  let i = 0;
-  let t = 0.0001; // NOTE: This const setting will not necessarily work well for a given opt problem.
+    let xs = [...xs0]; // Don't use xs
+    let fxs = 0.0;
+    let gradfxs = repeat(xs0.length, 0);
+    let gradientPreconditioned = [...gradfxs];
+    let normGradfxs = 0.0;
+    let i = 0;
+    let t = 0.0001; // NOTE: This const setting will not necessarily work well for a given opt problem.
 
-  let newLbfgsInfo = { ...lbfgsInfo };
+    let newLbfgsInfo = { ...lbfgsInfo };
 
-  while (i < numSteps) {
-    fxs = f(xs);
-    gradfxs = gradf(xs);
+    while (i < numSteps) {
+        fxs = f(xs);
+        gradfxs = gradf(xs);
 
-    const { gradfxsPreconditioned, updatedLbfgsInfo } = lbfgs(
-      xs,
-      gradfxs,
-      newLbfgsInfo
-    );
-    newLbfgsInfo = updatedLbfgsInfo;
-    gradientPreconditioned = gradfxsPreconditioned;
+        const { gradfxsPreconditioned, updatedLbfgsInfo } = lbfgs(
+            xs,
+            gradfxs,
+            newLbfgsInfo
+        );
+        newLbfgsInfo = updatedLbfgsInfo;
+        gradientPreconditioned = gradfxsPreconditioned;
 
-    // Don't take the Euclidean norm. According to Boyd (485), we should use the Newton descent check, with the norm of the gradient pulled back to the nicer space.
-    normGradfxs = dot(gradfxs, gradfxsPreconditioned);
+        // Don't take the Euclidean norm. According to Boyd (485), we should use the Newton descent check, with the norm of the gradient pulled back to the nicer space.
+        normGradfxs = dot(gradfxs, gradfxsPreconditioned);
 
-    if (BREAK_EARLY && unconstrainedConverged2(normGradfxs)) {
-      // This is on the original gradient, not the preconditioned one
-      log.info(
-        "descent converged early, on step",
-        i,
-        "of",
-        numSteps,
-        "(per display cycle); stopping early"
-      );
-      break;
-    }
-
-    if (USE_LINE_SEARCH) {
-      t = awLineSearch2(xs, f, gradf, gradfxsPreconditioned, fxs); // The search direction is conditioned (here, by an approximation of the inverse of the Hessian at the point)
-    }
-
-    const normGrad = normList(gradfxs);
-
-    if (DEBUG_GRAD_DESCENT) {
-      log.info("-----");
-      log.info("i", i);
-      log.info("num steps per display cycle", numSteps);
-      log.info("input (xs):", xs);
-      log.info("energy (f(xs)):", fxs);
-      log.info("grad (grad(f)(xs)):", gradfxs);
-      log.info("|grad f(x)|:", normGrad);
-      log.info("t", t, "use line search:", USE_LINE_SEARCH);
-    }
-
-    if (isNaN(fxs) || isNaN(normGrad)) {
-      log.info("-----");
-
-      const pathMap = _.zip(varyingPaths, xs, gradfxs) as [
-        string,
-        number,
-        number
-      ][];
-      log.info("[varying paths, current val, gradient of val]", pathMap);
-
-      for (const [name, x, dx] of pathMap) {
-        if (isNaN(dx)) {
-          log.info("NaN in varying val's gradient", name, "(current val):", x);
+        if (BREAK_EARLY && unconstrainedConverged2(normGradfxs)) {
+            // This is on the original gradient, not the preconditioned one
+            log.info(
+                "descent converged early, on step",
+                i,
+                "of",
+                numSteps,
+                "(per display cycle); stopping early"
+            );
+            break;
         }
-      }
 
-      log.info("i", i);
-      log.info("num steps per display cycle", numSteps);
-      log.info("input (xs):", xs);
-      log.info("energy (f(xs)):", fxs);
-      log.info("grad (grad(f)(xs)):", gradfxs);
-      log.info("|grad f(x)|:", normGrad);
-      log.info("t", t, "use line search:", USE_LINE_SEARCH);
-      throw Error("NaN reached in optimization energy or gradient norm!");
+        if (USE_LINE_SEARCH) {
+            t = awLineSearch2(xs, f, gradf, gradfxsPreconditioned, fxs); // The search direction is conditioned (here, by an approximation of the inverse of the Hessian at the point)
+        }
+
+        const normGrad = normList(gradfxs);
+
+        if (DEBUG_GRAD_DESCENT) {
+            log.info("-----");
+            log.info("i", i);
+            log.info("num steps per display cycle", numSteps);
+            log.info("input (xs):", xs);
+            log.info("energy (f(xs)):", fxs);
+            log.info("grad (grad(f)(xs)):", gradfxs);
+            log.info("|grad f(x)|:", normGrad);
+            log.info("t", t, "use line search:", USE_LINE_SEARCH);
+        }
+
+        if (isNaN(fxs) || isNaN(normGrad)) {
+            log.info("-----");
+
+            const pathMap = _.zip(varyingPaths, xs, gradfxs) as [
+                string,
+                number,
+                number
+            ][];
+            log.info("[varying paths, current val, gradient of val]", pathMap);
+
+            for (const [name, x, dx] of pathMap) {
+                if (isNaN(dx)) {
+                    log.info("NaN in varying val's gradient", name, "(current val):", x);
+                }
+            }
+
+            log.info("i", i);
+            log.info("num steps per display cycle", numSteps);
+            log.info("input (xs):", xs);
+            log.info("energy (f(xs)):", fxs);
+            log.info("grad (grad(f)(xs)):", gradfxs);
+            log.info("|grad f(x)|:", normGrad);
+            log.info("t", t, "use line search:", USE_LINE_SEARCH);
+            throw Error("NaN reached in optimization energy or gradient norm!");
+        }
+
+        xs = xs.map((x, j) => x - t * gradfxsPreconditioned[j]); // The GD update uses the conditioned search direction, as well as the timestep found by moving along it
+        i++;
     }
 
-    xs = xs.map((x, j) => x - t * gradfxsPreconditioned[j]); // The GD update uses the conditioned search direction, as well as the timestep found by moving along it
-    i++;
-  }
+    // TODO: Log stats for last one?
 
-  // TODO: Log stats for last one?
-
-  return {
-    xs,
-    energyVal: fxs,
-    normGrad: normGradfxs,
-    newLbfgsInfo,
-    gradient: gradfxs,
-    gradientPreconditioned,
-  };
+    return {
+        xs,
+        energyVal: fxs,
+        normGrad: normGradfxs,
+        newLbfgsInfo,
+        gradient: gradfxs,
+        gradientPreconditioned,
+    };
 };
 
 /**
@@ -851,204 +851,204 @@ const minimize = (
  * @returns a function that takes in a list of `VarAD`s and return a `Scalar`
  */
 export const evalEnergyOnCustom = (state: State) => {
-  // TODO: types
-  return (...xsVars: VarAD[]): any => {
-    // TODO: Could this line be causing a memory leak?
-    const { objFns, constrFns, varyingPaths } = state;
+    // TODO: types
+    return (...xsVars: VarAD[]): any => {
+        // TODO: Could this line be causing a memory leak?
+        const { objFns, constrFns, varyingPaths } = state;
 
-    // Clone the translation to use in the `evalFns` top-level calls, because they mutate the translation while interpreting the energy function in order to cache/reuse VarAD (computation) results
-    // Note that we have to do a "round trip" on the translation types, from VarAD to number to VarAD, to clear the computational graph of the VarADs. Otherwise, there may be cycles in the translation (since 1) we run `evalShapes` in `processData`, which mutates the VarADs, and 2) the computational graph contains DAGs and stores both parent and child pointers). Cycles in the translation cause `clone` to be very slow, and anyway, the VarADs should be "fresh" since the point of this function is to build the comp graph from scratch by interpreting the translation.
-    const translationInit = makeTranslationDifferentiable(
-      clone(makeTranslationNumeric(state.translation))
-    );
+        // Clone the translation to use in the `evalFns` top-level calls, because they mutate the translation while interpreting the energy function in order to cache/reuse VarAD (computation) results
+        // Note that we have to do a "round trip" on the translation types, from VarAD to number to VarAD, to clear the computational graph of the VarADs. Otherwise, there may be cycles in the translation (since 1) we run `evalShapes` in `processData`, which mutates the VarADs, and 2) the computational graph contains DAGs and stores both parent and child pointers). Cycles in the translation cause `clone` to be very slow, and anyway, the VarADs should be "fresh" since the point of this function is to build the comp graph from scratch by interpreting the translation.
+        const translationInit = makeTranslationDifferentiable(
+            clone(makeTranslationNumeric(state.translation))
+        );
 
-    const varyingMapList = _.zip(varyingPaths, xsVars) as [Path, VarAD][];
-    // Insert varying vals into translation (e.g. VectorAccesses of varying vals are found in the translation, although I guess in practice they should use varyingMap)
-    const translation = insertVaryings(translationInit, varyingMapList);
+        const varyingMapList = _.zip(varyingPaths, xsVars) as [Path, VarAD][];
+        // Insert varying vals into translation (e.g. VectorAccesses of varying vals are found in the translation, although I guess in practice they should use varyingMap)
+        const translation = insertVaryings(translationInit, varyingMapList);
 
-    // construct a new varying map
-    const varyingMap = genPathMap(varyingPaths, xsVars) as VaryMap<VarAD>;
+        // construct a new varying map
+        const varyingMap = genPathMap(varyingPaths, xsVars) as VaryMap<VarAD>;
 
-    // NOTE: This will mutate the var inputs
-    const objEvaled = evalFns(objFns, translation, varyingMap);
-    const constrEvaled = evalFns(constrFns, translation, varyingMap);
+        // NOTE: This will mutate the var inputs
+        const objEvaled = evalFns(objFns, translation, varyingMap);
+        const constrEvaled = evalFns(constrFns, translation, varyingMap);
 
-    const objEngs: VarAD[] = objEvaled.map((o) => applyFn(o, objDict));
-    const constrEngs: VarAD[] = constrEvaled.map((c) =>
-      fns.toPenalty(applyFn(c, constrDict))
-    );
+        const objEngs: VarAD[] = objEvaled.map((o) => applyFn(o, objDict));
+        const constrEngs: VarAD[] = constrEvaled.map((c) =>
+            fns.toPenalty(applyFn(c, constrDict))
+        );
 
-    // Note there are two energies, each of which does NOT know about its children, but the root nodes should now have parents up to the objfn energies. The computational graph can be seen in inspecting varyingValuesTF's parents
-    // The energies are in the val field of the results (w/o grads)
-    // log.info("objEngs", objFns, objEngs);
-    // log.info("vars", varyingValuesTF);
+        // Note there are two energies, each of which does NOT know about its children, but the root nodes should now have parents up to the objfn energies. The computational graph can be seen in inspecting varyingValuesTF's parents
+        // The energies are in the val field of the results (w/o grads)
+        // log.info("objEngs", objFns, objEngs);
+        // log.info("vars", varyingValuesTF);
 
-    // TODO make this check more robust to empty lists of objectives/constraints
-    if (!objEngs[0] && !constrEngs[0]) {
-      log.info("WARNING: no objectives and no constraints");
-    }
+        // TODO make this check more robust to empty lists of objectives/constraints
+        if (!objEngs[0] && !constrEngs[0]) {
+            log.info("WARNING: no objectives and no constraints");
+        }
 
-    // This is fixed during the whole optimization
-    const constrWeightNode = varOf(
-      constraintWeight,
-      String(constraintWeight),
-      "constraintWeight"
-    );
+        // This is fixed during the whole optimization
+        const constrWeightNode = varOf(
+            constraintWeight,
+            String(constraintWeight),
+            "constraintWeight"
+        );
 
-    // This changes with the EP round, gets bigger to weight the constraints
-    // Therefore it's marked as an input to the generated objective function, which can be partially applied with the ep weight (-1 is an index; means it appears as the first argument)
-    const epWeightNode = markInput(
-      varOf(state.params.weight, String(state.params.weight), "epWeight"),
-      -1
-    );
+        // This changes with the EP round, gets bigger to weight the constraints
+        // Therefore it's marked as an input to the generated objective function, which can be partially applied with the ep weight (-1 is an index; means it appears as the first argument)
+        const epWeightNode = markInput(
+            varOf(state.params.weight, String(state.params.weight), "epWeight"),
+            -1
+        );
 
-    const objEng: VarAD = ops.vsum(objEngs);
-    const constrEng: VarAD = ops.vsum(constrEngs);
-    // F(x) = o(x) + c0 * penalty * c(x)
-    const overallEng: VarAD = add(
-      objEng,
-      mul(constrEng, mul(constrWeightNode, epWeightNode))
-    );
+        const objEng: VarAD = ops.vsum(objEngs);
+        const constrEng: VarAD = ops.vsum(constrEngs);
+        // F(x) = o(x) + c0 * penalty * c(x)
+        const overallEng: VarAD = add(
+            objEng,
+            mul(constrEng, mul(constrWeightNode, epWeightNode))
+        );
 
-    // NOTE: This is necessary because we have to state the seed for the autodiff, which is the last output
-    overallEng.gradVal = { tag: "Just" as const, contents: 1.0 };
-    log.info("overall eng from custom AD", overallEng, overallEng.val);
+        // NOTE: This is necessary because we have to state the seed for the autodiff, which is the last output
+        overallEng.gradVal = { tag: "Just" as const, contents: 1.0 };
+        log.info("overall eng from custom AD", overallEng, overallEng.val);
 
-    return {
-      energyGraph: overallEng,
-      constrWeightNode,
-      epWeightNode,
+        return {
+            energyGraph: overallEng,
+            constrWeightNode,
+            epWeightNode,
+        };
     };
-  };
 };
 
 export const genOptProblem = (state: State): State => {
-  const xs: number[] = state.varyingValues;
-  log.trace("step newIter, xs", xs);
+    const xs: number[] = state.varyingValues;
+    log.trace("step newIter, xs", xs);
 
-  // if (!state.params.functionsCompiled) {
-  // TODO: Doesn't reuse compiled function for now (since caching function in App currently does not work)
-  // Compile objective and gradient
-  log.info("Compiling objective and gradient");
+    // if (!state.params.functionsCompiled) {
+    // TODO: Doesn't reuse compiled function for now (since caching function in App currently does not work)
+    // Compile objective and gradient
+    log.info("Compiling objective and gradient");
 
-  // `overallEnergy` is a partially applied function, waiting for an input.
-  // When applied, it will interpret the energy via lookups on the computational graph
-  // TODO: Could save the interpreted energy graph across amples
-  const overallObjective = evalEnergyOnCustom(state);
-  const xsVars: VarAD[] = makeADInputVars(xs);
-  const res = overallObjective(...xsVars); // Note: `overallObjective` mutates `xsVars`
-  // `energyGraph` is a VarAD that is a handle to the top of the graph
+    // `overallEnergy` is a partially applied function, waiting for an input.
+    // When applied, it will interpret the energy via lookups on the computational graph
+    // TODO: Could save the interpreted energy graph across amples
+    const overallObjective = evalEnergyOnCustom(state);
+    const xsVars: VarAD[] = makeADInputVars(xs);
+    const res = overallObjective(...xsVars); // Note: `overallObjective` mutates `xsVars`
+    // `energyGraph` is a VarAD that is a handle to the top of the graph
 
-  log.info("interpreted energy graph", res.energyGraph);
-  log.info("input vars", xsVars);
+    log.info("interpreted energy graph", res.energyGraph);
+    log.info("input vars", xsVars);
 
-  const weightInfo = {
-    // TODO: factor out
-    constrWeightNode: res.constrWeightNode,
-    epWeightNode: res.epWeightNode,
-    constrWeight: constraintWeight,
-    epWeight: initConstraintWeight,
-  };
+    const weightInfo = {
+        // TODO: factor out
+        constrWeightNode: res.constrWeightNode,
+        epWeightNode: res.epWeightNode,
+        constrWeight: constraintWeight,
+        epWeight: initConstraintWeight,
+    };
 
-  const { graphs, f, gradf } = energyAndGradCompiled(
-    xs,
-    xsVars,
-    res.energyGraph,
-    { tag: "Just", contents: weightInfo }
-  );
+    const { graphs, f, gradf } = energyAndGradCompiled(
+        xs,
+        xsVars,
+        res.energyGraph,
+        { tag: "Just", contents: weightInfo }
+    );
 
-  eig.GC.flush(); // Clear allocated matrix, vector objects in L-BFGS params
+    eig.GC.flush(); // Clear allocated matrix, vector objects in L-BFGS params
 
-  const newParams: Params = {
-    ...state.params,
-    xsVars,
+    const newParams: Params = {
+        ...state.params,
+        xsVars,
 
-    lastGradient: repeat(xs.length, 0),
-    lastGradientPreconditioned: repeat(xs.length, 0),
+        lastGradient: repeat(xs.length, 0),
+        lastGradientPreconditioned: repeat(xs.length, 0),
 
-    graphs,
-    objective: f,
-    gradient: gradf,
+        graphs,
+        objective: f,
+        gradient: gradf,
 
-    functionsCompiled: true,
+        functionsCompiled: true,
 
-    currObjective: f(initConstraintWeight),
-    currGradient: gradf(initConstraintWeight),
+        currObjective: f(initConstraintWeight),
+        currGradient: gradf(initConstraintWeight),
 
-    energyGraph: res.energyGraph,
-    constrWeightNode: res.constrWeightNode,
-    epWeightNode: res.epWeightNode,
-    weight: initConstraintWeight,
-    UOround: 0,
-    EPround: 0,
-    optStatus: "UnconstrainedRunning",
+        energyGraph: res.energyGraph,
+        constrWeightNode: res.constrWeightNode,
+        epWeightNode: res.epWeightNode,
+        weight: initConstraintWeight,
+        UOround: 0,
+        EPround: 0,
+        optStatus: "UnconstrainedRunning",
 
-    lbfgsInfo: defaultLbfgsParams,
-  };
+        lbfgsInfo: defaultLbfgsParams,
+    };
 
-  return { ...state, params: newParams };
+    return { ...state, params: newParams };
 };
 
 // Eval a single function on the state (using VarADs). Based off of `evalEnergyOfCustom` -- see that function for comments.
 const evalFnOn = (fn: Fn, s: State) => {
-  const dict = fn.optType === "ObjFn" ? objDict : constrDict;
+    const dict = fn.optType === "ObjFn" ? objDict : constrDict;
 
-  return (...xsVars: VarAD[]): VarAD => {
-    const { varyingPaths } = s;
+    return (...xsVars: VarAD[]): VarAD => {
+        const { varyingPaths } = s;
 
-    const translationInit = makeTranslationDifferentiable(
-      clone(makeTranslationNumeric(s.translation))
-    );
+        const translationInit = makeTranslationDifferentiable(
+            clone(makeTranslationNumeric(s.translation))
+        );
 
-    const varyingMapList = _.zip(varyingPaths, xsVars) as [Path, VarAD][];
-    const translation = insertVaryings(translationInit, varyingMapList);
-    const varyingMap = genPathMap(varyingPaths, xsVars) as VaryMap<VarAD>;
+        const varyingMapList = _.zip(varyingPaths, xsVars) as [Path, VarAD][];
+        const translation = insertVaryings(translationInit, varyingMapList);
+        const varyingMap = genPathMap(varyingPaths, xsVars) as VaryMap<VarAD>;
 
-    // NOTE: This will mutate the var inputs
-    const fnArgsEvaled: FnDone<VarAD> = evalFn(fn, translation, varyingMap);
-    const fnEnergy: VarAD = applyFn(fnArgsEvaled, dict);
+        // NOTE: This will mutate the var inputs
+        const fnArgsEvaled: FnDone<VarAD> = evalFn(fn, translation, varyingMap);
+        const fnEnergy: VarAD = applyFn(fnArgsEvaled, dict);
 
-    return fnEnergy;
-  };
+        return fnEnergy;
+    };
 };
 
 // For a given objective or constraint, precompile it and its gradient, without any weights. (variation on `genOptProblem`)
 const genFn = (fn: Fn, s: State): FnCached => {
-  const xs: number[] = clone(s.varyingValues);
+    const xs: number[] = clone(s.varyingValues);
 
-  const overallObjective = evalFnOn(fn, s);
-  const xsVars: VarAD[] = makeADInputVars(xs);
-  const energyGraph: VarAD = overallObjective(...xsVars); // Note: `overallObjective` mutates `xsVars`
+    const overallObjective = evalFnOn(fn, s);
+    const xsVars: VarAD[] = makeADInputVars(xs);
+    const energyGraph: VarAD = overallObjective(...xsVars); // Note: `overallObjective` mutates `xsVars`
 
-  const weightInfo: MaybeVal<WeightInfo> = { tag: "Nothing" };
+    const weightInfo: MaybeVal<WeightInfo> = { tag: "Nothing" };
 
-  const { graphs, f, gradf } = energyAndGradCompiled(
-    xs,
-    xsVars,
-    energyGraph,
-    weightInfo
-  );
+    const { graphs, f, gradf } = energyAndGradCompiled(
+        xs,
+        xsVars,
+        energyGraph,
+        weightInfo
+    );
 
-  // Note this throws away the energy/gradient graphs (`VarAD`s). Presumably not needed?
-  return { f, gradf };
+    // Note this throws away the energy/gradient graphs (`VarAD`s). Presumably not needed?
+    return { f, gradf };
 };
 
 // For each objective and constraint, precompile it and its gradient and cache it in the state.
 export const genFns = (s: State): State => {
-  const p = s.params;
-  const objCache = {};
-  const constrCache = {};
+    const p = s.params;
+    const objCache = {};
+    const constrCache = {};
 
-  for (const f of s.objFns) {
-    objCache[prettyPrintFn(f)] = genFn(f, s);
-  }
+    for (const f of s.objFns) {
+        objCache[prettyPrintFn(f)] = genFn(f, s);
+    }
 
-  for (const f of s.constrFns) {
-    constrCache[prettyPrintFn(f)] = genFn(f, s);
-  }
+    for (const f of s.constrFns) {
+        constrCache[prettyPrintFn(f)] = genFn(f, s);
+    }
 
-  p.objFnCache = objCache;
-  p.constrFnCache = constrCache;
+    p.objFnCache = objCache;
+    p.constrFnCache = constrCache;
 
-  return s;
+    return s;
 };

--- a/packages/core/src/engine/Optimizer.ts
+++ b/packages/core/src/engine/Optimizer.ts
@@ -2,56 +2,56 @@ import consola, { LogLevel } from "consola";
 import { constrDict, objDict } from "contrib/Constraints";
 import eig from "eigen";
 import {
-    add,
-    differentiable,
-    energyAndGradCompiled,
-    fns,
-    makeADInputVars,
-    markInput,
-    mul,
-    ops,
-    varOf,
+  add,
+  differentiable,
+  energyAndGradCompiled,
+  fns,
+  makeADInputVars,
+  markInput,
+  mul,
+  ops,
+  varOf,
 } from "engine/Autodiff";
 import {
-    defaultLbfgsParams,
-    initConstraintWeight,
-    makeTranslationDifferentiable,
-    makeTranslationNumeric,
+  defaultLbfgsParams,
+  initConstraintWeight,
+  makeTranslationDifferentiable,
+  makeTranslationNumeric,
 } from "engine/EngineUtils";
 import {
-    argValue,
-    evalFn,
-    evalFns,
-    evalShapes,
-    genPathMap,
-    insertVaryings,
+  argValue,
+  evalFn,
+  evalFns,
+  evalShapes,
+  genPathMap,
+  insertVaryings,
 } from "engine/Evaluator";
 import * as _ from "lodash";
 import rfdc from "rfdc";
 import { OptInfo, VarAD } from "types/ad";
 import { MaybeVal } from "types/common";
 import {
-    Fn,
-    FnCached,
-    FnDone,
-    LbfgsParams,
-    Params,
-    State,
-    VaryMap,
-    WeightInfo,
+  Fn,
+  FnCached,
+  FnDone,
+  LbfgsParams,
+  Params,
+  State,
+  VaryMap,
+  WeightInfo,
 } from "types/state";
 import { Path } from "types/style";
 import {
-    addv,
-    dot,
-    negv,
-    normList,
-    prettyPrintFn,
-    prettyPrintFns,
-    prettyPrintPath,
-    repeat,
-    scalev,
-    subv,
+  addv,
+  dot,
+  negv,
+  normList,
+  prettyPrintFn,
+  prettyPrintFns,
+  prettyPrintPath,
+  repeat,
+  scalev,
+  subv,
 } from "utils/OtherUtils";
 
 // NOTE: to view logs, change `level` below to `LogLevel.Info`, otherwise it should be `LogLevel.Warn`
@@ -100,39 +100,39 @@ const EPS = uoStop;
 ////////////////////////////////////////////////////////////////////////////////
 
 const unconstrainedConverged2 = (normGrad: number): boolean => {
-    if (DEBUG_GRAD_DESCENT) {
-        log.info("UO convergence check: ||grad f(x)||", normGrad);
-    }
-    return normGrad < uoStop;
+  if (DEBUG_GRAD_DESCENT) {
+    log.info("UO convergence check: ||grad f(x)||", normGrad);
+  }
+  return normGrad < uoStop;
 };
 
 const epConverged2 = (
-    xs0: number[],
-    xs1: number[],
-    fxs0: number,
-    fxs1: number
+  xs0: number[],
+  xs1: number[],
+  fxs0: number,
+  fxs1: number
 ): boolean => {
-    // TODO: These dx and dfx should really be scaled to account for magnitudes
-    const stateChange = normList(subv(xs1, xs0));
-    const energyChange = Math.abs(fxs1 - fxs0);
-    log.info(
-        "epConverged?: stateChange: ",
-        stateChange,
-        " | energyChange: ",
-        energyChange
-    );
+  // TODO: These dx and dfx should really be scaled to account for magnitudes
+  const stateChange = normList(subv(xs1, xs0));
+  const energyChange = Math.abs(fxs1 - fxs0);
+  log.info(
+    "epConverged?: stateChange: ",
+    stateChange,
+    " | energyChange: ",
+    energyChange
+  );
 
-    return stateChange < epStop || energyChange < epStop;
+  return stateChange < epStop || energyChange < epStop;
 };
 
 const applyFn = (f: FnDone<VarAD>, dict: any) => {
-    if (dict[f.name]) {
-        return dict[f.name](...f.args.map(argValue));
-    } else {
-        throw new Error(
-            `constraint or objective ${f.name} not found in dirctionary`
-        );
-    }
+  if (dict[f.name]) {
+    return dict[f.name](...f.args.map(argValue));
+  } else {
+    throw new Error(
+      `constraint or objective ${f.name} not found in dirctionary`
+    );
+  }
 };
 
 /**
@@ -153,7 +153,7 @@ const applyFn = (f: FnDone<VarAD>, dict: any) => {
 // 2) fix initial value of the penalty parameter so that the magnitude of the penalty term is not much smaller than the magnitude of objective function
 
 export const initializeMat = async () => {
-    await eig.ready;
+  await eig.ready;
 };
 
 /**
@@ -163,380 +163,380 @@ export const initializeMat = async () => {
  * @param evaluate
  */
 export const step = (state: State, steps: number, evaluate = true) => {
-    const { optStatus, weight } = state.params;
-    let newState = { ...state };
-    const optParams = newState.params; // this is just a reference, so updating this will update newState as well
-    let xs: number[] = state.varyingValues;
+  const { optStatus, weight } = state.params;
+  let newState = { ...state };
+  const optParams = newState.params; // this is just a reference, so updating this will update newState as well
+  let xs: number[] = state.varyingValues;
 
-    log.info("===============");
-    log.info(
-        "step | weight: ",
-        weight,
-        "| EP round: ",
-        optParams.EPround,
-        " | UO round: ",
-        optParams.UOround
-    );
-    log.info("params: ", optParams);
-    // log.info("state: ", state);
-    log.info("fns: ", prettyPrintFns(state));
-    log.info(
-        "variables: ",
-        state.varyingPaths.map((p: Path): string => prettyPrintPath(p))
-    );
+  log.info("===============");
+  log.info(
+    "step | weight: ",
+    weight,
+    "| EP round: ",
+    optParams.EPround,
+    " | UO round: ",
+    optParams.UOround
+  );
+  log.info("params: ", optParams);
+  // log.info("state: ", state);
+  log.info("fns: ", prettyPrintFns(state));
+  log.info(
+    "variables: ",
+    state.varyingPaths.map((p: Path): string => prettyPrintPath(p))
+  );
 
-    switch (optStatus) {
-        case "NewIter": {
-            log.trace("step newIter, xs", xs);
+  switch (optStatus) {
+    case "NewIter": {
+      log.trace("step newIter, xs", xs);
 
-            // if (!state.params.functionsCompiled) {
-            // TODO: Doesn't reuse compiled function for now (since caching function in App currently does not work)
-            if (true) {
-                const { objective, gradient } = state.params;
-                if (!objective || !gradient) {
-                    return genOptProblem(state);
-                } else {
-                    return {
-                        ...state,
-                        params: {
-                            ...state.params,
-                            weight: initConstraintWeight,
-                            UOround: 0,
-                            EPround: 0,
-                            optStatus: "UnconstrainedRunning" as const,
-                            lbfgsInfo: defaultLbfgsParams,
-                        },
-                    };
-                }
-            } else {
-                // Reuse compiled functions for resample; set other initialization params accordingly
-                // The computational graph gets destroyed in resample (just for now, because it can't get serialized)
-                // But it's not needed for the optimization
-                log.info("Reusing compiled objective and gradients");
-                const params = state.params;
-
-                const newParams: Params = {
-                    ...params,
-                    lastGradient: repeat(xs.length, 0),
-                    lastGradientPreconditioned: repeat(xs.length, 0),
-                    currObjective: params.objective(initConstraintWeight),
-                    currGradient: params.gradient(initConstraintWeight),
-                    weight: initConstraintWeight,
-                    UOround: 0,
-                    EPround: 0,
-                    optStatus: "UnconstrainedRunning",
-                    lbfgsInfo: defaultLbfgsParams,
-                };
-
-                return { ...state, params: newParams };
-            }
+      // if (!state.params.functionsCompiled) {
+      // TODO: Doesn't reuse compiled function for now (since caching function in App currently does not work)
+      if (true) {
+        const { objective, gradient } = state.params;
+        if (!objective || !gradient) {
+          return genOptProblem(state);
+        } else {
+          return {
+            ...state,
+            params: {
+              ...state.params,
+              weight: initConstraintWeight,
+              UOround: 0,
+              EPround: 0,
+              optStatus: "UnconstrainedRunning" as const,
+              lbfgsInfo: defaultLbfgsParams,
+            },
+          };
         }
+      } else {
+        // Reuse compiled functions for resample; set other initialization params accordingly
+        // The computational graph gets destroyed in resample (just for now, because it can't get serialized)
+        // But it's not needed for the optimization
+        log.info("Reusing compiled objective and gradients");
+        const params = state.params;
 
-        case "UnconstrainedRunning": {
-            // NOTE: use cached varying values
-            log.info("step step, xs", xs);
+        const newParams: Params = {
+          ...params,
+          lastGradient: repeat(xs.length, 0),
+          lastGradientPreconditioned: repeat(xs.length, 0),
+          currObjective: params.objective(initConstraintWeight),
+          currGradient: params.gradient(initConstraintWeight),
+          weight: initConstraintWeight,
+          UOround: 0,
+          EPround: 0,
+          optStatus: "UnconstrainedRunning",
+          lbfgsInfo: defaultLbfgsParams,
+        };
 
-            const res = minimize(
-                xs,
-                state.params.currObjective,
-                state.params.currGradient,
-                state.params.lbfgsInfo,
-                state.varyingPaths.map((p) => prettyPrintPath(p)),
-                steps
-            );
-            xs = res.xs;
-
-            // the new `xs` is put into the `newState`, which is returned at end of function
-            // we don't need the updated xsVars and energyGraph as they are always cleared on evaluation; only their structure matters
-            const {
-                energyVal,
-                normGrad,
-                newLbfgsInfo,
-                gradient,
-                gradientPreconditioned,
-            } = res;
-
-            optParams.lastUOstate = xs;
-            optParams.lastUOenergy = energyVal;
-            optParams.UOround = optParams.UOround + 1;
-            optParams.lbfgsInfo = newLbfgsInfo;
-            optParams.lastGradient = gradient;
-            optParams.lastGradientPreconditioned = gradientPreconditioned;
-
-            // NOTE: `varyingValues` is updated in `state` after each step by putting it into `newState` and passing it to `evalTranslation`, which returns another state
-
-            // TODO. In the original optimizer, we cheat by using the EP cond here, because the UO cond is sometimes too strong.
-            if (unconstrainedConverged2(normGrad)) {
-                optParams.optStatus = "UnconstrainedConverged";
-                eig.GC.flush(); // Clear allocated matrix, vector objects in L-BFGS params
-                optParams.lbfgsInfo = defaultLbfgsParams;
-                log.info(
-                    "Unconstrained converged with energy",
-                    energyVal,
-                    "gradient norm",
-                    normGrad
-                );
-            } else {
-                optParams.optStatus = "UnconstrainedRunning";
-                // Note that lbfgs prams have already been updated
-                log.info(
-                    `Took ${steps} steps. Current energy`,
-                    energyVal,
-                    "gradient norm",
-                    normGrad
-                );
-            }
-
-            break;
-        }
-
-        case "UnconstrainedConverged": {
-            // No minimization step should be taken. Just figure out if we should start another UO round with higher EP weight.
-            // We are using the last UO state and energy because they serve as the current EP state and energy, and comparing it to the last EP stuff.
-
-            // Do EP convergence check on the last EP state (and its energy), and curr EP state (and its energy)
-            // (There is no EP state or energy on the first round)
-            // Note that lbfgs params have already been reset to default
-
-            // TODO. Make a diagram to clarify vocabulary
-            log.info("step: unconstrained converged", optParams);
-
-            // We force EP to run at least two rounds (State 0 -> State 1 -> State 2; the first check is only between States 1 and 2)
-            if (
-                optParams.EPround > 1 &&
-                epConverged2(
-                    optParams.lastEPstate,
-                    optParams.lastUOstate,
-                    optParams.lastEPenergy,
-                    optParams.lastUOenergy
-                )
-            ) {
-                optParams.optStatus = "EPConverged";
-                log.info("EP converged with energy", optParams.lastUOenergy);
-            } else {
-                // If EP has not converged, increase weight and continue.
-                // The point is that, for the next round, the last converged UO state becomes both the last EP state and the initial state for the next round--starting with a harsher penalty.
-                log.info(
-                    "step: UO converged but EP did not converge; starting next round"
-                );
-                optParams.optStatus = "UnconstrainedRunning";
-
-                optParams.weight = weightGrowthFactor * weight;
-                optParams.EPround = optParams.EPround + 1;
-                optParams.UOround = 0;
-
-                optParams.currObjective = optParams.objective(optParams.weight);
-                optParams.currGradient = optParams.gradient(optParams.weight);
-
-                log.info(
-                    "increased EP weight to",
-                    optParams.weight,
-                    "in compiled energy and gradient"
-                );
-            }
-
-            // Done with EP check, so save the curr EP state as the last EP state for the future.
-            optParams.lastEPstate = optParams.lastUOstate;
-            optParams.lastEPenergy = optParams.lastUOenergy;
-
-            break;
-        }
-
-        case "EPConverged": {
-            // do nothing if converged
-            log.info("step: EP converged");
-            return state;
-        }
+        return { ...state, params: newParams };
+      }
     }
 
-    // return the state with a new set of shapes
-    if (evaluate) {
-        const varyingValues = xs;
-        // log.info("evaluating state with varying values", varyingValues);
-        // log.info("varyingMap", zip(state.varyingPaths, varyingValues) as [Path, number][]);
+    case "UnconstrainedRunning": {
+      // NOTE: use cached varying values
+      log.info("step step, xs", xs);
 
-        newState.translation = insertVaryings(
-            state.translation,
-            _.zip(state.varyingPaths, varyingValues.map(differentiable)) as [
-                Path,
-                VarAD
-            ][]
+      const res = minimize(
+        xs,
+        state.params.currObjective,
+        state.params.currGradient,
+        state.params.lbfgsInfo,
+        state.varyingPaths.map((p) => prettyPrintPath(p)),
+        steps
+      );
+      xs = res.xs;
+
+      // the new `xs` is put into the `newState`, which is returned at end of function
+      // we don't need the updated xsVars and energyGraph as they are always cleared on evaluation; only their structure matters
+      const {
+        energyVal,
+        normGrad,
+        newLbfgsInfo,
+        gradient,
+        gradientPreconditioned,
+      } = res;
+
+      optParams.lastUOstate = xs;
+      optParams.lastUOenergy = energyVal;
+      optParams.UOround = optParams.UOround + 1;
+      optParams.lbfgsInfo = newLbfgsInfo;
+      optParams.lastGradient = gradient;
+      optParams.lastGradientPreconditioned = gradientPreconditioned;
+
+      // NOTE: `varyingValues` is updated in `state` after each step by putting it into `newState` and passing it to `evalTranslation`, which returns another state
+
+      // TODO. In the original optimizer, we cheat by using the EP cond here, because the UO cond is sometimes too strong.
+      if (unconstrainedConverged2(normGrad)) {
+        optParams.optStatus = "UnconstrainedConverged";
+        eig.GC.flush(); // Clear allocated matrix, vector objects in L-BFGS params
+        optParams.lbfgsInfo = defaultLbfgsParams;
+        log.info(
+          "Unconstrained converged with energy",
+          energyVal,
+          "gradient norm",
+          normGrad
         );
+      } else {
+        optParams.optStatus = "UnconstrainedRunning";
+        // Note that lbfgs prams have already been updated
+        log.info(
+          `Took ${steps} steps. Current energy`,
+          energyVal,
+          "gradient norm",
+          normGrad
+        );
+      }
 
-        newState.varyingValues = varyingValues;
-        newState = evalShapes(newState);
+      break;
     }
 
-    return newState;
+    case "UnconstrainedConverged": {
+      // No minimization step should be taken. Just figure out if we should start another UO round with higher EP weight.
+      // We are using the last UO state and energy because they serve as the current EP state and energy, and comparing it to the last EP stuff.
+
+      // Do EP convergence check on the last EP state (and its energy), and curr EP state (and its energy)
+      // (There is no EP state or energy on the first round)
+      // Note that lbfgs params have already been reset to default
+
+      // TODO. Make a diagram to clarify vocabulary
+      log.info("step: unconstrained converged", optParams);
+
+      // We force EP to run at least two rounds (State 0 -> State 1 -> State 2; the first check is only between States 1 and 2)
+      if (
+        optParams.EPround > 1 &&
+        epConverged2(
+          optParams.lastEPstate,
+          optParams.lastUOstate,
+          optParams.lastEPenergy,
+          optParams.lastUOenergy
+        )
+      ) {
+        optParams.optStatus = "EPConverged";
+        log.info("EP converged with energy", optParams.lastUOenergy);
+      } else {
+        // If EP has not converged, increase weight and continue.
+        // The point is that, for the next round, the last converged UO state becomes both the last EP state and the initial state for the next round--starting with a harsher penalty.
+        log.info(
+          "step: UO converged but EP did not converge; starting next round"
+        );
+        optParams.optStatus = "UnconstrainedRunning";
+
+        optParams.weight = weightGrowthFactor * weight;
+        optParams.EPround = optParams.EPround + 1;
+        optParams.UOround = 0;
+
+        optParams.currObjective = optParams.objective(optParams.weight);
+        optParams.currGradient = optParams.gradient(optParams.weight);
+
+        log.info(
+          "increased EP weight to",
+          optParams.weight,
+          "in compiled energy and gradient"
+        );
+      }
+
+      // Done with EP check, so save the curr EP state as the last EP state for the future.
+      optParams.lastEPstate = optParams.lastUOstate;
+      optParams.lastEPenergy = optParams.lastUOenergy;
+
+      break;
+    }
+
+    case "EPConverged": {
+      // do nothing if converged
+      log.info("step: EP converged");
+      return state;
+    }
+  }
+
+  // return the state with a new set of shapes
+  if (evaluate) {
+    const varyingValues = xs;
+    // log.info("evaluating state with varying values", varyingValues);
+    // log.info("varyingMap", zip(state.varyingPaths, varyingValues) as [Path, number][]);
+
+    newState.translation = insertVaryings(
+      state.translation,
+      _.zip(state.varyingPaths, varyingValues.map(differentiable)) as [
+        Path,
+        VarAD
+      ][]
+    );
+
+    newState.varyingValues = varyingValues;
+    newState = evalShapes(newState);
+  }
+
+  return newState;
 };
 
 // Note: line search seems to be quite sensitive to the maxSteps parameter; with maxSteps=25, the line search might
 
 const awLineSearch2 = (
-    xs0: number[],
-    f: (zs: number[]) => number,
-    gradf: (zs: number[]) => number[],
+  xs0: number[],
+  f: (zs: number[]) => number,
+  gradf: (zs: number[]) => number[],
 
-    gradfxs0: number[],
-    fxs0: number,
-    maxSteps = 10
+  gradfxs0: number[],
+  fxs0: number,
+  maxSteps = 10
 ) => {
-    const descentDir = negv(gradfxs0); // This is preconditioned by L-BFGS
+  const descentDir = negv(gradfxs0); // This is preconditioned by L-BFGS
 
-    const duf = (u: number[]) => {
-        return (zs: number[]) => {
-            return dot(u, gradf(zs));
-        };
+  const duf = (u: number[]) => {
+    return (zs: number[]) => {
+      return dot(u, gradf(zs));
     };
+  };
 
-    const dufDescent = duf(descentDir);
-    const dufAtx0 = dufDescent(xs0);
-    const minInterval = 10e-10;
+  const dufDescent = duf(descentDir);
+  const dufAtx0 = dufDescent(xs0);
+  const minInterval = 10e-10;
 
-    // HS (Haskell?): duf, TS: dufDescent
-    // HS: x0, TS: xs
+  // HS (Haskell?): duf, TS: dufDescent
+  // HS: x0, TS: xs
 
-    // Hyperparameters
-    const c1 = 0.001; // Armijo
-    const c2 = 0.9; // Wolfe
+  // Hyperparameters
+  const c1 = 0.001; // Armijo
+  const c2 = 0.9; // Wolfe
 
-    // Armijo condition
-    // f(x0 + t * descentDir) <= (f(x0) + c1 * t * <grad(f)(x0), x0>)
-    const armijo = (ti: number): boolean => {
-        const cond1 = f(addv(xs0, scalev(ti, descentDir)));
-        const cond2 = fxs0 + c1 * ti * dufAtx0;
-        return cond1 <= cond2;
-    };
+  // Armijo condition
+  // f(x0 + t * descentDir) <= (f(x0) + c1 * t * <grad(f)(x0), x0>)
+  const armijo = (ti: number): boolean => {
+    const cond1 = f(addv(xs0, scalev(ti, descentDir)));
+    const cond2 = fxs0 + c1 * ti * dufAtx0;
+    return cond1 <= cond2;
+  };
 
-    // D(u) := <grad f, u>
-    // D(u, f, x) = <grad f(x), u>
-    // u is the descentDir (i.e. -grad(f)(x))
+  // D(u) := <grad f, u>
+  // D(u, f, x) = <grad f(x), u>
+  // u is the descentDir (i.e. -grad(f)(x))
 
-    // Strong Wolfe condition
-    // |<grad(f)(x0 + t * descentDir), u>| <= c2 * |<grad f(x0), u>|
-    const strongWolfe = (ti: number) => {
-        const cond1 = Math.abs(dufDescent(addv(xs0, scalev(ti, descentDir))));
-        const cond2 = c2 * Math.abs(dufAtx0);
-        return cond1 <= cond2;
-    };
+  // Strong Wolfe condition
+  // |<grad(f)(x0 + t * descentDir), u>| <= c2 * |<grad f(x0), u>|
+  const strongWolfe = (ti: number) => {
+    const cond1 = Math.abs(dufDescent(addv(xs0, scalev(ti, descentDir))));
+    const cond2 = c2 * Math.abs(dufAtx0);
+    return cond1 <= cond2;
+  };
 
-    // Weak Wolfe condition
-    // <grad(f)(x0 + t * descentDir), u> >= c2 * <grad f(x0), u>
-    const weakWolfe = (ti: number) => {
-        const cond1 = dufDescent(addv(xs0, scalev(ti, descentDir)));
-        const cond2 = c2 * dufAtx0;
-        return cond1 >= cond2;
-    };
+  // Weak Wolfe condition
+  // <grad(f)(x0 + t * descentDir), u> >= c2 * <grad f(x0), u>
+  const weakWolfe = (ti: number) => {
+    const cond1 = dufDescent(addv(xs0, scalev(ti, descentDir)));
+    const cond2 = c2 * dufAtx0;
+    return cond1 >= cond2;
+  };
 
-    const wolfe = weakWolfe; // Set this if using strongWolfe instead
+  const wolfe = weakWolfe; // Set this if using strongWolfe instead
 
-    // Interval check
-    const shouldStop = (numUpdates: number, ai: number, bi: number) => {
-        const intervalTooSmall = Math.abs(bi - ai) < minInterval;
-        const tooManySteps = numUpdates > maxSteps;
+  // Interval check
+  const shouldStop = (numUpdates: number, ai: number, bi: number) => {
+    const intervalTooSmall = Math.abs(bi - ai) < minInterval;
+    const tooManySteps = numUpdates > maxSteps;
 
-        if (intervalTooSmall && DEBUG_LINE_SEARCH) {
-            log.info("line search stopping: interval too small");
-        }
-        if (tooManySteps && DEBUG_LINE_SEARCH) {
-            log.info("line search stopping: step count exceeded");
-        }
+    if (intervalTooSmall && DEBUG_LINE_SEARCH) {
+      log.info("line search stopping: interval too small");
+    }
+    if (tooManySteps && DEBUG_LINE_SEARCH) {
+      log.info("line search stopping: step count exceeded");
+    }
 
-        return intervalTooSmall || tooManySteps;
-    };
+    return intervalTooSmall || tooManySteps;
+  };
 
-    // Consts / initial values
-    // TODO: port comments from original
+  // Consts / initial values
+  // TODO: port comments from original
 
-    // const t = 0.002; // for venn_simple.sty
-    // const t = 0.1; // for tree.sty
+  // const t = 0.002; // for venn_simple.sty
+  // const t = 0.1; // for tree.sty
 
-    let a = 0;
-    let b = Infinity;
-    let t = 1.0;
-    let i = 0;
-    const DEBUG_LINE_SEARCH = false;
+  let a = 0;
+  let b = Infinity;
+  let t = 1.0;
+  let i = 0;
+  const DEBUG_LINE_SEARCH = false;
 
+  if (DEBUG_LINE_SEARCH) {
+    log.info("line search", xs0, gradfxs0, duf(xs0)(xs0));
+  }
+
+  // Main loop + update check
+  while (true) {
+    const needToStop = shouldStop(i, a, b);
+
+    if (needToStop) {
+      if (DEBUG_LINE_SEARCH) {
+        log.info("stopping early: (i, a, b, t) = ", i, a, b, t);
+      }
+      break;
+    }
+
+    const isArmijo = armijo(t);
+    const isWolfe = wolfe(t);
     if (DEBUG_LINE_SEARCH) {
-        log.info("line search", xs0, gradfxs0, duf(xs0)(xs0));
+      log.info("(i, a, b, t), armijo, wolfe", i, a, b, t, isArmijo, isWolfe);
     }
 
-    // Main loop + update check
-    while (true) {
-        const needToStop = shouldStop(i, a, b);
-
-        if (needToStop) {
-            if (DEBUG_LINE_SEARCH) {
-                log.info("stopping early: (i, a, b, t) = ", i, a, b, t);
-            }
-            break;
-        }
-
-        const isArmijo = armijo(t);
-        const isWolfe = wolfe(t);
-        if (DEBUG_LINE_SEARCH) {
-            log.info("(i, a, b, t), armijo, wolfe", i, a, b, t, isArmijo, isWolfe);
-        }
-
-        if (!isArmijo) {
-            if (DEBUG_LINE_SEARCH) {
-                log.info("not armijo");
-            }
-            b = t;
-        } else if (!isWolfe) {
-            if (DEBUG_LINE_SEARCH) {
-                log.info("not wolfe");
-            }
-            a = t;
-        } else {
-            if (DEBUG_LINE_SEARCH) {
-                log.info("found good interval");
-                log.info("stopping: (i, a, b, t) = ", i, a, b, t);
-            }
-            break;
-        }
-
-        if (b < Infinity) {
-            if (DEBUG_LINE_SEARCH) {
-                log.info("already found armijo");
-            }
-            t = (a + b) / 2.0;
-        } else {
-            if (DEBUG_LINE_SEARCH) {
-                log.info("did not find armijo");
-            }
-            t = 2.0 * a;
-        }
-
-        i++;
+    if (!isArmijo) {
+      if (DEBUG_LINE_SEARCH) {
+        log.info("not armijo");
+      }
+      b = t;
+    } else if (!isWolfe) {
+      if (DEBUG_LINE_SEARCH) {
+        log.info("not wolfe");
+      }
+      a = t;
+    } else {
+      if (DEBUG_LINE_SEARCH) {
+        log.info("found good interval");
+        log.info("stopping: (i, a, b, t) = ", i, a, b, t);
+      }
+      break;
     }
 
-    return t;
+    if (b < Infinity) {
+      if (DEBUG_LINE_SEARCH) {
+        log.info("already found armijo");
+      }
+      t = (a + b) / 2.0;
+    } else {
+      if (DEBUG_LINE_SEARCH) {
+        log.info("did not find armijo");
+      }
+      t = 2.0 * a;
+    }
+
+    i++;
+  }
+
+  return t;
 };
 
 const vecList = (xs: any): number[] => {
-    // Prints a col vector (nx1)
-    const res = [];
-    for (let i = 0; i < xs.rows(); i++) {
-        res.push(xs.get(i, 0));
-    }
-    return res;
+  // Prints a col vector (nx1)
+  const res = [];
+  for (let i = 0; i < xs.rows(); i++) {
+    res.push(xs.get(i, 0));
+  }
+  return res;
 };
 
 const printVec = (xs: any) => {
-    // Prints a col vector (nx1)
-    log.info("xs (matrix)", vecList(xs));
+  // Prints a col vector (nx1)
+  log.info("xs (matrix)", vecList(xs));
 };
 
 const colVec = (xs: number[]): any => {
-    // Return a col vector (nx1)
-    // TODO: What is the performance of this?
-    const m = eig.Matrix.constant(xs.length, 1, 0); // rows x cols
-    xs.forEach((e, i) => m.set(i, 0, e));
+  // Return a col vector (nx1)
+  // TODO: What is the performance of this?
+  const m = eig.Matrix.constant(xs.length, 1, 0); // rows x cols
+  xs.forEach((e, i) => m.set(i, 0, e));
 
-    // log.info("original xs", xs);
-    // printVec(m);
-    return m;
+  // log.info("original xs", xs);
+  // printVec(m);
+  return m;
 };
 
 // v is a col vec, w is a col vec, they need to be the same size, returns v dot w (removed from its container)
@@ -548,300 +548,301 @@ const dotVec = (v: any, w: any): number => v.transpose().matMul(w).get(0, 0);
 
 // `any` here is a column vector type
 const lbfgsInner = (grad_fx_k: any, ss: any[], ys: any[]): any => {
-    // TODO: See if using the mutation methods in linear-algebra-js (instead of the return-a-new-matrix ones) yield any speedup
-    // Also see if rewriting outside the functional style yields speedup (e.g. less copying of matrix objects -> less garbage collection)
+  // TODO: See if using the mutation methods in linear-algebra-js (instead of the return-a-new-matrix ones) yield any speedup
+  // Also see if rewriting outside the functional style yields speedup (e.g. less copying of matrix objects -> less garbage collection)
 
-    // Helper functions
-    const calculate_rho = (s: any, y: any): number => {
-        return 1.0 / (dotVec(y, s) + EPSD);
-    };
+  // Helper functions
+  const calculate_rho = (s: any, y: any): number => {
+    return 1.0 / (dotVec(y, s) + EPSD);
+  };
 
-    // `any` = column vec
-    const pull_q_back = (
-        acc: [any, number[]],
-        curr: [number, any, any]
-    ): [any, number[]] => {
-        const [q_i_plus_1, alphas2] = acc; // alphas2 is the same stuff as alphas, just renamed to avoid shadowing
-        const [rho_i, s_i, y_i] = curr;
+  // `any` = column vec
+  const pull_q_back = (
+    acc: [any, number[]],
+    curr: [number, any, any]
+  ): [any, number[]] => {
+    const [q_i_plus_1, alphas2] = acc; // alphas2 is the same stuff as alphas, just renamed to avoid shadowing
+    const [rho_i, s_i, y_i] = curr;
 
-        const alpha_i: number = rho_i * dotVec(s_i, q_i_plus_1);
-        const q_i: any = q_i_plus_1.matSub(y_i.mul(alpha_i));
+    const alpha_i: number = rho_i * dotVec(s_i, q_i_plus_1);
+    const q_i: any = q_i_plus_1.matSub(y_i.mul(alpha_i));
 
-        return [q_i, alphas2.concat([alpha_i])]; // alphas, left to right
-    };
+    return [q_i, alphas2.concat([alpha_i])]; // alphas, left to right
+  };
 
-    // takes two column vectors (nx1), returns a square matrix (nxn)
-    const estimate_hess = (y_km1: any, s_km1: any): any => {
-        const gamma_k = dotVec(s_km1, y_km1) / (dotVec(y_km1, y_km1) + EPSD);
-        const n = y_km1.rows();
-        return eig.Matrix.identity(n, n).mul(gamma_k);
-    };
+  // takes two column vectors (nx1), returns a square matrix (nxn)
+  const estimate_hess = (y_km1: any, s_km1: any): any => {
+    const gamma_k = dotVec(s_km1, y_km1) / (dotVec(y_km1, y_km1) + EPSD);
+    const n = y_km1.rows();
+    return eig.Matrix.identity(n, n).mul(gamma_k);
+  };
 
-    // `any` = column vec
-    const push_r_forward = (
-        r_i: any,
-        curr: [[number, number], [any, any]]
-    ): any => {
-        const [[rho_i, alpha_i], [s_i, y_i]] = curr;
-        const beta_i: number = rho_i * dotVec(y_i, r_i);
-        const r_i_plus_1 = r_i.matAdd(s_i.mul(alpha_i - beta_i));
-        return r_i_plus_1;
-    };
+  // `any` = column vec
+  const push_r_forward = (
+    r_i: any,
+    curr: [[number, number], [any, any]]
+  ): any => {
+    const [[rho_i, alpha_i], [s_i, y_i]] = curr;
+    const beta_i: number = rho_i * dotVec(y_i, r_i);
+    const r_i_plus_1 = r_i.matAdd(s_i.mul(alpha_i - beta_i));
+    return r_i_plus_1;
+  };
 
-    // BACKWARD: for i = k-1 ... k-m
-    // The length of any list should be the number of stored vectors
-    const rhos = _.zip(ss, ys).map(([s, y]) => calculate_rho(s, y));
-    const q_k = grad_fx_k;
-    // Note the order of alphas will be from k-1 through k-m for the push_r_forward loop
-    // (Note that `reduce` is a left fold)
-    const [q_k_minus_m, alphas] = (_.zip(rhos, ss, ys) as any).reduce(
-        pull_q_back,
-        [q_k, []]
-    );
+  // BACKWARD: for i = k-1 ... k-m
+  // The length of any list should be the number of stored vectors
+  const rhos = _.zip(ss, ys).map(([s, y]) => calculate_rho(s, y));
+  const q_k = grad_fx_k;
+  // Note the order of alphas will be from k-1 through k-m for the push_r_forward loop
+  // (Note that `reduce` is a left fold)
+  const [q_k_minus_m, alphas] = (_.zip(rhos, ss, ys) as any).reduce(
+    pull_q_back,
+    [q_k, []]
+  );
 
-    const h_0_k = estimate_hess(ys[0], ss[0]); // nxn matrix, according to Nocedal p226, eqn 9.6
+  const h_0_k = estimate_hess(ys[0], ss[0]); // nxn matrix, according to Nocedal p226, eqn 9.6
 
-    // FORWARD: for i = k-m .. k-1
-    // below: [nxn matrix * nx1 (col) vec] -> nx1 (col) vec
-    const r_k_minus_m = h_0_k.matMul(q_k_minus_m);
-    // Note that rhos, alphas, ss, and ys are all in order from `k-1` to `k-m` so we just reverse all of them together to go from `k-m` to `k-1`
-    // NOTE: `reverse` mutates the array in-place, which is fine because we don't need it later
-    const inputs = _.zip(_.zip(rhos, alphas), _.zip(ss, ys)).reverse() as any;
-    const r_k = inputs.reduce(push_r_forward, r_k_minus_m);
+  // FORWARD: for i = k-m .. k-1
+  // below: [nxn matrix * nx1 (col) vec] -> nx1 (col) vec
+  const r_k_minus_m = h_0_k.matMul(q_k_minus_m);
+  // Note that rhos, alphas, ss, and ys are all in order from `k-1` to `k-m` so we just reverse all of them together to go from `k-m` to `k-1`
+  // NOTE: `reverse` mutates the array in-place, which is fine because we don't need it later
+  const inputs = _.zip(_.zip(rhos, alphas), _.zip(ss, ys)).reverse() as any;
+  const r_k = inputs.reduce(push_r_forward, r_k_minus_m);
 
-    // result r_k is H_k * grad f(x_k)
-    return r_k;
+  // result r_k is H_k * grad f(x_k)
+  return r_k;
 };
 
 // Outer loop of lbfgs
 // See Optimizer.hs for any add'l comments
 const lbfgs = (xs: number[], gradfxs: number[], lbfgsInfo: LbfgsParams) => {
-    // Comments for normal BFGS:
-    // For x_{k+1}, to compute H_k, we need the (k-1) info
-    // Our convention is that we are always working "at" k to compute k+1
-    // x_0 doesn't require any H; x_1 (the first step) with k = 0 requires H_0
-    // x_2 (the NEXT step) with k=1 requires H_1. For example>
-    // x_2 = x_1 - alpha_1 H_1 grad f(x_1)   [GD step]
-    // H_1 = V_0 H_0 V_0 + rho_0 s_0 s_0^T   [This is confusing because the book adds an extra +1 to the H index]
-    // V_0 = I - rho_0 y_0 s_0^T
-    // rho_0 = 1 / y_0^T s_0
-    // s_0 = x_1 - x_0
-    // y_0 = grad f(x_1) - grad f(x_0)
+  // Comments for normal BFGS:
+  // For x_{k+1}, to compute H_k, we need the (k-1) info
+  // Our convention is that we are always working "at" k to compute k+1
+  // x_0 doesn't require any H; x_1 (the first step) with k = 0 requires H_0
+  // x_2 (the NEXT step) with k=1 requires H_1. For example>
+  // x_2 = x_1 - alpha_1 H_1 grad f(x_1)   [GD step]
+  // H_1 = V_0 H_0 V_0 + rho_0 s_0 s_0^T   [This is confusing because the book adds an extra +1 to the H index]
+  // V_0 = I - rho_0 y_0 s_0^T
+  // rho_0 = 1 / y_0^T s_0
+  // s_0 = x_1 - x_0
+  // y_0 = grad f(x_1) - grad f(x_0)
 
+  if (DEBUG_LBFGS) {
+    log.info(
+      "Starting lbfgs calculation with xs",
+      xs,
+      "gradfxs",
+      gradfxs,
+      "lbfgs params",
+      lbfgsInfo
+    );
+  }
+
+  if (lbfgsInfo.numUnconstrSteps === 0) {
+    // Initialize state
+    // Perform normal gradient descent on first step
+    // Store x_k, grad f(x_k) so we can compute s_k, y_k on next step
+
+    return {
+      gradfxsPreconditioned: gradfxs,
+      updatedLbfgsInfo: {
+        ...lbfgsInfo,
+        lastState: { tag: "Just" as const, contents: colVec(xs) },
+        lastGrad: { tag: "Just" as const, contents: colVec(gradfxs) },
+        s_list: [],
+        y_list: [],
+        numUnconstrSteps: 1,
+      },
+    };
+  } else if (
+    lbfgsInfo.lastState.tag === "Just" &&
+    lbfgsInfo.lastGrad.tag === "Just"
+  ) {
+    // Our current step is k; the last step is km1 (k_minus_1)
+    const x_k = colVec(xs);
+    const grad_fx_k = colVec(gradfxs);
+
+    const km1 = lbfgsInfo.numUnconstrSteps;
+    const x_km1 = lbfgsInfo.lastState.contents;
+    const grad_fx_km1 = lbfgsInfo.lastGrad.contents;
+    const ss_km2 = lbfgsInfo.s_list;
+    const ys_km2 = lbfgsInfo.y_list;
+
+    // Compute s_{k-1} = x_k - x_{k-1} and y_{k-1} = (analogous with grads)
+    // Unlike Nocedal, compute the difference vectors first instead of last (same result, just a loop rewrite)
+    // Use the updated {s_i} and {y_i}. (If k < m, this reduces to normal BFGS, i.e. we use all the vectors so far)
+    // Newest vectors added to front
+
+    const s_km1 = x_k.matSub(x_km1);
+    const y_km1 = grad_fx_k.matSub(grad_fx_km1);
+
+    // The limited-memory part: drop stale vectors
+    // Haskell `ss` -> JS `ss_km2`; Haskell `ss'` -> JS `ss_km1`
+    const ss_km1 = _.take([s_km1].concat(ss_km2), lbfgsInfo.memSize);
+    const ys_km1 = _.take([y_km1].concat(ys_km2), lbfgsInfo.memSize);
+    const gradPreconditioned = lbfgsInner(grad_fx_k, ss_km1, ys_km1);
+
+    // Reset L-BFGS if the result is not a descent direction, and use steepest descent direction
+    // https://github.com/JuliaNLSolvers/Optim.jl/issues/143
+    // https://github.com/JuliaNLSolvers/Optim.jl/pull/144
+    // A descent direction is a vector p s.t. <p `dot` grad_fx_k> < 0
+    // If P is a positive definite matrix, then p = -P grad f(x) is a descent dir at x
+    const descentDirCheck = -1.0 * dotVec(gradPreconditioned, grad_fx_k);
+
+    if (descentDirCheck > 0.0) {
+      log.info(
+        "L-BFGS did not find a descent direction. Resetting correction vectors.",
+        lbfgsInfo
+      );
+      return {
+        gradfxsPreconditioned: gradfxs,
+        updatedLbfgsInfo: {
+          ...lbfgsInfo,
+          lastState: { tag: "Just" as const, contents: x_k },
+          lastGrad: { tag: "Just" as const, contents: grad_fx_k },
+          s_list: [],
+          y_list: [],
+          numUnconstrSteps: 1,
+        },
+      };
+    }
+
+    // Found a direction; update the state
+    // TODO: check the curvature condition y_k^T s_k > 0 (8.7) (Nocedal 201)
+    // https://github.com/JuliaNLSolvers/Optim.jl/issues/26
     if (DEBUG_LBFGS) {
-        log.info(
-            "Starting lbfgs calculation with xs",
-            xs,
-            "gradfxs",
-            gradfxs,
-            "lbfgs params",
-            lbfgsInfo
-        );
+      log.info("Descent direction found.", vecList(gradPreconditioned));
     }
 
-    if (lbfgsInfo.numUnconstrSteps === 0) {
-        // Initialize state
-        // Perform normal gradient descent on first step
-        // Store x_k, grad f(x_k) so we can compute s_k, y_k on next step
-
-        return {
-            gradfxsPreconditioned: gradfxs,
-            updatedLbfgsInfo: {
-                ...lbfgsInfo,
-                lastState: { tag: "Just" as const, contents: colVec(xs) },
-                lastGrad: { tag: "Just" as const, contents: colVec(gradfxs) },
-                s_list: [],
-                y_list: [],
-                numUnconstrSteps: 1,
-            },
-        };
-    } else if (
-        lbfgsInfo.lastState.tag === "Just" &&
-        lbfgsInfo.lastGrad.tag === "Just"
-    ) {
-        // Our current step is k; the last step is km1 (k_minus_1)
-        const x_k = colVec(xs);
-        const grad_fx_k = colVec(gradfxs);
-
-        const km1 = lbfgsInfo.numUnconstrSteps;
-        const x_km1 = lbfgsInfo.lastState.contents;
-        const grad_fx_km1 = lbfgsInfo.lastGrad.contents;
-        const ss_km2 = lbfgsInfo.s_list;
-        const ys_km2 = lbfgsInfo.y_list;
-
-        // Compute s_{k-1} = x_k - x_{k-1} and y_{k-1} = (analogous with grads)
-        // Unlike Nocedal, compute the difference vectors first instead of last (same result, just a loop rewrite)
-        // Use the updated {s_i} and {y_i}. (If k < m, this reduces to normal BFGS, i.e. we use all the vectors so far)
-        // Newest vectors added to front
-
-        const s_km1 = x_k.matSub(x_km1);
-        const y_km1 = grad_fx_k.matSub(grad_fx_km1);
-
-        // The limited-memory part: drop stale vectors
-        // Haskell `ss` -> JS `ss_km2`; Haskell `ss'` -> JS `ss_km1`
-        const ss_km1 = _.take([s_km1].concat(ss_km2), lbfgsInfo.memSize);
-        const ys_km1 = _.take([y_km1].concat(ys_km2), lbfgsInfo.memSize);
-        const gradPreconditioned = lbfgsInner(grad_fx_k, ss_km1, ys_km1);
-
-        // Reset L-BFGS if the result is not a descent direction, and use steepest descent direction
-        // https://github.com/JuliaNLSolvers/Optim.jl/issues/143
-        // https://github.com/JuliaNLSolvers/Optim.jl/pull/144
-        // A descent direction is a vector p s.t. <p `dot` grad_fx_k> < 0
-        // If P is a positive definite matrix, then p = -P grad f(x) is a descent dir at x
-        const descentDirCheck = -1.0 * dotVec(gradPreconditioned, grad_fx_k);
-
-        if (descentDirCheck > 0.0) {
-            log.info(
-                "L-BFGS did not find a descent direction. Resetting correction vectors.",
-                lbfgsInfo
-            );
-            return {
-                gradfxsPreconditioned: gradfxs,
-                updatedLbfgsInfo: {
-                    ...lbfgsInfo,
-                    lastState: { tag: "Just" as const, contents: x_k },
-                    lastGrad: { tag: "Just" as const, contents: grad_fx_k },
-                    s_list: [],
-                    y_list: [],
-                    numUnconstrSteps: 1,
-                },
-            };
-        }
-
-        // Found a direction; update the state
-        // TODO: check the curvature condition y_k^T s_k > 0 (8.7) (Nocedal 201)
-        // https://github.com/JuliaNLSolvers/Optim.jl/issues/26
-        if (DEBUG_LBFGS) {
-            log.info("Descent direction found.", vecList(gradPreconditioned));
-        }
-
-        return {
-            gradfxsPreconditioned: vecList(gradPreconditioned),
-            updatedLbfgsInfo: {
-                ...lbfgsInfo,
-                lastState: { tag: "Just" as const, contents: x_k },
-                lastGrad: { tag: "Just" as const, contents: grad_fx_k },
-                s_list: ss_km1,
-                y_list: ys_km1,
-                numUnconstrSteps: km1 + 1,
-            },
-        };
-    } else {
-        log.info("State:", lbfgsInfo);
-        throw Error("Invalid L-BFGS state");
-    }
+    return {
+      gradfxsPreconditioned: vecList(gradPreconditioned),
+      updatedLbfgsInfo: {
+        ...lbfgsInfo,
+        lastState: { tag: "Just" as const, contents: x_k },
+        lastGrad: { tag: "Just" as const, contents: grad_fx_k },
+        s_list: ss_km1,
+        y_list: ys_km1,
+        numUnconstrSteps: km1 + 1,
+      },
+    };
+  } else {
+    log.info("State:", lbfgsInfo);
+    throw Error("Invalid L-BFGS state");
+  }
 };
 
 const minimize = (
-    xs0: number[],
-    f: (zs: number[]) => number,
-    gradf: (zs: number[]) => number[],
-    lbfgsInfo: LbfgsParams,
-    varyingPaths: string[],
-    numSteps: number
+  xs0: number[],
+  f: (zs: number[]) => number,
+  gradf: (zs: number[]) => number[],
+  lbfgsInfo: LbfgsParams,
+  varyingPaths: string[],
+  numSteps: number
 ): OptInfo => {
-    // TODO: Do a UO convergence check here? Since the EP check is tied to the render cycle...
+  // TODO: Do a UO convergence check here? Since the EP check is tied to the render cycle...
 
-    log.info("-------------------------------------");
-    log.info("minimize, num steps", numSteps);
+  log.info("-------------------------------------");
+  log.info("minimize, num steps", numSteps);
 
-    // (10,000 steps / 100ms) * (10 ms / s) (???) = 100k steps/s (on this simple problem (just `sameCenter` or just `contains`, with no line search, and not sure about mem use)
-    // this is just a factor of 5 slowdown over the compiled energy function
+  // (10,000 steps / 100ms) * (10 ms / s) (???) = 100k steps/s (on this simple problem (just `sameCenter` or just `contains`, with no line search, and not sure about mem use)
+  // this is just a factor of 5 slowdown over the compiled energy function
 
-    let xs = [...xs0]; // Don't use xs
-    let fxs = 0.0;
-    let gradfxs = repeat(xs0.length, 0);
-    let gradientPreconditioned = [...gradfxs];
-    let normGradfxs = 0.0;
-    let i = 0;
-    let t = 0.0001; // NOTE: This const setting will not necessarily work well for a given opt problem.
+  let xs = [...xs0]; // Don't use xs
+  let fxs = 0.0;
+  let gradfxs = repeat(xs0.length, 0);
+  let gradientPreconditioned = [...gradfxs];
+  let normGradfxs = 0.0;
+  let i = 0;
+  let t = 0.0001; // NOTE: This const setting will not necessarily work well for a given opt problem.
 
-    let newLbfgsInfo = { ...lbfgsInfo };
+  let newLbfgsInfo = { ...lbfgsInfo };
 
-    while (i < numSteps) {
-        fxs = f(xs);
-        gradfxs = gradf(xs);
+  while (i < numSteps) {
+    fxs = f(xs);
+    gradfxs = gradf(xs);
 
-        const { gradfxsPreconditioned, updatedLbfgsInfo } = lbfgs(
-            xs,
-            gradfxs,
-            newLbfgsInfo
-        );
-        newLbfgsInfo = updatedLbfgsInfo;
-        gradientPreconditioned = gradfxsPreconditioned;
+    const { gradfxsPreconditioned, updatedLbfgsInfo } = lbfgs(
+      xs,
+      gradfxs,
+      newLbfgsInfo
+    );
+    newLbfgsInfo = updatedLbfgsInfo;
+    gradientPreconditioned = gradfxsPreconditioned;
 
-        // Don't take the Euclidean norm. According to Boyd (485), we should use the Newton descent check, with the norm of the gradient pulled back to the nicer space.
-        normGradfxs = dot(gradfxs, gradfxsPreconditioned);
+    // Don't take the Euclidean norm. According to Boyd (485), we should use the Newton descent check, with the norm of the gradient pulled back to the nicer space.
+    normGradfxs = dot(gradfxs, gradfxsPreconditioned);
 
-        if (BREAK_EARLY && unconstrainedConverged2(normGradfxs)) {
-            // This is on the original gradient, not the preconditioned one
-            log.info(
-                "descent converged early, on step",
-                i,
-                "of",
-                numSteps,
-                "(per display cycle); stopping early"
-            );
-            break;
-        }
-
-        if (USE_LINE_SEARCH) {
-            t = awLineSearch2(xs, f, gradf, gradfxsPreconditioned, fxs); // The search direction is conditioned (here, by an approximation of the inverse of the Hessian at the point)
-        }
-
-        const normGrad = normList(gradfxs);
-
-        if (DEBUG_GRAD_DESCENT) {
-            log.info("-----");
-            log.info("i", i);
-            log.info("num steps per display cycle", numSteps);
-            log.info("input (xs):", xs);
-            log.info("energy (f(xs)):", fxs);
-            log.info("grad (grad(f)(xs)):", gradfxs);
-            log.info("|grad f(x)|:", normGrad);
-            log.info("t", t, "use line search:", USE_LINE_SEARCH);
-        }
-
-        if (isNaN(fxs) || isNaN(normGrad)) {
-            log.info("-----");
-
-            const pathMap = _.zip(varyingPaths, xs, gradfxs) as [
-                string,
-                number,
-                number
-            ][];
-            log.info("[varying paths, current val, gradient of val]", pathMap);
-
-            for (const [name, x, dx] of pathMap) {
-                if (isNaN(dx)) {
-                    log.info("NaN in varying val's gradient", name, "(current val):", x);
-                }
-            }
-
-            log.info("i", i);
-            log.info("num steps per display cycle", numSteps);
-            log.info("input (xs):", xs);
-            log.info("energy (f(xs)):", fxs);
-            log.info("grad (grad(f)(xs)):", gradfxs);
-            log.info("|grad f(x)|:", normGrad);
-            log.info("t", t, "use line search:", USE_LINE_SEARCH);
-            throw Error("NaN reached in optimization energy or gradient norm!");
-        }
-
-        xs = xs.map((x, j) => x - t * gradfxsPreconditioned[j]); // The GD update uses the conditioned search direction, as well as the timestep found by moving along it
-        i++;
+    if (BREAK_EARLY && unconstrainedConverged2(normGradfxs)) {
+      // This is on the original gradient, not the preconditioned one
+      log.info(
+        "descent converged early, on step",
+        i,
+        "of",
+        numSteps,
+        "(per display cycle); stopping early"
+      );
+      break;
     }
 
-    // TODO: Log stats for last one?
+    if (USE_LINE_SEARCH) {
+      t = awLineSearch2(xs, f, gradf, gradfxsPreconditioned, fxs); // The search direction is conditioned (here, by an approximation of the inverse of the Hessian at the point)
+    }
 
-    return {
-        xs,
-        energyVal: fxs,
-        normGrad: normGradfxs,
-        newLbfgsInfo,
-        gradient: gradfxs,
-        gradientPreconditioned,
-    };
+    const normGrad = normList(gradfxs);
+
+    if (DEBUG_GRAD_DESCENT) {
+      log.info("-----");
+      log.info("i", i);
+      log.info("num steps per display cycle", numSteps);
+      log.info("input (xs):", xs);
+      log.info("energy (f(xs)):", fxs);
+      log.info("grad (grad(f)(xs)):", gradfxs);
+      log.info("|grad f(x)|:", normGrad);
+      log.info("t", t, "use line search:", USE_LINE_SEARCH);
+    }
+
+    if (isNaN(fxs) || isNaN(normGrad)) {
+      log.info("-----");
+
+      const pathMap = _.zip(varyingPaths, xs, gradfxs) as [
+        string,
+        number,
+        number
+      ][];
+
+      log.info("[varying paths, current val, gradient of val]", pathMap);
+
+      for (const [name, x, dx] of pathMap) {
+        if (isNaN(dx)) {
+          log.info("NaN in varying val's gradient", name, "(current val):", x);
+        }
+      }
+
+      log.info("i", i);
+      log.info("num steps per display cycle", numSteps);
+      log.info("input (xs):", xs);
+      log.info("energy (f(xs)):", fxs);
+      log.info("grad (grad(f)(xs)):", gradfxs);
+      log.info("|grad f(x)|:", normGrad);
+      log.info("t", t, "use line search:", USE_LINE_SEARCH);
+      throw Error("NaN reached in optimization energy or gradient norm!");
+    }
+
+    xs = xs.map((x, j) => x - t * gradfxsPreconditioned[j]); // The GD update uses the conditioned search direction, as well as the timestep found by moving along it
+    i++;
+  }
+
+  // TODO: Log stats for last one?
+
+  return {
+    xs,
+    energyVal: fxs,
+    normGrad: normGradfxs,
+    newLbfgsInfo,
+    gradient: gradfxs,
+    gradientPreconditioned,
+  };
 };
 
 /**
@@ -851,204 +852,204 @@ const minimize = (
  * @returns a function that takes in a list of `VarAD`s and return a `Scalar`
  */
 export const evalEnergyOnCustom = (state: State) => {
-    // TODO: types
-    return (...xsVars: VarAD[]): any => {
-        // TODO: Could this line be causing a memory leak?
-        const { objFns, constrFns, varyingPaths } = state;
+  // TODO: types
+  return (...xsVars: VarAD[]): any => {
+    // TODO: Could this line be causing a memory leak?
+    const { objFns, constrFns, varyingPaths } = state;
 
-        // Clone the translation to use in the `evalFns` top-level calls, because they mutate the translation while interpreting the energy function in order to cache/reuse VarAD (computation) results
-        // Note that we have to do a "round trip" on the translation types, from VarAD to number to VarAD, to clear the computational graph of the VarADs. Otherwise, there may be cycles in the translation (since 1) we run `evalShapes` in `processData`, which mutates the VarADs, and 2) the computational graph contains DAGs and stores both parent and child pointers). Cycles in the translation cause `clone` to be very slow, and anyway, the VarADs should be "fresh" since the point of this function is to build the comp graph from scratch by interpreting the translation.
-        const translationInit = makeTranslationDifferentiable(
-            clone(makeTranslationNumeric(state.translation))
-        );
+    // Clone the translation to use in the `evalFns` top-level calls, because they mutate the translation while interpreting the energy function in order to cache/reuse VarAD (computation) results
+    // Note that we have to do a "round trip" on the translation types, from VarAD to number to VarAD, to clear the computational graph of the VarADs. Otherwise, there may be cycles in the translation (since 1) we run `evalShapes` in `processData`, which mutates the VarADs, and 2) the computational graph contains DAGs and stores both parent and child pointers). Cycles in the translation cause `clone` to be very slow, and anyway, the VarADs should be "fresh" since the point of this function is to build the comp graph from scratch by interpreting the translation.
+    const translationInit = makeTranslationDifferentiable(
+      clone(makeTranslationNumeric(state.translation))
+    );
 
-        const varyingMapList = _.zip(varyingPaths, xsVars) as [Path, VarAD][];
-        // Insert varying vals into translation (e.g. VectorAccesses of varying vals are found in the translation, although I guess in practice they should use varyingMap)
-        const translation = insertVaryings(translationInit, varyingMapList);
+    const varyingMapList = _.zip(varyingPaths, xsVars) as [Path, VarAD][];
+    // Insert varying vals into translation (e.g. VectorAccesses of varying vals are found in the translation, although I guess in practice they should use varyingMap)
+    const translation = insertVaryings(translationInit, varyingMapList);
 
-        // construct a new varying map
-        const varyingMap = genPathMap(varyingPaths, xsVars) as VaryMap<VarAD>;
+    // construct a new varying map
+    const varyingMap = genPathMap(varyingPaths, xsVars) as VaryMap<VarAD>;
 
-        // NOTE: This will mutate the var inputs
-        const objEvaled = evalFns(objFns, translation, varyingMap);
-        const constrEvaled = evalFns(constrFns, translation, varyingMap);
+    // NOTE: This will mutate the var inputs
+    const objEvaled = evalFns(objFns, translation, varyingMap);
+    const constrEvaled = evalFns(constrFns, translation, varyingMap);
 
-        const objEngs: VarAD[] = objEvaled.map((o) => applyFn(o, objDict));
-        const constrEngs: VarAD[] = constrEvaled.map((c) =>
-            fns.toPenalty(applyFn(c, constrDict))
-        );
+    const objEngs: VarAD[] = objEvaled.map((o) => applyFn(o, objDict));
+    const constrEngs: VarAD[] = constrEvaled.map((c) =>
+      fns.toPenalty(applyFn(c, constrDict))
+    );
 
-        // Note there are two energies, each of which does NOT know about its children, but the root nodes should now have parents up to the objfn energies. The computational graph can be seen in inspecting varyingValuesTF's parents
-        // The energies are in the val field of the results (w/o grads)
-        // log.info("objEngs", objFns, objEngs);
-        // log.info("vars", varyingValuesTF);
+    // Note there are two energies, each of which does NOT know about its children, but the root nodes should now have parents up to the objfn energies. The computational graph can be seen in inspecting varyingValuesTF's parents
+    // The energies are in the val field of the results (w/o grads)
+    // log.info("objEngs", objFns, objEngs);
+    // log.info("vars", varyingValuesTF);
 
-        // TODO make this check more robust to empty lists of objectives/constraints
-        if (!objEngs[0] && !constrEngs[0]) {
-            log.info("WARNING: no objectives and no constraints");
-        }
+    // TODO make this check more robust to empty lists of objectives/constraints
+    if (!objEngs[0] && !constrEngs[0]) {
+      log.info("WARNING: no objectives and no constraints");
+    }
 
-        // This is fixed during the whole optimization
-        const constrWeightNode = varOf(
-            constraintWeight,
-            String(constraintWeight),
-            "constraintWeight"
-        );
+    // This is fixed during the whole optimization
+    const constrWeightNode = varOf(
+      constraintWeight,
+      String(constraintWeight),
+      "constraintWeight"
+    );
 
-        // This changes with the EP round, gets bigger to weight the constraints
-        // Therefore it's marked as an input to the generated objective function, which can be partially applied with the ep weight (-1 is an index; means it appears as the first argument)
-        const epWeightNode = markInput(
-            varOf(state.params.weight, String(state.params.weight), "epWeight"),
-            -1
-        );
+    // This changes with the EP round, gets bigger to weight the constraints
+    // Therefore it's marked as an input to the generated objective function, which can be partially applied with the ep weight (-1 is an index; means it appears as the first argument)
+    const epWeightNode = markInput(
+      varOf(state.params.weight, String(state.params.weight), "epWeight"),
+      -1
+    );
 
-        const objEng: VarAD = ops.vsum(objEngs);
-        const constrEng: VarAD = ops.vsum(constrEngs);
-        // F(x) = o(x) + c0 * penalty * c(x)
-        const overallEng: VarAD = add(
-            objEng,
-            mul(constrEng, mul(constrWeightNode, epWeightNode))
-        );
+    const objEng: VarAD = ops.vsum(objEngs);
+    const constrEng: VarAD = ops.vsum(constrEngs);
+    // F(x) = o(x) + c0 * penalty * c(x)
+    const overallEng: VarAD = add(
+      objEng,
+      mul(constrEng, mul(constrWeightNode, epWeightNode))
+    );
 
-        // NOTE: This is necessary because we have to state the seed for the autodiff, which is the last output
-        overallEng.gradVal = { tag: "Just" as const, contents: 1.0 };
-        log.info("overall eng from custom AD", overallEng, overallEng.val);
+    // NOTE: This is necessary because we have to state the seed for the autodiff, which is the last output
+    overallEng.gradVal = { tag: "Just" as const, contents: 1.0 };
+    log.info("overall eng from custom AD", overallEng, overallEng.val);
 
-        return {
-            energyGraph: overallEng,
-            constrWeightNode,
-            epWeightNode,
-        };
+    return {
+      energyGraph: overallEng,
+      constrWeightNode,
+      epWeightNode,
     };
+  };
 };
 
 export const genOptProblem = (state: State): State => {
-    const xs: number[] = state.varyingValues;
-    log.trace("step newIter, xs", xs);
+  const xs: number[] = state.varyingValues;
+  log.trace("step newIter, xs", xs);
 
-    // if (!state.params.functionsCompiled) {
-    // TODO: Doesn't reuse compiled function for now (since caching function in App currently does not work)
-    // Compile objective and gradient
-    log.info("Compiling objective and gradient");
+  // if (!state.params.functionsCompiled) {
+  // TODO: Doesn't reuse compiled function for now (since caching function in App currently does not work)
+  // Compile objective and gradient
+  log.info("Compiling objective and gradient");
 
-    // `overallEnergy` is a partially applied function, waiting for an input.
-    // When applied, it will interpret the energy via lookups on the computational graph
-    // TODO: Could save the interpreted energy graph across amples
-    const overallObjective = evalEnergyOnCustom(state);
-    const xsVars: VarAD[] = makeADInputVars(xs);
-    const res = overallObjective(...xsVars); // Note: `overallObjective` mutates `xsVars`
-    // `energyGraph` is a VarAD that is a handle to the top of the graph
+  // `overallEnergy` is a partially applied function, waiting for an input.
+  // When applied, it will interpret the energy via lookups on the computational graph
+  // TODO: Could save the interpreted energy graph across amples
+  const overallObjective = evalEnergyOnCustom(state);
+  const xsVars: VarAD[] = makeADInputVars(xs);
+  const res = overallObjective(...xsVars); // Note: `overallObjective` mutates `xsVars`
+  // `energyGraph` is a VarAD that is a handle to the top of the graph
 
-    log.info("interpreted energy graph", res.energyGraph);
-    log.info("input vars", xsVars);
+  log.info("interpreted energy graph", res.energyGraph);
+  log.info("input vars", xsVars);
 
-    const weightInfo = {
-        // TODO: factor out
-        constrWeightNode: res.constrWeightNode,
-        epWeightNode: res.epWeightNode,
-        constrWeight: constraintWeight,
-        epWeight: initConstraintWeight,
-    };
+  const weightInfo = {
+    // TODO: factor out
+    constrWeightNode: res.constrWeightNode,
+    epWeightNode: res.epWeightNode,
+    constrWeight: constraintWeight,
+    epWeight: initConstraintWeight,
+  };
 
-    const { graphs, f, gradf } = energyAndGradCompiled(
-        xs,
-        xsVars,
-        res.energyGraph,
-        { tag: "Just", contents: weightInfo }
-    );
+  const { graphs, f, gradf } = energyAndGradCompiled(
+    xs,
+    xsVars,
+    res.energyGraph,
+    { tag: "Just", contents: weightInfo }
+  );
 
-    eig.GC.flush(); // Clear allocated matrix, vector objects in L-BFGS params
+  eig.GC.flush(); // Clear allocated matrix, vector objects in L-BFGS params
 
-    const newParams: Params = {
-        ...state.params,
-        xsVars,
+  const newParams: Params = {
+    ...state.params,
+    xsVars,
 
-        lastGradient: repeat(xs.length, 0),
-        lastGradientPreconditioned: repeat(xs.length, 0),
+    lastGradient: repeat(xs.length, 0),
+    lastGradientPreconditioned: repeat(xs.length, 0),
 
-        graphs,
-        objective: f,
-        gradient: gradf,
+    graphs,
+    objective: f,
+    gradient: gradf,
 
-        functionsCompiled: true,
+    functionsCompiled: true,
 
-        currObjective: f(initConstraintWeight),
-        currGradient: gradf(initConstraintWeight),
+    currObjective: f(initConstraintWeight),
+    currGradient: gradf(initConstraintWeight),
 
-        energyGraph: res.energyGraph,
-        constrWeightNode: res.constrWeightNode,
-        epWeightNode: res.epWeightNode,
-        weight: initConstraintWeight,
-        UOround: 0,
-        EPround: 0,
-        optStatus: "UnconstrainedRunning",
+    energyGraph: res.energyGraph,
+    constrWeightNode: res.constrWeightNode,
+    epWeightNode: res.epWeightNode,
+    weight: initConstraintWeight,
+    UOround: 0,
+    EPround: 0,
+    optStatus: "UnconstrainedRunning",
 
-        lbfgsInfo: defaultLbfgsParams,
-    };
+    lbfgsInfo: defaultLbfgsParams,
+  };
 
-    return { ...state, params: newParams };
+  return { ...state, params: newParams };
 };
 
 // Eval a single function on the state (using VarADs). Based off of `evalEnergyOfCustom` -- see that function for comments.
 const evalFnOn = (fn: Fn, s: State) => {
-    const dict = fn.optType === "ObjFn" ? objDict : constrDict;
+  const dict = fn.optType === "ObjFn" ? objDict : constrDict;
 
-    return (...xsVars: VarAD[]): VarAD => {
-        const { varyingPaths } = s;
+  return (...xsVars: VarAD[]): VarAD => {
+    const { varyingPaths } = s;
 
-        const translationInit = makeTranslationDifferentiable(
-            clone(makeTranslationNumeric(s.translation))
-        );
+    const translationInit = makeTranslationDifferentiable(
+      clone(makeTranslationNumeric(s.translation))
+    );
 
-        const varyingMapList = _.zip(varyingPaths, xsVars) as [Path, VarAD][];
-        const translation = insertVaryings(translationInit, varyingMapList);
-        const varyingMap = genPathMap(varyingPaths, xsVars) as VaryMap<VarAD>;
+    const varyingMapList = _.zip(varyingPaths, xsVars) as [Path, VarAD][];
+    const translation = insertVaryings(translationInit, varyingMapList);
+    const varyingMap = genPathMap(varyingPaths, xsVars) as VaryMap<VarAD>;
 
-        // NOTE: This will mutate the var inputs
-        const fnArgsEvaled: FnDone<VarAD> = evalFn(fn, translation, varyingMap);
-        const fnEnergy: VarAD = applyFn(fnArgsEvaled, dict);
+    // NOTE: This will mutate the var inputs
+    const fnArgsEvaled: FnDone<VarAD> = evalFn(fn, translation, varyingMap);
+    const fnEnergy: VarAD = applyFn(fnArgsEvaled, dict);
 
-        return fnEnergy;
-    };
+    return fnEnergy;
+  };
 };
 
 // For a given objective or constraint, precompile it and its gradient, without any weights. (variation on `genOptProblem`)
 const genFn = (fn: Fn, s: State): FnCached => {
-    const xs: number[] = clone(s.varyingValues);
+  const xs: number[] = clone(s.varyingValues);
 
-    const overallObjective = evalFnOn(fn, s);
-    const xsVars: VarAD[] = makeADInputVars(xs);
-    const energyGraph: VarAD = overallObjective(...xsVars); // Note: `overallObjective` mutates `xsVars`
+  const overallObjective = evalFnOn(fn, s);
+  const xsVars: VarAD[] = makeADInputVars(xs);
+  const energyGraph: VarAD = overallObjective(...xsVars); // Note: `overallObjective` mutates `xsVars`
 
-    const weightInfo: MaybeVal<WeightInfo> = { tag: "Nothing" };
+  const weightInfo: MaybeVal<WeightInfo> = { tag: "Nothing" };
 
-    const { graphs, f, gradf } = energyAndGradCompiled(
-        xs,
-        xsVars,
-        energyGraph,
-        weightInfo
-    );
+  const { graphs, f, gradf } = energyAndGradCompiled(
+    xs,
+    xsVars,
+    energyGraph,
+    weightInfo
+  );
 
-    // Note this throws away the energy/gradient graphs (`VarAD`s). Presumably not needed?
-    return { f, gradf };
+  // Note this throws away the energy/gradient graphs (`VarAD`s). Presumably not needed?
+  return { f, gradf };
 };
 
 // For each objective and constraint, precompile it and its gradient and cache it in the state.
 export const genFns = (s: State): State => {
-    const p = s.params;
-    const objCache = {};
-    const constrCache = {};
+  const p = s.params;
+  const objCache = {};
+  const constrCache = {};
 
-    for (const f of s.objFns) {
-        objCache[prettyPrintFn(f)] = genFn(f, s);
-    }
+  for (const f of s.objFns) {
+    objCache[prettyPrintFn(f)] = genFn(f, s);
+  }
 
-    for (const f of s.constrFns) {
-        constrCache[prettyPrintFn(f)] = genFn(f, s);
-    }
+  for (const f of s.constrFns) {
+    constrCache[prettyPrintFn(f)] = genFn(f, s);
+  }
 
-    p.objFnCache = objCache;
-    p.constrFnCache = constrCache;
+  p.objFnCache = objCache;
+  p.constrFnCache = constrCache;
 
-    return s;
+  return s;
 };

--- a/packages/core/src/types/errors.ts
+++ b/packages/core/src/types/errors.ts
@@ -10,115 +10,124 @@ import { SubExpr, Deconstructor, TypeConsApp } from "./substance";
 // type RuntimeError = OptimizerError | EvaluatorError;
 // type StyleError = StyleParseError | StyleCheckError | TranslationError;
 export type PenroseError =
-  | (DomainError & { errorType: "DomainError" })
-  | (SubstanceError & { errorType: "SubstanceError" })
-  | (StyleError & { errorType: "StyleError" });
+    | (DomainError & { errorType: "DomainError" })
+    | (SubstanceError & { errorType: "SubstanceError" })
+    | (StyleError & { errorType: "StyleError" })
+    | (RuntimeError & { errorType: "RuntimeError" });
+
+export type RuntimeError =
+    | RuntimeErrorWithContents;
+
+export interface RuntimeErrorWithContents {
+    tag: "RuntimeError";
+    message: string;
+}
 
 export type Warning = StyleError;
 export type StyleErrors = StyleError[];
 
 // TODO: does type var ever appear in Substance? If not, can we encode that at the type level?
 export type SubstanceError =
-  | ParseError
-  | DuplicateName
-  | TypeNotFound
-  | TypeVarNotFound
-  | TypeMismatch
-  | ArgLengthMismatch
-  | TypeArgLengthMismatch
-  | VarNotFound
-  | DeconstructNonconstructor
-  | UnexpectedExprForNestedPred
-  | FatalError; // TODO: resolve all fatal errors in the Substance module
+    | ParseError
+    | DuplicateName
+    | TypeNotFound
+    | TypeVarNotFound
+    | TypeMismatch
+    | ArgLengthMismatch
+    | TypeArgLengthMismatch
+    | VarNotFound
+    | DeconstructNonconstructor
+    | UnexpectedExprForNestedPred
+    | FatalError; // TODO: resolve all fatal errors in the Substance module
 
 export type DomainError =
-  | ParseError
-  | TypeDeclared
-  | TypeVarNotFound
-  | TypeNotFound
-  | DuplicateName
-  | CyclicSubtypes
-  | NotTypeConsInSubtype
-  | NotTypeConsInPrelude;
+    | ParseError
+    | TypeDeclared
+    | TypeVarNotFound
+    | TypeNotFound
+    | DuplicateName
+    | CyclicSubtypes
+    | NotTypeConsInSubtype
+    | NotTypeConsInPrelude;
 
 export interface UnexpectedExprForNestedPred {
-  tag: "UnexpectedExprForNestedPred";
-  sourceType: TypeConstructor;
-  sourceExpr: ASTNode;
-  expectedExpr: ASTNode;
+    tag: "UnexpectedExprForNestedPred";
+    sourceType: TypeConstructor;
+    sourceExpr: ASTNode;
+    expectedExpr: ASTNode;
 }
 
 export interface CyclicSubtypes {
-  tag: "CyclicSubtypes";
-  cycles: string[][];
+    tag: "CyclicSubtypes";
+    cycles: string[][];
 }
 export interface NotTypeConsInPrelude {
-  tag: "NotTypeConsInPrelude";
-  type: Prop | TypeVar;
+    tag: "NotTypeConsInPrelude";
+    type: Prop | TypeVar;
 }
 
 export interface NotTypeConsInSubtype {
-  tag: "NotTypeConsInSubtype";
-  type: Prop | TypeVar;
+    tag: "NotTypeConsInSubtype";
+    type: Prop | TypeVar;
 }
 export interface TypeDeclared {
-  tag: "TypeDeclared";
-  typeName: Identifier;
+    tag: "TypeDeclared";
+    typeName: Identifier;
 }
 export interface DuplicateName {
-  tag: "DuplicateName";
-  name: Identifier;
-  location: ASTNode;
-  firstDefined: ASTNode;
+    tag: "DuplicateName";
+    name: Identifier;
+    location: ASTNode;
+    firstDefined: ASTNode;
 }
 export interface TypeVarNotFound {
-  tag: "TypeVarNotFound";
-  typeVar: TypeVar;
+    tag: "TypeVarNotFound";
+    typeVar: TypeVar;
 }
 export interface TypeNotFound {
-  tag: "TypeNotFound";
-  typeName: Identifier;
-  possibleTypes?: Identifier[];
+    tag: "TypeNotFound";
+    typeName: Identifier;
+    possibleTypes?: Identifier[];
 }
 export interface VarNotFound {
-  tag: "VarNotFound";
-  variable: Identifier;
-  possibleVars?: Identifier[];
+    tag: "VarNotFound";
+    variable: Identifier;
+    possibleVars?: Identifier[];
 }
 
 export interface TypeMismatch {
-  tag: "TypeMismatch";
-  sourceType: TypeConstructor;
-  expectedType: TypeConstructor;
-  sourceExpr: ASTNode;
-  expectedExpr: ASTNode;
+    tag: "TypeMismatch";
+    sourceType: TypeConstructor;
+    expectedType: TypeConstructor;
+    sourceExpr: ASTNode;
+    expectedExpr: ASTNode;
 }
 export interface ArgLengthMismatch {
-  tag: "ArgLengthMismatch";
-  name: Identifier;
-  argsGiven: SubExpr[];
-  argsExpected: Arg[];
-  sourceExpr: ASTNode;
-  expectedExpr: ASTNode;
+    tag: "ArgLengthMismatch";
+    name: Identifier;
+    argsGiven: SubExpr[];
+    argsExpected: Arg[];
+    sourceExpr: ASTNode;
+    expectedExpr: ASTNode;
 }
 
 export interface TypeArgLengthMismatch {
-  tag: "TypeArgLengthMismatch";
-  sourceType: TypeConstructor;
-  expectedType: TypeConstructor;
-  sourceExpr: ASTNode;
-  expectedExpr: ASTNode;
+    tag: "TypeArgLengthMismatch";
+    sourceType: TypeConstructor;
+    expectedType: TypeConstructor;
+    sourceExpr: ASTNode;
+    expectedExpr: ASTNode;
 }
 
 export interface DeconstructNonconstructor {
-  tag: "DeconstructNonconstructor";
-  deconstructor: Deconstructor;
+    tag: "DeconstructNonconstructor";
+    deconstructor: Deconstructor;
 }
 
 // NOTE: for debugging purposes
 export interface FatalError {
-  tag: "Fatal";
-  message: string;
+    tag: "Fatal";
+    message: string;
 }
 
 // NOTE: aliased to ASTNode for now, can include more types for different errors
@@ -129,251 +138,251 @@ export type ErrorSource = ASTNode;
 //#region Style errors
 
 export type StyleError =
-  // Misc errors
-  | ParseError
-  | GenericStyleError
-  | StyleErrorList
-  // Selector errors (from Substance)
-  | SelectorDeclTypeError
-  | SelectorVarMultipleDecl
-  | SelectorDeclTypeMismatch
-  | SelectorRelTypeMismatch
-  | TaggedSubstanceError
-  // Block static errors
-  | InvalidGPITypeError
-  | InvalidGPIPropertyError
-  | InvalidFunctionNameError
-  | InvalidObjectiveNameError
-  | InvalidConstraintNameError
-  // Translation errors (deletion)
-  | DeletedPropWithNoSubObjError
-  | DeletedPropWithNoFieldError
-  | DeletedPropWithNoGPIError
-  | CircularPathAlias
-  | DeletedNonexistentFieldError
-  | DeletedVectorElemError
-  // Translation errors (insertion)
-  | InsertedPathWithoutOverrideError
-  | InsertedPropWithNoFieldError
-  | InsertedPropWithNoGPIError
-  // Translation validation errors
-  | NonexistentNameError
-  | NonexistentFieldError
-  | NonexistentGPIError
-  | NonexistentPropertyError
-  | ExpectedGPIGotFieldError
-  | InvalidAccessPathError
-  | CanvasNonexistentError
-  | CanvasNonexistentDimsError
-  // Runtime errors
-  | RuntimeValueTypeError;
+    // Misc errors
+    | ParseError
+    | GenericStyleError
+    | StyleErrorList
+    // Selector errors (from Substance)
+    | SelectorDeclTypeError
+    | SelectorVarMultipleDecl
+    | SelectorDeclTypeMismatch
+    | SelectorRelTypeMismatch
+    | TaggedSubstanceError
+    // Block static errors
+    | InvalidGPITypeError
+    | InvalidGPIPropertyError
+    | InvalidFunctionNameError
+    | InvalidObjectiveNameError
+    | InvalidConstraintNameError
+    // Translation errors (deletion)
+    | DeletedPropWithNoSubObjError
+    | DeletedPropWithNoFieldError
+    | DeletedPropWithNoGPIError
+    | CircularPathAlias
+    | DeletedNonexistentFieldError
+    | DeletedVectorElemError
+    // Translation errors (insertion)
+    | InsertedPathWithoutOverrideError
+    | InsertedPropWithNoFieldError
+    | InsertedPropWithNoGPIError
+    // Translation validation errors
+    | NonexistentNameError
+    | NonexistentFieldError
+    | NonexistentGPIError
+    | NonexistentPropertyError
+    | ExpectedGPIGotFieldError
+    | InvalidAccessPathError
+    | CanvasNonexistentError
+    | CanvasNonexistentDimsError
+    // Runtime errors
+    | RuntimeValueTypeError;
 
 export type StyleWarning = IntOrFloat;
 
 export type StyleWarnings = StyleWarning[];
 
 export interface StyleResults {
-  errors: StyleErrors;
-  warnings: StyleWarnings;
+    errors: StyleErrors;
+    warnings: StyleWarnings;
 }
 
 export interface IntOrFloat {
-  tag: "IntOrFloat";
-  message: string;
+    tag: "IntOrFloat";
+    message: string;
 } // COMBAK: Use this in block checking
 
 export interface GenericStyleError {
-  tag: "GenericStyleError";
-  messages: string[];
+    tag: "GenericStyleError";
+    messages: string[];
 }
 
 export interface StyleErrorList {
-  tag: "StyleErrorList";
-  errors: StyleError[];
+    tag: "StyleErrorList";
+    errors: StyleError[];
 }
 
 export interface ParseError {
-  tag: "ParseError";
-  message: string;
-  location?: SourceLoc;
+    tag: "ParseError";
+    message: string;
+    location?: SourceLoc;
 }
 
 export interface SelectorDeclTypeError {
-  tag: "SelectorDeclTypeError";
-  typeName: Identifier;
+    tag: "SelectorDeclTypeError";
+    typeName: Identifier;
 }
 
 export interface SelectorVarMultipleDecl {
-  tag: "SelectorVarMultipleDecl";
-  varName: BindingForm;
+    tag: "SelectorVarMultipleDecl";
+    varName: BindingForm;
 }
 
 export interface SelectorDeclTypeMismatch {
-  tag: "SelectorDeclTypeMismatch";
-  subType: TypeConsApp;
-  styType: TypeConsApp;
+    tag: "SelectorDeclTypeMismatch";
+    subType: TypeConsApp;
+    styType: TypeConsApp;
 }
 
 export interface SelectorRelTypeMismatch {
-  tag: "SelectorRelTypeMismatch";
-  varType: TypeConsApp;
-  exprType: TypeConsApp;
+    tag: "SelectorRelTypeMismatch";
+    varType: TypeConsApp;
+    exprType: TypeConsApp;
 }
 
 export interface TaggedSubstanceError {
-  tag: "TaggedSubstanceError";
-  error: SubstanceError;
+    tag: "TaggedSubstanceError";
+    error: SubstanceError;
 }
 
 //#region Block statics
 
 export interface InvalidGPITypeError {
-  tag: "InvalidGPITypeError";
-  givenType: Identifier;
-  // expectedType: string;
+    tag: "InvalidGPITypeError";
+    givenType: Identifier;
+    // expectedType: string;
 }
 
 export interface InvalidGPIPropertyError {
-  tag: "InvalidGPIPropertyError";
-  givenProperty: Identifier;
-  expectedProperties: string[];
+    tag: "InvalidGPIPropertyError";
+    givenProperty: Identifier;
+    expectedProperties: string[];
 }
 
 export interface InvalidFunctionNameError {
-  tag: "InvalidFunctionNameError";
-  givenName: Identifier;
-  // expectedName: string;
+    tag: "InvalidFunctionNameError";
+    givenName: Identifier;
+    // expectedName: string;
 }
 
 export interface InvalidObjectiveNameError {
-  tag: "InvalidObjectiveNameError";
-  givenName: Identifier;
-  // expectedName: string;
+    tag: "InvalidObjectiveNameError";
+    givenName: Identifier;
+    // expectedName: string;
 }
 
 export interface InvalidConstraintNameError {
-  tag: "InvalidConstraintNameError";
-  givenName: Identifier;
-  // expectedName: string;
+    tag: "InvalidConstraintNameError";
+    givenName: Identifier;
+    // expectedName: string;
 }
 
 //#endregion Block statics
 
 export interface DeletedPropWithNoSubObjError {
-  tag: "DeletedPropWithNoSubObjError";
-  subObj: BindingForm;
-  path: Path;
+    tag: "DeletedPropWithNoSubObjError";
+    subObj: BindingForm;
+    path: Path;
 }
 
 export interface DeletedPropWithNoFieldError {
-  tag: "DeletedPropWithNoFieldError";
-  subObj: BindingForm;
-  field: Identifier;
-  path: Path;
+    tag: "DeletedPropWithNoFieldError";
+    subObj: BindingForm;
+    field: Identifier;
+    path: Path;
 }
 
 export interface CircularPathAlias {
-  tag: "CircularPathAlias";
-  path: Path;
+    tag: "CircularPathAlias";
+    path: Path;
 }
 
 export interface DeletedPropWithNoGPIError {
-  tag: "DeletedPropWithNoGPIError";
-  subObj: BindingForm;
-  field: Identifier;
-  property: Identifier;
-  path: Path;
+    tag: "DeletedPropWithNoGPIError";
+    subObj: BindingForm;
+    field: Identifier;
+    property: Identifier;
+    path: Path;
 }
 
 export interface DeletedNonexistentFieldError {
-  tag: "DeletedNonexistentFieldError";
-  subObj: BindingForm;
-  field: Identifier;
-  path: Path;
+    tag: "DeletedNonexistentFieldError";
+    subObj: BindingForm;
+    field: Identifier;
+    path: Path;
 }
 
 export interface DeletedVectorElemError {
-  tag: "DeletedVectorElemError";
-  path: Path;
+    tag: "DeletedVectorElemError";
+    path: Path;
 }
 
 export interface InsertedPathWithoutOverrideError {
-  tag: "InsertedPathWithoutOverrideError";
-  path: Path;
+    tag: "InsertedPathWithoutOverrideError";
+    path: Path;
 }
 
 export interface InsertedPropWithNoFieldError {
-  tag: "InsertedPropWithNoFieldError";
-  subObj: BindingForm;
-  field: Identifier;
-  property: Identifier;
-  path: Path;
+    tag: "InsertedPropWithNoFieldError";
+    subObj: BindingForm;
+    field: Identifier;
+    property: Identifier;
+    path: Path;
 }
 
 export interface InsertedPropWithNoGPIError {
-  tag: "InsertedPropWithNoGPIError";
-  subObj: BindingForm;
-  field: Identifier;
-  property: Identifier;
-  path: Path;
+    tag: "InsertedPropWithNoGPIError";
+    subObj: BindingForm;
+    field: Identifier;
+    property: Identifier;
+    path: Path;
 }
 
 //#region Translation validation errors
 
 export interface NonexistentNameError {
-  tag: "NonexistentNameError";
-  name: Identifier;
-  path: Path;
+    tag: "NonexistentNameError";
+    name: Identifier;
+    path: Path;
 }
 
 export interface NonexistentFieldError {
-  tag: "NonexistentFieldError";
-  field: Identifier;
-  path: Path;
+    tag: "NonexistentFieldError";
+    field: Identifier;
+    path: Path;
 }
 
 export interface NonexistentGPIError {
-  tag: "NonexistentGPIError";
-  gpi: Identifier;
-  path: Path;
+    tag: "NonexistentGPIError";
+    gpi: Identifier;
+    path: Path;
 }
 
 export interface NonexistentPropertyError {
-  tag: "NonexistentPropertyError";
-  property: Identifier;
-  path: Path;
+    tag: "NonexistentPropertyError";
+    property: Identifier;
+    path: Path;
 }
 
 export interface ExpectedGPIGotFieldError {
-  tag: "ExpectedGPIGotFieldError";
-  field: Identifier;
-  path: Path;
+    tag: "ExpectedGPIGotFieldError";
+    field: Identifier;
+    path: Path;
 }
 
 export interface InvalidAccessPathError {
-  tag: "InvalidAccessPathError";
-  path: Path;
+    tag: "InvalidAccessPathError";
+    path: Path;
 }
 
 export interface CanvasNonexistentError {
-  tag: "CanvasNonexistentError";
+    tag: "CanvasNonexistentError";
 }
 
 export interface CanvasNonexistentDimsError {
-  tag: "CanvasNonexistentDimsError";
-  attr: "width" | "height";
-  kind: "missing" | "GPI" | "uninitialized" | "wrong type";
-  type?: string;
+    tag: "CanvasNonexistentDimsError";
+    attr: "width" | "height";
+    kind: "missing" | "GPI" | "uninitialized" | "wrong type";
+    type?: string;
 }
 
 //#endregion Translation validation errors
 
 // TODO(errors): use identifiers here
 export interface RuntimeValueTypeError {
-  tag: "RuntimeValueTypeError";
-  path: Path;
-  expectedType: string;
-  actualType: string;
+    tag: "RuntimeValueTypeError";
+    path: Path;
+    expectedType: string;
+    actualType: string;
 }
 
 //#endregion Style errors

--- a/packages/core/src/types/errors.ts
+++ b/packages/core/src/types/errors.ts
@@ -1,5 +1,4 @@
 //#region ErrorTypes
-
 import { ASTNode, Identifier, SourceLoc } from "./ast";
 import { TypeConstructor, Prop, TypeVar, Arg } from "./domain";
 import { BindingForm, Path } from "./style";
@@ -10,17 +9,16 @@ import { SubExpr, Deconstructor, TypeConsApp } from "./substance";
 // type RuntimeError = OptimizerError | EvaluatorError;
 // type StyleError = StyleParseError | StyleCheckError | TranslationError;
 export type PenroseError =
-    | (DomainError & { errorType: "DomainError" })
-    | (SubstanceError & { errorType: "SubstanceError" })
-    | (StyleError & { errorType: "StyleError" })
-    | (RuntimeError & { errorType: "RuntimeError" });
+  | (DomainError & { errorType: "DomainError" })
+  | (SubstanceError & { errorType: "SubstanceError" })
+  | (StyleError & { errorType: "StyleError" })
+  | (RuntimeError & { errorType: "RuntimeError" });
 
-export type RuntimeError =
-    | RuntimeErrorWithContents;
+export type RuntimeError = RuntimeErrorWithContents;
 
 export interface RuntimeErrorWithContents {
-    tag: "RuntimeError";
-    message: string;
+  tag: "RuntimeError";
+  message: string;
 }
 
 export type Warning = StyleError;
@@ -28,106 +26,106 @@ export type StyleErrors = StyleError[];
 
 // TODO: does type var ever appear in Substance? If not, can we encode that at the type level?
 export type SubstanceError =
-    | ParseError
-    | DuplicateName
-    | TypeNotFound
-    | TypeVarNotFound
-    | TypeMismatch
-    | ArgLengthMismatch
-    | TypeArgLengthMismatch
-    | VarNotFound
-    | DeconstructNonconstructor
-    | UnexpectedExprForNestedPred
-    | FatalError; // TODO: resolve all fatal errors in the Substance module
+  | ParseError
+  | DuplicateName
+  | TypeNotFound
+  | TypeVarNotFound
+  | TypeMismatch
+  | ArgLengthMismatch
+  | TypeArgLengthMismatch
+  | VarNotFound
+  | DeconstructNonconstructor
+  | UnexpectedExprForNestedPred
+  | FatalError; // TODO: resolve all fatal errors in the Substance module
 
 export type DomainError =
-    | ParseError
-    | TypeDeclared
-    | TypeVarNotFound
-    | TypeNotFound
-    | DuplicateName
-    | CyclicSubtypes
-    | NotTypeConsInSubtype
-    | NotTypeConsInPrelude;
+  | ParseError
+  | TypeDeclared
+  | TypeVarNotFound
+  | TypeNotFound
+  | DuplicateName
+  | CyclicSubtypes
+  | NotTypeConsInSubtype
+  | NotTypeConsInPrelude;
 
 export interface UnexpectedExprForNestedPred {
-    tag: "UnexpectedExprForNestedPred";
-    sourceType: TypeConstructor;
-    sourceExpr: ASTNode;
-    expectedExpr: ASTNode;
+  tag: "UnexpectedExprForNestedPred";
+  sourceType: TypeConstructor;
+  sourceExpr: ASTNode;
+  expectedExpr: ASTNode;
 }
 
 export interface CyclicSubtypes {
-    tag: "CyclicSubtypes";
-    cycles: string[][];
+  tag: "CyclicSubtypes";
+  cycles: string[][];
 }
 export interface NotTypeConsInPrelude {
-    tag: "NotTypeConsInPrelude";
-    type: Prop | TypeVar;
+  tag: "NotTypeConsInPrelude";
+  type: Prop | TypeVar;
 }
 
 export interface NotTypeConsInSubtype {
-    tag: "NotTypeConsInSubtype";
-    type: Prop | TypeVar;
+  tag: "NotTypeConsInSubtype";
+  type: Prop | TypeVar;
 }
 export interface TypeDeclared {
-    tag: "TypeDeclared";
-    typeName: Identifier;
+  tag: "TypeDeclared";
+  typeName: Identifier;
 }
 export interface DuplicateName {
-    tag: "DuplicateName";
-    name: Identifier;
-    location: ASTNode;
-    firstDefined: ASTNode;
+  tag: "DuplicateName";
+  name: Identifier;
+  location: ASTNode;
+  firstDefined: ASTNode;
 }
 export interface TypeVarNotFound {
-    tag: "TypeVarNotFound";
-    typeVar: TypeVar;
+  tag: "TypeVarNotFound";
+  typeVar: TypeVar;
 }
 export interface TypeNotFound {
-    tag: "TypeNotFound";
-    typeName: Identifier;
-    possibleTypes?: Identifier[];
+  tag: "TypeNotFound";
+  typeName: Identifier;
+  possibleTypes?: Identifier[];
 }
 export interface VarNotFound {
-    tag: "VarNotFound";
-    variable: Identifier;
-    possibleVars?: Identifier[];
+  tag: "VarNotFound";
+  variable: Identifier;
+  possibleVars?: Identifier[];
 }
 
 export interface TypeMismatch {
-    tag: "TypeMismatch";
-    sourceType: TypeConstructor;
-    expectedType: TypeConstructor;
-    sourceExpr: ASTNode;
-    expectedExpr: ASTNode;
+  tag: "TypeMismatch";
+  sourceType: TypeConstructor;
+  expectedType: TypeConstructor;
+  sourceExpr: ASTNode;
+  expectedExpr: ASTNode;
 }
 export interface ArgLengthMismatch {
-    tag: "ArgLengthMismatch";
-    name: Identifier;
-    argsGiven: SubExpr[];
-    argsExpected: Arg[];
-    sourceExpr: ASTNode;
-    expectedExpr: ASTNode;
+  tag: "ArgLengthMismatch";
+  name: Identifier;
+  argsGiven: SubExpr[];
+  argsExpected: Arg[];
+  sourceExpr: ASTNode;
+  expectedExpr: ASTNode;
 }
 
 export interface TypeArgLengthMismatch {
-    tag: "TypeArgLengthMismatch";
-    sourceType: TypeConstructor;
-    expectedType: TypeConstructor;
-    sourceExpr: ASTNode;
-    expectedExpr: ASTNode;
+  tag: "TypeArgLengthMismatch";
+  sourceType: TypeConstructor;
+  expectedType: TypeConstructor;
+  sourceExpr: ASTNode;
+  expectedExpr: ASTNode;
 }
 
 export interface DeconstructNonconstructor {
-    tag: "DeconstructNonconstructor";
-    deconstructor: Deconstructor;
+  tag: "DeconstructNonconstructor";
+  deconstructor: Deconstructor;
 }
 
 // NOTE: for debugging purposes
 export interface FatalError {
-    tag: "Fatal";
-    message: string;
+  tag: "Fatal";
+  message: string;
 }
 
 // NOTE: aliased to ASTNode for now, can include more types for different errors
@@ -138,251 +136,251 @@ export type ErrorSource = ASTNode;
 //#region Style errors
 
 export type StyleError =
-    // Misc errors
-    | ParseError
-    | GenericStyleError
-    | StyleErrorList
-    // Selector errors (from Substance)
-    | SelectorDeclTypeError
-    | SelectorVarMultipleDecl
-    | SelectorDeclTypeMismatch
-    | SelectorRelTypeMismatch
-    | TaggedSubstanceError
-    // Block static errors
-    | InvalidGPITypeError
-    | InvalidGPIPropertyError
-    | InvalidFunctionNameError
-    | InvalidObjectiveNameError
-    | InvalidConstraintNameError
-    // Translation errors (deletion)
-    | DeletedPropWithNoSubObjError
-    | DeletedPropWithNoFieldError
-    | DeletedPropWithNoGPIError
-    | CircularPathAlias
-    | DeletedNonexistentFieldError
-    | DeletedVectorElemError
-    // Translation errors (insertion)
-    | InsertedPathWithoutOverrideError
-    | InsertedPropWithNoFieldError
-    | InsertedPropWithNoGPIError
-    // Translation validation errors
-    | NonexistentNameError
-    | NonexistentFieldError
-    | NonexistentGPIError
-    | NonexistentPropertyError
-    | ExpectedGPIGotFieldError
-    | InvalidAccessPathError
-    | CanvasNonexistentError
-    | CanvasNonexistentDimsError
-    // Runtime errors
-    | RuntimeValueTypeError;
+  // Misc errors
+  | ParseError
+  | GenericStyleError
+  | StyleErrorList
+  // Selector errors (from Substance)
+  | SelectorDeclTypeError
+  | SelectorVarMultipleDecl
+  | SelectorDeclTypeMismatch
+  | SelectorRelTypeMismatch
+  | TaggedSubstanceError
+  // Block static errors
+  | InvalidGPITypeError
+  | InvalidGPIPropertyError
+  | InvalidFunctionNameError
+  | InvalidObjectiveNameError
+  | InvalidConstraintNameError
+  // Translation errors (deletion)
+  | DeletedPropWithNoSubObjError
+  | DeletedPropWithNoFieldError
+  | DeletedPropWithNoGPIError
+  | CircularPathAlias
+  | DeletedNonexistentFieldError
+  | DeletedVectorElemError
+  // Translation errors (insertion)
+  | InsertedPathWithoutOverrideError
+  | InsertedPropWithNoFieldError
+  | InsertedPropWithNoGPIError
+  // Translation validation errors
+  | NonexistentNameError
+  | NonexistentFieldError
+  | NonexistentGPIError
+  | NonexistentPropertyError
+  | ExpectedGPIGotFieldError
+  | InvalidAccessPathError
+  | CanvasNonexistentError
+  | CanvasNonexistentDimsError
+  // Runtime errors
+  | RuntimeValueTypeError;
 
 export type StyleWarning = IntOrFloat;
 
 export type StyleWarnings = StyleWarning[];
 
 export interface StyleResults {
-    errors: StyleErrors;
-    warnings: StyleWarnings;
+  errors: StyleErrors;
+  warnings: StyleWarnings;
 }
 
 export interface IntOrFloat {
-    tag: "IntOrFloat";
-    message: string;
+  tag: "IntOrFloat";
+  message: string;
 } // COMBAK: Use this in block checking
 
 export interface GenericStyleError {
-    tag: "GenericStyleError";
-    messages: string[];
+  tag: "GenericStyleError";
+  messages: string[];
 }
 
 export interface StyleErrorList {
-    tag: "StyleErrorList";
-    errors: StyleError[];
+  tag: "StyleErrorList";
+  errors: StyleError[];
 }
 
 export interface ParseError {
-    tag: "ParseError";
-    message: string;
-    location?: SourceLoc;
+  tag: "ParseError";
+  message: string;
+  location?: SourceLoc;
 }
 
 export interface SelectorDeclTypeError {
-    tag: "SelectorDeclTypeError";
-    typeName: Identifier;
+  tag: "SelectorDeclTypeError";
+  typeName: Identifier;
 }
 
 export interface SelectorVarMultipleDecl {
-    tag: "SelectorVarMultipleDecl";
-    varName: BindingForm;
+  tag: "SelectorVarMultipleDecl";
+  varName: BindingForm;
 }
 
 export interface SelectorDeclTypeMismatch {
-    tag: "SelectorDeclTypeMismatch";
-    subType: TypeConsApp;
-    styType: TypeConsApp;
+  tag: "SelectorDeclTypeMismatch";
+  subType: TypeConsApp;
+  styType: TypeConsApp;
 }
 
 export interface SelectorRelTypeMismatch {
-    tag: "SelectorRelTypeMismatch";
-    varType: TypeConsApp;
-    exprType: TypeConsApp;
+  tag: "SelectorRelTypeMismatch";
+  varType: TypeConsApp;
+  exprType: TypeConsApp;
 }
 
 export interface TaggedSubstanceError {
-    tag: "TaggedSubstanceError";
-    error: SubstanceError;
+  tag: "TaggedSubstanceError";
+  error: SubstanceError;
 }
 
 //#region Block statics
 
 export interface InvalidGPITypeError {
-    tag: "InvalidGPITypeError";
-    givenType: Identifier;
-    // expectedType: string;
+  tag: "InvalidGPITypeError";
+  givenType: Identifier;
+  // expectedType: string;
 }
 
 export interface InvalidGPIPropertyError {
-    tag: "InvalidGPIPropertyError";
-    givenProperty: Identifier;
-    expectedProperties: string[];
+  tag: "InvalidGPIPropertyError";
+  givenProperty: Identifier;
+  expectedProperties: string[];
 }
 
 export interface InvalidFunctionNameError {
-    tag: "InvalidFunctionNameError";
-    givenName: Identifier;
-    // expectedName: string;
+  tag: "InvalidFunctionNameError";
+  givenName: Identifier;
+  // expectedName: string;
 }
 
 export interface InvalidObjectiveNameError {
-    tag: "InvalidObjectiveNameError";
-    givenName: Identifier;
-    // expectedName: string;
+  tag: "InvalidObjectiveNameError";
+  givenName: Identifier;
+  // expectedName: string;
 }
 
 export interface InvalidConstraintNameError {
-    tag: "InvalidConstraintNameError";
-    givenName: Identifier;
-    // expectedName: string;
+  tag: "InvalidConstraintNameError";
+  givenName: Identifier;
+  // expectedName: string;
 }
 
 //#endregion Block statics
 
 export interface DeletedPropWithNoSubObjError {
-    tag: "DeletedPropWithNoSubObjError";
-    subObj: BindingForm;
-    path: Path;
+  tag: "DeletedPropWithNoSubObjError";
+  subObj: BindingForm;
+  path: Path;
 }
 
 export interface DeletedPropWithNoFieldError {
-    tag: "DeletedPropWithNoFieldError";
-    subObj: BindingForm;
-    field: Identifier;
-    path: Path;
+  tag: "DeletedPropWithNoFieldError";
+  subObj: BindingForm;
+  field: Identifier;
+  path: Path;
 }
 
 export interface CircularPathAlias {
-    tag: "CircularPathAlias";
-    path: Path;
+  tag: "CircularPathAlias";
+  path: Path;
 }
 
 export interface DeletedPropWithNoGPIError {
-    tag: "DeletedPropWithNoGPIError";
-    subObj: BindingForm;
-    field: Identifier;
-    property: Identifier;
-    path: Path;
+  tag: "DeletedPropWithNoGPIError";
+  subObj: BindingForm;
+  field: Identifier;
+  property: Identifier;
+  path: Path;
 }
 
 export interface DeletedNonexistentFieldError {
-    tag: "DeletedNonexistentFieldError";
-    subObj: BindingForm;
-    field: Identifier;
-    path: Path;
+  tag: "DeletedNonexistentFieldError";
+  subObj: BindingForm;
+  field: Identifier;
+  path: Path;
 }
 
 export interface DeletedVectorElemError {
-    tag: "DeletedVectorElemError";
-    path: Path;
+  tag: "DeletedVectorElemError";
+  path: Path;
 }
 
 export interface InsertedPathWithoutOverrideError {
-    tag: "InsertedPathWithoutOverrideError";
-    path: Path;
+  tag: "InsertedPathWithoutOverrideError";
+  path: Path;
 }
 
 export interface InsertedPropWithNoFieldError {
-    tag: "InsertedPropWithNoFieldError";
-    subObj: BindingForm;
-    field: Identifier;
-    property: Identifier;
-    path: Path;
+  tag: "InsertedPropWithNoFieldError";
+  subObj: BindingForm;
+  field: Identifier;
+  property: Identifier;
+  path: Path;
 }
 
 export interface InsertedPropWithNoGPIError {
-    tag: "InsertedPropWithNoGPIError";
-    subObj: BindingForm;
-    field: Identifier;
-    property: Identifier;
-    path: Path;
+  tag: "InsertedPropWithNoGPIError";
+  subObj: BindingForm;
+  field: Identifier;
+  property: Identifier;
+  path: Path;
 }
 
 //#region Translation validation errors
 
 export interface NonexistentNameError {
-    tag: "NonexistentNameError";
-    name: Identifier;
-    path: Path;
+  tag: "NonexistentNameError";
+  name: Identifier;
+  path: Path;
 }
 
 export interface NonexistentFieldError {
-    tag: "NonexistentFieldError";
-    field: Identifier;
-    path: Path;
+  tag: "NonexistentFieldError";
+  field: Identifier;
+  path: Path;
 }
 
 export interface NonexistentGPIError {
-    tag: "NonexistentGPIError";
-    gpi: Identifier;
-    path: Path;
+  tag: "NonexistentGPIError";
+  gpi: Identifier;
+  path: Path;
 }
 
 export interface NonexistentPropertyError {
-    tag: "NonexistentPropertyError";
-    property: Identifier;
-    path: Path;
+  tag: "NonexistentPropertyError";
+  property: Identifier;
+  path: Path;
 }
 
 export interface ExpectedGPIGotFieldError {
-    tag: "ExpectedGPIGotFieldError";
-    field: Identifier;
-    path: Path;
+  tag: "ExpectedGPIGotFieldError";
+  field: Identifier;
+  path: Path;
 }
 
 export interface InvalidAccessPathError {
-    tag: "InvalidAccessPathError";
-    path: Path;
+  tag: "InvalidAccessPathError";
+  path: Path;
 }
 
 export interface CanvasNonexistentError {
-    tag: "CanvasNonexistentError";
+  tag: "CanvasNonexistentError";
 }
 
 export interface CanvasNonexistentDimsError {
-    tag: "CanvasNonexistentDimsError";
-    attr: "width" | "height";
-    kind: "missing" | "GPI" | "uninitialized" | "wrong type";
-    type?: string;
+  tag: "CanvasNonexistentDimsError";
+  attr: "width" | "height";
+  kind: "missing" | "GPI" | "uninitialized" | "wrong type";
+  type?: string;
 }
 
 //#endregion Translation validation errors
 
 // TODO(errors): use identifiers here
 export interface RuntimeValueTypeError {
-    tag: "RuntimeValueTypeError";
-    path: Path;
-    expectedType: string;
-    actualType: string;
+  tag: "RuntimeValueTypeError";
+  path: Path;
+  expectedType: string;
+  actualType: string;
 }
 
 //#endregion Style errors

--- a/packages/core/src/utils/Error.ts
+++ b/packages/core/src/utils/Error.ts
@@ -1,38 +1,38 @@
 import { prettyPrintPath } from "utils/OtherUtils";
 import { Maybe, Result } from "true-myth";
 const {
-    or,
-    and,
-    ok,
-    err,
-    andThen,
-    match,
-    ap,
-    unsafelyUnwrap,
-    isErr,
-    unsafelyGetErr,
+  or,
+  and,
+  ok,
+  err,
+  andThen,
+  match,
+  ap,
+  unsafelyUnwrap,
+  isErr,
+  unsafelyGetErr,
 } = Result;
 
 import { ShapeDef, shapedefs } from "renderer/ShapeDef";
 import {
-    DomainError,
-    SubstanceError,
-    CyclicSubtypes,
-    NotTypeConsInPrelude,
-    NotTypeConsInSubtype,
-    DuplicateName,
-    TypeNotFound,
-    VarNotFound,
-    TypeMismatch,
-    UnexpectedExprForNestedPred,
-    ArgLengthMismatch,
-    TypeArgLengthMismatch,
-    DeconstructNonconstructor,
-    FatalError,
-    ParseError,
-    PenroseError,
-    StyleError,
-    RuntimeError
+  DomainError,
+  SubstanceError,
+  CyclicSubtypes,
+  NotTypeConsInPrelude,
+  NotTypeConsInSubtype,
+  DuplicateName,
+  TypeNotFound,
+  VarNotFound,
+  TypeMismatch,
+  UnexpectedExprForNestedPred,
+  ArgLengthMismatch,
+  TypeArgLengthMismatch,
+  DeconstructNonconstructor,
+  FatalError,
+  ParseError,
+  PenroseError,
+  StyleError,
+  RuntimeError,
 } from "types/errors";
 import { Identifier, ASTNode, SourceLoc } from "types/ast";
 import { Type, Prop, TypeVar, TypeConstructor, Arg } from "types/domain";
@@ -45,494 +45,509 @@ import { isConcrete } from "engine/EngineUtils";
  * @param t Type to be printed
  */
 export const showType = (t: Type): string => {
-    if (t.tag === "Prop") {
-        return "Prop";
-    } else if (t.tag === "TypeVar") {
-        return `'${t.name.value}`;
-    } else {
-        const { name, args } = t;
-        if (args.length > 0) {
-            const argStrs = args.map(showType);
-            return `${name.value}(${argStrs.join(", ")})`;
-        } else return `${name.value}`;
-    }
+  if (t.tag === "Prop") {
+    return "Prop";
+  } else if (t.tag === "TypeVar") {
+    return `'${t.name.value}`;
+  } else {
+    const { name, args } = t;
+    if (args.length > 0) {
+      const argStrs = args.map(showType);
+      return `${name.value}(${argStrs.join(", ")})`;
+    } else return `${name.value}`;
+  }
 };
 // COMBAK What's a better way to model warnings?
 export const styWarnings = [
-    "DeletedPropWithNoSubObjError",
-    "DeletedPropWithNoFieldError",
-    "DeletedPropWithNoGPIError",
-    "DeletedNonexistentFieldError",
+  "DeletedPropWithNoSubObjError",
+  "DeletedPropWithNoFieldError",
+  "DeletedPropWithNoGPIError",
+  "DeletedNonexistentFieldError",
 ];
 
 // TODO: fix template formatting
 export const showError = (
-    error: DomainError | SubstanceError | StyleError | RuntimeError
+  error: DomainError | SubstanceError | StyleError | RuntimeError
 ): string => {
-    switch (error.tag) {
-        case "RuntimeError": {
-            return error.message;
-        }
-        case "ParseError":
-            return error.message;
-        case "TypeDeclared": {
-            return `Type ${error.typeName.value} already exists.`;
-        }
-        // TODO: abstract out this pattern if it becomes more common
-        case "VarNotFound": {
-            const { variable, possibleVars } = error;
-            const msg = `Variable ${variable.value} (at ${loc(
-                variable
-            )}) does not exist.`;
-            if (possibleVars) {
-                const suggestions = possibleVars.map((v) => v.value).join(", ");
-                return msg + ` Declared variables are: ${suggestions}`;
-            } else return msg;
-        }
-        case "TypeNotFound": {
-            const { typeName, possibleTypes } = error;
-            const msg = `Type ${typeName.value} (at ${loc(
-                typeName
-            )}) does not exist.`;
-            if (possibleTypes) {
-                const suggestions = possibleTypes
-                    .map(({ value }: Identifier) => value)
-                    .join(", ");
-                return msg + ` Possible types are: ${suggestions}`;
-            } else return msg;
-        }
-        case "TypeVarNotFound": {
-            return `Type variable ${error.typeVar.name.value} (at ${loc(
-                error.typeVar
-            )}) does not exist.`;
-        }
-        case "DuplicateName": {
-            const { firstDefined, name, location } = error;
-            return `Name ${name.value} (at ${loc(
-                location
-            )}) already exists, first declared at ${loc(firstDefined)}.`;
-        }
-        case "NotTypeConsInSubtype": {
-            if (error.type.tag === "Prop") {
-                return `Prop (at ${loc(
-                    error.type
-                )}) is not a type constructor. Only type constructors are allowed in subtyping relations.`;
-            } else {
-                return `${error.type.name.value} (at ${loc(
-                    error.type
-                )}) is not a type constructor. Only type constructors are allowed in subtyping relations.`;
-            }
-        }
-        case "CyclicSubtypes": {
-            return `Subtyping relations in this program form a cycle. Cycles of types are:\n${showCycles(
-                error.cycles
-            )}`;
-        }
-        case "NotTypeConsInPrelude": {
-            if (error.type.tag === "Prop") {
-                return `Prop (at ${loc(
-                    error.type
-                )}) is not a type constructor. Only type constructors are allowed for prelude values.`;
-            } else {
-                return `${error.type.name.value} (at ${loc(
-                    error.type
-                )}) is not a type constructor. Only type constructors are allowed in prelude values.`;
-            }
-        }
-        case "TypeMismatch": {
-            const { sourceExpr, sourceType, expectedExpr, expectedType } = error;
-            return `The type of the expression at ${loc(sourceExpr)} '${showType(
-                sourceType
-            )}' does not match with the expected type '${showType(
-                expectedType
-            )}' derived from the expression at ${loc(expectedExpr)}.`;
-        }
-        case "TypeArgLengthMismatch": {
-            const { sourceExpr, sourceType, expectedExpr, expectedType } = error;
-            return `${expectedType.args.length} arguments expected for type ${expectedType.name.value
-                } (defined at ${loc(expectedExpr)}), but ${sourceType.args.length
-                } arguments were given for ${sourceType.name.value} at ${loc(
-                    sourceExpr
-                )} `;
-        }
-        case "ArgLengthMismatch": {
-            const { name, argsGiven, argsExpected, sourceExpr, expectedExpr } = error;
-            return `${name.value} expects ${argsExpected.length
-                } arguments (originally defined at ${loc(expectedExpr)}), but was given ${argsGiven.length
-                } arguments instead at ${loc(sourceExpr)}.`;
-        }
-        case "DeconstructNonconstructor": {
-            const { variable, field } = error.deconstructor;
-            return `Becuase ${variable.value} is not bound to a constructor, ${variable.value
-                }.${field.value} (at ${loc(
-                    error.deconstructor
-                )}) does not correspond to a field value.`;
-        }
-        case "UnexpectedExprForNestedPred": {
-            const { sourceExpr, sourceType, expectedExpr } = error;
-            return `A nested predicate is expected (defined at ${loc(
-                expectedExpr
-            )}), but an expression of '${showType(
-                sourceType
-            )}' type was given at ${loc(sourceExpr)}.`;
-        }
+  switch (error.tag) {
+    case "RuntimeError": {
+      return error.message;
+    }
+    case "ParseError":
+      return error.message;
+    case "TypeDeclared": {
+      return `Type ${error.typeName.value} already exists.`;
+    }
+    // TODO: abstract out this pattern if it becomes more common
+    case "VarNotFound": {
+      const { variable, possibleVars } = error;
+      const msg = `Variable ${variable.value} (at ${loc(
+        variable
+      )}) does not exist.`;
+      if (possibleVars) {
+        const suggestions = possibleVars.map((v) => v.value).join(", ");
+        return msg + ` Declared variables are: ${suggestions}`;
+      } else return msg;
+    }
+    case "TypeNotFound": {
+      const { typeName, possibleTypes } = error;
+      const msg = `Type ${typeName.value} (at ${loc(
+        typeName
+      )}) does not exist.`;
+      if (possibleTypes) {
+        const suggestions = possibleTypes
+          .map(({ value }: Identifier) => value)
+          .join(", ");
+        return msg + ` Possible types are: ${suggestions}`;
+      } else return msg;
+    }
+    case "TypeVarNotFound": {
+      return `Type variable ${error.typeVar.name.value} (at ${loc(
+        error.typeVar
+      )}) does not exist.`;
+    }
+    case "DuplicateName": {
+      const { firstDefined, name, location } = error;
+      return `Name ${name.value} (at ${loc(
+        location
+      )}) already exists, first declared at ${loc(firstDefined)}.`;
+    }
+    case "NotTypeConsInSubtype": {
+      if (error.type.tag === "Prop") {
+        return `Prop (at ${loc(
+          error.type
+        )}) is not a type constructor. Only type constructors are allowed in subtyping relations.`;
+      } else {
+        return `${error.type.name.value} (at ${loc(
+          error.type
+        )}) is not a type constructor. Only type constructors are allowed in subtyping relations.`;
+      }
+    }
+    case "CyclicSubtypes": {
+      return `Subtyping relations in this program form a cycle. Cycles of types are:\n${showCycles(
+        error.cycles
+      )}`;
+    }
+    case "NotTypeConsInPrelude": {
+      if (error.type.tag === "Prop") {
+        return `Prop (at ${loc(
+          error.type
+        )}) is not a type constructor. Only type constructors are allowed for prelude values.`;
+      } else {
+        return `${error.type.name.value} (at ${loc(
+          error.type
+        )}) is not a type constructor. Only type constructors are allowed in prelude values.`;
+      }
+    }
+    case "TypeMismatch": {
+      const { sourceExpr, sourceType, expectedExpr, expectedType } = error;
+      return `The type of the expression at ${loc(sourceExpr)} '${showType(
+        sourceType
+      )}' does not match with the expected type '${showType(
+        expectedType
+      )}' derived from the expression at ${loc(expectedExpr)}.`;
+    }
+    case "TypeArgLengthMismatch": {
+      const { sourceExpr, sourceType, expectedExpr, expectedType } = error;
+      return `${expectedType.args.length} arguments expected for type ${
+        expectedType.name.value
+      } (defined at ${loc(expectedExpr)}), but ${
+        sourceType.args.length
+      } arguments were given for ${sourceType.name.value} at ${loc(
+        sourceExpr
+      )} `;
+    }
+    case "ArgLengthMismatch": {
+      const { name, argsGiven, argsExpected, sourceExpr, expectedExpr } = error;
+      return `${name.value} expects ${
+        argsExpected.length
+      } arguments (originally defined at ${loc(expectedExpr)}), but was given ${
+        argsGiven.length
+      } arguments instead at ${loc(sourceExpr)}.`;
+    }
+    case "DeconstructNonconstructor": {
+      const { variable, field } = error.deconstructor;
+      return `Becuase ${variable.value} is not bound to a constructor, ${
+        variable.value
+      }.${field.value} (at ${loc(
+        error.deconstructor
+      )}) does not correspond to a field value.`;
+    }
+    case "UnexpectedExprForNestedPred": {
+      const { sourceExpr, sourceType, expectedExpr } = error;
+      return `A nested predicate is expected (defined at ${loc(
+        expectedExpr
+      )}), but an expression of '${showType(
+        sourceType
+      )}' type was given at ${loc(sourceExpr)}.`;
+    }
 
-        // ---- BEGIN STYLE ERRORS
-        // COMBAK suggest improvements after reporting errors
+    // ---- BEGIN STYLE ERRORS
+    // COMBAK suggest improvements after reporting errors
 
-        case "GenericStyleError": {
-            return `DEBUG: Style failed with errors:\n ${error.messages.join("\n")}`;
-        }
+    case "GenericStyleError": {
+      return `DEBUG: Style failed with errors:\n ${error.messages.join("\n")}`;
+    }
 
-        case "SelectorDeclTypeError": {
-            // COMBAK Maybe this should be a TaggedSubstanceError?
-            return "Substance type error in declaration in selector";
-        }
+    case "SelectorDeclTypeError": {
+      // COMBAK Maybe this should be a TaggedSubstanceError?
+      return "Substance type error in declaration in selector";
+    }
 
-        case "StyleErrorList": {
-            return error.errors.map(showError).join(", ");
-        }
+    case "StyleErrorList": {
+      return error.errors.map(showError).join(", ");
+    }
 
-        case "SelectorVarMultipleDecl": {
-            return `Style pattern statement has already declared the variable ${error.varName.contents.value}`;
-        }
+    case "SelectorVarMultipleDecl": {
+      return `Style pattern statement has already declared the variable ${error.varName.contents.value}`;
+    }
 
-        case "SelectorDeclTypeMismatch": {
-            // COMBAK: Add code for prettyprinting types
-            return "Mismatched types or wrong subtypes between Substance and Style variables in selector";
-        }
+    case "SelectorDeclTypeMismatch": {
+      // COMBAK: Add code for prettyprinting types
+      return "Mismatched types or wrong subtypes between Substance and Style variables in selector";
+    }
 
-        case "SelectorRelTypeMismatch": {
-            // COMBAK: Add code for prettyprinting types
-            return "Mismatched types or wrong subtypes between variable and expression in relational statement in selector";
-        }
+    case "SelectorRelTypeMismatch": {
+      // COMBAK: Add code for prettyprinting types
+      return "Mismatched types or wrong subtypes between variable and expression in relational statement in selector";
+    }
 
-        case "TaggedSubstanceError": {
-            return showError(error.error); // Substance error
-        }
+    case "TaggedSubstanceError": {
+      return showError(error.error); // Substance error
+    }
 
-        // --- BEGIN BLOCK STATIC ERRORS
+    // --- BEGIN BLOCK STATIC ERRORS
 
-        case "InvalidGPITypeError": {
-            const shapeNames: string[] = shapedefs.map((e: ShapeDef) => e.shapeType);
-            return `Got invalid GPI type ${error.givenType.value}. Available shape types: ${shapeNames}`;
-        }
+    case "InvalidGPITypeError": {
+      const shapeNames: string[] = shapedefs.map((e: ShapeDef) => e.shapeType);
+      return `Got invalid GPI type ${error.givenType.value}. Available shape types: ${shapeNames}`;
+    }
 
-        case "InvalidGPIPropertyError": {
-            return `Got invalid GPI property ${error.givenProperty.value}. Available properties: ${error.expectedProperties}`;
-        }
+    case "InvalidGPIPropertyError": {
+      return `Got invalid GPI property ${error.givenProperty.value}. Available properties: ${error.expectedProperties}`;
+    }
 
-        case "InvalidFunctionNameError": {
-            return `Got invalid Function name '${error.givenName.value}'.`;
-            // COMBAK: Function suggestions, or just print the list
-        }
+    case "InvalidFunctionNameError": {
+      return `Got invalid Function name '${error.givenName.value}'.`;
+      // COMBAK: Function suggestions, or just print the list
+    }
 
-        case "InvalidObjectiveNameError": {
-            return `Got invalid objective name '${error.givenName.value}'.`;
-            // COMBAK: Objective suggestions, or just print the list
-        }
+    case "InvalidObjectiveNameError": {
+      return `Got invalid objective name '${error.givenName.value}'.`;
+      // COMBAK: Objective suggestions, or just print the list
+    }
 
-        case "InvalidConstraintNameError": {
-            return `Got invalid constraint name '${error.givenName.value}'.`;
-            // COMBAK: Constraint suggestions, or just print the list
-        }
+    case "InvalidConstraintNameError": {
+      return `Got invalid constraint name '${error.givenName.value}'.`;
+      // COMBAK: Constraint suggestions, or just print the list
+    }
 
-        // --- END BLOCK STATIC ERRORS
+    // --- END BLOCK STATIC ERRORS
 
-        case "DeletedPropWithNoSubObjError": {
-            return `Sub obj '${error.subObj.contents.value
-                }' has no fields; can't delete path '${prettyPrintPath(error.path)}'`;
-        }
+    case "DeletedPropWithNoSubObjError": {
+      return `Sub obj '${
+        error.subObj.contents.value
+      }' has no fields; can't delete path '${prettyPrintPath(error.path)}'`;
+    }
 
-        case "DeletedPropWithNoFieldError": {
-            return `Sub obj '${error.subObj.contents.value}' already lacks field ${error.field.value
-                }; can't delete path '${prettyPrintPath(error.path)}'`;
-        }
+    case "DeletedPropWithNoFieldError": {
+      return `Sub obj '${error.subObj.contents.value}' already lacks field ${
+        error.field.value
+      }; can't delete path '${prettyPrintPath(error.path)}'`;
+    }
 
-        case "CircularPathAlias": {
-            return `Path '${prettyPrintPath(error.path)}' was aliased to itself`;
-        }
+    case "CircularPathAlias": {
+      return `Path '${prettyPrintPath(error.path)}' was aliased to itself`;
+    }
 
-        case "DeletedPropWithNoGPIError": {
-            return `Sub obj '${error.subObj.contents.value}' does not have GPI '${error.field.value
-                }'; cannot delete property '${error.property.value
-                }' in '${prettyPrintPath(error.path)}'`;
-        }
+    case "DeletedPropWithNoGPIError": {
+      return `Sub obj '${error.subObj.contents.value}' does not have GPI '${
+        error.field.value
+      }'; cannot delete property '${
+        error.property.value
+      }' in '${prettyPrintPath(error.path)}'`;
+    }
 
-        // TODO: Use input path to report location?
-        case "DeletedNonexistentFieldError": {
-            return `Trying to delete '${error.field.value}' from SubObj '${error.subObj.contents.value}', which already lacks the field`;
-        }
+    // TODO: Use input path to report location?
+    case "DeletedNonexistentFieldError": {
+      return `Trying to delete '${error.field.value}' from SubObj '${error.subObj.contents.value}', which already lacks the field`;
+    }
 
-        case "DeletedVectorElemError": {
-            return `Cannot delete an element of a vector: '${prettyPrintPath(
-                error.path
-            )}'`;
-        }
+    case "DeletedVectorElemError": {
+      return `Cannot delete an element of a vector: '${prettyPrintPath(
+        error.path
+      )}'`;
+    }
 
-        case "InsertedPathWithoutOverrideError": {
-            return `Overriding path '${prettyPrintPath(
-                error.path
-            )}' without override flag set`;
-        }
+    case "InsertedPathWithoutOverrideError": {
+      return `Overriding path '${prettyPrintPath(
+        error.path
+      )}' without override flag set`;
+    }
 
-        case "InsertedPropWithNoFieldError": {
-            return `Sub obj '${error.subObj.contents.value}' does not have field '${error.field.value
-                }'; cannot add property '${error.property.value}' in '${prettyPrintPath(
-                    error.path
-                )}'`;
-        }
+    case "InsertedPropWithNoFieldError": {
+      return `Sub obj '${error.subObj.contents.value}' does not have field '${
+        error.field.value
+      }'; cannot add property '${error.property.value}' in '${prettyPrintPath(
+        error.path
+      )}'`;
+    }
 
-        case "InsertedPropWithNoGPIError": {
-            return `Sub obj '${error.subObj.contents.value
-                }' has field but does not have GPI '${error.field.value
-                }'; cannot add property '${error.property.value}' in '${prettyPrintPath(
-                    error.path
-                )}'. Expected GPI.`;
-        }
+    case "InsertedPropWithNoGPIError": {
+      return `Sub obj '${
+        error.subObj.contents.value
+      }' has field but does not have GPI '${
+        error.field.value
+      }'; cannot add property '${error.property.value}' in '${prettyPrintPath(
+        error.path
+      )}'. Expected GPI.`;
+    }
 
-        // ----- BEGIN TRANSLATION VALIDATION ERRORS
+    // ----- BEGIN TRANSLATION VALIDATION ERRORS
 
-        case "NonexistentNameError": {
-            return `Error looking up path '${prettyPrintPath(
-                error.path
-            )}' in translation. Name '${error.name.value}' does not exist.`;
-        }
+    case "NonexistentNameError": {
+      return `Error looking up path '${prettyPrintPath(
+        error.path
+      )}' in translation. Name '${error.name.value}' does not exist.`;
+    }
 
-        case "NonexistentFieldError": {
-            return `Error looking up path '${prettyPrintPath(
-                error.path
-            )}' in translation. Field '${error.field.value}' does not exist.`;
-        }
+    case "NonexistentFieldError": {
+      return `Error looking up path '${prettyPrintPath(
+        error.path
+      )}' in translation. Field '${error.field.value}' does not exist.`;
+    }
 
-        case "NonexistentGPIError": {
-            return `Error looking up path '${prettyPrintPath(
-                error.path
-            )}' in translation. GPI '${error.gpi.value}' does not exist.`;
-        }
+    case "NonexistentGPIError": {
+      return `Error looking up path '${prettyPrintPath(
+        error.path
+      )}' in translation. GPI '${error.gpi.value}' does not exist.`;
+    }
 
-        case "NonexistentPropertyError": {
-            return `Error looking up path '${prettyPrintPath(
-                error.path
-            )}' in translation. Property '${error.property.value}' does not exist.`;
-        }
+    case "NonexistentPropertyError": {
+      return `Error looking up path '${prettyPrintPath(
+        error.path
+      )}' in translation. Property '${error.property.value}' does not exist.`;
+    }
 
-        case "ExpectedGPIGotFieldError": {
-            return `Error looking up path '${prettyPrintPath(
-                error.path
-            )}' in translation. Expected GPI '${error.field.value
-                }' does not exist; got a field instead.`;
-        }
+    case "ExpectedGPIGotFieldError": {
+      return `Error looking up path '${prettyPrintPath(
+        error.path
+      )}' in translation. Expected GPI '${
+        error.field.value
+      }' does not exist; got a field instead.`;
+    }
 
-        case "InvalidAccessPathError": {
-            return `Error looking up path '${prettyPrintPath(
-                error.path
-            )}' in translation.`;
-        }
+    case "InvalidAccessPathError": {
+      return `Error looking up path '${prettyPrintPath(
+        error.path
+      )}' in translation.`;
+    }
 
-        case "CanvasNonexistentError": {
-            return `Canvas properties are not defined.\nTry adding:
+    case "CanvasNonexistentError": {
+      return `Canvas properties are not defined.\nTry adding:
 canvas {
     width = <my desired width>
     height = <my desired height>
 }`;
-        }
+    }
 
-        case "CanvasNonexistentDimsError": {
-            switch (error.kind) {
-                case "missing":
-                    return `Canvas ${error.attr} is not defined.\nTry adding:
+    case "CanvasNonexistentDimsError": {
+      switch (error.kind) {
+        case "missing":
+          return `Canvas ${error.attr} is not defined.\nTry adding:
 canvas {
     ${error.attr} = <my desired ${error.attr}>
 }`;
-                case "GPI":
-                    return `Canvas ${error.attr} must be a numeric literal, but it is a shape.`;
-                case "uninitialized":
-                    return `Canvas ${error.attr} must be a numeric literal, but it is an expression or uninitialized.`;
-                case "wrong type":
-                    return `Canvas ${error.attr} must be a numeric literal, but it has type ${error.type}.`;
-            }
-        }
-
-        // ----- END TRANSLATION VALIDATION ERRORS
-
-        // TODO(errors): use identifiers here
-        case "RuntimeValueTypeError": {
-            return `Runtime type error in looking up path '${prettyPrintPath(
-                error.path
-            )}''s value in translation. Expected type: '${error.expectedType
-                }]. Got type: ]${error.actualType}].`;
-        }
-
-        // ----- END STYLE ERRORS
-
-        case "Fatal": {
-            return `FATAL: ${error.message}`;
-        }
-
-        default: {
-            return `Meta: Cannot render error with contents: ${JSON.stringify(
-                error
-            )}`;
-        }
+        case "GPI":
+          return `Canvas ${error.attr} must be a numeric literal, but it is a shape.`;
+        case "uninitialized":
+          return `Canvas ${error.attr} must be a numeric literal, but it is an expression or uninitialized.`;
+        case "wrong type":
+          return `Canvas ${error.attr} must be a numeric literal, but it has type ${error.type}.`;
+      }
     }
+
+    // ----- END TRANSLATION VALIDATION ERRORS
+
+    // TODO(errors): use identifiers here
+    case "RuntimeValueTypeError": {
+      return `Runtime type error in looking up path '${prettyPrintPath(
+        error.path
+      )}''s value in translation. Expected type: '${
+        error.expectedType
+      }]. Got type: ]${error.actualType}].`;
+    }
+
+    // ----- END STYLE ERRORS
+
+    case "Fatal": {
+      return `FATAL: ${error.message}`;
+    }
+
+    default: {
+      return `Meta: Cannot render error with contents: ${JSON.stringify(
+        error
+      )}`;
+    }
+  }
 };
 
 const showCycles = (cycles: string[][]) => {
-    const pathString = (path: string[]) => path.join(" -> ");
-    return cycles.map(pathString).join("\n");
+  const pathString = (path: string[]) => path.join(" -> ");
+  return cycles.map(pathString).join("\n");
 };
 
 export const cyclicSubtypes = (cycles: string[][]): CyclicSubtypes => ({
-    tag: "CyclicSubtypes",
-    cycles,
+  tag: "CyclicSubtypes",
+  cycles,
 });
 
 export const notTypeConsInPrelude = (
-    type: Prop | TypeVar
+  type: Prop | TypeVar
 ): NotTypeConsInPrelude => ({
-    tag: "NotTypeConsInPrelude",
-    type,
+  tag: "NotTypeConsInPrelude",
+  type,
 });
 
 export const notTypeConsInSubtype = (
-    type: Prop | TypeVar
+  type: Prop | TypeVar
 ): NotTypeConsInSubtype => ({
-    tag: "NotTypeConsInSubtype",
-    type,
+  tag: "NotTypeConsInSubtype",
+  type,
 });
 
 // action constructors for error
 export const duplicateName = (
-    name: Identifier,
-    location: ASTNode,
-    firstDefined: ASTNode
+  name: Identifier,
+  location: ASTNode,
+  firstDefined: ASTNode
 ): DuplicateName => ({
-    tag: "DuplicateName",
-    name,
-    location,
-    firstDefined,
+  tag: "DuplicateName",
+  name,
+  location,
+  firstDefined,
 });
 
 export const typeNotFound = (
-    typeName: Identifier,
-    possibleTypes?: Identifier[]
+  typeName: Identifier,
+  possibleTypes?: Identifier[]
 ): TypeNotFound => ({
-    tag: "TypeNotFound",
-    typeName,
-    possibleTypes,
+  tag: "TypeNotFound",
+  typeName,
+  possibleTypes,
 });
 
 export const varNotFound = (
-    variable: Identifier,
-    possibleVars?: Identifier[]
+  variable: Identifier,
+  possibleVars?: Identifier[]
 ): VarNotFound => ({
-    tag: "VarNotFound",
-    variable,
-    possibleVars,
+  tag: "VarNotFound",
+  variable,
+  possibleVars,
 });
 
 export const typeMismatch = (
-    sourceType: TypeConstructor,
-    expectedType: TypeConstructor,
-    sourceExpr: ASTNode,
-    expectedExpr: ASTNode
+  sourceType: TypeConstructor,
+  expectedType: TypeConstructor,
+  sourceExpr: ASTNode,
+  expectedExpr: ASTNode
 ): TypeMismatch => ({
-    tag: "TypeMismatch",
-    sourceExpr,
-    sourceType,
-    expectedExpr,
-    expectedType,
+  tag: "TypeMismatch",
+  sourceExpr,
+  sourceType,
+  expectedExpr,
+  expectedType,
 });
 
 export const unexpectedExprForNestedPred = (
-    sourceType: TypeConstructor,
-    sourceExpr: ASTNode,
-    expectedExpr: ASTNode
+  sourceType: TypeConstructor,
+  sourceExpr: ASTNode,
+  expectedExpr: ASTNode
 ): UnexpectedExprForNestedPred => ({
-    tag: "UnexpectedExprForNestedPred",
-    sourceType,
-    sourceExpr,
-    expectedExpr,
+  tag: "UnexpectedExprForNestedPred",
+  sourceType,
+  sourceExpr,
+  expectedExpr,
 });
 
 export const argLengthMismatch = (
-    name: Identifier,
-    argsGiven: SubExpr[],
-    argsExpected: Arg[],
-    sourceExpr: ASTNode,
-    expectedExpr: ASTNode
+  name: Identifier,
+  argsGiven: SubExpr[],
+  argsExpected: Arg[],
+  sourceExpr: ASTNode,
+  expectedExpr: ASTNode
 ): ArgLengthMismatch => ({
-    tag: "ArgLengthMismatch",
-    name,
-    argsGiven,
-    argsExpected,
-    sourceExpr,
-    expectedExpr,
+  tag: "ArgLengthMismatch",
+  name,
+  argsGiven,
+  argsExpected,
+  sourceExpr,
+  expectedExpr,
 });
 
 export const typeArgLengthMismatch = (
-    sourceType: TypeConstructor,
-    expectedType: TypeConstructor,
-    sourceExpr: ASTNode,
-    expectedExpr: ASTNode
+  sourceType: TypeConstructor,
+  expectedType: TypeConstructor,
+  sourceExpr: ASTNode,
+  expectedExpr: ASTNode
 ): TypeArgLengthMismatch => ({
-    tag: "TypeArgLengthMismatch",
-    sourceExpr,
-    sourceType,
-    expectedExpr,
-    expectedType,
+  tag: "TypeArgLengthMismatch",
+  sourceExpr,
+  sourceType,
+  expectedExpr,
+  expectedType,
 });
 
 export const deconstructNonconstructor = (
-    deconstructor: Deconstructor
+  deconstructor: Deconstructor
 ): DeconstructNonconstructor => ({
-    tag: "DeconstructNonconstructor",
-    deconstructor,
+  tag: "DeconstructNonconstructor",
+  deconstructor,
 });
 
 export const fatalError = (message: string): FatalError => ({
-    tag: "Fatal",
-    message,
+  tag: "Fatal",
+  message,
 });
 
 export const parseError = (
-    message: string,
-    location?: SourceLoc
+  message: string,
+  location?: SourceLoc
 ): ParseError => ({
-    tag: "ParseError",
-    message,
-    location,
+  tag: "ParseError",
+  message,
+  location,
 });
 
 // If there are multiple errors, just return the tag of the first one
 export const toStyleErrors = (errors: StyleError[]): PenroseError => {
-    if (!errors.length) {
-        throw Error("internal error: expected at least one Style error");
-    }
+  if (!errors.length) {
+    throw Error("internal error: expected at least one Style error");
+  }
 
-    return {
-        errorType: "StyleError",
-        tag: "StyleErrorList",
-        errors,
-    };
+  return {
+    errorType: "StyleError",
+    tag: "StyleErrorList",
+    errors,
+  };
 };
 
 export const genericStyleError = (messages: StyleError[]): PenroseError => ({
-    errorType: "StyleError",
-    tag: "GenericStyleError",
-    messages: messages.map(showError),
+  errorType: "StyleError",
+  tag: "GenericStyleError",
+  messages: messages.map(showError),
 });
 
 // const loc = (node: ASTNode) => `${node.start.line}:${node.start.col}`;
 // TODO: Show file name
 const loc = (node: ASTNode): string => {
-    if (isConcrete(node)) {
-        return `line ${node.start.line}, column ${node.start.col + 1} of ${node.nodeType
-            } program`;
-    } else {
-        return `generated code by the compiler`; // TODO: better description of where the node is coming from
-    }
+  if (isConcrete(node)) {
+    return `line ${node.start.line}, column ${node.start.col + 1} of ${
+      node.nodeType
+    } program`;
+  } else {
+    return `generated code by the compiler`; // TODO: better description of where the node is coming from
+  }
 };
 
 // #endregion
@@ -540,62 +555,62 @@ const loc = (node: ASTNode): string => {
 // #region Either monad
 
 export const every = <Ok, Error>(
-    ...results: Result<Ok, Error>[]
+  ...results: Result<Ok, Error>[]
 ): Result<Ok, Error> =>
-    results.reduce(
-        (currentResult: Result<Ok, Error>, nextResult: Result<Ok, Error>) =>
-            and(nextResult, currentResult),
-        results[0] // TODO: separate out this element in argument
-    );
+  results.reduce(
+    (currentResult: Result<Ok, Error>, nextResult: Result<Ok, Error>) =>
+      and(nextResult, currentResult),
+    results[0] // TODO: separate out this element in argument
+  );
 
 export const safeChain = <Item, Ok, Error>(
-    itemList: Item[],
-    func: (nextItem: Item, currentResult: Ok) => Result<Ok, Error>,
-    initialResult: Result<Ok, Error>
+  itemList: Item[],
+  func: (nextItem: Item, currentResult: Ok) => Result<Ok, Error>,
+  initialResult: Result<Ok, Error>
 ): Result<Ok, Error> =>
-    itemList.reduce(
-        (currentResult: Result<Ok, Error>, nextItem: Item) =>
-            andThen((res: Ok) => func(nextItem, res), currentResult),
-        initialResult
-    );
+  itemList.reduce(
+    (currentResult: Result<Ok, Error>, nextItem: Item) =>
+      andThen((res: Ok) => func(nextItem, res), currentResult),
+    initialResult
+  );
 
 /**
  * Hand-written version of `Result.all`.
  */
 export const all = <Ok, Error>(
-    results: Result<Ok, Error>[]
+  results: Result<Ok, Error>[]
 ): Result<Ok[], Error> => {
-    return results.reduce(
-        (
-            currentResults: Result<Ok[], Error>,
-            nextResult: Result<Ok, Error>
-        ): Result<Ok[], Error> =>
-            currentResults.match({
-                Ok: (current: Ok[]) =>
-                    nextResult.match({
-                        Ok: (next: Ok) => ok([...current, next]),
-                        Err: (e: Error) => err(e),
-                    }),
-                Err: (e: Error) => err(e),
-            }),
-        ok([])
-    );
+  return results.reduce(
+    (
+      currentResults: Result<Ok[], Error>,
+      nextResult: Result<Ok, Error>
+    ): Result<Ok[], Error> =>
+      currentResults.match({
+        Ok: (current: Ok[]) =>
+          nextResult.match({
+            Ok: (next: Ok) => ok([...current, next]),
+            Err: (e: Error) => err(e),
+          }),
+        Err: (e: Error) => err(e),
+      }),
+    ok([])
+  );
 };
 
 // NOTE: re-export all true-myth types to reduce boilerplate
 export {
-    Maybe,
-    Result,
-    and,
-    or,
-    ok,
-    err,
-    andThen,
-    ap,
-    match,
-    unsafelyUnwrap,
-    isErr,
-    unsafelyGetErr,
+  Maybe,
+  Result,
+  and,
+  or,
+  ok,
+  err,
+  andThen,
+  ap,
+  match,
+  unsafelyUnwrap,
+  isErr,
+  unsafelyGetErr,
 };
 
 // #endregion

--- a/packages/core/src/utils/Error.ts
+++ b/packages/core/src/utils/Error.ts
@@ -1,37 +1,38 @@
 import { prettyPrintPath } from "utils/OtherUtils";
 import { Maybe, Result } from "true-myth";
 const {
-  or,
-  and,
-  ok,
-  err,
-  andThen,
-  match,
-  ap,
-  unsafelyUnwrap,
-  isErr,
-  unsafelyGetErr,
+    or,
+    and,
+    ok,
+    err,
+    andThen,
+    match,
+    ap,
+    unsafelyUnwrap,
+    isErr,
+    unsafelyGetErr,
 } = Result;
 
 import { ShapeDef, shapedefs } from "renderer/ShapeDef";
 import {
-  DomainError,
-  SubstanceError,
-  CyclicSubtypes,
-  NotTypeConsInPrelude,
-  NotTypeConsInSubtype,
-  DuplicateName,
-  TypeNotFound,
-  VarNotFound,
-  TypeMismatch,
-  UnexpectedExprForNestedPred,
-  ArgLengthMismatch,
-  TypeArgLengthMismatch,
-  DeconstructNonconstructor,
-  FatalError,
-  ParseError,
-  PenroseError,
-  StyleError,
+    DomainError,
+    SubstanceError,
+    CyclicSubtypes,
+    NotTypeConsInPrelude,
+    NotTypeConsInSubtype,
+    DuplicateName,
+    TypeNotFound,
+    VarNotFound,
+    TypeMismatch,
+    UnexpectedExprForNestedPred,
+    ArgLengthMismatch,
+    TypeArgLengthMismatch,
+    DeconstructNonconstructor,
+    FatalError,
+    ParseError,
+    PenroseError,
+    StyleError,
+    RuntimeError
 } from "types/errors";
 import { Identifier, ASTNode, SourceLoc } from "types/ast";
 import { Type, Prop, TypeVar, TypeConstructor, Arg } from "types/domain";
@@ -44,506 +45,494 @@ import { isConcrete } from "engine/EngineUtils";
  * @param t Type to be printed
  */
 export const showType = (t: Type): string => {
-  if (t.tag === "Prop") {
-    return "Prop";
-  } else if (t.tag === "TypeVar") {
-    return `'${t.name.value}`;
-  } else {
-    const { name, args } = t;
-    if (args.length > 0) {
-      const argStrs = args.map(showType);
-      return `${name.value}(${argStrs.join(", ")})`;
-    } else return `${name.value}`;
-  }
+    if (t.tag === "Prop") {
+        return "Prop";
+    } else if (t.tag === "TypeVar") {
+        return `'${t.name.value}`;
+    } else {
+        const { name, args } = t;
+        if (args.length > 0) {
+            const argStrs = args.map(showType);
+            return `${name.value}(${argStrs.join(", ")})`;
+        } else return `${name.value}`;
+    }
 };
 // COMBAK What's a better way to model warnings?
 export const styWarnings = [
-  "DeletedPropWithNoSubObjError",
-  "DeletedPropWithNoFieldError",
-  "DeletedPropWithNoGPIError",
-  "DeletedNonexistentFieldError",
+    "DeletedPropWithNoSubObjError",
+    "DeletedPropWithNoFieldError",
+    "DeletedPropWithNoGPIError",
+    "DeletedNonexistentFieldError",
 ];
 
 // TODO: fix template formatting
 export const showError = (
-  error: DomainError | SubstanceError | StyleError
+    error: DomainError | SubstanceError | StyleError | RuntimeError
 ): string => {
-  switch (error.tag) {
-    case "ParseError":
-      return error.message;
-    case "TypeDeclared": {
-      return `Type ${error.typeName.value} already exists.`;
-    }
-    // TODO: abstract out this pattern if it becomes more common
-    case "VarNotFound": {
-      const { variable, possibleVars } = error;
-      const msg = `Variable ${variable.value} (at ${loc(
-        variable
-      )}) does not exist.`;
-      if (possibleVars) {
-        const suggestions = possibleVars.map((v) => v.value).join(", ");
-        return msg + ` Declared variables are: ${suggestions}`;
-      } else return msg;
-    }
-    case "TypeNotFound": {
-      const { typeName, possibleTypes } = error;
-      const msg = `Type ${typeName.value} (at ${loc(
-        typeName
-      )}) does not exist.`;
-      if (possibleTypes) {
-        const suggestions = possibleTypes
-          .map(({ value }: Identifier) => value)
-          .join(", ");
-        return msg + ` Possible types are: ${suggestions}`;
-      } else return msg;
-    }
-    case "TypeVarNotFound": {
-      return `Type variable ${error.typeVar.name.value} (at ${loc(
-        error.typeVar
-      )}) does not exist.`;
-    }
-    case "DuplicateName": {
-      const { firstDefined, name, location } = error;
-      return `Name ${name.value} (at ${loc(
-        location
-      )}) already exists, first declared at ${loc(firstDefined)}.`;
-    }
-    case "NotTypeConsInSubtype": {
-      if (error.type.tag === "Prop") {
-        return `Prop (at ${loc(
-          error.type
-        )}) is not a type constructor. Only type constructors are allowed in subtyping relations.`;
-      } else {
-        return `${error.type.name.value} (at ${loc(
-          error.type
-        )}) is not a type constructor. Only type constructors are allowed in subtyping relations.`;
-      }
-    }
-    case "CyclicSubtypes": {
-      return `Subtyping relations in this program form a cycle. Cycles of types are:\n${showCycles(
-        error.cycles
-      )}`;
-    }
-    case "NotTypeConsInPrelude": {
-      if (error.type.tag === "Prop") {
-        return `Prop (at ${loc(
-          error.type
-        )}) is not a type constructor. Only type constructors are allowed for prelude values.`;
-      } else {
-        return `${error.type.name.value} (at ${loc(
-          error.type
-        )}) is not a type constructor. Only type constructors are allowed in prelude values.`;
-      }
-    }
-    case "TypeMismatch": {
-      const { sourceExpr, sourceType, expectedExpr, expectedType } = error;
-      return `The type of the expression at ${loc(sourceExpr)} '${showType(
-        sourceType
-      )}' does not match with the expected type '${showType(
-        expectedType
-      )}' derived from the expression at ${loc(expectedExpr)}.`;
-    }
-    case "TypeArgLengthMismatch": {
-      const { sourceExpr, sourceType, expectedExpr, expectedType } = error;
-      return `${expectedType.args.length} arguments expected for type ${
-        expectedType.name.value
-      } (defined at ${loc(expectedExpr)}), but ${
-        sourceType.args.length
-      } arguments were given for ${sourceType.name.value} at ${loc(
-        sourceExpr
-      )} `;
-    }
-    case "ArgLengthMismatch": {
-      const { name, argsGiven, argsExpected, sourceExpr, expectedExpr } = error;
-      return `${name.value} expects ${
-        argsExpected.length
-      } arguments (originally defined at ${loc(expectedExpr)}), but was given ${
-        argsGiven.length
-      } arguments instead at ${loc(sourceExpr)}.`;
-    }
-    case "DeconstructNonconstructor": {
-      const { variable, field } = error.deconstructor;
-      return `Becuase ${variable.value} is not bound to a constructor, ${
-        variable.value
-      }.${field.value} (at ${loc(
-        error.deconstructor
-      )}) does not correspond to a field value.`;
-    }
-    case "UnexpectedExprForNestedPred": {
-      const { sourceExpr, sourceType, expectedExpr } = error;
-      return `A nested predicate is expected (defined at ${loc(
-        expectedExpr
-      )}), but an expression of '${showType(
-        sourceType
-      )}' type was given at ${loc(sourceExpr)}.`;
-    }
+    switch (error.tag) {
+        case "RuntimeError": {
+            return error.message;
+        }
+        case "ParseError":
+            return error.message;
+        case "TypeDeclared": {
+            return `Type ${error.typeName.value} already exists.`;
+        }
+        // TODO: abstract out this pattern if it becomes more common
+        case "VarNotFound": {
+            const { variable, possibleVars } = error;
+            const msg = `Variable ${variable.value} (at ${loc(
+                variable
+            )}) does not exist.`;
+            if (possibleVars) {
+                const suggestions = possibleVars.map((v) => v.value).join(", ");
+                return msg + ` Declared variables are: ${suggestions}`;
+            } else return msg;
+        }
+        case "TypeNotFound": {
+            const { typeName, possibleTypes } = error;
+            const msg = `Type ${typeName.value} (at ${loc(
+                typeName
+            )}) does not exist.`;
+            if (possibleTypes) {
+                const suggestions = possibleTypes
+                    .map(({ value }: Identifier) => value)
+                    .join(", ");
+                return msg + ` Possible types are: ${suggestions}`;
+            } else return msg;
+        }
+        case "TypeVarNotFound": {
+            return `Type variable ${error.typeVar.name.value} (at ${loc(
+                error.typeVar
+            )}) does not exist.`;
+        }
+        case "DuplicateName": {
+            const { firstDefined, name, location } = error;
+            return `Name ${name.value} (at ${loc(
+                location
+            )}) already exists, first declared at ${loc(firstDefined)}.`;
+        }
+        case "NotTypeConsInSubtype": {
+            if (error.type.tag === "Prop") {
+                return `Prop (at ${loc(
+                    error.type
+                )}) is not a type constructor. Only type constructors are allowed in subtyping relations.`;
+            } else {
+                return `${error.type.name.value} (at ${loc(
+                    error.type
+                )}) is not a type constructor. Only type constructors are allowed in subtyping relations.`;
+            }
+        }
+        case "CyclicSubtypes": {
+            return `Subtyping relations in this program form a cycle. Cycles of types are:\n${showCycles(
+                error.cycles
+            )}`;
+        }
+        case "NotTypeConsInPrelude": {
+            if (error.type.tag === "Prop") {
+                return `Prop (at ${loc(
+                    error.type
+                )}) is not a type constructor. Only type constructors are allowed for prelude values.`;
+            } else {
+                return `${error.type.name.value} (at ${loc(
+                    error.type
+                )}) is not a type constructor. Only type constructors are allowed in prelude values.`;
+            }
+        }
+        case "TypeMismatch": {
+            const { sourceExpr, sourceType, expectedExpr, expectedType } = error;
+            return `The type of the expression at ${loc(sourceExpr)} '${showType(
+                sourceType
+            )}' does not match with the expected type '${showType(
+                expectedType
+            )}' derived from the expression at ${loc(expectedExpr)}.`;
+        }
+        case "TypeArgLengthMismatch": {
+            const { sourceExpr, sourceType, expectedExpr, expectedType } = error;
+            return `${expectedType.args.length} arguments expected for type ${expectedType.name.value
+                } (defined at ${loc(expectedExpr)}), but ${sourceType.args.length
+                } arguments were given for ${sourceType.name.value} at ${loc(
+                    sourceExpr
+                )} `;
+        }
+        case "ArgLengthMismatch": {
+            const { name, argsGiven, argsExpected, sourceExpr, expectedExpr } = error;
+            return `${name.value} expects ${argsExpected.length
+                } arguments (originally defined at ${loc(expectedExpr)}), but was given ${argsGiven.length
+                } arguments instead at ${loc(sourceExpr)}.`;
+        }
+        case "DeconstructNonconstructor": {
+            const { variable, field } = error.deconstructor;
+            return `Becuase ${variable.value} is not bound to a constructor, ${variable.value
+                }.${field.value} (at ${loc(
+                    error.deconstructor
+                )}) does not correspond to a field value.`;
+        }
+        case "UnexpectedExprForNestedPred": {
+            const { sourceExpr, sourceType, expectedExpr } = error;
+            return `A nested predicate is expected (defined at ${loc(
+                expectedExpr
+            )}), but an expression of '${showType(
+                sourceType
+            )}' type was given at ${loc(sourceExpr)}.`;
+        }
 
-    // ---- BEGIN STYLE ERRORS
-    // COMBAK suggest improvements after reporting errors
+        // ---- BEGIN STYLE ERRORS
+        // COMBAK suggest improvements after reporting errors
 
-    case "GenericStyleError": {
-      return `DEBUG: Style failed with errors:\n ${error.messages.join("\n")}`;
-    }
+        case "GenericStyleError": {
+            return `DEBUG: Style failed with errors:\n ${error.messages.join("\n")}`;
+        }
 
-    case "SelectorDeclTypeError": {
-      // COMBAK Maybe this should be a TaggedSubstanceError?
-      return "Substance type error in declaration in selector";
-    }
+        case "SelectorDeclTypeError": {
+            // COMBAK Maybe this should be a TaggedSubstanceError?
+            return "Substance type error in declaration in selector";
+        }
 
-    case "StyleErrorList": {
-      return error.errors.map(showError).join(", ");
-    }
+        case "StyleErrorList": {
+            return error.errors.map(showError).join(", ");
+        }
 
-    case "SelectorVarMultipleDecl": {
-      return `Style pattern statement has already declared the variable ${error.varName.contents.value}`;
-    }
+        case "SelectorVarMultipleDecl": {
+            return `Style pattern statement has already declared the variable ${error.varName.contents.value}`;
+        }
 
-    case "SelectorDeclTypeMismatch": {
-      // COMBAK: Add code for prettyprinting types
-      return "Mismatched types or wrong subtypes between Substance and Style variables in selector";
-    }
+        case "SelectorDeclTypeMismatch": {
+            // COMBAK: Add code for prettyprinting types
+            return "Mismatched types or wrong subtypes between Substance and Style variables in selector";
+        }
 
-    case "SelectorRelTypeMismatch": {
-      // COMBAK: Add code for prettyprinting types
-      return "Mismatched types or wrong subtypes between variable and expression in relational statement in selector";
-    }
+        case "SelectorRelTypeMismatch": {
+            // COMBAK: Add code for prettyprinting types
+            return "Mismatched types or wrong subtypes between variable and expression in relational statement in selector";
+        }
 
-    case "TaggedSubstanceError": {
-      return showError(error.error); // Substance error
-    }
+        case "TaggedSubstanceError": {
+            return showError(error.error); // Substance error
+        }
 
-    // --- BEGIN BLOCK STATIC ERRORS
+        // --- BEGIN BLOCK STATIC ERRORS
 
-    case "InvalidGPITypeError": {
-      const shapeNames: string[] = shapedefs.map((e: ShapeDef) => e.shapeType);
-      return `Got invalid GPI type ${error.givenType.value}. Available shape types: ${shapeNames}`;
-    }
+        case "InvalidGPITypeError": {
+            const shapeNames: string[] = shapedefs.map((e: ShapeDef) => e.shapeType);
+            return `Got invalid GPI type ${error.givenType.value}. Available shape types: ${shapeNames}`;
+        }
 
-    case "InvalidGPIPropertyError": {
-      return `Got invalid GPI property ${error.givenProperty.value}. Available properties: ${error.expectedProperties}`;
-    }
+        case "InvalidGPIPropertyError": {
+            return `Got invalid GPI property ${error.givenProperty.value}. Available properties: ${error.expectedProperties}`;
+        }
 
-    case "InvalidFunctionNameError": {
-      return `Got invalid Function name '${error.givenName.value}'.`;
-      // COMBAK: Function suggestions, or just print the list
-    }
+        case "InvalidFunctionNameError": {
+            return `Got invalid Function name '${error.givenName.value}'.`;
+            // COMBAK: Function suggestions, or just print the list
+        }
 
-    case "InvalidObjectiveNameError": {
-      return `Got invalid objective name '${error.givenName.value}'.`;
-      // COMBAK: Objective suggestions, or just print the list
-    }
+        case "InvalidObjectiveNameError": {
+            return `Got invalid objective name '${error.givenName.value}'.`;
+            // COMBAK: Objective suggestions, or just print the list
+        }
 
-    case "InvalidConstraintNameError": {
-      return `Got invalid constraint name '${error.givenName.value}'.`;
-      // COMBAK: Constraint suggestions, or just print the list
-    }
+        case "InvalidConstraintNameError": {
+            return `Got invalid constraint name '${error.givenName.value}'.`;
+            // COMBAK: Constraint suggestions, or just print the list
+        }
 
-    // --- END BLOCK STATIC ERRORS
+        // --- END BLOCK STATIC ERRORS
 
-    case "DeletedPropWithNoSubObjError": {
-      return `Sub obj '${
-        error.subObj.contents.value
-      }' has no fields; can't delete path '${prettyPrintPath(error.path)}'`;
-    }
+        case "DeletedPropWithNoSubObjError": {
+            return `Sub obj '${error.subObj.contents.value
+                }' has no fields; can't delete path '${prettyPrintPath(error.path)}'`;
+        }
 
-    case "DeletedPropWithNoFieldError": {
-      return `Sub obj '${error.subObj.contents.value}' already lacks field ${
-        error.field.value
-      }; can't delete path '${prettyPrintPath(error.path)}'`;
-    }
+        case "DeletedPropWithNoFieldError": {
+            return `Sub obj '${error.subObj.contents.value}' already lacks field ${error.field.value
+                }; can't delete path '${prettyPrintPath(error.path)}'`;
+        }
 
-    case "CircularPathAlias": {
-      return `Path '${prettyPrintPath(error.path)}' was aliased to itself`;
-    }
+        case "CircularPathAlias": {
+            return `Path '${prettyPrintPath(error.path)}' was aliased to itself`;
+        }
 
-    case "DeletedPropWithNoGPIError": {
-      return `Sub obj '${error.subObj.contents.value}' does not have GPI '${
-        error.field.value
-      }'; cannot delete property '${
-        error.property.value
-      }' in '${prettyPrintPath(error.path)}'`;
-    }
+        case "DeletedPropWithNoGPIError": {
+            return `Sub obj '${error.subObj.contents.value}' does not have GPI '${error.field.value
+                }'; cannot delete property '${error.property.value
+                }' in '${prettyPrintPath(error.path)}'`;
+        }
 
-    // TODO: Use input path to report location?
-    case "DeletedNonexistentFieldError": {
-      return `Trying to delete '${error.field.value}' from SubObj '${error.subObj.contents.value}', which already lacks the field`;
-    }
+        // TODO: Use input path to report location?
+        case "DeletedNonexistentFieldError": {
+            return `Trying to delete '${error.field.value}' from SubObj '${error.subObj.contents.value}', which already lacks the field`;
+        }
 
-    case "DeletedVectorElemError": {
-      return `Cannot delete an element of a vector: '${prettyPrintPath(
-        error.path
-      )}'`;
-    }
+        case "DeletedVectorElemError": {
+            return `Cannot delete an element of a vector: '${prettyPrintPath(
+                error.path
+            )}'`;
+        }
 
-    case "InsertedPathWithoutOverrideError": {
-      return `Overriding path '${prettyPrintPath(
-        error.path
-      )}' without override flag set`;
-    }
+        case "InsertedPathWithoutOverrideError": {
+            return `Overriding path '${prettyPrintPath(
+                error.path
+            )}' without override flag set`;
+        }
 
-    case "InsertedPropWithNoFieldError": {
-      return `Sub obj '${error.subObj.contents.value}' does not have field '${
-        error.field.value
-      }'; cannot add property '${error.property.value}' in '${prettyPrintPath(
-        error.path
-      )}'`;
-    }
+        case "InsertedPropWithNoFieldError": {
+            return `Sub obj '${error.subObj.contents.value}' does not have field '${error.field.value
+                }'; cannot add property '${error.property.value}' in '${prettyPrintPath(
+                    error.path
+                )}'`;
+        }
 
-    case "InsertedPropWithNoGPIError": {
-      return `Sub obj '${
-        error.subObj.contents.value
-      }' has field but does not have GPI '${
-        error.field.value
-      }'; cannot add property '${error.property.value}' in '${prettyPrintPath(
-        error.path
-      )}'. Expected GPI.`;
-    }
+        case "InsertedPropWithNoGPIError": {
+            return `Sub obj '${error.subObj.contents.value
+                }' has field but does not have GPI '${error.field.value
+                }'; cannot add property '${error.property.value}' in '${prettyPrintPath(
+                    error.path
+                )}'. Expected GPI.`;
+        }
 
-    // ----- BEGIN TRANSLATION VALIDATION ERRORS
+        // ----- BEGIN TRANSLATION VALIDATION ERRORS
 
-    case "NonexistentNameError": {
-      return `Error looking up path '${prettyPrintPath(
-        error.path
-      )}' in translation. Name '${error.name.value}' does not exist.`;
-    }
+        case "NonexistentNameError": {
+            return `Error looking up path '${prettyPrintPath(
+                error.path
+            )}' in translation. Name '${error.name.value}' does not exist.`;
+        }
 
-    case "NonexistentFieldError": {
-      return `Error looking up path '${prettyPrintPath(
-        error.path
-      )}' in translation. Field '${error.field.value}' does not exist.`;
-    }
+        case "NonexistentFieldError": {
+            return `Error looking up path '${prettyPrintPath(
+                error.path
+            )}' in translation. Field '${error.field.value}' does not exist.`;
+        }
 
-    case "NonexistentGPIError": {
-      return `Error looking up path '${prettyPrintPath(
-        error.path
-      )}' in translation. GPI '${error.gpi.value}' does not exist.`;
-    }
+        case "NonexistentGPIError": {
+            return `Error looking up path '${prettyPrintPath(
+                error.path
+            )}' in translation. GPI '${error.gpi.value}' does not exist.`;
+        }
 
-    case "NonexistentPropertyError": {
-      return `Error looking up path '${prettyPrintPath(
-        error.path
-      )}' in translation. Property '${error.property.value}' does not exist.`;
-    }
+        case "NonexistentPropertyError": {
+            return `Error looking up path '${prettyPrintPath(
+                error.path
+            )}' in translation. Property '${error.property.value}' does not exist.`;
+        }
 
-    case "ExpectedGPIGotFieldError": {
-      return `Error looking up path '${prettyPrintPath(
-        error.path
-      )}' in translation. Expected GPI '${
-        error.field.value
-      }' does not exist; got a field instead.`;
-    }
+        case "ExpectedGPIGotFieldError": {
+            return `Error looking up path '${prettyPrintPath(
+                error.path
+            )}' in translation. Expected GPI '${error.field.value
+                }' does not exist; got a field instead.`;
+        }
 
-    case "InvalidAccessPathError": {
-      return `Error looking up path '${prettyPrintPath(
-        error.path
-      )}' in translation.`;
-    }
+        case "InvalidAccessPathError": {
+            return `Error looking up path '${prettyPrintPath(
+                error.path
+            )}' in translation.`;
+        }
 
-    case "CanvasNonexistentError": {
-      return `Canvas properties are not defined.\nTry adding:
+        case "CanvasNonexistentError": {
+            return `Canvas properties are not defined.\nTry adding:
 canvas {
     width = <my desired width>
     height = <my desired height>
 }`;
-    }
+        }
 
-    case "CanvasNonexistentDimsError": {
-      switch (error.kind) {
-        case "missing":
-          return `Canvas ${error.attr} is not defined.\nTry adding:
+        case "CanvasNonexistentDimsError": {
+            switch (error.kind) {
+                case "missing":
+                    return `Canvas ${error.attr} is not defined.\nTry adding:
 canvas {
     ${error.attr} = <my desired ${error.attr}>
 }`;
-        case "GPI":
-          return `Canvas ${error.attr} must be a numeric literal, but it is a shape.`;
-        case "uninitialized":
-          return `Canvas ${error.attr} must be a numeric literal, but it is an expression or uninitialized.`;
-        case "wrong type":
-          return `Canvas ${error.attr} must be a numeric literal, but it has type ${error.type}.`;
-      }
+                case "GPI":
+                    return `Canvas ${error.attr} must be a numeric literal, but it is a shape.`;
+                case "uninitialized":
+                    return `Canvas ${error.attr} must be a numeric literal, but it is an expression or uninitialized.`;
+                case "wrong type":
+                    return `Canvas ${error.attr} must be a numeric literal, but it has type ${error.type}.`;
+            }
+        }
+
+        // ----- END TRANSLATION VALIDATION ERRORS
+
+        // TODO(errors): use identifiers here
+        case "RuntimeValueTypeError": {
+            return `Runtime type error in looking up path '${prettyPrintPath(
+                error.path
+            )}''s value in translation. Expected type: '${error.expectedType
+                }]. Got type: ]${error.actualType}].`;
+        }
+
+        // ----- END STYLE ERRORS
+
+        case "Fatal": {
+            return `FATAL: ${error.message}`;
+        }
+
+        default: {
+            return `Meta: Cannot render error with contents: ${JSON.stringify(
+                error
+            )}`;
+        }
     }
-
-    // ----- END TRANSLATION VALIDATION ERRORS
-
-    // TODO(errors): use identifiers here
-    case "RuntimeValueTypeError": {
-      return `Runtime type error in looking up path '${prettyPrintPath(
-        error.path
-      )}''s value in translation. Expected type: '${
-        error.expectedType
-      }]. Got type: ]${error.actualType}].`;
-    }
-
-    // ----- END STYLE ERRORS
-
-    case "Fatal": {
-      return `FATAL: ${error.message}`;
-    }
-
-    default: {
-      return `Meta: Cannot render error with contents: ${JSON.stringify(
-        error
-      )}`;
-    }
-  }
 };
 
 const showCycles = (cycles: string[][]) => {
-  const pathString = (path: string[]) => path.join(" -> ");
-  return cycles.map(pathString).join("\n");
+    const pathString = (path: string[]) => path.join(" -> ");
+    return cycles.map(pathString).join("\n");
 };
 
 export const cyclicSubtypes = (cycles: string[][]): CyclicSubtypes => ({
-  tag: "CyclicSubtypes",
-  cycles,
+    tag: "CyclicSubtypes",
+    cycles,
 });
 
 export const notTypeConsInPrelude = (
-  type: Prop | TypeVar
+    type: Prop | TypeVar
 ): NotTypeConsInPrelude => ({
-  tag: "NotTypeConsInPrelude",
-  type,
+    tag: "NotTypeConsInPrelude",
+    type,
 });
 
 export const notTypeConsInSubtype = (
-  type: Prop | TypeVar
+    type: Prop | TypeVar
 ): NotTypeConsInSubtype => ({
-  tag: "NotTypeConsInSubtype",
-  type,
+    tag: "NotTypeConsInSubtype",
+    type,
 });
 
 // action constructors for error
 export const duplicateName = (
-  name: Identifier,
-  location: ASTNode,
-  firstDefined: ASTNode
+    name: Identifier,
+    location: ASTNode,
+    firstDefined: ASTNode
 ): DuplicateName => ({
-  tag: "DuplicateName",
-  name,
-  location,
-  firstDefined,
+    tag: "DuplicateName",
+    name,
+    location,
+    firstDefined,
 });
 
 export const typeNotFound = (
-  typeName: Identifier,
-  possibleTypes?: Identifier[]
+    typeName: Identifier,
+    possibleTypes?: Identifier[]
 ): TypeNotFound => ({
-  tag: "TypeNotFound",
-  typeName,
-  possibleTypes,
+    tag: "TypeNotFound",
+    typeName,
+    possibleTypes,
 });
 
 export const varNotFound = (
-  variable: Identifier,
-  possibleVars?: Identifier[]
+    variable: Identifier,
+    possibleVars?: Identifier[]
 ): VarNotFound => ({
-  tag: "VarNotFound",
-  variable,
-  possibleVars,
+    tag: "VarNotFound",
+    variable,
+    possibleVars,
 });
 
 export const typeMismatch = (
-  sourceType: TypeConstructor,
-  expectedType: TypeConstructor,
-  sourceExpr: ASTNode,
-  expectedExpr: ASTNode
+    sourceType: TypeConstructor,
+    expectedType: TypeConstructor,
+    sourceExpr: ASTNode,
+    expectedExpr: ASTNode
 ): TypeMismatch => ({
-  tag: "TypeMismatch",
-  sourceExpr,
-  sourceType,
-  expectedExpr,
-  expectedType,
+    tag: "TypeMismatch",
+    sourceExpr,
+    sourceType,
+    expectedExpr,
+    expectedType,
 });
 
 export const unexpectedExprForNestedPred = (
-  sourceType: TypeConstructor,
-  sourceExpr: ASTNode,
-  expectedExpr: ASTNode
+    sourceType: TypeConstructor,
+    sourceExpr: ASTNode,
+    expectedExpr: ASTNode
 ): UnexpectedExprForNestedPred => ({
-  tag: "UnexpectedExprForNestedPred",
-  sourceType,
-  sourceExpr,
-  expectedExpr,
+    tag: "UnexpectedExprForNestedPred",
+    sourceType,
+    sourceExpr,
+    expectedExpr,
 });
 
 export const argLengthMismatch = (
-  name: Identifier,
-  argsGiven: SubExpr[],
-  argsExpected: Arg[],
-  sourceExpr: ASTNode,
-  expectedExpr: ASTNode
+    name: Identifier,
+    argsGiven: SubExpr[],
+    argsExpected: Arg[],
+    sourceExpr: ASTNode,
+    expectedExpr: ASTNode
 ): ArgLengthMismatch => ({
-  tag: "ArgLengthMismatch",
-  name,
-  argsGiven,
-  argsExpected,
-  sourceExpr,
-  expectedExpr,
+    tag: "ArgLengthMismatch",
+    name,
+    argsGiven,
+    argsExpected,
+    sourceExpr,
+    expectedExpr,
 });
 
 export const typeArgLengthMismatch = (
-  sourceType: TypeConstructor,
-  expectedType: TypeConstructor,
-  sourceExpr: ASTNode,
-  expectedExpr: ASTNode
+    sourceType: TypeConstructor,
+    expectedType: TypeConstructor,
+    sourceExpr: ASTNode,
+    expectedExpr: ASTNode
 ): TypeArgLengthMismatch => ({
-  tag: "TypeArgLengthMismatch",
-  sourceExpr,
-  sourceType,
-  expectedExpr,
-  expectedType,
+    tag: "TypeArgLengthMismatch",
+    sourceExpr,
+    sourceType,
+    expectedExpr,
+    expectedType,
 });
 
 export const deconstructNonconstructor = (
-  deconstructor: Deconstructor
+    deconstructor: Deconstructor
 ): DeconstructNonconstructor => ({
-  tag: "DeconstructNonconstructor",
-  deconstructor,
+    tag: "DeconstructNonconstructor",
+    deconstructor,
 });
 
 export const fatalError = (message: string): FatalError => ({
-  tag: "Fatal",
-  message,
+    tag: "Fatal",
+    message,
 });
 
 export const parseError = (
-  message: string,
-  location?: SourceLoc
+    message: string,
+    location?: SourceLoc
 ): ParseError => ({
-  tag: "ParseError",
-  message,
-  location,
+    tag: "ParseError",
+    message,
+    location,
 });
 
 // If there are multiple errors, just return the tag of the first one
 export const toStyleErrors = (errors: StyleError[]): PenroseError => {
-  if (!errors.length) {
-    throw Error("internal error: expected at least one Style error");
-  }
+    if (!errors.length) {
+        throw Error("internal error: expected at least one Style error");
+    }
 
-  return {
-    errorType: "StyleError",
-    tag: "StyleErrorList",
-    errors,
-  };
+    return {
+        errorType: "StyleError",
+        tag: "StyleErrorList",
+        errors,
+    };
 };
 
 export const genericStyleError = (messages: StyleError[]): PenroseError => ({
-  errorType: "StyleError",
-  tag: "GenericStyleError",
-  messages: messages.map(showError),
+    errorType: "StyleError",
+    tag: "GenericStyleError",
+    messages: messages.map(showError),
 });
 
 // const loc = (node: ASTNode) => `${node.start.line}:${node.start.col}`;
 // TODO: Show file name
 const loc = (node: ASTNode): string => {
-  if (isConcrete(node)) {
-    return `line ${node.start.line}, column ${node.start.col + 1} of ${
-      node.nodeType
-    } program`;
-  } else {
-    return `generated code by the compiler`; // TODO: better description of where the node is coming from
-  }
+    if (isConcrete(node)) {
+        return `line ${node.start.line}, column ${node.start.col + 1} of ${node.nodeType
+            } program`;
+    } else {
+        return `generated code by the compiler`; // TODO: better description of where the node is coming from
+    }
 };
 
 // #endregion
@@ -551,62 +540,62 @@ const loc = (node: ASTNode): string => {
 // #region Either monad
 
 export const every = <Ok, Error>(
-  ...results: Result<Ok, Error>[]
+    ...results: Result<Ok, Error>[]
 ): Result<Ok, Error> =>
-  results.reduce(
-    (currentResult: Result<Ok, Error>, nextResult: Result<Ok, Error>) =>
-      and(nextResult, currentResult),
-    results[0] // TODO: separate out this element in argument
-  );
+    results.reduce(
+        (currentResult: Result<Ok, Error>, nextResult: Result<Ok, Error>) =>
+            and(nextResult, currentResult),
+        results[0] // TODO: separate out this element in argument
+    );
 
 export const safeChain = <Item, Ok, Error>(
-  itemList: Item[],
-  func: (nextItem: Item, currentResult: Ok) => Result<Ok, Error>,
-  initialResult: Result<Ok, Error>
+    itemList: Item[],
+    func: (nextItem: Item, currentResult: Ok) => Result<Ok, Error>,
+    initialResult: Result<Ok, Error>
 ): Result<Ok, Error> =>
-  itemList.reduce(
-    (currentResult: Result<Ok, Error>, nextItem: Item) =>
-      andThen((res: Ok) => func(nextItem, res), currentResult),
-    initialResult
-  );
+    itemList.reduce(
+        (currentResult: Result<Ok, Error>, nextItem: Item) =>
+            andThen((res: Ok) => func(nextItem, res), currentResult),
+        initialResult
+    );
 
 /**
  * Hand-written version of `Result.all`.
  */
 export const all = <Ok, Error>(
-  results: Result<Ok, Error>[]
+    results: Result<Ok, Error>[]
 ): Result<Ok[], Error> => {
-  return results.reduce(
-    (
-      currentResults: Result<Ok[], Error>,
-      nextResult: Result<Ok, Error>
-    ): Result<Ok[], Error> =>
-      currentResults.match({
-        Ok: (current: Ok[]) =>
-          nextResult.match({
-            Ok: (next: Ok) => ok([...current, next]),
-            Err: (e: Error) => err(e),
-          }),
-        Err: (e: Error) => err(e),
-      }),
-    ok([])
-  );
+    return results.reduce(
+        (
+            currentResults: Result<Ok[], Error>,
+            nextResult: Result<Ok, Error>
+        ): Result<Ok[], Error> =>
+            currentResults.match({
+                Ok: (current: Ok[]) =>
+                    nextResult.match({
+                        Ok: (next: Ok) => ok([...current, next]),
+                        Err: (e: Error) => err(e),
+                    }),
+                Err: (e: Error) => err(e),
+            }),
+        ok([])
+    );
 };
 
 // NOTE: re-export all true-myth types to reduce boilerplate
 export {
-  Maybe,
-  Result,
-  and,
-  or,
-  ok,
-  err,
-  andThen,
-  ap,
-  match,
-  unsafelyUnwrap,
-  isErr,
-  unsafelyGetErr,
+    Maybe,
+    Result,
+    and,
+    or,
+    ok,
+    err,
+    andThen,
+    ap,
+    match,
+    unsafelyUnwrap,
+    isErr,
+    unsafelyGetErr,
 };
 
 // #endregion

--- a/yarn.lock
+++ b/yarn.lock
@@ -6228,10 +6228,10 @@ cytoscape-dagre@^2.3.2:
   dependencies:
     dagre "^0.8.5"
 
-cytoscape@^3.18.2:
-  version "3.18.2"
-  resolved "https://registry.yarnpkg.com/cytoscape/-/cytoscape-3.18.2.tgz#e5a1b37de3b53946a6d8f8586eefa44a0978ade4"
-  integrity sha512-NRY3JTrUzx0fSn44LyMlPqC8/zuuOo8kbr2hFlfjiObRmtir+lnxVg08f8wUA4X/P80df9vSThKDASl39yH+Iw==
+cytoscape@^3.19.0:
+  version "3.19.0"
+  resolved "https://registry.yarnpkg.com/cytoscape/-/cytoscape-3.19.0.tgz#b3e3136f823ca00a1c7752741c2a349e52545f57"
+  integrity sha512-DANM8bM4EuSTS3DraPK0nLSmzANrzQ2g/cb3u5Biexu/NVsJA+xAoXVvWHRIHDXz3y0gpMjTPv3Z13ZbkNrEPw==
   dependencies:
     heap "^0.2.6"
     lodash.debounce "^4.0.8"


### PR DESCRIPTION
# Description

Related issue/PR: #592

Catch errors thrown in `core` in `browser-ui`. Also fix dependency error for cytoscape.

# Implementation strategy and design decisions

Use `try-catch` statement around any `browser-ui` call to `core` that might throw error, including `stepState` and `stepUntilConvergence`; report it in inspector and in console

# Examples with steps to reproduce them

Add a `throw Error` to anywhere in `core` (e.g. `NaN` in optimizer)

<img width="1425" alt="Screen Shot 2021-07-20 at 11 31 14 AM" src="https://user-images.githubusercontent.com/2762356/126352307-210b0fc0-837b-4212-81a7-eda361bcec39.png">

# Checklist

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] New and existing tests pass locally using `yarn test`
- [x] I ran `yarn docs` and there were no errors when generating the HTML site
- [x] My code follows the style guidelines of this project (e.g.: no ESLint warnings)

# Open questions

Questions that require more discussion or to be addressed in future development: 

- Get this functionality to work in the IDE
