### PR TITLE
chore: disable the mod tab #664

### DIFF
--- a/packages/browser-ui/src/inspector/views/viewMap.tsx
+++ b/packages/browser-ui/src/inspector/views/viewMap.tsx
@@ -10,7 +10,7 @@ const viewMap = {
   frames: Frames,
   errors: Errors,
   shapes: ShapeView,
-  mod: Mod,
+  // mod: Mod, // NOTE: mod tab temporarily deprecated
   "optimization status": Opt,
   compGraph: CompGraph,
   settings: Settings,


### PR DESCRIPTION
# Description

Related issue/PR: #664

# Implementation strategy and design decisions

Remove `mod` from `viewMap`. The source code for mod is still in the codebase so we can revive it later.

