### PR TITLE
feat: Domain syntax highlighting

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "build": "lerna run build --stream --concurrency 1",
     "clean": "lerna clean && lerna exec -- rimraf build",
     "start": "lerna run watch --stream --parallel --scope=@penrose/core --scope=@penrose/browser-ui",
+    "start:ide": "lerna run watch --stream --parallel --scope=@penrose/core --scope=@penrose/panels",
     "build:ide": "lerna run build --stream --scope=@penrose/core --scope=@penrose/panels",
     "test": "lerna run test --stream",
     "docs": "lerna run docs --stream",

--- a/packages/panels/package.json
+++ b/packages/panels/package.json
@@ -17,7 +17,8 @@
     "styled-components": "4.4.1"
   },
   "scripts": {
-    "start": "node build.js -w",
+    "start": "yarn watch",
+    "watch": "node build.js -w",
     "build": "node build.js",
     "test": "echo NO TESTS",
     "prepack": "yarn build"

--- a/packages/panels/src/App.tsx
+++ b/packages/panels/src/App.tsx
@@ -27,7 +27,8 @@ import AuthorshipTitle from "./components/AuthorshipTitle";
 import BlueButton from "./components/BlueButton";
 import { useParams } from "react-router-dom";
 import StylePane from "./StylePane";
-import SubPane from "./SubPane";
+import SubstancePane from "./SubstancePane";
+import DomainPane from "./DomainPane";
 
 const TabButton = styled.a<{ open: boolean }>`
   outline: none;
@@ -271,7 +272,7 @@ function App({ location }: any) {
       >
         <ColumnContainer show={state.openPanes.sub} numOpen={numOpen}>
           {
-            <SubPane
+            <SubstancePane
               value={state.currentInstance.sub}
               domainCache={state.currentInstance.domainCache}
               numOpen={numOpen}
@@ -289,18 +290,13 @@ function App({ location }: any) {
           }
         </ColumnContainer>
         <ColumnContainer show={state.openPanes.dsl} numOpen={numOpen}>
-          <MonacoEditor
-            value={state.currentInstance.dsl}
-            onChange={(content) =>
-              dispatch({
-                kind: "CHANGE_CODE",
-                lang: "dsl",
-                content: content as string,
-              })
-            }
-            width={`${window.innerWidth / numOpen}px`}
-            options={monacoOptions}
-          />
+          {
+            <DomainPane
+              value={state.currentInstance.dsl}
+              numOpen={numOpen}
+              dispatch={dispatch}
+            />
+          }
         </ColumnContainer>
         <ColumnContainer show={state.openPanes.preview} numOpen={numOpen}>
           <div

--- a/packages/panels/src/DomainPane.tsx
+++ b/packages/panels/src/DomainPane.tsx
@@ -1,0 +1,68 @@
+import * as React from "react";
+import { Dispatcher } from "./reducer";
+import MonacoEditor, { useMonaco } from "@monaco-editor/react";
+import { monacoOptions } from "./Util";
+import { useEffect } from "react";
+import {
+  DomainCompletions,
+  DomainConfig,
+  DomainLanguageTokens,
+} from "./languages/DomainConfig";
+import { IRange } from "monaco-editor";
+
+const DomainPane = ({
+  value,
+  dispatch,
+  numOpen,
+}: {
+  value: string;
+  dispatch: Dispatcher;
+  numOpen: number;
+}) => {
+  const monaco = useMonaco();
+  useEffect(() => {
+    if (monaco) {
+      monaco.languages.register({ id: "domain" });
+      monaco.languages.setLanguageConfiguration("domain", DomainConfig);
+      monaco.languages.setMonarchTokensProvider(
+        "domain",
+        DomainLanguageTokens()
+      );
+      const dispose = monaco.languages.registerCompletionItemProvider(
+        "domain",
+        {
+          provideCompletionItems: (model, position) => {
+            const word = model.getWordUntilPosition(position);
+            const range: IRange = {
+              startLineNumber: position.lineNumber,
+              endLineNumber: position.lineNumber,
+              startColumn: word.startColumn,
+              endColumn: word.endColumn,
+            };
+            return { suggestions: DomainCompletions(range) };
+          },
+        }
+      );
+      return () => {
+        dispose.dispose();
+      };
+    }
+  }, [monaco]);
+  return (
+    <MonacoEditor
+      value={value}
+      width={`${window.innerWidth / numOpen}px`}
+      onChange={(content) =>
+        dispatch({
+          kind: "CHANGE_CODE",
+          lang: "dsl",
+          content: content as string,
+        })
+      }
+      defaultLanguage="domain"
+      options={monacoOptions}
+    />
+  );
+};
+
+export default DomainPane;

--- a/packages/panels/src/StylePane.tsx
+++ b/packages/panels/src/StylePane.tsx
@@ -7,7 +7,7 @@ import {
   StyleCompletions,
   StyleConfig,
   StyleLanguageTokens,
-} from "./languageConfigs";
+} from "./languages/StyleConfig";
 import { IRange } from "monaco-editor";
 
 const StylePane = ({

--- a/packages/panels/src/SubstancePane.tsx
+++ b/packages/panels/src/SubstancePane.tsx
@@ -4,16 +4,13 @@ import MonacoEditor, { useMonaco } from "@monaco-editor/react";
 import { monacoOptions } from "./Util";
 import { useCallback, useEffect } from "react";
 import {
-  StyleCompletions,
-  StyleConfig,
-  StyleLanguageTokens,
   SubstanceCompletions,
   SubstanceConfig,
   SubstanceLanguageTokens,
-} from "./languageConfigs";
+} from "./languages/SubstanceConfig";
 import { IRange } from "monaco-editor";
 
-const SubPane = ({
+const SubstancePane = ({
   value,
   domainCache,
   dispatch,
@@ -77,4 +74,4 @@ const SubPane = ({
   );
 };
 
-export default SubPane;
+export default SubstancePane;

--- a/packages/panels/src/languages/DomainConfig.ts
+++ b/packages/panels/src/languages/DomainConfig.ts
@@ -1,0 +1,60 @@
+import { languages, IRange } from "monaco-editor";
+import { CommentCommon, CommonTokens } from "./common";
+
+export const DomainConfig: languages.LanguageConfiguration = {
+  comments: {
+    blockComment: ["/*", "*/"],
+    lineComment: "--",
+  },
+  autoClosingPairs: [{ open: '"', close: '"', notIn: ["string", "comment"] }],
+  surroundingPairs: [{ open: '"', close: '"' }],
+};
+
+const domainOperators: string[] = ["*", "->", ":", "<:"];
+
+const domainKeywords: string[] = [
+  "type",
+  "notation",
+  "predicate",
+  "function",
+  "constructor",
+  "prelude",
+];
+
+export const DomainLanguageTokens = (): languages.IMonarchLanguage => {
+  const refs = {
+    control: domainKeywords,
+    operator: domainOperators,
+  };
+  return {
+    ...refs,
+    tokenizer: {
+      root: [
+        ...CommonTokens,
+        [/\$.*\$/, "comment.doc"],
+        [
+          /[a-z_A-Z$][\w$]*/,
+          {
+            cases: {
+              "@control": "keyword",
+              "@default": "identifier",
+              "@operator": "operator",
+            },
+          },
+        ],
+        { include: "@whitespace" },
+      ],
+      ...CommentCommon,
+    },
+  };
+};
+
+export const DomainCompletions = (range: IRange) => {
+  return domainKeywords.map((type) => ({
+    label: type,
+    insertText: type,
+    kind: languages.CompletionItemKind.Keyword,
+    detail: "Domain keywords",
+    range,
+  }));
+};

--- a/packages/panels/src/languages/StyleConfig.ts
+++ b/packages/panels/src/languages/StyleConfig.ts
@@ -1,42 +1,5 @@
 import { languages, IRange } from "monaco-editor";
-
-const CommentCommon: any = {
-  comment: [
-    [/[^/*]+/, "comment"],
-    [/\/\*/, "comment", "@push"], // nested comment
-    ["\\*/", "comment", "@pop"],
-    [/[/*]/, "comment"],
-  ],
-  whitespace: [
-    [/[ \t\r\n]+/, "white"],
-    [/\/\*/, "comment", "@comment"],
-    [/--.*?$/, "comment"],
-  ],
-};
-
-export const SubstanceConfig: languages.LanguageConfiguration = {
-  comments: {
-    blockComment: ["/*", "*/"],
-    lineComment: "--",
-  },
-  autoClosingPairs: [
-    { open: "(", close: ")", notIn: ["string", "comment"] },
-    { open: '"', close: '"', notIn: ["string", "comment"] },
-    { open: "$", close: "$", notIn: ["string", "comment"] },
-  ],
-  surroundingPairs: [
-    { open: "(", close: ")" },
-    { open: '"', close: '"' },
-    { open: "$", close: "$" },
-  ],
-  brackets: [["(", ")"]],
-  folding: {
-    markers: {
-      start: /\(/,
-      end: /\)/,
-    },
-  },
-};
+import { CommentCommon, CommonTokens } from "./common";
 
 export const StyleConfig: languages.LanguageConfiguration = {
   comments: {
@@ -68,10 +31,6 @@ export const StyleConfig: languages.LanguageConfiguration = {
     },
   },
 };
-
-const CommonTokens: languages.IMonarchLanguageRule[] = [
-  [/"(?:[^\n"]|\\["\\ntbfr])*"/, "string"],
-];
 
 const styleCustoms = {
   keywords: [
@@ -194,7 +153,7 @@ export const StyleLanguageTokens: languages.IMonarchLanguage = {
   tokenizer: {
     root: [
       ...CommonTokens,
-      [/[{}()[]]/, "@brackets"],
+      [/[{}\[\]()]/, "@brackets"],
       [
         /[a-z_A-Z$][\w$]*/,
         {
@@ -268,95 +227,3 @@ export const StyleCompletions = (range: IRange): languages.CompletionItem[] => [
     range,
   })),
 ];
-
-export const SubstanceLanguageTokens = (
-  domainCache: any
-): languages.IMonarchLanguage => {
-  const refs = {
-    types: [...domainCache.types.keys()],
-    functionLikes: [
-      ...domainCache.constructors.keys(),
-      ...domainCache.functions.keys(),
-      ...domainCache.predicates.keys(),
-    ],
-    control: ["AutoLabel", "Label", "NoLabel", "All"],
-  };
-  return {
-    ...refs,
-    tokenizer: {
-      root: [
-        ...CommonTokens,
-        [/[()]/, "@brackets"],
-        [/\$.*\$/, "comment.doc"],
-        [
-          /[a-z_A-Z$][\w$]*/,
-          {
-            cases: {
-              "@types": "keyword",
-              "@control": "keyword",
-              "@functionLikes": "tag",
-              "@default": "identifier",
-            },
-          },
-        ],
-        { include: "@whitespace" },
-      ],
-      ...CommentCommon,
-    },
-  };
-};
-
-export const SubstanceCompletions = (
-  range: IRange,
-  domainCache: any
-): languages.CompletionItem[] => {
-  const types = [...domainCache.types.keys()].map((type) => ({
-    label: type,
-    insertText: type + " $0",
-    insertTextRules: languages.CompletionItemInsertTextRule.InsertAsSnippet,
-    kind: languages.CompletionItemKind.TypeParameter,
-    detail: "type",
-    range,
-  }));
-  const predicates = [...domainCache.predicates.keys()].map((type) => ({
-    label: type,
-    insertText: type + "($0)",
-    insertTextRules: languages.CompletionItemInsertTextRule.InsertAsSnippet,
-    kind: languages.CompletionItemKind.Property,
-    detail: "predicate",
-    range,
-  }));
-  const constructors = [...domainCache.constructors.keys()].map((type) => ({
-    label: type,
-    insertText: type + "($0)",
-    insertTextRules: languages.CompletionItemInsertTextRule.InsertAsSnippet,
-    kind: languages.CompletionItemKind.Constructor,
-    detail: "constructor",
-    range,
-  }));
-  const labeling = ["AutoLabel", "Label", "NoLabel", "All"].map((type) => ({
-    label: type,
-    insertText: type,
-    kind: languages.CompletionItemKind.Color,
-    detail: "labeling",
-    range,
-  }));
-
-  const fns = [...domainCache.functions.entries()].map(([name, fn]) => ({
-    label: name,
-    insertText: `${name}($0)`,
-    insertTextRules: languages.CompletionItemInsertTextRule.InsertAsSnippet,
-    kind: languages.CompletionItemKind.Function,
-    detail: `function -> ${fn.output.type.name.value}`,
-    documentation: {
-      value: `${fn.args
-        .map((arg: any) => {
-          return arg.type.name.value + " " + arg.variable.value;
-        })
-        .join(" * ")} -> ${fn.output.type.name.value}`,
-    },
-    range,
-  }));
-
-  return [...types, ...fns, ...predicates, ...constructors, ...labeling];
-};

--- a/packages/panels/src/languages/SubstanceConfig.ts
+++ b/packages/panels/src/languages/SubstanceConfig.ts
@@ -1,0 +1,119 @@
+import { Env } from "@penrose/core";
+import { languages, IRange } from "monaco-editor";
+import { CommentCommon, CommonTokens } from "./common";
+
+export const SubstanceConfig: languages.LanguageConfiguration = {
+  comments: {
+    blockComment: ["/*", "*/"],
+    lineComment: "--",
+  },
+  autoClosingPairs: [
+    { open: "(", close: ")", notIn: ["string", "comment"] },
+    { open: '"', close: '"', notIn: ["string", "comment"] },
+    { open: "$", close: "$", notIn: ["string", "comment"] },
+  ],
+  surroundingPairs: [
+    { open: "(", close: ")" },
+    { open: '"', close: '"' },
+    { open: "$", close: "$" },
+  ],
+  brackets: [["(", ")"]],
+  folding: {
+    markers: {
+      start: /\(/,
+      end: /\)/,
+    },
+  },
+};
+
+export const SubstanceLanguageTokens = (
+  domainCache: Env
+): languages.IMonarchLanguage => {
+  const refs = {
+    types: [...domainCache.types.keys()],
+    functionLikes: [
+      ...domainCache.constructors.keys(),
+      ...domainCache.functions.keys(),
+      ...domainCache.predicates.keys(),
+    ],
+    control: ["AutoLabel", "Label", "NoLabel", "All"],
+  };
+  return {
+    ...refs,
+    tokenizer: {
+      root: [
+        ...CommonTokens,
+        [/[()]/, "@brackets"],
+        [/\$.*\$/, "comment.doc"],
+        [
+          /[a-z_A-Z$][\w$]*/,
+          {
+            cases: {
+              "@types": "keyword",
+              "@control": "keyword",
+              "@functionLikes": "tag",
+              "@default": "identifier",
+            },
+          },
+        ],
+        { include: "@whitespace" },
+      ],
+      ...CommentCommon,
+    },
+  };
+};
+
+export const SubstanceCompletions = (
+  range: IRange,
+  domainCache: any
+): languages.CompletionItem[] => {
+  const types = [...domainCache.types.keys()].map((type) => ({
+    label: type,
+    insertText: type + " $0",
+    insertTextRules: languages.CompletionItemInsertTextRule.InsertAsSnippet,
+    kind: languages.CompletionItemKind.TypeParameter,
+    detail: "type",
+    range,
+  }));
+  const predicates = [...domainCache.predicates.keys()].map((type) => ({
+    label: type,
+    insertText: type + "($0)",
+    insertTextRules: languages.CompletionItemInsertTextRule.InsertAsSnippet,
+    kind: languages.CompletionItemKind.Property,
+    detail: "predicate",
+    range,
+  }));
+  const constructors = [...domainCache.constructors.keys()].map((type) => ({
+    label: type,
+    insertText: type + "($0)",
+    insertTextRules: languages.CompletionItemInsertTextRule.InsertAsSnippet,
+    kind: languages.CompletionItemKind.Constructor,
+    detail: "constructor",
+    range,
+  }));
+  const labeling = ["AutoLabel", "Label", "NoLabel", "All"].map((type) => ({
+    label: type,
+    insertText: type,
+    kind: languages.CompletionItemKind.Color,
+    detail: "labeling",
+    range,
+  }));
+
+  const fns = [...domainCache.functions.entries()].map(([name, fn]) => ({
+    label: name,
+    insertText: `${name}($0)`,
+    insertTextRules: languages.CompletionItemInsertTextRule.InsertAsSnippet,
+    kind: languages.CompletionItemKind.Function,
+    detail: `function -> ${fn.output.type.name.value}`,
+    documentation: {
+      value: `${fn.args
+        .map((arg: any) => {
+          return arg.type.name.value + " " + arg.variable.value;
+        })
+        .join(" * ")} -> ${fn.output.type.name.value}`,
+    },
+    range,
+  }));
+
+  return [...types, ...fns, ...predicates, ...constructors, ...labeling];
+};

--- a/packages/panels/src/languages/common.ts
+++ b/packages/panels/src/languages/common.ts
@@ -1,0 +1,19 @@
+import { languages } from "monaco-editor";
+
+export const CommentCommon: any = {
+  comment: [
+    [/[^/*]+/, "comment"],
+    [/\/\*/, "comment", "@push"], // nested comment
+    ["\\*/", "comment", "@pop"],
+    [/[/*]/, "comment"],
+  ],
+  whitespace: [
+    [/[ \t\r\n]+/, "white"],
+    [/\/\*/, "comment", "@comment"],
+    [/--.*?$/, "comment"],
+  ],
+};
+
+export const CommonTokens: languages.IMonarchLanguageRule[] = [
+  [/"(?:[^\n"]|\\["\\ntbfr])*"/, "string"],
+];

--- a/packages/panels/tsconfig.json
+++ b/packages/panels/tsconfig.json
@@ -12,6 +12,7 @@
     "noFallthroughCasesInSwitch": true,
     "module": "esnext",
     "moduleResolution": "node",
+    "downlevelIteration": true,
     "resolveJsonModule": true,
     "isolatedModules": true,
     "noEmit": true,


### PR DESCRIPTION
# Description

Related issue/PR: #659 

`@penrose/panels` doesn't highlight Domain programs. This PR adds language configuration for the Domain language.

# Implementation strategy and design decisions

* Separate `languageConfigs` into individual modules and add `DomainConfig`. 
* Fix small issue with errors related to `@brackets`

# Examples with steps to reproduce them

Run `yarn start:ide` at the top-level and write a Domain program!

![image](https://user-images.githubusercontent.com/11740102/141519915-ac090a63-140e-45ca-b2c0-e0ab437a922d.png)


# Open questions

* I noticed the Style config hard code a lot of things. Perhaps we can export the keywords, type annotations, or even constraint/computation dicts from `core` to fix this. 