### PR TITLE
fix: resolved NaN in the nested.sub by increasing the max size of sets shapes #498

### DIFF
--- a/examples/set-theory-domain/venn.sty
+++ b/examples/set-theory-domain/venn.sty
@@ -14,7 +14,7 @@ forall Set x {
 
     ensure contains(x.icon, x.text)
     ensure minSize(x.icon)
-    ensure maxSize(x.icon, canvas.height / 3.)
+    ensure maxSize(x.icon, canvas.height / 1.)
     encourage sameCenter(x.text, x.icon)
     x.textLayering = x.text above x.icon
 }

--- a/examples/set-theory-domain/venn.sty
+++ b/examples/set-theory-domain/venn.sty
@@ -14,7 +14,7 @@ forall Set x {
 
     ensure contains(x.icon, x.text)
     ensure minSize(x.icon)
-    ensure maxSize(x.icon, canvas.height / 1.)
+    ensure maxSize(x.icon, canvas.height / 2)
     encourage sameCenter(x.text, x.icon)
     x.textLayering = x.text above x.icon
 }

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -229,7 +229,7 @@ export const evalEnergy = (s: State): number => {
   const { objective, weight } = s.params;
   // NOTE: if `prepareState` hasn't been called before, log a warning message and generate a fresh optimization problem
   if (!objective) {
-    log.warn(
+    log.debug(
       "State is not prepared for energy evaluation. Call `prepareState` to initialize the optimization problem first."
     );
     const newState = genOptProblem(s);


### PR DESCRIPTION

# Description

Related issue/PR: #498

Resolved NaN in nested.sub example by increasing maximum size of circles representing sets to accommodate the amount of nesting in this example without creating unsatisfiable constraints.

# Implementation strategy and design decisions

N/A

# Examples with steps to reproduce them

# Checklist

- [x] I have commented my code, particularly in hard-to-understand areas
- [X] My changes generate no new warnings
- [X] New and existing tests pass locally using `yarn test`
- [X] I ran `yarn docs` and there were no errors when generating the HTML site
- [X] My code follows the style guidelines of this project (e.g.: no ESLint warnings)

# Open questions

Questions that require more discussion or to be addressed in future development:

- Seems brittle; tests fail (the "cross-instance energy evaluation") if `maxSize`'s parameter is decreased to, e.g. `canvasSize/1.5`.
