### PR TITLE
chore: new nanerror Penrose error + full propagation 

### DIFF
--- a/examples/set-theory-domain/venn.sty
+++ b/examples/set-theory-domain/venn.sty
@@ -14,7 +14,7 @@ forall Set x {
 
     ensure contains(x.icon, x.text)
     ensure minSize(x.icon)
-    ensure maxSize(x.icon, canvas.height / 3.)
+    ensure maxSize(x.icon, canvas.height / 1.)
     encourage sameCenter(x.text, x.icon)
     x.textLayering = x.text above x.icon
 }

--- a/examples/set-theory-domain/venn.sty
+++ b/examples/set-theory-domain/venn.sty
@@ -14,7 +14,7 @@ forall Set x {
 
     ensure contains(x.icon, x.text)
     ensure minSize(x.icon)
-    ensure maxSize(x.icon, canvas.height / 1.)
+    ensure maxSize(x.icon, canvas.height / 3)
     encourage sameCenter(x.text, x.icon)
     x.textLayering = x.text above x.icon
 }

--- a/packages/browser-ui/src/App.tsx
+++ b/packages/browser-ui/src/App.tsx
@@ -165,9 +165,11 @@ class App extends React.Component<any, ICanvasState> {
       const stepped = stepState(this.state.data, 1);
       void this.onCanvasState(stepped);
     } catch (e) {
-        const error: PenroseError = {
-          errorType: "RuntimeError", tag: "RuntimeError", message: `Runtime error encountered: '${e}' Check console for more information.`
-        };
+      const error: PenroseError = {
+        errorType: "RuntimeError",
+        tag: "RuntimeError",
+        message: `Runtime error encountered: '${e}' Check console for more information.`,
+      };
 
       const errorWrapper = { error, data: undefined };
       this.setState(errorWrapper);
@@ -176,19 +178,15 @@ class App extends React.Component<any, ICanvasState> {
   };
 
   public stepUntilConvergence = (): void => {
-    try {
-      const stepped = stepUntilConvergence(
-        this.state.data,
-        this.state.settings.autoStepSize
-      );
-      void this.onCanvasState(stepped);
-    } catch (e) {
-        const error: PenroseError = {
-          errorType: "RuntimeError", tag: "RuntimeError", message: `Runtime error encountered: '${e}' Check console for more information.`
-        };
-      const errorWrapper = { error, data: undefined };
+    const stepped = stepUntilConvergence(
+      this.state.data,
+      this.state.settings.autoStepSize
+    );
+    if (stepped.isErr()) {
+      const errorWrapper = { error: stepped.error, data: undefined };
       this.setState(errorWrapper);
-      throw e;
+    } else {
+      void this.onCanvasState(stepped);
     }
   };
 
@@ -218,12 +216,16 @@ class App extends React.Component<any, ICanvasState> {
         );
         if (compileRes.isOk()) {
           try {
-            const initState: PenroseState = await prepareState(compileRes.value);
+            const initState: PenroseState = await prepareState(
+              compileRes.value
+            );
             void this.onCanvasState(initState);
           } catch (e) {
-              const error: PenroseError = {
-                errorType: "RuntimeError", tag: "RuntimeError", message: `Runtime error encountered: '${e}' Check console for more information.`
-              };
+            const error: PenroseError = {
+              errorType: "RuntimeError",
+              tag: "RuntimeError",
+              message: `Runtime error encountered: '${e}' Check console for more information.`,
+            };
 
             const errorWrapper = { error, data: undefined };
             this.setState(errorWrapper);
@@ -362,8 +364,8 @@ class App extends React.Component<any, ICanvasState> {
                 setSettings={this.setSettings}
               />
             ) : (
-                <div />
-              )}
+              <div />
+            )}
           </SplitPane>
         </div>
       </div>

--- a/packages/core/src/__tests__/overall.test.ts
+++ b/packages/core/src/__tests__/overall.test.ts
@@ -41,7 +41,12 @@ describe("End-to-end testing of existing diagrams", () => {
       const res = compileTrio(dsl, sub, sty);
       if (res.isOk()) {
         const state = await prepareState(res.value);
-        const optimized = stepUntilConvergence(state);
+        const opt = stepUntilConvergence(state);
+        if (opt.isErr()) {
+          fail("optimization failed");
+        }
+        const optimized = opt.value;
+
         const rendered = RenderStatic(optimized);
         fs.writeFileSync(
           path.join(OUTPUT, `${name}.svg`),
@@ -61,7 +66,11 @@ describe("Energy API", () => {
     const res = compileTrio(setDomain, twoSubsets, vennStyle);
     if (res.isOk()) {
       const stateEvaled = await prepareState(res.value);
-      const stateOptimized = stepUntilConvergence(stateEvaled);
+      const stateOpt = stepUntilConvergence(stateEvaled);
+      if (stateOpt.isErr()) {
+        fail("optimization failed");
+      }
+      const stateOptimized = stateOpt.value;
       const initEng = evalEnergy(stateEvaled);
       const optedEng = evalEnergy(stateOptimized);
       expect(initEng).toBeGreaterThan(optedEng);
@@ -96,20 +105,22 @@ describe("Cross-instance energy eval", () => {
     if (state1.isOk() && state2.isOk()) {
       const state1Done = stepUntilConvergence(await prepareState(state1.value));
       const state2Done = stepUntilConvergence(await prepareState(state2.value));
-      const crossState21 = {
-        ...state2Done,
-        constrFns: state1Done.constrFns,
-        objFns: state1Done.objFns,
-      };
-      expect(evalEnergy(await prepareState(crossState21))).toBeCloseTo(0);
-      const crossState12 = {
-        ...state1Done,
-        constrFns: state2Done.constrFns,
-        objFns: state2Done.objFns,
-      };
-      expect(evalEnergy(await prepareState(crossState12))).toBeGreaterThan(0);
-      // console.log(RenderStatic(crossState12).outerHTML);
-      // console.log(RenderStatic(crossState21).outerHTML);
+      if (state1Done.isOk() && state2Done.isOk()) {
+        const crossState21 = {
+          ...state2Done.value,
+          constrFns: state1Done.value.constrFns,
+          objFns: state1Done.value.objFns,
+        };
+        expect(evalEnergy(await prepareState(crossState21))).toBeCloseTo(0);
+        const crossState12 = {
+          ...state1Done.value,
+          constrFns: state2Done.value.constrFns,
+          objFns: state2Done.value.objFns,
+        };
+        expect(evalEnergy(await prepareState(crossState12))).toBeGreaterThan(0);
+      } else {
+        fail("optimization failed");
+      }
     } else {
       fail("compilation failed");
     }
@@ -126,14 +137,18 @@ describe("Run individual functions", () => {
 
     if (res.isOk()) {
       const stateEvaled = await prepareState(res.value);
-      const stateOptimized = stepUntilConvergence(stateEvaled);
+      const stateOpt = stepUntilConvergence(stateEvaled);
+      if (stateOpt.isErr()) {
+        fail("optimization failed");
+      }
+      const stateOptimizedValue = stateOpt.value;
 
       // console.log("# objectives", stateEvaled.objFns.length);
       // console.log("# constraints", stateEvaled.constrFns.length);
 
       // Test objectives
       const initEngsObj = evalFns(stateEvaled.objFns, stateEvaled);
-      const optedEngsObj = evalFns(stateEvaled.objFns, stateOptimized);
+      const optedEngsObj = evalFns(stateEvaled.objFns, stateOptimizedValue);
 
       for (let i = 0; i < initEngsObj.length; i++) {
         // console.log("obj energies", initEngsObj[i], optedEngsObj[i]);
@@ -143,7 +158,10 @@ describe("Run individual functions", () => {
 
       // Test constraints
       const initEngsConstr = evalFns(stateEvaled.constrFns, stateEvaled);
-      const optedEngsConstr = evalFns(stateEvaled.constrFns, stateOptimized);
+      const optedEngsConstr = evalFns(
+        stateEvaled.constrFns,
+        stateOptimizedValue
+      );
 
       for (let i = 0; i < initEngsConstr.length; i++) {
         // console.log("constr energies", initEngsConstr[i], optedEngsConstr[i]);

--- a/packages/core/src/engine/Optimizer.ts
+++ b/packages/core/src/engine/Optimizer.ts
@@ -162,7 +162,7 @@ export const initializeMat = async () => {
  * @param steps
  * @param evaluate
  */
-export const step = (state: State, steps: number, evaluate = true) => {
+export const step = (state: State, steps: number, evaluate = true): State => {
   const { optStatus, weight } = state.params;
   let newState = { ...state };
   const optParams = newState.params; // this is just a reference, so updating this will update newState as well
@@ -351,6 +351,10 @@ export const step = (state: State, steps: number, evaluate = true) => {
     case "EPConverged": {
       // do nothing if converged
       log.info("step: EP converged");
+      return state;
+    }
+    case "Error": {
+      log.warn("step: Error");
       return state;
     }
   }

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -59,7 +59,11 @@ export const stepState = (state: State, numSteps = 10000): State => {
  */
 export const stepUntilConvergence = (state: State, numSteps = 10000): State => {
   let currentState = state;
-  while (!stateConverged(currentState)) {
+  while (
+    !stateConverged(currentState) &&
+    !(currentState.params.optStatus === "Error")
+  ) {
+    console.log("optStatus: " + currentState.params.optStatus);
     currentState = step(currentState, numSteps, true);
   }
   return currentState;

--- a/packages/core/src/types/ad.ts
+++ b/packages/core/src/types/ad.ts
@@ -82,6 +82,7 @@ export interface IOptInfo {
   newLbfgsInfo: LbfgsParams;
   gradient: number[];
   gradientPreconditioned: number[];
+  failed: boolean;
 }
 
 export type OptDebugInfo = IOptDebugInfo;

--- a/packages/core/src/types/errors.ts
+++ b/packages/core/src/types/errors.ts
@@ -1,6 +1,7 @@
 //#region ErrorTypes
 import { ASTNode, Identifier, SourceLoc } from "./ast";
 import { TypeConstructor, Prop, TypeVar, Arg } from "./domain";
+import { State } from "./state";
 import { BindingForm, Path } from "./style";
 import { SubExpr, Deconstructor, TypeConsApp } from "./substance";
 
@@ -14,11 +15,16 @@ export type PenroseError =
   | (StyleError & { errorType: "StyleError" })
   | (RuntimeError & { errorType: "RuntimeError" });
 
-export type RuntimeError = RuntimeErrorWithContents;
+export type RuntimeError = RuntimeErrorWithContents | NaNError;
 
 export interface RuntimeErrorWithContents {
   tag: "RuntimeError";
   message: string;
+}
+export interface NaNError {
+  tag: "NaNError";
+  message: string;
+  lastState: State;
 }
 
 export type Warning = StyleError;

--- a/packages/core/src/types/state.ts
+++ b/packages/core/src/types/state.ts
@@ -70,7 +70,8 @@ export type OptStatus =
   | "NewIter"
   | "UnconstrainedRunning"
   | "UnconstrainedConverged"
-  | "EPConverged";
+  | "EPConverged"
+  | "Error";
 
 export type LbfgsParams = ILbfgsParams;
 

--- a/packages/core/src/utils/Error.ts
+++ b/packages/core/src/utils/Error.ts
@@ -33,11 +33,13 @@ import {
   PenroseError,
   StyleError,
   RuntimeError,
+  NaNError,
 } from "types/errors";
 import { Identifier, ASTNode, SourceLoc } from "types/ast";
 import { Type, Prop, TypeVar, TypeConstructor, Arg } from "types/domain";
 import { SubExpr, Deconstructor } from "types/substance";
 import { isConcrete } from "engine/EngineUtils";
+import { State } from "types/state";
 // #region error rendering and construction
 
 /**
@@ -72,6 +74,9 @@ export const showError = (
   switch (error.tag) {
     case "RuntimeError": {
       return error.message;
+    }
+    case "NaNError": {
+      return `NaN encountered during optimization: ${error.message}`;
     }
     case "ParseError":
       return error.message;
@@ -517,6 +522,12 @@ export const parseError = (
   tag: "ParseError",
   message,
   location,
+});
+
+export const nanError = (message: string, lastState: State): NaNError => ({
+  tag: "NaNError",
+  message,
+  lastState,
 });
 
 // If there are multiple errors, just return the tag of the first one


### PR DESCRIPTION
# Description
Created a new subtype of RuntimeError to accommodate NaNs encountered at runtime.  The client should no longer hang when encountering a NaN. 

# Checklist

- [ X ] I have commented my code, particularly in hard-to-understand areas
- [ X ] My changes generate no new warnings
- [ X ] New and existing tests pass locally using `yarn test`
- [ ] I ran `yarn docs` and there were no errors when generating the HTML site
- [ X ] My code follows the style guidelines of this project (e.g.: no ESLint warnings)

