### PR TITLE
feat: Define bounding box function for every shape

### DIFF
--- a/packages/core/src/contrib/Constraints.ts
+++ b/packages/core/src/contrib/Constraints.ts
@@ -1011,7 +1011,6 @@ export const areDisjointBoxes = (a: BBox.BBox, b: BBox.BBox): VarAD => {
  *   (shape-specific)
  * Input: A shape.
  * Output: A new BBox
- * Errors: Throws an error if called on an unsupported shape type.
  */
 export const bboxFromShape = (t: string, s: any): BBox.BBox => {
   return findDef(t).bbox(s);

--- a/packages/core/src/contrib/Constraints.ts
+++ b/packages/core/src/contrib/Constraints.ts
@@ -27,7 +27,7 @@ import {
 } from "engine/Autodiff";
 import * as _ from "lodash";
 import { linePts } from "utils/OtherUtils";
-import { isLinelike, isRectlike } from "renderer/ShapeDef";
+import { findDef, isLinelike, isRectlike } from "renderer/ShapeDef";
 import { VarAD } from "types/ad";
 import { every } from "lodash";
 import * as BBox from "engine/BBox";
@@ -1008,51 +1008,11 @@ export const areDisjointBoxes = (a: BBox.BBox, b: BBox.BBox): VarAD => {
 
 /**
  * Preconditions:
- *   If the input is line-like, it must be axis-aligned.
- *   Assumes line-like shapes are longer than they are thick.
- * Input: A rect- or line-like shape.
+ *   (shape-specific)
+ * Input: A shape.
  * Output: A new BBox
- * Errors: Throws an error if the input shape is not rect- or line-like.
+ * Errors: Throws an error if called on an unsupported shape type.
  */
 export const bboxFromShape = (t: string, s: any): BBox.BBox => {
-  if (!(isRectlike(t) || isLinelike(t))) {
-    throw new Error(
-      `BBox expected a rect-like or line-like shape, but got ${t}`
-    );
-  }
-
-  // initialize w, h, and center depending on whether the input shape is line-like or rect/square-like
-  let w;
-  if (t == "Square") {
-    w = s.side.contents;
-  } else if (isLinelike(t)) {
-    w = max(
-      absVal(sub(s.start.contents[0], s.end.contents[0])),
-      s.thickness.contents
-    );
-  } else {
-    w = s.w.contents;
-  }
-
-  let h;
-  if (t == "Square") {
-    h = s.side.contents;
-  } else if (isLinelike(t)) {
-    h = max(
-      absVal(sub(s.start.contents[1], s.end.contents[1])),
-      s.thickness.contents
-    );
-  } else {
-    h = s.h.contents;
-  }
-
-  let center;
-  if (isLinelike(t)) {
-    // TODO: Compute the bbox of the line in a nicer way
-    center = ops.vdiv(ops.vadd(s.start.contents, s.end.contents), constOf(2));
-  } else {
-    center = s.center.contents;
-  }
-
-  return BBox.bbox(w, h, center);
+  return findDef(t).bbox(s);
 };

--- a/packages/core/src/contrib/Functions.ts
+++ b/packages/core/src/contrib/Functions.ts
@@ -218,7 +218,7 @@ export const compDict = {
     return {
       tag: "ColorV",
       contents: {
-        tag: "NONE"
+        tag: "NONE",
       },
     };
   },
@@ -559,7 +559,7 @@ export const compDict = {
 
   /**
            * Figure out which side of the rectangle `[t1, s1]` the `start->end` line is hitting, assuming that `start` is located at the rect's center and `end` is located outside the rectangle, and return the size of the OTHER side. Also assuming axis-aligned rectangle. This is used for arrow placement in box-and-arrow diagrams.
-        
+
        @deprecated Don't use this function, it does not fully work
            */
   intersectingSideSize: (
@@ -682,18 +682,18 @@ export const compDict = {
    */
   setOpacity: (color: Color<VarAD>, frac: VarAD): IColorV<VarAD> => {
     // If paint=none, opacity is irreelevant
-    if(color.tag === "NONE") {
+    if (color.tag === "NONE") {
       return {
         tag: "ColorV",
-        contents: color
-      }
-    // Otherwise, retain tag and color; only modify opacity
+        contents: color,
+      };
+      // Otherwise, retain tag and color; only modify opacity
     } else {
       const props = color.contents;
       return {
         tag: "ColorV",
-        contents: { 
-          tag: color.tag, 
+        contents: {
+          tag: color.tag,
           contents: [props[0], props[1], props[2], mul(frac, props[3])],
         },
       };

--- a/packages/core/src/contrib/Functions.ts
+++ b/packages/core/src/contrib/Functions.ts
@@ -75,6 +75,17 @@ export const compDict = {
       .getPath();
   },
 
+  curveFromPoints: (start: Pt2, cp: Pt2, pts: Pt2[]): IPathDataV<IVarAD> => {
+    const path = new PathBuilder();
+    path.moveTo(start);
+    const [second, ...tailpts] = pts;
+    path.quadraticCurveTo(cp, second);
+    for (const pt of tailpts) {
+      path.quadraticCurveJoin(pt);
+    }
+    return path.getPath();
+  },
+
   /**
    * Return the derivative of `varName`.
    * NOTE: This is a special system function. Don't change it!

--- a/packages/core/src/renderer/Path.ts
+++ b/packages/core/src/renderer/Path.ts
@@ -61,18 +61,10 @@ export const Path = ({ shape, canvasSize }: ShapeProps) => {
   const elem = document.createElementNS("http://www.w3.org/2000/svg", "g");
   const strokeWidth = (shape.properties.strokeWidth as IFloatV<number>)
     .contents;
-  const strokeColor = toSvgPaintProperty(
-    (shape.properties.color as IColorV<number>).contents
-  );
-  const strokeOpacity = toSvgOpacityProperty(
-    (shape.properties.color as IColorV<number>).contents
-  );
-  const fillColor = toSvgPaintProperty(
-    (shape.properties.fill as IColorV<number>).contents
-  );
-  const fillOpacity = toSvgOpacityProperty(
-    (shape.properties.fill as IColorV<number>).contents
-  );
+  const strokeColor = toSvgPaintProperty((shape.properties.color as IColorV<number>).contents);
+  const strokeOpacity = toSvgOpacityProperty((shape.properties.color as IColorV<number>).contents);
+  const fillColor = toSvgPaintProperty((shape.properties.fill as IColorV<number>).contents);
+  const fillOpacity = toSvgOpacityProperty((shape.properties.fill as IColorV<number>).contents);
   const arrowheadStyle = (shape.properties.arrowheadStyle as IStrV).contents;
   const arrowheadSize = (shape.properties.arrowheadSize as IFloatV<number>)
     .contents;
@@ -103,12 +95,12 @@ export const Path = ({ shape, canvasSize }: ShapeProps) => {
   path.setAttribute("stroke", strokeColor);
   path.setAttribute("fill", fillColor);
   // Stroke opacity and width only relevant if paint is present
-  if ((shape.properties.color as IColorV<number>).contents.tag !== "NONE") {
+  if((shape.properties.color as IColorV<number>).contents.tag !== "NONE") {
     path.setAttribute("stroke-width", strokeWidth.toString());
     path.setAttribute("stroke-opacity", strokeOpacity.toString());
   }
   // Fill opacity only relevant if paint is present
-  if ((shape.properties.fill as IColorV<number>).contents.tag !== "NONE") {
+  if((shape.properties.fill as IColorV<number>).contents.tag !== "NONE") {
     path.setAttribute("fill-opacity", fillOpacity.toString());
   }
   // factor out an AttrHelper

--- a/packages/core/src/renderer/Path.ts
+++ b/packages/core/src/renderer/Path.ts
@@ -3,7 +3,7 @@ import { arrowHead } from "./Arrow";
 import { ShapeProps } from "./Renderer";
 import { flatten } from "lodash";
 import { attrTitle, DASH_ARRAY } from "./AttrHelper";
-import { IFloatV, IPathCmd, IStrV, IColorV } from "types/value";
+import { IFloatV, IPathCmd, IStrV, IColorV, ISubPath } from "types/value";
 
 const toPathString = (
   pathData: IPathCmd<number>[],
@@ -17,8 +17,9 @@ const toPathString = (
         return "";
       }
       const pathStr = flatten(
-        contents.map((c: any) => {
-          if (c.tag === "CoordV") return toScreen(c.contents, canvasSize);
+        contents.map((c: ISubPath<number>) => {
+          if (c.tag === "CoordV")
+            return toScreen(c.contents as [number, number], canvasSize);
           else if (c.tag === "ValueV") return c.contents;
           else {
             console.error("WARNING: improperly formed pathData");
@@ -60,10 +61,18 @@ export const Path = ({ shape, canvasSize }: ShapeProps) => {
   const elem = document.createElementNS("http://www.w3.org/2000/svg", "g");
   const strokeWidth = (shape.properties.strokeWidth as IFloatV<number>)
     .contents;
-  const strokeColor = toSvgPaintProperty((shape.properties.color as IColorV<number>).contents);
-  const strokeOpacity = toSvgOpacityProperty((shape.properties.color as IColorV<number>).contents);
-  const fillColor = toSvgPaintProperty((shape.properties.fill as IColorV<number>).contents);
-  const fillOpacity = toSvgOpacityProperty((shape.properties.fill as IColorV<number>).contents);
+  const strokeColor = toSvgPaintProperty(
+    (shape.properties.color as IColorV<number>).contents
+  );
+  const strokeOpacity = toSvgOpacityProperty(
+    (shape.properties.color as IColorV<number>).contents
+  );
+  const fillColor = toSvgPaintProperty(
+    (shape.properties.fill as IColorV<number>).contents
+  );
+  const fillOpacity = toSvgOpacityProperty(
+    (shape.properties.fill as IColorV<number>).contents
+  );
   const arrowheadStyle = (shape.properties.arrowheadStyle as IStrV).contents;
   const arrowheadSize = (shape.properties.arrowheadSize as IFloatV<number>)
     .contents;
@@ -94,12 +103,12 @@ export const Path = ({ shape, canvasSize }: ShapeProps) => {
   path.setAttribute("stroke", strokeColor);
   path.setAttribute("fill", fillColor);
   // Stroke opacity and width only relevant if paint is present
-  if((shape.properties.color as IColorV<number>).contents.tag !== "NONE") {
+  if ((shape.properties.color as IColorV<number>).contents.tag !== "NONE") {
     path.setAttribute("stroke-width", strokeWidth.toString());
     path.setAttribute("stroke-opacity", strokeOpacity.toString());
   }
   // Fill opacity only relevant if paint is present
-  if((shape.properties.fill as IColorV<number>).contents.tag !== "NONE") {
+  if ((shape.properties.fill as IColorV<number>).contents.tag !== "NONE") {
     path.setAttribute("fill-opacity", fillOpacity.toString());
   }
   // factor out an AttrHelper

--- a/packages/core/src/renderer/ShapeDef.test.ts
+++ b/packages/core/src/renderer/ShapeDef.test.ts
@@ -100,7 +100,7 @@ const squareSty = `Square {
 }
 `;
 
-const lineSty = `Line {
+const lineSty = (t: string) => `${t} {
   start: (-300., 200.)
   end: (100., -150.)
   thickness: 50
@@ -254,17 +254,29 @@ describe("ShapeDef", () => {
   // no Text test because w and h seem to just be set to 0 when using getShape
 
   test("lineDef.bbox", async () => {
-    const shape = await getShape(lineSty);
+    const shape = await getShape(lineSty("Line"));
     const {
       w,
       h,
       center: [x, y],
     } = ShapeDef.lineDef.bbox(shape.properties);
-    // TODO
+    expect(numOf(w)).toBeCloseTo(432.925);
+    expect(numOf(h)).toBeCloseTo(387.629);
+    expect(numOf(x)).toBeCloseTo(-100);
+    expect(numOf(y)).toBeCloseTo(25);
   });
 
-  test("arrowDef.bbox", () => {
-    const { bbox } = ShapeDef.arrowDef; // TODO
+  test("arrowDef.bbox", async () => {
+    const shape = await getShape(lineSty("Arrow"));
+    const {
+      w,
+      h,
+      center: [x, y],
+    } = ShapeDef.arrowDef.bbox(shape.properties);
+    expect(numOf(w)).toBeCloseTo(432.925);
+    expect(numOf(h)).toBeCloseTo(387.629);
+    expect(numOf(x)).toBeCloseTo(-100);
+    expect(numOf(y)).toBeCloseTo(25);
   });
 
   test("curveDef.bbox", () => {

--- a/packages/core/src/renderer/ShapeDef.test.ts
+++ b/packages/core/src/renderer/ShapeDef.test.ts
@@ -54,6 +54,23 @@ const rectSty = `Rectangle {
 }
 `;
 
+const calloutStyNoPadding = `Callout {
+  center: (-50., -100.)
+  w: 100.
+  h: 100.
+  anchor: (100., -200.)
+}
+`;
+
+const calloutStyPadding = `Callout {
+  center: (-50., -100.)
+  w: 100.
+  h: 100.
+  anchor: (100., -200.)
+  padding: 20
+}
+`;
+
 const lineSty = `Line {
   start: (-300., 200.)
   end: (100., -150.)
@@ -114,8 +131,30 @@ describe("ShapeDef", () => {
     expect(numOf(y)).toBeCloseTo(0);
   });
 
-  test("calloutDef.bbox", () => {
-    const { bbox } = ShapeDef.calloutDef; // TODO
+  test("calloutDef.bbox no padding", async () => {
+    const shape = await getShape(calloutStyNoPadding);
+    const {
+      w,
+      h,
+      center: [x, y],
+    } = ShapeDef.calloutDef.bbox(shape.properties);
+    expect(numOf(w)).toBeCloseTo(215);
+    expect(numOf(h)).toBeCloseTo(165);
+    expect(numOf(x)).toBeCloseTo(-7.5);
+    expect(numOf(y)).toBeCloseTo(-117.5);
+  });
+
+  test("calloutDef.bbox padding", async () => {
+    const shape = await getShape(calloutStyPadding);
+    const {
+      w,
+      h,
+      center: [x, y],
+    } = ShapeDef.calloutDef.bbox(shape.properties);
+    expect(numOf(w)).toBeCloseTo(210);
+    expect(numOf(h)).toBeCloseTo(160);
+    expect(numOf(x)).toBeCloseTo(-5);
+    expect(numOf(y)).toBeCloseTo(-120);
   });
 
   test("polygonDef.bbox", async () => {

--- a/packages/core/src/renderer/ShapeDef.test.ts
+++ b/packages/core/src/renderer/ShapeDef.test.ts
@@ -1,0 +1,59 @@
+import * as ShapeDef from "renderer/ShapeDef";
+
+describe("ShapeDef", () => {
+  test("circleDef.bbox", () => {
+    const { bbox } = ShapeDef.circleDef;
+  });
+
+  test("ellipseDef.bbox", () => {
+    const { bbox } = ShapeDef.ellipseDef;
+  });
+
+  test("rectDef.bbox", () => {
+    const { bbox } = ShapeDef.rectDef;
+  });
+
+  test("calloutDef.bbox", () => {
+    const { bbox } = ShapeDef.calloutDef;
+  });
+
+  test("polygonDef.bbox", () => {
+    const { bbox } = ShapeDef.polygonDef;
+  });
+
+  test("freeformPolygonDef.bbox", () => {
+    const { bbox } = ShapeDef.freeformPolygonDef;
+  });
+
+  test("pathStringDef.bbox", () => {
+    const { bbox } = ShapeDef.pathStringDef;
+  });
+
+  test("polylineDef.bbox", () => {
+    const { bbox } = ShapeDef.polylineDef;
+  });
+
+  test("imageDef.bbox", () => {
+    const { bbox } = ShapeDef.imageDef;
+  });
+
+  test("squareDef.bbox", () => {
+    const { bbox } = ShapeDef.squareDef;
+  });
+
+  test("textDef.bbox", () => {
+    const { bbox } = ShapeDef.textDef;
+  });
+
+  test("lineDef.bbox", () => {
+    const { bbox } = ShapeDef.lineDef;
+  });
+
+  test("arrowDef.bbox", () => {
+    const { bbox } = ShapeDef.arrowDef;
+  });
+
+  test("curveDef.bbox", () => {
+    const { bbox } = ShapeDef.curveDef;
+  });
+});

--- a/packages/core/src/renderer/ShapeDef.test.ts
+++ b/packages/core/src/renderer/ShapeDef.test.ts
@@ -1,4 +1,33 @@
+import { Shape } from "types/shape";
 import * as ShapeDef from "renderer/ShapeDef";
+import { unsafelyUnwrap } from "utils/Error";
+import { compileDomain, compileSubstance } from "index";
+import { compileStyle } from "compiler/Style";
+
+const makeSty = (shapeSty: string): string =>
+  `canvas {
+  width = 800
+  height = 700
+}
+
+global {
+  global.shape = ${shapeSty}
+}
+`;
+
+const getShapes = (shapeSty: string): Shape[] => {
+  const env0 = unsafelyUnwrap(compileDomain(""));
+  const [subEnv, varEnv] = unsafelyUnwrap(compileSubstance("", env0));
+  const state = unsafelyUnwrap(compileStyle(makeSty(shapeSty), subEnv, varEnv));
+  return state.shapes;
+};
+
+const rectSty = `Rectangle {
+  center: (0., 0.)
+  w: 150.
+  h: 200.
+}
+`;
 
 describe("ShapeDef", () => {
   test("circleDef.bbox", () => {
@@ -11,6 +40,8 @@ describe("ShapeDef", () => {
 
   test("rectDef.bbox", () => {
     const { bbox } = ShapeDef.rectDef;
+    const shapes = getShapes(rectSty);
+    expect(shapes).toEqual(["something"]);
   });
 
   test("calloutDef.bbox", () => {

--- a/packages/core/src/renderer/ShapeDef.test.ts
+++ b/packages/core/src/renderer/ShapeDef.test.ts
@@ -31,6 +31,12 @@ const rectSty = `Rectangle {
 }
 `;
 
+const lineSty = `Line {
+  start: (1., 2.)
+  end: (3., 7.)
+}
+`;
+
 describe("ShapeDef", () => {
   test("circleDef.bbox", () => {
     const { bbox } = ShapeDef.circleDef;
@@ -85,8 +91,17 @@ describe("ShapeDef", () => {
     const { bbox } = ShapeDef.textDef;
   });
 
-  test("lineDef.bbox", () => {
-    const { bbox } = ShapeDef.lineDef;
+  test("lineDef.bbox", async () => {
+    const shape = await getShape(lineSty);
+    const {
+      w,
+      h,
+      center: [x, y],
+    } = ShapeDef.lineDef.bbox(shape.properties);
+    expect(w).toBeCloseTo(2);
+    expect(h).toBeCloseTo(5);
+    expect(x).toBeCloseTo(2);
+    expect(y).toBeCloseTo(4.5);
   });
 
   test("arrowDef.bbox", () => {

--- a/packages/core/src/renderer/ShapeDef.test.ts
+++ b/packages/core/src/renderer/ShapeDef.test.ts
@@ -71,17 +71,18 @@ const calloutStyPadding = `Callout {
 }
 `;
 
-const lineSty = `Line {
-  start: (-300., 200.)
-  end: (100., -150.)
-  thickness: 50
-}
-`;
-
 // https://en.wikipedia.org/wiki/Polygon#/media/File:Assorted_polygons.svg
 const polygonSty = (t: string) => `${t} {
   points: [(564., 24.), (733., 54.), (755., 154.), (693., 257.), (548., 216.), (571., 145.), (630., 146.), (617., 180.), (664., 196.), (701., 120.), (591., 90.), (528., 129.)]
   scale: .5
+}
+`;
+
+const pathStringSty = `PathString {
+  center: (-50., 100.)
+  w: 100
+  h: 200
+  rotation: 30
 }
 `;
 
@@ -96,6 +97,13 @@ const squareSty = `Square {
   side: 50.
   center: (30., 70.)
   rotation: 30.
+}
+`;
+
+const lineSty = `Line {
+  start: (-300., 200.)
+  end: (100., -150.)
+  thickness: 50
 }
 `;
 
@@ -191,8 +199,17 @@ describe("ShapeDef", () => {
     expect(numOf(y)).toBeCloseTo(70.25);
   });
 
-  test("pathStringDef.bbox", () => {
-    const { bbox } = ShapeDef.pathStringDef; // TODO
+  test("pathStringDef.bbox", async () => {
+    const shape = await getShape(pathStringSty);
+    const {
+      w,
+      h,
+      center: [x, y],
+    } = ShapeDef.pathStringDef.bbox(shape.properties);
+    expect(numOf(w)).toBeCloseTo(186.603);
+    expect(numOf(h)).toBeCloseTo(223.205);
+    expect(numOf(x)).toBeCloseTo(-106.699);
+    expect(numOf(y)).toBeCloseTo(88.397);
   });
 
   test("polylineDef.bbox", async () => {
@@ -230,8 +247,8 @@ describe("ShapeDef", () => {
     } = ShapeDef.squareDef.bbox(shape.properties);
     expect(numOf(w)).toBeCloseTo(68.301);
     expect(numOf(h)).toBeCloseTo(68.301);
-    expect(numOf(x)).toBeCloseTo(39.151);
-    expect(numOf(y)).toBeCloseTo(54.151);
+    expect(numOf(x)).toBeCloseTo(14.151);
+    expect(numOf(y)).toBeCloseTo(60.849);
   });
 
   // no Text test because w and h seem to just be set to 0 when using getShape

--- a/packages/core/src/renderer/ShapeDef.test.ts
+++ b/packages/core/src/renderer/ShapeDef.test.ts
@@ -107,13 +107,13 @@ const lineSty = (t: string) => `${t} {
 }
 `;
 
-const pathStyQ = `Path {
-  pathData: makePath((-100, 0), (100, 0), 50, 10)
+const pathStyL = `Path {
+  pathData: pathFromPoints("open", [(-100, -100), (100, -50), (-50, 100)])
 }
 `;
 
-const pathStyL = `Path {
-  pathData: pathFromPoints("open", [(-100, -100), (100, -50), (-50, 100)])
+const pathStyQ = `Path {
+  pathData: makePath((-100, 0), (100, 0), 50, 10)
 }
 `;
 

--- a/packages/core/src/renderer/ShapeDef.test.ts
+++ b/packages/core/src/renderer/ShapeDef.test.ts
@@ -64,6 +64,7 @@ const lineSty = `Line {
 // https://en.wikipedia.org/wiki/Polygon#/media/File:Assorted_polygons.svg
 const freeformPolygonSty = `FreeformPolygon {
   points: [(564., 24.), (733., 54.), (755., 154.), (693., 257.), (548., 216.), (571., 145.), (630., 146.), (617., 180.), (664., 196.), (701., 120.), (591., 90.), (528., 129.)]
+  scale: .5
 }
 `;
 
@@ -128,10 +129,10 @@ describe("ShapeDef", () => {
       h,
       center: [x, y],
     } = ShapeDef.freeformPolygonDef.bbox(shape.properties);
-    expect(numOf(w)).toBeCloseTo(227);
-    expect(numOf(h)).toBeCloseTo(233);
-    expect(numOf(x)).toBeCloseTo(641.5);
-    expect(numOf(y)).toBeCloseTo(140.5);
+    expect(numOf(w)).toBeCloseTo(113.5);
+    expect(numOf(h)).toBeCloseTo(116.5);
+    expect(numOf(x)).toBeCloseTo(320.75);
+    expect(numOf(y)).toBeCloseTo(70.25);
   });
 
   test("pathStringDef.bbox", () => {

--- a/packages/core/src/renderer/ShapeDef.test.ts
+++ b/packages/core/src/renderer/ShapeDef.test.ts
@@ -117,6 +117,11 @@ const pathStyL = `Path {
 }
 `;
 
+const pathStyT = `Path {
+  pathData: curveFromPoints((0, 0), (50, 50), [(75, -25), (200, 0)])
+}
+`;
+
 const pathStyAUnscaled = `Path {
   pathData: arc("open", (-50, 50), (100, -25), (200, 100), 30, 1, 0)
 }
@@ -304,6 +309,19 @@ describe("ShapeDef", () => {
     expect(numOf(y)).toBeCloseTo(25);
   });
 
+  test("curveDef.bbox lines", async () => {
+    const shape = await getShape(pathStyL);
+    const {
+      w,
+      h,
+      center: [x, y],
+    } = ShapeDef.curveDef.bbox(shape.properties);
+    expect(numOf(w)).toBeCloseTo(200);
+    expect(numOf(h)).toBeCloseTo(200);
+    expect(numOf(x)).toBeCloseTo(0);
+    expect(numOf(y)).toBeCloseTo(0);
+  });
+
   test("curveDef.bbox quadratic", async () => {
     const shape = await getShape(pathStyQ);
     const {
@@ -317,17 +335,17 @@ describe("ShapeDef", () => {
     expect(numOf(y)).toBeCloseTo(-25);
   });
 
-  test("curveDef.bbox lines", async () => {
-    const shape = await getShape(pathStyL);
+  test("curveDef.bbox quadratic join", async () => {
+    const shape = await getShape(pathStyT);
     const {
       w,
       h,
       center: [x, y],
     } = ShapeDef.curveDef.bbox(shape.properties);
     expect(numOf(w)).toBeCloseTo(200);
-    expect(numOf(h)).toBeCloseTo(200);
-    expect(numOf(x)).toBeCloseTo(0);
-    expect(numOf(y)).toBeCloseTo(0);
+    expect(numOf(h)).toBeCloseTo(150);
+    expect(numOf(x)).toBeCloseTo(100);
+    expect(numOf(y)).toBeCloseTo(-25);
   });
 
   test("curveDef.bbox arc unscaled", async () => {
@@ -369,7 +387,6 @@ describe("ShapeDef", () => {
     expect(numOf(y)).toBeCloseTo(-12.5);
   });
 
-  // no Path tests using C or T or S because nothing in contrib/Functions.ts
-  // uses bezierCurveTo or quadraticCurveJoin or cubicCurveJoin from
-  // renderer/PathBuilder.ts
+  // no Path tests using C or S because nothing in contrib/Functions.ts uses
+  // bezierCurveTo or cubicCurveJoin from renderer/PathBuilder.ts
 });

--- a/packages/core/src/renderer/ShapeDef.test.ts
+++ b/packages/core/src/renderer/ShapeDef.test.ts
@@ -107,6 +107,21 @@ const lineSty = (t: string) => `${t} {
 }
 `;
 
+const pathStyQ = `Path {
+  pathData: makePath((-100., 0.), (100., 0.), 50., 10.)
+}
+`;
+
+const pathStyL = `Path {
+  pathData: pathFromPoints("open", [(-100, -100), (100, -50), (-50, 100)])
+}
+`;
+
+const pathStyA = `Path {
+  pathData: arc("open", (-50, 50), (100, -25), (200, 100), 30, 0, 0)
+}
+`;
+
 describe("ShapeDef", () => {
   test("circleDef.bbox", async () => {
     const shape = await getShape(circleSty);
@@ -279,7 +294,43 @@ describe("ShapeDef", () => {
     expect(numOf(y)).toBeCloseTo(25);
   });
 
-  test("curveDef.bbox", () => {
-    const { bbox } = ShapeDef.curveDef; // TODO
+  test("curveDef.bbox quadratic", async () => {
+    const shape = await getShape(pathStyQ);
+    const {
+      w,
+      h,
+      center: [x, y],
+    } = ShapeDef.curveDef.bbox(shape.properties);
+    expect(numOf(w)).toBeCloseTo(180);
+    expect(numOf(h)).toBeCloseTo(50);
+    expect(numOf(x)).toBeCloseTo(0);
+    expect(numOf(y)).toBeCloseTo(-25);
   });
+
+  test("curveDef.bbox lines", async () => {
+    const shape = await getShape(pathStyL);
+    const {
+      w,
+      h,
+      center: [x, y],
+    } = ShapeDef.curveDef.bbox(shape.properties);
+    expect(numOf(w)).toBeCloseTo(200);
+    expect(numOf(h)).toBeCloseTo(200);
+    expect(numOf(x)).toBeCloseTo(0);
+    expect(numOf(y)).toBeCloseTo(0);
+  });
+
+  test("curveDef.bbox arc", async () => {
+    const shape = await getShape(pathStyA);
+    const {
+      w,
+      h,
+      center: [x, y],
+    } = ShapeDef.curveDef.bbox(shape.properties);
+    // TODO
+  });
+
+  // no Path tests using C or T or S because nothing in contrib/Functions.ts
+  // uses bezierCurveTo or quadraticCurveJoin or cubicCurveJoin from
+  // renderer/PathBuilder.ts
 });

--- a/packages/core/src/renderer/ShapeDef.test.ts
+++ b/packages/core/src/renderer/ShapeDef.test.ts
@@ -35,51 +35,51 @@ const getShape = async (shapeSty: string): Promise<ShapeAD> => {
 };
 
 const circleSty = `Circle {
-  r: 100.
-  center: (42., 121.)
+  r: 100
+  center: (42, 121)
 }
 `;
 
 const ellipseSty = `Ellipse {
-  rx: 200.
-  ry: 100.
-  center: (42., 121.)
+  rx: 200
+  ry: 100
+  center: (42, 121)
 }
 `;
 
 const rectSty = `Rectangle {
-  center: (0., 0.)
-  w: 150.
-  h: 200.
+  center: (0, 0)
+  w: 150
+  h: 200
 }
 `;
 
 const calloutStyNoPadding = `Callout {
-  center: (-50., -100.)
-  w: 100.
-  h: 100.
-  anchor: (100., -200.)
+  center: (-50, -100)
+  w: 100
+  h: 100
+  anchor: (100, -200)
 }
 `;
 
 const calloutStyPadding = `Callout {
-  center: (-50., -100.)
-  w: 100.
-  h: 100.
-  anchor: (100., -200.)
+  center: (-50, -100)
+  w: 100
+  h: 100
+  anchor: (100, -200)
   padding: 20
 }
 `;
 
 // https://en.wikipedia.org/wiki/Polygon#/media/File:Assorted_polygons.svg
 const polygonSty = (t: string) => `${t} {
-  points: [(564., 24.), (733., 54.), (755., 154.), (693., 257.), (548., 216.), (571., 145.), (630., 146.), (617., 180.), (664., 196.), (701., 120.), (591., 90.), (528., 129.)]
+  points: [(564, 24), (733, 54), (755, 154), (693, 257), (548, 216), (571, 145), (630, 146), (617, 180), (664, 196), (701, 120), (591, 90), (528, 129)]
   scale: .5
 }
 `;
 
 const pathStringSty = `PathString {
-  center: (-50., 100.)
+  center: (-50, 100)
   w: 100
   h: 200
   rotation: 30
@@ -87,28 +87,28 @@ const pathStringSty = `PathString {
 `;
 
 const imageSty = `Image {
-  center: (0., 0.)
-  w: 150.
-  h: 200.
+  center: (0, 0)
+  w: 150
+  h: 200
 }
 `;
 
 const squareSty = `Square {
-  side: 50.
-  center: (30., 70.)
-  rotation: 30.
+  side: 50
+  center: (30, 70)
+  rotation: 30
 }
 `;
 
 const lineSty = (t: string) => `${t} {
-  start: (-300., 200.)
-  end: (100., -150.)
+  start: (-300, 200)
+  end: (100, -150)
   thickness: 50
 }
 `;
 
 const pathStyQ = `Path {
-  pathData: makePath((-100., 0.), (100., 0.), 50., 10.)
+  pathData: makePath((-100, 0), (100, 0), 50, 10)
 }
 `;
 
@@ -321,12 +321,12 @@ describe("ShapeDef", () => {
   });
 
   test("curveDef.bbox arc", async () => {
-    const shape = await getShape(pathStyA);
-    const {
-      w,
-      h,
-      center: [x, y],
-    } = ShapeDef.curveDef.bbox(shape.properties);
+    // const shape = await getShape(pathStyA);
+    // const {
+    //   w,
+    //   h,
+    //   center: [x, y],
+    // } = ShapeDef.curveDef.bbox(shape.properties);
     // TODO
   });
 

--- a/packages/core/src/renderer/ShapeDef.test.ts
+++ b/packages/core/src/renderer/ShapeDef.test.ts
@@ -117,8 +117,18 @@ const pathStyQ = `Path {
 }
 `;
 
+const pathStyC = `Path {
+  pathData: cubicCurveFromPoints("open", [(0, 0), (50, 50), (200, 0), (75, -25)])
+}
+`;
+
 const pathStyT = `Path {
-  pathData: curveFromPoints((0, 0), (50, 50), [(75, -25), (200, 0)])
+  pathData: quadraticCurveFromPoints("open", [(0, 0), (50, 50), (75, -25), (200, 0)])
+}
+`;
+
+const pathStyS = `Path {
+  pathData: cubicCurveFromPoints("open", [(0, 0), (50, 50), (200, 0), (75, -25), (0, -100), (100, -75)])
 }
 `;
 
@@ -335,6 +345,19 @@ describe("ShapeDef", () => {
     expect(numOf(y)).toBeCloseTo(-25);
   });
 
+  test("curveDef.bbox cubic", async () => {
+    const shape = await getShape(pathStyC);
+    const {
+      w,
+      h,
+      center: [x, y],
+    } = ShapeDef.curveDef.bbox(shape.properties);
+    expect(numOf(w)).toBeCloseTo(200);
+    expect(numOf(h)).toBeCloseTo(75);
+    expect(numOf(x)).toBeCloseTo(100);
+    expect(numOf(y)).toBeCloseTo(12.5);
+  });
+
   test("curveDef.bbox quadratic join", async () => {
     const shape = await getShape(pathStyT);
     const {
@@ -345,6 +368,19 @@ describe("ShapeDef", () => {
     expect(numOf(w)).toBeCloseTo(200);
     expect(numOf(h)).toBeCloseTo(150);
     expect(numOf(x)).toBeCloseTo(100);
+    expect(numOf(y)).toBeCloseTo(-25);
+  });
+
+  test("curveDef.bbox cubic join", async () => {
+    const shape = await getShape(pathStyS);
+    const {
+      w,
+      h,
+      center: [x, y],
+    } = ShapeDef.curveDef.bbox(shape.properties);
+    expect(numOf(w)).toBeCloseTo(250);
+    expect(numOf(h)).toBeCloseTo(150);
+    expect(numOf(x)).toBeCloseTo(75);
     expect(numOf(y)).toBeCloseTo(-25);
   });
 
@@ -386,7 +422,4 @@ describe("ShapeDef", () => {
     expect(numOf(x)).toBeCloseTo(62.5);
     expect(numOf(y)).toBeCloseTo(-12.5);
   });
-
-  // no Path tests using C or S because nothing in contrib/Functions.ts uses
-  // bezierCurveTo or cubicCurveJoin from renderer/PathBuilder.ts
 });

--- a/packages/core/src/renderer/ShapeDef.test.ts
+++ b/packages/core/src/renderer/ShapeDef.test.ts
@@ -1,8 +1,10 @@
-import { Shape } from "types/shape";
+import { ShapeAD } from "types/shape";
+import { evalShapes } from "engine/Evaluator";
 import * as ShapeDef from "renderer/ShapeDef";
 import { unsafelyUnwrap } from "utils/Error";
-import { compileDomain, compileSubstance, prepareState } from "index";
+import { compileDomain, compileSubstance, initializeMat } from "index";
 import { compileStyle } from "compiler/Style";
+import { numOf } from "engine/Autodiff";
 
 const makeSty = (shapeSty: string): string =>
   `canvas {
@@ -15,14 +17,35 @@ global {
 }
 `;
 
-const getShape = async (shapeSty: string): Promise<Shape> => {
+const getShape = async (shapeSty: string): Promise<ShapeAD> => {
+  // adapted from loadProgs function in compiler/Style.test.ts
   const env0 = unsafelyUnwrap(compileDomain(""));
   const [subEnv, varEnv] = unsafelyUnwrap(compileSubstance("", env0));
   const state = unsafelyUnwrap(compileStyle(makeSty(shapeSty), subEnv, varEnv));
-  const { shapes } = await prepareState(state);
+
+  // adapted from prepareState function in index.ts
+  await initializeMat();
+  const shapes = evalShapes({
+    ...state,
+    originalTranslation: state.originalTranslation,
+  });
+
   expect(shapes.length).toBe(1);
   return shapes[0];
 };
+
+const circleSty = `Circle {
+  r: 100.
+  center: (42., 121.)
+}
+`;
+
+const ellipseSty = `Ellipse {
+  rx: 200.
+  ry: 100.
+  center: (42., 121.)
+}
+`;
 
 const rectSty = `Rectangle {
   center: (0., 0.)
@@ -32,18 +55,49 @@ const rectSty = `Rectangle {
 `;
 
 const lineSty = `Line {
-  start: (1., 2.)
-  end: (3., 7.)
+  start: (-300., 200.)
+  end: (100., -150.)
+  thickness: 50
+}
+`;
+
+// https://en.wikipedia.org/wiki/Polygon#/media/File:Assorted_polygons.svg
+const freeformPolygonSty = `FreeformPolygon {
+  points: [(564., 24.), (733., 54.), (755., 154.), (693., 257.), (548., 216.), (571., 145.), (630., 146.), (617., 180.), (664., 196.), (701., 120.), (591., 90.), (528., 129.)]
+}
+`;
+
+const squareSty = `Square {
+  side: 50.
+  center: (30., 70.)
 }
 `;
 
 describe("ShapeDef", () => {
-  test("circleDef.bbox", () => {
-    const { bbox } = ShapeDef.circleDef;
+  test("circleDef.bbox", async () => {
+    const shape = await getShape(circleSty);
+    const {
+      w,
+      h,
+      center: [x, y],
+    } = ShapeDef.circleDef.bbox(shape.properties);
+    expect(numOf(w)).toBeCloseTo(200);
+    expect(numOf(h)).toBeCloseTo(200);
+    expect(numOf(x)).toBeCloseTo(42);
+    expect(numOf(y)).toBeCloseTo(121);
   });
 
-  test("ellipseDef.bbox", () => {
-    const { bbox } = ShapeDef.ellipseDef;
+  test("ellipseDef.bbox", async () => {
+    const shape = await getShape(ellipseSty);
+    const {
+      w,
+      h,
+      center: [x, y],
+    } = ShapeDef.ellipseDef.bbox(shape.properties);
+    expect(numOf(w)).toBeCloseTo(400);
+    expect(numOf(h)).toBeCloseTo(200);
+    expect(numOf(x)).toBeCloseTo(42);
+    expect(numOf(y)).toBeCloseTo(121);
   });
 
   test("rectDef.bbox", async () => {
@@ -53,42 +107,60 @@ describe("ShapeDef", () => {
       h,
       center: [x, y],
     } = ShapeDef.rectDef.bbox(shape.properties);
-    expect(w).toBeCloseTo(150);
-    expect(h).toBeCloseTo(200);
-    expect(x).toBeCloseTo(0);
-    expect(y).toBeCloseTo(0);
+    expect(numOf(w)).toBeCloseTo(150);
+    expect(numOf(h)).toBeCloseTo(200);
+    expect(numOf(x)).toBeCloseTo(0);
+    expect(numOf(y)).toBeCloseTo(0);
   });
 
   test("calloutDef.bbox", () => {
-    const { bbox } = ShapeDef.calloutDef;
+    const { bbox } = ShapeDef.calloutDef; // TODO
   });
 
   test("polygonDef.bbox", () => {
-    const { bbox } = ShapeDef.polygonDef;
+    const { bbox } = ShapeDef.polygonDef; // TODO
   });
 
-  test("freeformPolygonDef.bbox", () => {
-    const { bbox } = ShapeDef.freeformPolygonDef;
+  test("freeformPolygonDef.bbox", async () => {
+    const shape = await getShape(freeformPolygonSty);
+    const {
+      w,
+      h,
+      center: [x, y],
+    } = ShapeDef.freeformPolygonDef.bbox(shape.properties);
+    expect(numOf(w)).toBeCloseTo(227);
+    expect(numOf(h)).toBeCloseTo(233);
+    expect(numOf(x)).toBeCloseTo(641.5);
+    expect(numOf(y)).toBeCloseTo(140.5);
   });
 
   test("pathStringDef.bbox", () => {
-    const { bbox } = ShapeDef.pathStringDef;
+    const { bbox } = ShapeDef.pathStringDef; // TODO
   });
 
   test("polylineDef.bbox", () => {
-    const { bbox } = ShapeDef.polylineDef;
+    const { bbox } = ShapeDef.polylineDef; // TODO
   });
 
   test("imageDef.bbox", () => {
-    const { bbox } = ShapeDef.imageDef;
+    const { bbox } = ShapeDef.imageDef; // TODO
   });
 
-  test("squareDef.bbox", () => {
-    const { bbox } = ShapeDef.squareDef;
+  test("squareDef.bbox", async () => {
+    const shape = await getShape(squareSty);
+    const {
+      w,
+      h,
+      center: [x, y],
+    } = ShapeDef.squareDef.bbox(shape.properties);
+    expect(numOf(w)).toBeCloseTo(50);
+    expect(numOf(h)).toBeCloseTo(50);
+    expect(numOf(x)).toBeCloseTo(30);
+    expect(numOf(y)).toBeCloseTo(70);
   });
 
   test("textDef.bbox", () => {
-    const { bbox } = ShapeDef.textDef;
+    const { bbox } = ShapeDef.textDef; // TODO
   });
 
   test("lineDef.bbox", async () => {
@@ -98,17 +170,14 @@ describe("ShapeDef", () => {
       h,
       center: [x, y],
     } = ShapeDef.lineDef.bbox(shape.properties);
-    expect(w).toBeCloseTo(2);
-    expect(h).toBeCloseTo(5);
-    expect(x).toBeCloseTo(2);
-    expect(y).toBeCloseTo(4.5);
+    // TODO
   });
 
   test("arrowDef.bbox", () => {
-    const { bbox } = ShapeDef.arrowDef;
+    const { bbox } = ShapeDef.arrowDef; // TODO
   });
 
   test("curveDef.bbox", () => {
-    const { bbox } = ShapeDef.curveDef;
+    const { bbox } = ShapeDef.curveDef; // TODO
   });
 });

--- a/packages/core/src/renderer/ShapeDef.test.ts
+++ b/packages/core/src/renderer/ShapeDef.test.ts
@@ -88,6 +88,7 @@ const polygonSty = (t: string) => `${t} {
 const squareSty = `Square {
   side: 50.
   center: (30., 70.)
+  rotation: 30.
 }
 `;
 
@@ -211,10 +212,10 @@ describe("ShapeDef", () => {
       h,
       center: [x, y],
     } = ShapeDef.squareDef.bbox(shape.properties);
-    expect(numOf(w)).toBeCloseTo(50);
-    expect(numOf(h)).toBeCloseTo(50);
-    expect(numOf(x)).toBeCloseTo(30);
-    expect(numOf(y)).toBeCloseTo(70);
+    expect(numOf(w)).toBeCloseTo(68.301);
+    expect(numOf(h)).toBeCloseTo(68.301);
+    expect(numOf(x)).toBeCloseTo(39.151);
+    expect(numOf(y)).toBeCloseTo(54.151);
   });
 
   test("textDef.bbox", () => {

--- a/packages/core/src/renderer/ShapeDef.test.ts
+++ b/packages/core/src/renderer/ShapeDef.test.ts
@@ -117,8 +117,18 @@ const pathStyL = `Path {
 }
 `;
 
-const pathStyA = `Path {
+const pathStyAUnscaled = `Path {
+  pathData: arc("open", (-50, 50), (100, -25), (200, 100), 30, 1, 0)
+}
+`;
+
+const pathStyASmall = `Path {
   pathData: arc("open", (-50, 50), (100, -25), (200, 100), 30, 0, 0)
+}
+`;
+
+const pathStyAScaled = `Path {
+  pathData: arc("open", (-75, -50), (200, 25), (25, 50), 60, 0, 0)
 }
 `;
 
@@ -320,14 +330,43 @@ describe("ShapeDef", () => {
     expect(numOf(y)).toBeCloseTo(0);
   });
 
-  test("curveDef.bbox arc", async () => {
-    // const shape = await getShape(pathStyA);
-    // const {
-    //   w,
-    //   h,
-    //   center: [x, y],
-    // } = ShapeDef.curveDef.bbox(shape.properties);
-    // TODO
+  test("curveDef.bbox arc unscaled", async () => {
+    const shape = await getShape(pathStyAUnscaled);
+    const {
+      w,
+      h,
+      center: [x, y],
+    } = ShapeDef.curveDef.bbox(shape.properties);
+    expect(numOf(w)).toBeCloseTo(400);
+    expect(numOf(h)).toBeCloseTo(400);
+    expect(numOf(x)).toBeCloseTo(-1.297);
+    expect(numOf(y)).toBeCloseTo(-76.281);
+  });
+
+  test("curveDef.bbox arc small", async () => {
+    const shape = await getShape(pathStyASmall);
+    const {
+      w,
+      h,
+      center: [x, y],
+    } = ShapeDef.curveDef.bbox(shape.properties);
+    expect(numOf(w)).toBeCloseTo(400);
+    expect(numOf(h)).toBeCloseTo(400);
+    expect(numOf(x)).toBeCloseTo(51.297);
+    expect(numOf(y)).toBeCloseTo(101.282);
+  });
+
+  test("curveDef.bbox arc scaled", async () => {
+    const shape = await getShape(pathStyAScaled);
+    const {
+      w,
+      h,
+      center: [x, y],
+    } = ShapeDef.curveDef.bbox(shape.properties);
+    expect(numOf(w)).toBeCloseTo(311.512);
+    expect(numOf(h)).toBeCloseTo(311.512);
+    expect(numOf(x)).toBeCloseTo(62.5);
+    expect(numOf(y)).toBeCloseTo(-12.5);
   });
 
   // no Path tests using C or T or S because nothing in contrib/Functions.ts

--- a/packages/core/src/renderer/ShapeDef.test.ts
+++ b/packages/core/src/renderer/ShapeDef.test.ts
@@ -62,7 +62,7 @@ const lineSty = `Line {
 `;
 
 // https://en.wikipedia.org/wiki/Polygon#/media/File:Assorted_polygons.svg
-const freeformPolygonSty = `FreeformPolygon {
+const polygonSty = (t: string) => `${t} {
   points: [(564., 24.), (733., 54.), (755., 154.), (693., 257.), (548., 216.), (571., 145.), (630., 146.), (617., 180.), (664., 196.), (701., 120.), (591., 90.), (528., 129.)]
   scale: .5
 }
@@ -118,12 +118,21 @@ describe("ShapeDef", () => {
     const { bbox } = ShapeDef.calloutDef; // TODO
   });
 
-  test("polygonDef.bbox", () => {
-    const { bbox } = ShapeDef.polygonDef; // TODO
+  test("polygonDef.bbox", async () => {
+    const shape = await getShape(polygonSty("Polygon"));
+    const {
+      w,
+      h,
+      center: [x, y],
+    } = ShapeDef.polygonDef.bbox(shape.properties);
+    expect(numOf(w)).toBeCloseTo(113.5);
+    expect(numOf(h)).toBeCloseTo(116.5);
+    expect(numOf(x)).toBeCloseTo(320.75);
+    expect(numOf(y)).toBeCloseTo(70.25);
   });
 
   test("freeformPolygonDef.bbox", async () => {
-    const shape = await getShape(freeformPolygonSty);
+    const shape = await getShape(polygonSty("FreeformPolygon"));
     const {
       w,
       h,
@@ -139,8 +148,17 @@ describe("ShapeDef", () => {
     const { bbox } = ShapeDef.pathStringDef; // TODO
   });
 
-  test("polylineDef.bbox", () => {
-    const { bbox } = ShapeDef.polylineDef; // TODO
+  test("polylineDef.bbox", async () => {
+    const shape = await getShape(polygonSty("Polyline"));
+    const {
+      w,
+      h,
+      center: [x, y],
+    } = ShapeDef.polylineDef.bbox(shape.properties);
+    expect(numOf(w)).toBeCloseTo(113.5);
+    expect(numOf(h)).toBeCloseTo(116.5);
+    expect(numOf(x)).toBeCloseTo(320.75);
+    expect(numOf(y)).toBeCloseTo(70.25);
   });
 
   test("imageDef.bbox", () => {

--- a/packages/core/src/renderer/ShapeDef.test.ts
+++ b/packages/core/src/renderer/ShapeDef.test.ts
@@ -85,6 +85,13 @@ const polygonSty = (t: string) => `${t} {
 }
 `;
 
+const imageSty = `Image {
+  center: (0., 0.)
+  w: 150.
+  h: 200.
+}
+`;
+
 const squareSty = `Square {
   side: 50.
   center: (30., 70.)
@@ -201,8 +208,17 @@ describe("ShapeDef", () => {
     expect(numOf(y)).toBeCloseTo(70.25);
   });
 
-  test("imageDef.bbox", () => {
-    const { bbox } = ShapeDef.imageDef; // TODO
+  test("imageDef.bbox", async () => {
+    const shape = await getShape(imageSty);
+    const {
+      w,
+      h,
+      center: [x, y],
+    } = ShapeDef.imageDef.bbox(shape.properties);
+    expect(numOf(w)).toBeCloseTo(150);
+    expect(numOf(h)).toBeCloseTo(200);
+    expect(numOf(x)).toBeCloseTo(0);
+    expect(numOf(y)).toBeCloseTo(0);
   });
 
   test("squareDef.bbox", async () => {
@@ -218,9 +234,7 @@ describe("ShapeDef", () => {
     expect(numOf(y)).toBeCloseTo(54.151);
   });
 
-  test("textDef.bbox", () => {
-    const { bbox } = ShapeDef.textDef; // TODO
-  });
+  // no Text test because w and h seem to just be set to 0 when using getShape
 
   test("lineDef.bbox", async () => {
     const shape = await getShape(lineSty);

--- a/packages/core/src/renderer/ShapeDef.ts
+++ b/packages/core/src/renderer/ShapeDef.ts
@@ -515,27 +515,27 @@ const bboxFromRectlike = ({
   // https://github.com/penrose/penrose/issues/701
   if (center.tag !== "VectorV") {
     throw new Error(
-      `bboxFromPathString expected center to be VectorV, but got ${center.tag}`
+      `bboxFromRectlike expected center to be VectorV, but got ${center.tag}`
     );
   }
   if (!isPt2(center.contents)) {
     throw new Error(
-      `bboxFromPathString expected center to be Pt2, but got length ${center.contents.length}`
+      `bboxFromRectlike expected center to be Pt2, but got length ${center.contents.length}`
     );
   }
   if (w.tag !== "FloatV") {
     throw new Error(
-      `bboxFromPathString expected w to be FloatV, but got ${w.tag}`
+      `bboxFromRectlike expected w to be FloatV, but got ${w.tag}`
     );
   }
   if (h.tag !== "FloatV") {
     throw new Error(
-      `bboxFromPathString expected h to be FloatV, but got ${h.tag}`
+      `bboxFromRectlike expected h to be FloatV, but got ${h.tag}`
     );
   }
   if (rotation.tag !== "FloatV") {
     throw new Error(
-      `bboxFromPathString expected rotation to be FloatV, but got ${rotation.tag}`
+      `bboxFromRectlike expected rotation to be FloatV, but got ${rotation.tag}`
     );
   }
 

--- a/packages/core/src/renderer/ShapeDef.ts
+++ b/packages/core/src/renderer/ShapeDef.ts
@@ -227,7 +227,6 @@ const bboxFromCircle = ({ r, center }: Properties<VarAD>): BBox.BBox => {
   }
 
   const diameter = mul(constOf(2), r.contents);
-  // assuming it's OK not to clone diameter
   return BBox.bbox(diameter, diameter, center.contents);
 };
 
@@ -684,13 +683,6 @@ export const textDef: ShapeDef = {
   bbox: bboxFromRectlike, // assumes w and h correspond to string
 };
 
-/**
- * Preconditions:
- *   s must be axis-aligned.
- *   Assumes s is longer than it is thick.
- * Input: A line-like shape.
- * Output: A new BBox
- */
 const bboxFromLinelike = ({
   start,
   end,

--- a/packages/core/src/renderer/ShapeDef.ts
+++ b/packages/core/src/renderer/ShapeDef.ts
@@ -723,22 +723,24 @@ const bboxFromLinelike = ({
     );
   }
 
-  // TODO: handle non-axis-aligned
-
-  const w = max(
-    absVal(sub(start.contents[0], end.contents[0])),
-    thickness.contents
+  const d = ops.vmul(
+    div(thickness.contents, constOf(2)),
+    ops.rot90(ops.vnormalize(ops.vsub(end.contents, start.contents)))
   );
-  const h = max(
-    absVal(sub(start.contents[1], end.contents[1])),
-    thickness.contents
+  return bboxFromPoints(
+    [
+      ops.vadd(start.contents, d),
+      ops.vsub(start.contents, d),
+      ops.vadd(end.contents, d),
+      ops.vsub(end.contents, d),
+    ].map((point) => {
+      if (isPt2(point)) {
+        return point;
+      } else {
+        throw new Error("ops did not preserve dimension");
+      }
+    })
   );
-  // TODO: Compute the bbox of the line in a nicer way
-  const center = ops.vdiv(ops.vadd(start.contents, end.contents), constOf(2));
-  if (!isPt2(center)) {
-    throw new Error("ops.vadd and ops.vdiv did not preserve dimension");
-  }
-  return BBox.bbox(w, h, center);
 };
 
 export const lineDef: ShapeDef = {

--- a/packages/core/src/renderer/ShapeDef.ts
+++ b/packages/core/src/renderer/ShapeDef.ts
@@ -306,40 +306,7 @@ export const calloutDef: ShapeDef = {
   bbox: bboxFromCallout,
 };
 
-const bboxFromPolygon = (s: Properties<VarAD>): BBox.BBox => {
-  // TODO: handle scale
-  // https://github.com/penrose/penrose/issues/709
-  throw new Error("bboxFromPolygon not implemented"); // TODO
-};
-
-export const polygonDef: ShapeDef = {
-  shapeType: "Polygon",
-  properties: {
-    strokeWidth: ["FloatV", strokeSampler],
-    style: ["StrV", constValue("StrV", "filled")],
-    strokeStyle: ["StrV", constValue("StrV", "solid")],
-    strokeColor: ["ColorV", () => noPaint],
-    color: ["ColorV", colorSampler],
-    center: ["VectorV", vectorSampler],
-    scale: ["FloatV", constValue("FloatV", 1)],
-    name: ["StrV", constValue("StrV", "defaultPolygon")],
-    points: [
-      "PtListV",
-      constValue("PtListV", [
-        [0, 0],
-        [0, 10],
-        [10, 0],
-      ]),
-    ],
-  },
-  positionalProps: ["center"],
-  bbox: bboxFromPolygon,
-};
-
-const bboxFromFreeformPolygon = ({
-  points,
-  scale,
-}: Properties<VarAD>): BBox.BBox => {
+const bboxFromPolygon = ({ points, scale }: Properties<VarAD>): BBox.BBox => {
   // https://github.com/penrose/penrose/issues/701
   // seems like this should be PtListV but apparently it isn't
   if (points.tag !== "LListV") {
@@ -380,6 +347,30 @@ const bboxFromFreeformPolygon = ({
   return BBox.bbox(w, h, center);
 };
 
+export const polygonDef: ShapeDef = {
+  shapeType: "Polygon",
+  properties: {
+    strokeWidth: ["FloatV", strokeSampler],
+    style: ["StrV", constValue("StrV", "filled")],
+    strokeStyle: ["StrV", constValue("StrV", "solid")],
+    strokeColor: ["ColorV", () => noPaint],
+    color: ["ColorV", colorSampler],
+    center: ["VectorV", vectorSampler],
+    scale: ["FloatV", constValue("FloatV", 1)],
+    name: ["StrV", constValue("StrV", "defaultPolygon")],
+    points: [
+      "PtListV",
+      constValue("PtListV", [
+        [0, 0],
+        [0, 10],
+        [10, 0],
+      ]),
+    ],
+  },
+  positionalProps: ["center"],
+  bbox: bboxFromPolygon, // https://github.com/penrose/penrose/issues/709
+};
+
 export const freeformPolygonDef: ShapeDef = {
   shapeType: "FreeformPolygon",
   properties: {
@@ -400,7 +391,7 @@ export const freeformPolygonDef: ShapeDef = {
     ],
   },
   positionalProps: [],
-  bbox: bboxFromFreeformPolygon,
+  bbox: bboxFromPolygon,
 };
 
 const DEFAULT_PATHSTR = `M 10,30
@@ -433,10 +424,6 @@ export const pathStringDef: ShapeDef = {
   bbox: bboxFromPathString,
 };
 
-const bboxFromPolyline = (_: Properties<VarAD>): BBox.BBox => {
-  throw new Error("bboxFromPolyline not implemented"); // TODO
-};
-
 export const polylineDef: ShapeDef = {
   shapeType: "Polyline",
   properties: {
@@ -458,7 +445,7 @@ export const polylineDef: ShapeDef = {
     ],
   },
   positionalProps: ["center"],
-  bbox: bboxFromPolyline,
+  bbox: bboxFromPolygon, // https://github.com/penrose/penrose/issues/709
 };
 
 export const imageDef: ShapeDef = {

--- a/packages/core/src/renderer/ShapeDef.ts
+++ b/packages/core/src/renderer/ShapeDef.ts
@@ -430,12 +430,12 @@ const bboxFromPolygon = ({ points, scale }: Properties<VarAD>): BBox.BBox => {
   // seems like this should be PtListV but apparently it isn't
   if (points.tag !== "LListV") {
     throw new Error(
-      `bboxFromFreeformPolygon expected points to be LListV, but got ${points.tag}`
+      `bboxFromPolygon expected points to be LListV, but got ${points.tag}`
     );
   }
   if (scale.tag !== "FloatV") {
     throw new Error(
-      `bboxFromFreeformPolygon expected scale to be FloatV, but got ${scale.tag}`
+      `bboxFromPolygon expected scale to be FloatV, but got ${scale.tag}`
     );
   }
 
@@ -446,7 +446,7 @@ const bboxFromPolygon = ({ points, scale }: Properties<VarAD>): BBox.BBox => {
         return pt;
       } else {
         throw new Error(
-          `bboxFromFreeformPolygon expected each point to be Pt2, but got length ${point.length}`
+          `bboxFromPolygon expected each point to be Pt2, but got length ${point.length}`
         );
       }
     })

--- a/packages/core/src/renderer/ShapeDef.ts
+++ b/packages/core/src/renderer/ShapeDef.ts
@@ -148,11 +148,11 @@ export interface IShapeDef {
 
 export type Sampler = (canvas: Canvas) => Value<number>;
 
-function bboxFromCircle(s: any): BBox.BBox {
+const bboxFromCircle = (s: any): BBox.BBox => {
   throw new Error(
     `BBox expected a rect-like or line-like shape, but got Circle`
   );
-}
+};
 
 export const circleDef: ShapeDef = {
   shapeType: "Circle",
@@ -171,11 +171,11 @@ export const circleDef: ShapeDef = {
   bbox: bboxFromCircle,
 };
 
-function bboxFromEllipse(s: any): BBox.BBox {
+const bboxFromEllipse = (s: any): BBox.BBox => {
   throw new Error(
     `BBox expected a rect-like or line-like shape, but got Ellipse`
   );
-}
+};
 
 export const ellipseDef: ShapeDef = {
   shapeType: "Ellipse",
@@ -196,9 +196,9 @@ export const ellipseDef: ShapeDef = {
   bbox: bboxFromEllipse,
 };
 
-function bboxFromRect(s: any): BBox.BBox {
+const bboxFromRect = (s: any): BBox.BBox => {
   return BBox.bbox(s.w.contents, s.h.contents, s.center.contents);
-}
+};
 
 export const rectDef: ShapeDef = {
   shapeType: "Rectangle",
@@ -219,11 +219,11 @@ export const rectDef: ShapeDef = {
   bbox: bboxFromRect,
 };
 
-function bboxFromCallout(s: any): BBox.BBox {
+const bboxFromCallout = (s: any): BBox.BBox => {
   throw new Error(
     `BBox expected a rect-like or line-like shape, but got Callout`
   );
-}
+};
 
 export const calloutDef: ShapeDef = {
   shapeType: "Callout",
@@ -245,11 +245,11 @@ export const calloutDef: ShapeDef = {
   bbox: bboxFromCallout,
 };
 
-function bboxFromPolygon(s: any): BBox.BBox {
+const bboxFromPolygon = (s: any): BBox.BBox => {
   throw new Error(
     `BBox expected a rect-like or line-like shape, but got Polygon`
   );
-}
+};
 
 export const polygonDef: ShapeDef = {
   shapeType: "Polygon",
@@ -275,11 +275,11 @@ export const polygonDef: ShapeDef = {
   bbox: bboxFromPolygon,
 };
 
-function bboxFromFreeformPolygon(s: any): BBox.BBox {
+const bboxFromFreeformPolygon = (s: any): BBox.BBox => {
   throw new Error(
     `BBox expected a rect-like or line-like shape, but got FreeformPolygon`
   );
-}
+};
 
 export const freeformPolygonDef: ShapeDef = {
   shapeType: "FreeformPolygon",
@@ -309,11 +309,11 @@ A 20,20 0,0,1 90,30
 Q 90,60 50,90
 Q 10,60 10,30 z`;
 
-function bboxFromPathString(s: any): BBox.BBox {
+const bboxFromPathString = (s: any): BBox.BBox => {
   throw new Error(
     `BBox expected a rect-like or line-like shape, but got PathString`
   );
-}
+};
 
 export const pathStringDef: ShapeDef = {
   shapeType: "PathString",
@@ -335,11 +335,11 @@ export const pathStringDef: ShapeDef = {
   bbox: bboxFromPathString,
 };
 
-function bboxFromPolyline(s: any): BBox.BBox {
+const bboxFromPolyline = (s: any): BBox.BBox => {
   throw new Error(
     `BBox expected a rect-like or line-like shape, but got Polyline`
   );
-}
+};
 
 export const polylineDef: ShapeDef = {
   shapeType: "Polyline",
@@ -382,9 +382,9 @@ export const imageDef: ShapeDef = {
   bbox: bboxFromRect,
 };
 
-function bboxFromSquare(s: any): BBox.BBox {
+const bboxFromSquare = (s: any): BBox.BBox => {
   return BBox.bbox(s.side.contents, s.side.contents, s.center.contents);
-}
+};
 
 export const squareDef: ShapeDef = {
   shapeType: "Square",
@@ -431,7 +431,7 @@ export const textDef: ShapeDef = {
  * Input: A line-like shape.
  * Output: A new BBox
  */
-function bboxFromLinelike(s: any): BBox.BBox {
+const bboxFromLinelike = (s: any): BBox.BBox => {
   const w = max(
     absVal(sub(s.start.contents[0], s.end.contents[0])),
     s.thickness.contents
@@ -446,7 +446,7 @@ function bboxFromLinelike(s: any): BBox.BBox {
     constOf(2)
   );
   return BBox.bbox(w, h, center as Pt2);
-}
+};
 
 export const lineDef: ShapeDef = {
   shapeType: "Line",
@@ -485,9 +485,9 @@ export const arrowDef: ShapeDef = {
   bbox: bboxFromLinelike,
 };
 
-function bboxFromPath(s: any): BBox.BBox {
+const bboxFromPath = (s: any): BBox.BBox => {
   throw new Error(`BBox expected a rect-like or line-like shape, but got Path`);
-}
+};
 
 export const curveDef: ShapeDef = {
   shapeType: "Path",

--- a/packages/core/src/renderer/ShapeDef.ts
+++ b/packages/core/src/renderer/ShapeDef.ts
@@ -607,7 +607,7 @@ export const imageDef: ShapeDef = {
     name: ["StrV", constValue("StrV", "defaultImage")],
   },
   positionalProps: ["center"],
-  bbox: bboxFromRectlike, // this may not handle rotation correctly for Image
+  bbox: bboxFromRectlike, // https://github.com/penrose/penrose/issues/712
 };
 
 const bboxFromSquare = ({

--- a/packages/core/src/renderer/ShapeDef.ts
+++ b/packages/core/src/renderer/ShapeDef.ts
@@ -544,7 +544,7 @@ export const imageDef: ShapeDef = {
     name: ["StrV", constValue("StrV", "defaultImage")],
   },
   positionalProps: ["center"],
-  bbox: bboxFromRect, // TODO: handle rotation
+  bbox: bboxFromRect, // doesn't handle rotation
 };
 
 const bboxFromSquare = ({
@@ -629,7 +629,7 @@ export const textDef: ShapeDef = {
     // HACK: typechecking is not passing due to Value mismatch. Not sure why
   },
   positionalProps: ["center"],
-  bbox: bboxFromRect, // TODO: handle rotation
+  bbox: bboxFromRect, // doesn't handle rotation
 };
 
 /**

--- a/packages/core/src/types/ad.ts
+++ b/packages/core/src/types/ad.ts
@@ -62,6 +62,8 @@ export type VecAD = VarAD[];
 
 export type Pt2 = [VarAD, VarAD];
 
+export const isPt2 = (vec: VarAD[]): vec is Pt2 => vec.length === 2;
+
 export type GradGraphs = IGradGraphs;
 
 export interface IGradGraphs {


### PR DESCRIPTION
# Description

Resolves #696.

This PR replaces the implementation of the `bboxFromShape` function (in `contrib/Constraints.ts`) with a call to the `bbox` method on the shape definition for the given shape type. That is, the `IShapeDef` interface (in `renderer/ShapeDef.ts`) is given a `bbox` field, and each shape definition in that file is given its own bbox implementation to use for that field.

The bbox implementations in this PR for the following shapes are precise modulo stroke width (as far as I am aware):

- `Circle`
- `Ellipse`
- `Rectangle`
- `Callout` (modulo some rendering weirdness)
- `Polygon` (see #709)
- `FreeformPolygon`
- `PathString` (I just use the given `center`, `w`, and `h`)
- `Polyline` (see https://github.com/penrose/penrose/issues/709#issuecomment-989203210)
- `Image` (modulo #712)
- `Text` (depending on your definition of "precise")
- `Line` and `Arrow` (modulo arrowheads)

The following are not:

- `Square` (when `rotation` and `rx` are both nonzero)
- `Path` (as per @keenancrane's suggestions, quoted in #696)
  - for Bézier curves, we use the bounding box of the control points
  - for arcs, we use the bounding box of the circle with radius `max(rx, ry)` whose center is the same as that of the ellipse

<details>
<summary>(expand for examples/visualizations of imprecise bboxes)</summary

![square bbox](https://user-images.githubusercontent.com/8246041/147026770-677063fa-8801-43ac-aeae-54c144699f89.png)

![Bézier bbox](https://user-images.githubusercontent.com/8246041/147027185-30f6539a-d5e0-461b-9cca-bb091fd8737b.png)

![arc bbox](https://user-images.githubusercontent.com/8246041/147026300-89143bab-9f21-4e81-81f8-1b5415d19511.png)
</details>

This PR adds tests for most of the bbox functions; the exception is `Text`, for which the testing strategy (see below) doesn't work. Still, the `bboxFromRectlike` function which `Text` uses is itself tested via the tests for `PathString` and `Image`, so this doesn't really result in lack of coverage.

# Implementation strategy and design decisions

Thanks to #710, the parameter for each bbox function is typed `Properties<VarAD>` instead of `any`. However, as mentioned in #701, this still isn't precise enough to distinguish individual shape types, so each bbox function contains a lot of checks on `tag`s and on lengths of vectors (using the `isPt2` function which this PR adds to `types/ad.ts`) to make TypeScript happy. These could be made somewhat less verbose by replacing them with unsound `as` casts, but probably a better solution would be to just wait for #701 to be resolved, which would remove the need for them entirely.

Several of the bbox functions use the `bboxFromPoints` helper function. This was originally written just for `Polygon`, but it also turned out to be convenient for handling rotation on rectangles, as well as `Line`s and `Arrow`s. However, it is also used for `Path`, although I feel like for that particular case, there's probably a more elegant way to compute the bbox instead of by first assembling an array of points.

The bbox implementation for arcs in paths is particularly loose: as described in comments in the code (and earlier in this PR description), it simply returns the bbox of the smallest circle containing the entire ellipse of which that arc is a part. That comment links to https://stackoverflow.com/a/65441277 as an example of a much more precise ellipse arc bbox implementation, but that is difficult to translate into autodiff code because of things like #642.

As mentioned in #700, there is currently no easy way to programmatically instantiate shapes, so this PR tests the bbox functions by compiling little Style programs and then extracting the shapes from them. This required some minor modifications to the current evaluation pipeline, so #710 needed to be merged first.

Because of this method for constructing shapes, this PR needed to add a couple new functions (`quadraticCurveFromPoints` and `cubicCurveFromPoints`) to `contrib/Functions.ts` to allow for testing more Bézier commands in `Path`. As #716 mentions, it would probably be a good idea to replace these with a more general, principled set of `Path` construction functions.

In the tests themselves, we call `numOf` (from `engine/Autodiff.ts`) to get JavaScript numbers from each of the four `VarAD`s from the computed bbox, and then use Jest's [`toBeCloseTo`](https://jestjs.io/docs/expect#tobeclosetonumber-numdigits) matcher to compare those to the expected values. This gets the job done, but is a bit annoying: because a common workflow is to implement or modify a bbox function, run it using a test case, and then use https://panes.penrose.ink/ to visually check that the bbox is correct (see below); but since each test has four different assertions instead of just one (e.g. using [`toEqual`](https://jestjs.io/docs/expect#toequalvalue)), it can take up to four sequential runs of the test to extract all the computed values.

# Examples with steps to reproduce them

All the tests in `renderer/ShapeDef.test.ts` serve as examples. To reproduce most of them:

- substitute a shape Style string from `renderer/ShapeDef.test.ts` into the `makeSty` template at the top of that file
- go to https://panes.penrose.ink/
- paste that Style program into the **sty** box
- add a `global.bbox` which is a `Rectangle` using the expected `w`, `h`, and `center` from the appropriate test case
- click **compile**

The exceptions are the ones using the newly introduced `quadraticCurveFromPoints` and `cubicCurveFromPoints` functions, for which you instead need to check out this PR locally and use `yarn start` and `npx roger watch`.

# Checklist

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] New and existing tests pass locally using `yarn test`
- [x] I ran `yarn docs` and there were no errors when generating the HTML site
- [x] My code follows the style guidelines of this project (e.g.: no ESLint warnings)

# Open questions

- Should the tag/length checks be replaced with unsound `as` casts to reduce verbosity?
- Should the bbox implementation for `Path` arcs (or for that matter, Bézier curves and rounded squares) be made precise?