### PR TITLE
fix: unwrap the result of `stepUntilConvergence` in `browser-ui`

### DIFF
--- a/packages/browser-ui/src/App.tsx
+++ b/packages/browser-ui/src/App.tsx
@@ -186,7 +186,7 @@ class App extends React.Component<any, ICanvasState> {
       const errorWrapper = { error: stepped.error, data: undefined };
       this.setState(errorWrapper);
     } else {
-      void this.onCanvasState(stepped);
+      void this.onCanvasState(stepped.value);
     }
   };
 

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -63,9 +63,10 @@ export const stepUntilConvergence = (
   numSteps = 10000
 ): Result<State, RuntimeError> => {
   let currentState = state;
+  log.warn(currentState.params.optStatus);
   while (
-    !stateConverged(currentState) &&
-    !(currentState.params.optStatus === "Error")
+    !(currentState.params.optStatus === "Error") &&
+    !stateConverged(currentState)
   ) {
     currentState = step(currentState, numSteps, true);
   }


### PR DESCRIPTION
Related issue/PR: #630 

