### PR TITLE
fix: Circle CI OOM error when building #651

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "packages/*"
   ],
   "scripts": {
-    "build": "lerna run build --stream",
+    "build": "lerna run build --stream --concurrency 1",
     "clean": "lerna clean && lerna exec -- rimraf build",
     "start": "lerna run watch --stream --parallel --scope=@penrose/core --scope=@penrose/browser-ui",
     "test": "lerna run test --stream",


### PR DESCRIPTION
# Description

Related issue: #651 

Build sequentially in CI to avoid OOM error caused by default build parallelization in Circle CI medium Docker instance.  

Another fix option discussed: change the resource type on the Circle CI Docker instance to one with more RAM.  Removing parallelization allows us to avoid switching resource types and CI plans without much difference in build time.  

# Implementation strategy and design decisions

Instruct lerna to limit build concurrency to 1 vs. lerna's default, which is based on the underlying CPU & core count.

# Examples with steps to reproduce them

Repeatedly re-run build in CircleCI.  Observe consistently successful build vs. previous intermittent failures.

# Checklist

- [X] I have commented my code where appropriate, particularly in hard-to-understand areas
- [X] My changes generate no new warnings
- [X] New and existing tests pass locally using `yarn test`
- [X] I ran `yarn docs` and there were no errors when generating the HTML site
- [X] My code follows the style guidelines of this project (e.g.: no ESLint warnings)

# Open questions

At a later point, provisioning more build resources and re-introducing build parallelization may be prudent.  But right now, our build times are short and we do not have a large number of packages to parallelize.
