### PR TITLE
chore: Add VS Code recommended extensions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,7 +32,8 @@ node_modules/
 build/
 .tmp/
 _region_.tex
-.vscode/
+/.vscode/*
+!/.vscode/extensions.json
 out*.txt
 penrose-ide/
 *.prof
@@ -48,4 +49,3 @@ examples/plugins/alloy/__temp.als__
 .java-version
 temp.als
 .*.sw*
-

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,7 @@
+{
+  "recommendations": [
+    "esbenp.prettier-vscode",
+    "folke.vscode-monorepo-workspace",
+    "penrose.penrose-vs"
+  ]
+}


### PR DESCRIPTION
# Description

This PR adds `.vscode/extensions.json`, to automatically recommend useful extensions like Monorepo Workspace.