### PR TITLE
fix: return types in exported functions

### DIFF
--- a/examples/set-theory-domain/tree.sub
+++ b/examples/set-theory-domain/tree.sub
@@ -1,5 +1,4 @@
 Set A, B, C, D, E, F, G
-Point H
 
 IsSubset(B, A)
 IsSubset(C, A)

--- a/packages/automator/index.tsx
+++ b/packages/automator/index.tsx
@@ -3,11 +3,11 @@ import {
   compileTrio,
   evalEnergy,
   prepareState,
-  RenderStatic,
   showError,
   stepUntilConvergence,
   PenroseState,
   getListOfStagedStates,
+  RenderStatic,
 } from "@penrose/core";
 import { renderArtifacts } from "./artifacts";
 
@@ -96,7 +96,11 @@ const singleProcess = async (
   console.log(`Stepping for ${out} ...`);
 
   const convergeStart = process.hrtime();
-  const optimizedState = stepUntilConvergence(initialState, 10000);
+  // TODO: report runtime errors
+  const optimizedState = stepUntilConvergence(
+    initialState,
+    10000
+  ).unsafelyUnwrap();
   const convergeEnd = process.hrtime(convergeStart);
 
   const reactRenderStart = process.hrtime();

--- a/packages/browser-ui/src/inspector/makeViewBoxes.tsx
+++ b/packages/browser-ui/src/inspector/makeViewBoxes.tsx
@@ -1,5 +1,5 @@
+import { bBoxDims, RenderShape, Shape } from "@penrose/core";
 import * as React from "react";
-import { RenderShape, bBoxDims, ShapeTypes } from "@penrose/core";
 import styled from "styled-components";
 
 // styling for shape inside viewbox - see ShapeView or Mod
@@ -19,7 +19,7 @@ export const ShapeItem = styled.li<any>`
 `;
 
 const makeViewBoxes = (
-  shapes: ShapeTypes.Shape[],
+  shapes: Shape[],
   selectedShape: number,
   setSelectedShape: (key: number) => void
 ) => {
@@ -35,38 +35,36 @@ const makeViewBoxes = (
           right: 0,
         }}
       >
-        {shapes.map(
-          ({ properties, shapeType }: ShapeTypes.Shape, key: number) => {
-            // If the inspector is crashing around here, then probably the shape doesn't have the width/height properties, so add a special case as below
-            // console.log("properties, shapeType", properties, shapeType, properties.w, properties.h);
-            const [w, h] = bBoxDims(properties, shapeType);
-            return (
-              <ShapeItem
-                key={`shapePreview-${key}`}
-                selected={selectedShape === key}
-                onClick={() => setSelectedShape(key)}
-              >
-                <div>
-                  <svg
-                    viewBox={`0 0 ${w} ${h}`}
-                    width="50"
-                    height="50"
-                    dangerouslySetInnerHTML={{
-                      __html: RenderShape({
-                        shape: { properties, shapeType },
-                        labels: [],
-                        canvasSize: [w, h],
-                      }).outerHTML,
-                    }}
-                  />
-                </div>
-                <div style={{ margin: "0.5em" }}>
-                  <span>{properties.name.contents}</span>
-                </div>
-              </ShapeItem>
-            );
-          }
-        )}
+        {shapes.map(({ properties, shapeType }: Shape, key: number) => {
+          // If the inspector is crashing around here, then probably the shape doesn't have the width/height properties, so add a special case as below
+          // console.log("properties, shapeType", properties, shapeType, properties.w, properties.h);
+          const [w, h] = bBoxDims(properties, shapeType);
+          return (
+            <ShapeItem
+              key={`shapePreview-${key}`}
+              selected={selectedShape === key}
+              onClick={() => setSelectedShape(key)}
+            >
+              <div>
+                <svg
+                  viewBox={`0 0 ${w} ${h}`}
+                  width="50"
+                  height="50"
+                  dangerouslySetInnerHTML={{
+                    __html: RenderShape({
+                      shape: { properties, shapeType },
+                      labels: [],
+                      canvasSize: [w, h],
+                    }).outerHTML,
+                  }}
+                />
+              </div>
+              <div style={{ margin: "0.5em" }}>
+                <span>{properties.name.contents}</span>
+              </div>
+            </ShapeItem>
+          );
+        })}
       </ul>
     </div>
   );

--- a/packages/browser-ui/src/inspector/views/GraphUtils.ts
+++ b/packages/browser-ui/src/inspector/views/GraphUtils.ts
@@ -1,16 +1,12 @@
 import {
-  ShapeTypes,
-  PenroseState,
   PenroseFn,
+  prettyPrintExpr,
   prettyPrintFn,
   prettyPrintPath,
-  prettyPrintExpr,
 } from "@penrose/core";
-import { FieldDict, Translation } from "@penrose/core/build/dist/types/value";
-import { uniqBy } from "lodash";
-import { Path } from "@penrose/core/build/dist/types/style";
 import { Fn } from "@penrose/core/build/dist/types/state";
-import { flatMap } from "lodash";
+import { Path } from "@penrose/core/build/dist/types/style";
+import { flatMap, uniqBy } from "lodash";
 import { VarAD } from "../../../../core/build/dist/types/ad";
 
 // TODO: The nodes and edges are left untyped for now because adding new keys to them (e.g. `DOF: true`) is used to style their CSS - not sure how to accommodate this as a TS type

--- a/packages/browser-ui/src/inspector/views/Mod.tsx
+++ b/packages/browser-ui/src/inspector/views/Mod.tsx
@@ -3,7 +3,7 @@ import * as React from "react";
 import IViewProps from "./IViewProps";
 import AttrPicker from "./mod/AttrPicker";
 import defmap from "./mod/defmap";
-import { ShapeTypes, PenroseState } from "@penrose/core";
+import { PenroseState, Value } from "@penrose/core";
 
 interface IState {
   selectedShape: number;
@@ -14,7 +14,7 @@ class Mod extends React.Component<IViewProps, IState> {
   public setSelectedShape = (key: number) => {
     this.setState({ selectedShape: key });
   };
-  public modAttr = (attrname: string, attrval: ShapeTypes.Value<any>) => {
+  public modAttr = (attrname: string, attrval: Value.Value<any>) => {
     const { frame, modShapes, frameIndex, history } = this.props;
     const { selectedShape } = this.state;
     if (frameIndex === -1 || frameIndex === history.length - 1) {

--- a/packages/browser-ui/src/inspector/views/mod/AttrPicker.tsx
+++ b/packages/browser-ui/src/inspector/views/mod/AttrPicker.tsx
@@ -1,11 +1,11 @@
 import * as React from "react";
 import LabeledInput from "./LabeledInput";
-import { Canvas, ShapeTypes } from "@penrose/core";
+import { Canvas, Value, Shape } from "@penrose/core";
 
 interface IProps {
-  shape: ShapeTypes.Shape;
+  shape: Shape;
   sAttrs: IShapeDef;
-  modAttr(attrname: string, attrval: ShapeTypes.Value<any>): void;
+  modAttr(attrname: string, attrval: Value.Value<any>): void;
   canvas: Canvas;
 }
 

--- a/packages/browser-ui/src/inspector/views/mod/LabeledInput.tsx
+++ b/packages/browser-ui/src/inspector/views/mod/LabeledInput.tsx
@@ -1,12 +1,12 @@
 import * as React from "react";
 import { round, cloneDeep } from "lodash";
-import { Canvas, ShapeTypes, toHex } from "@penrose/core";
+import { Canvas, Value, toHex } from "@penrose/core";
 
 interface IProps {
   inputProps: IInputProps;
   eAttr: string;
-  eValue: ShapeTypes.Value<any>; // is this the best typing?
-  modAttr(attrname: string, attrval: ShapeTypes.Value<any>): void;
+  eValue: Value.Value<any>; // is this the best typing?
+  modAttr(attrname: string, attrval: Value.Value<any>): void;
   canvas: Canvas;
 }
 
@@ -72,9 +72,9 @@ class LabeledInput extends React.Component<IProps> {
     evalue:
       | string
       | number
-      | ShapeTypes.Color<number>
+      | Value.Color<number>
       | boolean
-      | ShapeTypes.ISubPath<number>[]
+      | Value.ISubPath<number>[]
   ) => {
     const newstate = {
       eValue: {
@@ -83,7 +83,7 @@ class LabeledInput extends React.Component<IProps> {
       },
     };
     this.setState(newstate); // will update span values - could be phased out if spans are set manually
-    this.props.modAttr(id, newstate.eValue as ShapeTypes.Value<any>);
+    this.props.modAttr(id, newstate.eValue as Value.Value<any>);
   };
   public handleChange = (
     eattr: string,
@@ -216,88 +216,86 @@ class LabeledInput extends React.Component<IProps> {
     // todo - refactor the whole file so you can call makerange() and makelabel() with params
     return (
       <React.Fragment>
-        {subpaths.map((subpath: ShapeTypes.IPathCmd<number>, index: number) => {
+        {subpaths.map((subpath: Value.IPathCmd<number>, index: number) => {
           const ptarray = subpath.contents;
           // note - prob will crash on bezier stuff
           return (
             <React.Fragment key={"S" + index}>
-              {ptarray.map(
-                (pt: ShapeTypes.ISubPath<number>, subindex: number) => {
-                  // todo clean up following lines
-                  const xid = [
-                    "S",
-                    index.toString(),
-                    "x",
-                    subindex.toString(),
-                    eAttr,
-                  ].join("_");
-                  const xltxt =
-                    "S" + index.toString() + "x" + subindex.toString();
-                  const xspan = round(
-                    this.state.eValue.contents[index].contents[subindex]
-                      .contents[0]
-                  ).toString();
-                  const yspan = round(
-                    this.state.eValue.contents[index].contents[subindex]
-                      .contents[1]
-                  ).toString();
-                  const yid = [
-                    "S",
-                    index.toString(),
-                    "y",
-                    subindex.toString(),
-                    eAttr,
-                  ].join("_");
-                  const yltxt =
-                    "S" + index.toString() + "y" + subindex.toString();
-                  return (
-                    <React.Fragment key={"S" + index + "pt" + subindex}>
-                      <div
-                        style={{ display: "inline-block" }}
-                        className="sublabinput"
-                      >
-                        <input
-                          id={xid}
-                          type="range"
-                          onChange={(e) =>
-                            this.handleMulPtRange(eAttr, index, subindex, 0, e)
-                          }
-                          min={toCanvas(inputProps.minX!, canvas)}
-                          max={toCanvas(inputProps.maxX!, canvas)}
-                          value={round(pt.contents[0] as number)}
-                        />
-                        {this.makeSubLabel(
-                          xid,
-                          xspan,
-                          xltxt,
-                          inputProps.showValue === "true"
-                        )}
-                      </div>
-                      <div
-                        className="sublabinput"
-                        style={{ display: "inline-block" }}
-                      >
-                        <input
-                          id={yid}
-                          type="range"
-                          onChange={(e) =>
-                            this.handleMulPtRange(eAttr, index, subindex, 1, e)
-                          }
-                          min={toCanvas(inputProps.minY!, canvas)}
-                          max={toCanvas(inputProps.maxY!, canvas)}
-                          value={round(pt.contents[1] as number)}
-                        />
-                        {this.makeSubLabel(
-                          yid,
-                          yspan,
-                          yltxt,
-                          inputProps.showValue === "true"
-                        )}
-                      </div>
-                    </React.Fragment>
-                  );
-                }
-              )}{" "}
+              {ptarray.map((pt: Value.ISubPath<number>, subindex: number) => {
+                // todo clean up following lines
+                const xid = [
+                  "S",
+                  index.toString(),
+                  "x",
+                  subindex.toString(),
+                  eAttr,
+                ].join("_");
+                const xltxt =
+                  "S" + index.toString() + "x" + subindex.toString();
+                const xspan = round(
+                  this.state.eValue.contents[index].contents[subindex]
+                    .contents[0]
+                ).toString();
+                const yspan = round(
+                  this.state.eValue.contents[index].contents[subindex]
+                    .contents[1]
+                ).toString();
+                const yid = [
+                  "S",
+                  index.toString(),
+                  "y",
+                  subindex.toString(),
+                  eAttr,
+                ].join("_");
+                const yltxt =
+                  "S" + index.toString() + "y" + subindex.toString();
+                return (
+                  <React.Fragment key={"S" + index + "pt" + subindex}>
+                    <div
+                      style={{ display: "inline-block" }}
+                      className="sublabinput"
+                    >
+                      <input
+                        id={xid}
+                        type="range"
+                        onChange={(e) =>
+                          this.handleMulPtRange(eAttr, index, subindex, 0, e)
+                        }
+                        min={toCanvas(inputProps.minX!, canvas)}
+                        max={toCanvas(inputProps.maxX!, canvas)}
+                        value={round(pt.contents[0] as number)}
+                      />
+                      {this.makeSubLabel(
+                        xid,
+                        xspan,
+                        xltxt,
+                        inputProps.showValue === "true"
+                      )}
+                    </div>
+                    <div
+                      className="sublabinput"
+                      style={{ display: "inline-block" }}
+                    >
+                      <input
+                        id={yid}
+                        type="range"
+                        onChange={(e) =>
+                          this.handleMulPtRange(eAttr, index, subindex, 1, e)
+                        }
+                        min={toCanvas(inputProps.minY!, canvas)}
+                        max={toCanvas(inputProps.maxY!, canvas)}
+                        value={round(pt.contents[1] as number)}
+                      />
+                      {this.makeSubLabel(
+                        yid,
+                        yspan,
+                        yltxt,
+                        inputProps.showValue === "true"
+                      )}
+                    </div>
+                  </React.Fragment>
+                );
+              })}{" "}
             </React.Fragment>
           );
         })}

--- a/packages/browser-ui/src/ui/Embed.tsx
+++ b/packages/browser-ui/src/ui/Embed.tsx
@@ -89,7 +89,7 @@ class Embed extends React.Component<any, IEmbedState> {
             <div
               style={{ width: "100%", height: "100%" }}
               dangerouslySetInnerHTML={{
-                __html: RenderStatic(data.shapes, data.labelCache).outerHTML,
+                __html: RenderStatic(data.shapes).outerHTML,
               }}
             />
           )}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,39 +1,39 @@
-import { checkDomain, compileDomain, parseDomain } from "compiler/Domain";
-import { compileStyle } from "compiler/Style";
+import { checkDomain, compileDomain, parseDomain } from "./compiler/Domain";
+import { compileStyle } from "./compiler/Style";
 import {
   checkSubstance,
   compileSubstance,
   parseSubstance,
   prettySubstance,
-} from "compiler/Substance";
+} from "./compiler/Substance";
 import consola, { LogLevel } from "consola";
-import { evalShapes } from "engine/Evaluator";
-import { genFns, genOptProblem, initializeMat, step } from "engine/Optimizer";
-import { insertPending } from "engine/PropagateUpdate";
-import RenderStatic, {
+import { evalShapes } from "./engine/Evaluator";
+import { genFns, genOptProblem, initializeMat, step } from "./engine/Optimizer";
+import { insertPending } from "./engine/PropagateUpdate";
+import {
+  RenderStatic,
   RenderInteractive,
   RenderShape,
-} from "renderer/Renderer";
-import { resampleBest } from "renderer/Resample";
-import { Synthesizer, SynthesizerSetting } from "synthesis/Synthesizer";
-import { Env } from "types/domain";
-import { PenroseError, RuntimeError } from "types/errors";
-import { Registry, Trio } from "types/io";
-import * as ShapeTypes from "types/shape";
-import { FieldDict, Translation } from "types/value";
-import { Fn, LabelCache, State } from "types/state";
-import { SubstanceEnv } from "types/substance";
-import { collectLabels } from "utils/CollectLabels";
-import { andThen, err, nanError, ok, Result, showError } from "utils/Error";
+} from "./renderer/Renderer";
+import { resampleBest } from "./renderer/Resample";
+import { Synthesizer } from "./synthesis/Synthesizer";
+import { Env } from "./types/domain";
+import { PenroseError, RuntimeError } from "./types/errors";
+import { Registry, Trio } from "./types/io";
+import { FieldDict, Translation } from "./types/value";
+import { Fn, LabelCache, State } from "./types/state";
+import { SubProg, SubstanceEnv } from "./types/substance";
+import { collectLabels } from "./utils/CollectLabels";
+import { andThen, err, nanError, ok, Result, showError } from "./utils/Error";
 import {
   prettyPrintFn,
   prettyPrintPath,
   prettyPrintExpr,
-} from "utils/OtherUtils";
-import { bBoxDims, toHex, ops } from "utils/Util";
-import { Canvas } from "renderer/ShapeDef";
-import { showMutations } from "synthesis/Mutation";
-import { getListOfStagedStates } from "renderer/Staging";
+} from "./utils/OtherUtils";
+import { bBoxDims, toHex, ops } from "./utils/Util";
+import { Canvas } from "./renderer/ShapeDef";
+import { showMutations } from "./synthesis/Mutation";
+import { getListOfStagedStates } from "./renderer/Staging";
 
 const log = consola.create({ level: LogLevel.Warn }).withScope("Top Level");
 
@@ -318,18 +318,16 @@ export {
   checkSubstance,
   parseSubstance,
   parseDomain,
-  RenderStatic,
-  RenderShape,
   Synthesizer,
   showMutations,
+  RenderShape,
   RenderInteractive,
-  ShapeTypes,
+  RenderStatic,
   bBoxDims,
   prettySubstance,
   toHex,
   initializeMat,
   showError,
-  Result,
   prettyPrintFn,
   prettyPrintPath,
   prettyPrintExpr,
@@ -337,10 +335,16 @@ export {
   getListOfStagedStates,
 };
 export type { PenroseError } from "./types/errors";
+export * as Value from "./types/value";
+export type { Shape } from "./types/shape";
 export type { Registry, Trio };
 export type { Env };
-export type { SynthesizerSetting };
-export type { SubProg } from "types/substance";
+export type {
+  SynthesizerSetting,
+  SynthesizedSubstance,
+} from "./synthesis/Synthesizer";
+export type { SubProg };
+export type { Result } from "./utils/Error";
 export type { Canvas };
 export type { FieldDict };
 export type { Translation };

--- a/packages/core/src/renderer/Renderer.ts
+++ b/packages/core/src/renderer/Renderer.ts
@@ -128,11 +128,8 @@ export const RenderInteractive = (
  * @param shapes
  * @param labels
  */
-const RenderStatic = ({
-  shapes,
-  labelCache: labels,
-  canvas,
-}: State): SVGSVGElement => {
+export const RenderStatic = (state: State): SVGSVGElement => {
+  const { shapes, labelCache: labels, canvas } = state;
   const svg = document.createElementNS("http://www.w3.org/2000/svg", "svg");
   svg.setAttribute("width", "100%");
   svg.setAttribute("height", "100%");
@@ -144,5 +141,3 @@ const RenderStatic = ({
   );
   return svg;
 };
-
-export default RenderStatic;

--- a/packages/core/src/types/io.ts
+++ b/packages/core/src/types/io.ts
@@ -15,8 +15,8 @@ export interface Trio {
  * Schema for the registry of working examples
  */
 export interface Registry {
-  substances: { [subID: string]: { name: string; URI: string } }[];
-  styles: { [styID: string]: { name: string; URI: string } }[];
-  domains: { [domID: string]: { name: string; URI: string } }[];
+  substances: { [subID: string]: { name: string; URI: string } };
+  styles: { [styID: string]: { name: string; URI: string } };
+  domains: { [domID: string]: { name: string; URI: string } };
   trios: { substance: string; style: string; domain: string; meta?: string }[];
 }

--- a/packages/synthesizer/index.ts
+++ b/packages/synthesizer/index.ts
@@ -9,6 +9,7 @@ import {
   Synthesizer,
   SubProg,
   SynthesizerSetting,
+  SynthesizedSubstance,
 } from "@penrose/core";
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from "fs";
 import * as neodoc from "neodoc";
@@ -57,10 +58,16 @@ export const defaultSetting: SynthesizerSetting = {
     predicate: ["IsSubset"],
     // predicate: [],
   },
+  edit: {
+    type: [],
+    function: [],
+    constructor: [],
+    predicate: [],
+  },
 };
 
 const writePrograms = (
-  progs: SubProg[],
+  progs: SynthesizedSubstance[],
   domainSrc: string,
   prefix: string,
   styleSrc?: string,


### PR DESCRIPTION
# Description

Related issue/PR: N/A

Currently in `main`, the functions exported from `@penrose/core` sometimes have `any` as their return types whenever a client package (e.g. `@penrose/browser-ui` use them. Notable behaviors are the lack of auto-completion when developing in VSCode and uncaught type errors across packages. 

This PR fixes this issue by __re-exporting functions from relative paths__ and further change all client packages to fix the errors uncaught in the past.

# Implementation strategy and design decisions

* Change all imports in `packages/core/index.ts` to use relative path
* Explicitly re-export the `Result` type from `true-myth` at the top level.

# Open questions

Although this solution works, the exact cause of this issue is still unknown. My guess is that this has something to do with our `rootDir` and `baseUrl` settings in `tsconfig.json`.