### PR TITLE
fix: add duplicate name check in Substance checker

### DIFF
--- a/packages/core/src/compiler/Substance.test.ts
+++ b/packages/core/src/compiler/Substance.test.ts
@@ -185,7 +185,7 @@ A := D
     const env = envOrError(domainProg);
     const prog = `
 OpenSet D
-Set B, C, E
+Set B, C
 Set A := D
 Set E := Subset(B, C)
     `;
@@ -309,13 +309,23 @@ Set A, B, C ;;; shouldn't parse
     const res = compileSubstance(prog, env);
     expectErrorOf(res, "ParseError");
   });
+  test("duplicate name error", () => {
+    const env = envOrError(domainProg);
+    const prog = `
+Set A
+Point A
+AutoLabel All
+    `;
+    const res = compileSubstance(prog, env);
+    expectErrorOf(res, "DuplicateName");
+  });
   test("type not found", () => {
     const env = envOrError(domainProg);
     const prog = `
 Set A, B, C
 List(Set) l
-Alien A
-NotExistentType B
+Alien a
+NotExistentType b
     `;
     const res = compileSubstance(prog, env);
     expectErrorOf(res, "TypeNotFound");
@@ -526,9 +536,9 @@ D := C.A
 E := C.B
 List(Set) l
 List(OpenSet) nil
+OpenSet Z
 nil := Nil()
-OpenSet A
-l := Cons(A, nil)
+l := Cons(Z, nil)
 Empty(C)
 IsSubset(D, E)
 IsSubset(D, A)

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -64,7 +64,6 @@ export const stepUntilConvergence = (
   numSteps = 10000
 ): Result<State, RuntimeError> => {
   let currentState = state;
-  log.warn(currentState.params.optStatus);
   while (
     !(currentState.params.optStatus === "Error") &&
     !stateConverged(currentState)


### PR DESCRIPTION
# Description

Related issue/PR: #654 

The Substance checker doesn't check for duplicated names (since the Haskell days!?). This PR adds duplicate name checks for `Decl`s.

# Implementation strategy and design decisions

* In `checkStmt`, check if the name exists right after the type constructor check. 
* Fix all tests in the existing suite that had duplicate names (surprise!)
* Add a test of the example in #654 in the suite.
