### PR TITLE
fix: determine `pointer-event` for dragging based on shape kind

### DIFF
--- a/packages/core/src/contrib/Constraints.ts
+++ b/packages/core/src/contrib/Constraints.ts
@@ -27,29 +27,10 @@ import {
 } from "engine/Autodiff";
 import * as _ from "lodash";
 import { linePts } from "utils/OtherUtils";
+import { isLinelike, isRectlike } from "renderer/ShapeDef";
 import { VarAD } from "types/ad";
 import { every } from "lodash";
 import * as BBox from "engine/BBox";
-
-// Kinds of shapes
-/**
- * Takes a `shapeType`, returns whether it's rectlike. (excluding squares)
- */
-export const isRectlike = (shapeType: string): boolean => {
-  return (
-    shapeType == "Rectangle" ||
-    shapeType == "Square" ||
-    shapeType == "Image" ||
-    shapeType == "Text"
-  );
-};
-
-/**
- * Takes a `shapeType`, returns whether it's linelike.
- */
-export const isLinelike = (shapeType: string): boolean => {
-  return shapeType == "Line" || shapeType == "Arrow";
-};
 
 export const objDict = {
   /**

--- a/packages/core/src/contrib/Functions.ts
+++ b/packages/core/src/contrib/Functions.ts
@@ -1,4 +1,4 @@
-import { bboxFromShape, inRange, isRectlike } from "contrib/Constraints"; // TODO move this into graphics utils?
+import { bboxFromShape, inRange } from "contrib/Constraints"; // TODO move this into graphics utils?
 import {
   absVal,
   add,
@@ -37,6 +37,7 @@ import {
 } from "types/value";
 import { getStart, linePts } from "utils/OtherUtils";
 import { randFloat } from "utils/Util";
+import { isRectlike } from "renderer/ShapeDef";
 
 /**
  * Static dictionary of computation functions

--- a/packages/core/src/renderer/Renderer.ts
+++ b/packages/core/src/renderer/Renderer.ts
@@ -3,6 +3,7 @@ import { Shape } from "types/shape";
 import { dragUpdate } from "./dragUtils";
 import { IStrV } from "types/value";
 import { LabelCache, State } from "types/state";
+import { isLinelike, isRectlike } from "renderer/ShapeDef";
 
 export interface ShapeProps {
   shape: Shape;
@@ -67,7 +68,15 @@ export const DraggableShape = (
     canvasSize: canvasSizeCustom ? canvasSizeCustom : shapeProps.canvasSize,
   });
   const g = document.createElementNS("http://www.w3.org/2000/svg", "g");
-  g.setAttribute("pointer-events", "bounding-box");
+  const { shapeType } = shapeProps.shape;
+  if (isLinelike(shapeType)) {
+    console.log(shapeProps.shape);
+    g.setAttribute("pointer-events", "visibleStroke");
+  } else if (isRectlike(shapeType)) {
+    g.setAttribute("pointer-events", "bounding-box");
+  } else {
+    g.setAttribute("pointer-events", "auto");
+  }
   g.appendChild(elem);
 
   const onMouseDown = (e: MouseEvent) => {

--- a/packages/core/src/renderer/ShapeDef.ts
+++ b/packages/core/src/renderer/ShapeDef.ts
@@ -447,3 +447,25 @@ export const findDef = (type: string): ShapeDef => {
 };
 
 //#endregion
+
+//#region Shape kind queries
+// Kinds of shapes
+/**
+ * Takes a `shapeType`, returns whether it's rectlike. (excluding squares)
+ */
+export const isRectlike = (shapeType: string): boolean => {
+  return (
+    shapeType == "Rectangle" ||
+    shapeType == "Square" ||
+    shapeType == "Image" ||
+    shapeType == "Text"
+  );
+};
+
+/**
+ * Takes a `shapeType`, returns whether it's linelike.
+ */
+export const isLinelike = (shapeType: string): boolean => {
+  return shapeType == "Line" || shapeType == "Arrow";
+};
+//#endregion

--- a/packages/core/src/utils/CollectLabels.ts
+++ b/packages/core/src/utils/CollectLabels.ts
@@ -27,7 +27,7 @@ const tex = new TeX({
   ],
   processEscapes: true,
 });
-const svg = new SVG({ fontCache: "local" });
+const svg = new SVG({ fontCache: "none" });
 const html = mathjax.document("", { InputJax: tex, OutputJax: svg });
 
 // to re-scale baseline
@@ -49,31 +49,29 @@ const convert = (input: string, fontSize: string) => {
  * Call MathJax to render __non-empty__ labels.
  * NOTE: this function is memoized.
  */
-const tex2svg = async (
-  contents: string,
-  name: string,
-  fontSize: string
-): Promise<any> =>
-  new Promise((resolve) => {
-    const output = convert(contents, fontSize);
-    if (!output) {
-      console.error(`MathJax could not render ${contents}`);
-      resolve({ output: undefined, width: 0, height: 0 });
-      return;
-    }
-    // console.log(output);
-    // console.log(output.viewBox.baseVal);
-    const viewBox = output.getAttribute("viewBox")!.split(" ");
-    const width = parseFloat(viewBox[2]);
-    const height = parseFloat(viewBox[3]);
+const tex2svg = memoize(
+  async (contents: string, name: string, fontSize: string): Promise<any> =>
+    new Promise((resolve) => {
+      const output = convert(contents, fontSize);
+      if (!output) {
+        console.error(`MathJax could not render ${contents}`);
+        resolve({ output: undefined, width: 0, height: 0 });
+        return;
+      }
+      // console.log(output);
+      // console.log(output.viewBox.baseVal);
+      const viewBox = output.getAttribute("viewBox")!.split(" ");
+      const width = parseFloat(viewBox[2]);
+      const height = parseFloat(viewBox[3]);
 
-    // rescaling according to
-    // https://github.com/mathjax/MathJax-src/blob/32213009962a887e262d9930adcfb468da4967ce/ts/output/svg.ts#L248
-    const vAlignFloat = parseFloat(output.style.verticalAlign) * EX_CONSTANT;
-    const constHeight = parseFloat(fontSize) - vAlignFloat;
-    const scaledWidth = (constHeight / height) * width;
-    resolve({ body: output, width: scaledWidth, height: constHeight });
-  });
+      // rescaling according to
+      // https://github.com/mathjax/MathJax-src/blob/32213009962a887e262d9930adcfb468da4967ce/ts/output/svg.ts#L248
+      const vAlignFloat = parseFloat(output.style.verticalAlign) * EX_CONSTANT;
+      const constHeight = parseFloat(fontSize) - vAlignFloat;
+      const scaledWidth = (constHeight / height) * width;
+      resolve({ body: output, width: scaledWidth, height: constHeight });
+    })
+);
 
 export const retrieveLabel = (
   shapeName: string,


### PR DESCRIPTION
# Description

For line-like shapes (e.g. `Line`), `RenderInteractive` set the `pointer-event` attribute to `bounding-box`. Changing it such that we use `isRectlike` and `isLinelike` to determine the correct value. For instance, `pointer-event: visibleStroke` works better for line-like shapes.

