### PR TITLE
feat: added multiple tick mark functionality to euclidean style

### DIFF
--- a/examples/geometry-domain/euclidean.sty
+++ b/examples/geometry-domain/euclidean.sty
@@ -292,127 +292,60 @@ with Segment s2; Point p1, p2 {
 -- NOTE: Get rid of repetition
 Linelike s, t 
 where EqualLengthMarker1(s, t) {
-  override s.tick = Line {
-    start : midpointOffset(s.icon, 10.)
-    end : midpointOffset(s.icon, -10.)
+  override s.tick = Path {
+    pathData : ticksOnLine(s.icon.start, s.icon.end, 15., 1, 10.)
+    strokeWidth : 2.0
     color : Colors.black
-    thickness : 2.0
-    stroke : "none"
-    style : "solid"
+    fill: Colors.none
   }
-  override t.tick = Line {
-    start : midpointOffset(t.icon, 10.)
-    end : midpointOffset(t.icon, -10.)
+  override t.tick = Path {
+    pathData : ticksOnLine(t.icon.start, t.icon.end, 15., 1, 10.)
+    strokeWidth : 2.0
     color : Colors.black
-    thickness : 2.0
-    stroke : "none"
-    style : "solid"
+    fill: Colors.none
   }
   s.tick above s.icon
   t.tick above t.icon
 }
 
 -- NOTE: Get rid of repetition
--- TODO: equally space the tick marks along the segment instead of putting them on top of each other
 Linelike s, t 
 where EqualLengthMarker2(s, t) {
   --need slope of line, then need to equally distribute the tick marks
-  override s.tick = Line {
-    start : midpointOffset(s.icon, 10.)
-    end : midpointOffset(s.icon, -10.)
+  override s.tick = Path {
+    pathData : ticksOnLine(s.icon.start, s.icon.end, 15., 2., 10.)
+    strokeWidth : 2.0
     color : Colors.black
-    thickness : 2.0
-    stroke : "none"
-    style : "solid"
+    fill: Colors.none
   }
-  override t.tick = Line {
-    start : midpointOffset(t.icon, 10.)
-    end : midpointOffset(t.icon, -10.)
+  override t.tick = Path {
+    pathData : ticksOnLine(t.icon.start, t.icon.end, 15., 2., 10.)
+    strokeWidth : 2.0
     color : Colors.black
-    thickness : 2.0
-    stroke : "none"
-    style : "solid"
-  }
-  override s.tick2 = Line {
-    start : midpointOffset(s.icon, 10.)
-    end : midpointOffset(s.icon, -10.)
-    color : Colors.black
-    thickness : 2.0
-    stroke : "none"
-    style : "solid"
-  }
-  override t.tick2 = Line {
-    start : midpointOffset(t.icon, 10.)
-    end : midpointOffset(t.icon, -10.)
-    color : Colors.black
-    thickness : 2.0
-    stroke : "none"
-    style : "solid"
+    fill: Colors.none
   }
   s.tick above s.icon
-  s.tick2 above s.icon
   t.tick above t.icon
-  t.tick2 above t.icon
 }
 
 -- NOTE: Get rid of repetition
 Linelike s, t 
 where EqualLengthMarker3(s, t) {
   --need slope of line, then need to equally distribute the tick marks
-  override s.tick = Line {
-    start : midpointOffset(s.icon, 10.)
-    end : midpointOffset(s.icon, -10.)
+  override s.tick = Path {
+    pathData : ticksOnLine(s.icon.start, s.icon.end, 15., 3, 10.)
+    strokeWidth : 2.0
     color : Colors.black
-    thickness : 2.0
-    stroke : "none"
-    style : "solid"
+    fill: Colors.none
   }
-  override t.tick = Line {
-    start : midpointOffset(t.icon, 10.)
-    end : midpointOffset(t.icon, -10.)
+  override t.tick = Path {
+    pathData : ticksOnLine(t.icon.start, t.icon.end, 15., 3, 10.)
+    strokeWidth : 2.0
     color : Colors.black
-    thickness : 2.0
-    stroke : "none"
-    style : "solid"
-  }
-  override s.tick2 = Line {
-    start : midpointOffset(s.icon, 10.)
-    end : midpointOffset(s.icon, -10.)
-    color : Colors.black
-    thickness : 2.0
-    stroke : "none"
-    style : "solid"
-  }
-  override t.tick2 = Line {
-    start : midpointOffset(t.icon, 10.)
-    end : midpointOffset(t.icon, -10.)
-    color : Colors.black
-    thickness : 2.0
-    stroke : "none"
-    style : "solid"
-  }
-    override s.tick3 = Line {
-    start : midpointOffset(s.icon, 10.)
-    end : midpointOffset(s.icon, -10.)
-    color : Colors.black
-    thickness : 2.0
-    stroke : "none"
-    style : "solid"
-  }
-  override t.tick3 = Line {
-    start : midpointOffset(t.icon, 10.)
-    end : midpointOffset(t.icon, -10.)
-    color : Colors.black
-    thickness : 2.0
-    stroke : "none"
-    style : "solid"
+    fill: Colors.none
   }
   s.tick above s.icon
-  s.tick2 above s.icon
-  s.tick3 above s.icon
   t.tick above t.icon
-  t.tick2 above t.icon
-  t.tick3 above t.icon
 }
 
 --Angle

--- a/examples/geometry-domain/textbook_problems/c07p22.sub
+++ b/examples/geometry-domain/textbook_problems/c07p22.sub
@@ -4,8 +4,10 @@ Triangle UVW := MkTriangle(U, V, W)
 Segment SR := MkSegment(S, R)
 Segment ST := MkSegment(S, T)
 EqualLengthMarker1(SR, ST)
+EqualLength(SR, ST)
 
 Segment UV := MkSegment(U, V)
 Segment VW := MkSegment(V, W)
 EqualLengthMarker2(UV, VW)
+EqualLength(UV, VW)
 AutoLabel All

--- a/packages/core/src/contrib/Functions.ts
+++ b/packages/core/src/contrib/Functions.ts
@@ -481,6 +481,41 @@ export const compDict = {
     };
   },
   /**
+   * Create equally spaced tick marks centered at the midpoint of a line
+   * @param pt1: starting point of a line
+   * @param pt2: endping point of a line
+   * @param spacing: space in px between each tick
+   * @param numTicks: number of tick marks to create
+   * @param tickLength: 1/2 length of each tick
+   */
+  ticksOnLine: (
+    pt1: VarAD[],
+    pt2: VarAD[],
+    spacing: VarAD,
+    numTicks: VarAD,
+    tickLength: VarAD
+  ) => {
+    const path = new PathBuilder();
+    // calculate scalar multipliers to determine the placement of each tick mark
+    const multipliers = tickPlacement(spacing, numTicks);
+    const unit = ops.vnormalize(ops.vsub(pt2, pt1));
+    const normalDir = ops.vneg(rot90v(unit)); // rot90 rotates CW, neg to point in CCW direction
+
+    const mid = ops.vmul(constOf(0.5), ops.vadd(pt1, pt2));
+
+    // start/end pts of each tick will be placed parallel to each other, offset at dist of tickLength
+    // from the original pt1->pt2 line
+    const [x1p, y1p] = ops.vmove(mid, tickLength, normalDir);
+    const [x2p, y2p] = ops.vmove(mid, tickLength, ops.vneg(normalDir));
+
+    multipliers.map((multiplier) => {
+      const [sx, sy] = ops.vmove([x1p, y1p], multiplier, unit);
+      const [ex, ey] = ops.vmove([x2p, y2p], multiplier, unit);
+      path.moveTo([sx, sy]).lineTo([ex, ey]);
+    });
+    return path.getPath();
+  },
+  /**
    * Given two orthogonal segments that intersect at `intersection`, and a size `len`
    * return a path comprised of three points that describe a perpendicular mark at the angle where the segments intersect.
    */


### PR DESCRIPTION
# Description
![Screenshot from 2021-08-11 18-18-43](https://user-images.githubusercontent.com/31522997/129236361-98c9509e-1116-4175-9517-4b463cd5e2b7.png)
Previously, the `EqualLengthMarker` predicates would render `x` ticks directly on top of each other, making it look like there was only one tick at any given time. This PR makes them render properly.

# Implementation strategy and design decisions
* Used the new PathBuilder class to make the SVG path easily
* The function that was added in Functions.ts can be easily recycled in the future when we are able to iteratively add tick marks to any segments with `EqualLengthMarked` without explicitly calling `EqualLengthMarker1` `EqualLengthMarker2` `EqualLengthMarker3`

# Examples with steps to reproduce them
1. check out this branch, `yarn start`
2. `npx roger watch examples/geometry-domain/textbook_problems/ex.sub examples/geometry-domain/euclidean.sty  examples/geometry-domain/geometry.dsl`
3. This example will often lay the triangles directly on top of each other but you can still see the various 1,2, and 3 mark variants
# Checklist

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] New and existing tests pass locally using `yarn test`
- [x] I ran `yarn docs` and there were no errors when generating the HTML site
- [x] My code follows the style guidelines of this project (e.g.: no ESLint warnings)

# Open questions

Questions that require more discussion or to be addressed in future development:
