### PR TITLE
refactor: make `evalShapes` number type agnostic

### DIFF
--- a/packages/core/src/engine/EngineUtils.ts
+++ b/packages/core/src/engine/EngineUtils.ts
@@ -45,6 +45,8 @@ import {
   Translation,
 } from "types/value";
 import { showError } from "utils/Error";
+import { Shape, ShapeAD } from "types/shape";
+import { mapValues } from "lodash";
 const clone = rfdc({ proto: false, circles: false });
 
 // TODO: Is there a way to write these mapping/conversion functions with less boilerplate?
@@ -261,6 +263,14 @@ export function mapValueNumeric<T, S>(f: (arg: T) => S, v: Value<T>): Value<S> {
     );
   }
 }
+
+export const shapeAutodiffToNumber = (shapes: ShapeAD[]): Shape[] =>
+  shapes.map((s: ShapeAD) => ({
+    ...s,
+    properties: mapValues(s.properties, (p: Value<VarAD>) =>
+      valueAutodiffToNumber(p)
+    ),
+  }));
 
 export const valueAutodiffToNumber = (v: Value<VarAD>): Value<number> =>
   mapValueNumeric(numOf, v);

--- a/packages/core/src/engine/Evaluator.ts
+++ b/packages/core/src/engine/Evaluator.ts
@@ -26,7 +26,7 @@ import {
   GPI,
   IVectorV,
 } from "types/value";
-import { Shape } from "types/shape";
+import { Shape, ShapeAD } from "types/shape";
 import { Value } from "types/value";
 import { State, Fn, VaryMap, FnDone } from "types/state";
 import { Path, Expr, IPropertyPath, BinaryOp, UnaryOp } from "types/style";
@@ -102,10 +102,10 @@ export const evalShapes = (s: State): State => {
 
   // Evaluate each of the shapes (note: the translation is mutated, not returned)
   const [shapesEvaled, transEvaled]: [
-    Shape[],
+    ShapeAD[],
     Translation
   ] = shapeExprs.reduce(
-    ([currShapes, tr]: [Shape[], Translation], e: IFGPI<VarAD>) =>
+    ([currShapes, tr]: [ShapeAD[], Translation], e: IFGPI<VarAD>) =>
       evalShape(e, tr, s.varyingMap, currShapes, optDebugInfo),
     [[], trans]
   );
@@ -114,10 +114,17 @@ export const evalShapes = (s: State): State => {
     console.error("Invalid shape layering of length", s.shapeOrdering.length);
   }
 
+  const shapesNumeric: Shape[] = shapesEvaled.map((s: ShapeAD) => ({
+    ...s,
+    properties: mapValues(s.properties, (p: Value<VarAD>) =>
+      valueAutodiffToNumber(p)
+    ),
+  }));
+
   // Sort the shapes by ordering--note the null assertion
   const sortedShapesEvaled: Shape[] = s.shapeOrdering.map(
     (name) =>
-      shapesEvaled.find(({ properties }) => sameName(properties.name, name))!
+      shapesNumeric.find(({ properties }) => sameName(properties.name, name))!
   );
 
   // const nonEmpties = sortedShapesEvaled.filter(notEmptyLabel);
@@ -203,15 +210,15 @@ export const evalShape = (
   shapeExpr: IFGPI<VarAD>, // <number>?
   trans: Translation,
   varyingVars: VaryMap,
-  shapes: Shape[],
+  shapes: ShapeAD[],
   optDebugInfo: OptDebugInfo
-): [Shape[], Translation] => {
+): [ShapeAD[], Translation] => {
   const [shapeType, propExprs] = shapeExpr.contents;
 
   // Make sure all props are evaluated to values instead of shapes
   const props = mapValues(
     propExprs,
-    (prop: TagExpr<VarAD>): Value<number> => {
+    (prop: TagExpr<VarAD>): Value<VarAD> => {
       // TODO: Refactor these cases to be more concise
       if (prop.tag === "OptEval") {
         // For display, evaluate expressions with autodiff types (incl. varying vars as AD types), then convert to numbers
@@ -222,21 +229,19 @@ export const evalShape = (
           varyingVars,
           optDebugInfo
         ) as IVal<VarAD>).contents;
-        const resDisplay: Value<number> = valueAutodiffToNumber(res);
-        return resDisplay;
+        return res;
       } else if (prop.tag === "Done") {
-        return valueAutodiffToNumber(prop.contents);
+        return prop.contents;
       } else if (prop.tag === "Pending") {
         // Pending expressions are just converted because they get converted back to numbers later
-        const res = valueAutodiffToNumber(prop.contents);
-        return res;
+        return prop.contents;
       } else {
         throw Error("unknown tag");
       }
     }
   );
 
-  const shape: Shape = { shapeType, properties: props };
+  const shape: ShapeAD = { shapeType, properties: props };
 
   return [[...shapes, shape], trans];
 };

--- a/packages/core/src/engine/Optimizer.ts
+++ b/packages/core/src/engine/Optimizer.ts
@@ -17,6 +17,7 @@ import {
   initConstraintWeight,
   makeTranslationDifferentiable,
   makeTranslationNumeric,
+  shapeAutodiffToNumber,
 } from "engine/EngineUtils";
 import {
   argValue,
@@ -374,7 +375,10 @@ export const step = (state: State, steps: number, evaluate = true): State => {
     );
 
     newState.varyingValues = varyingValues;
-    newState = evalShapes(newState);
+    newState = {
+      ...newState,
+      shapes: shapeAutodiffToNumber(evalShapes(newState)),
+    };
   }
 
   return newState;

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -34,6 +34,7 @@ import { bBoxDims, toHex, ops } from "./utils/Util";
 import { Canvas } from "./renderer/ShapeDef";
 import { showMutations } from "./synthesis/Mutation";
 import { getListOfStagedStates } from "./renderer/Staging";
+import { shapeAutodiffToNumber } from "engine/EngineUtils";
 
 const log = consola.create({ level: LogLevel.Warn }).withScope("Top Level");
 
@@ -187,7 +188,10 @@ export const prepareState = async (state: State): Promise<State> => {
 
   // After the pending values load, they only use the evaluated shapes (all in terms of numbers)
   // The results of the pending values are then stored back in the translation as autodiff types
-  const stateEvaled: State = evalShapes(stateAD);
+  const stateEvaled: State = {
+    ...stateAD,
+    shapes: shapeAutodiffToNumber(evalShapes(stateAD)),
+  };
 
   const labelCache: LabelCache = await collectLabels(stateEvaled.shapes);
 

--- a/packages/core/src/renderer/Resample.ts
+++ b/packages/core/src/renderer/Resample.ts
@@ -3,6 +3,7 @@ import {
   tagExprNumberToAutodiff,
   insertExpr,
   initConstraintWeight,
+  shapeAutodiffToNumber,
 } from "engine/EngineUtils";
 import { prettyPrintPath } from "utils/OtherUtils";
 import { evalShapes } from "engine/Evaluator";
@@ -182,5 +183,8 @@ export const resampleBest = (state: State, numSamples: number): State => {
     },
     // pendingPaths: findPending(translation),
   };
-  return evalShapes(sampledState);
+  return {
+    ...sampledState,
+    shapes: shapeAutodiffToNumber(evalShapes(sampledState)),
+  };
 };

--- a/packages/core/src/renderer/dragUtils.ts
+++ b/packages/core/src/renderer/dragUtils.ts
@@ -61,11 +61,11 @@ const dragShape = (shape: Shape, offset: [number, number]): Shape => {
  * For each of the specified properties listed in `propPairs`, subtract a number from the original value.
  */
 const moveProperties = (
-  properties: Properties,
+  properties: Properties<number>,
   propsToMove: string[],
   [dx, dy]: [number, number]
-): Properties => {
-  const moveProperty = (props: Properties, propertyID: string) => {
+): Properties<number> => {
+  const moveProperty = (props: Properties<number>, propertyID: string) => {
     const [x, y] = props[propertyID].contents as [number, number];
     props[propertyID].contents = [x + dx, y + dy];
     return props;

--- a/packages/core/src/types/shape.ts
+++ b/packages/core/src/types/shape.ts
@@ -1,13 +1,15 @@
+import { VarAD } from "./ad";
 import { Value } from "./value";
 
-export type Shape = IShape;
+export type Shape = IShape<number>;
+export type ShapeAD = IShape<VarAD>;
 
-export type Properties = { [k: string]: Value<number> };
+export type Properties<T> = { [k: string]: Value<T> };
 
 /**
  * A shape (Graphical Primitive Instance, aka GPI) in penrose has a type (_e.g._ `Circle`) and a set of properties (_e.g._ `center`). This type is specifically used for rendering. See {@link GPI} for the version used for the runtime.
  */
-interface IShape {
+interface IShape<T> {
   shapeType: string;
-  properties: Properties;
+  properties: Properties<T>;
 }

--- a/packages/core/src/utils/Util.ts
+++ b/packages/core/src/utils/Util.ts
@@ -68,7 +68,7 @@ export const arrowheads = {
 };
 
 // calculates bounding box dimensions of a shape - used in inspector views
-export const bBoxDims = (properties: Properties, shapeType: string) => {
+export const bBoxDims = (properties: Properties<number>, shapeType: string) => {
   let [w, h] = [0, 0];
   if (shapeType === "Circle") {
     [w, h] = [


### PR DESCRIPTION
# Description

Related issue/PR: #698 

The current implementation of `evalShapes` has unclear semantics: it takes in a `State` and return another. Instead, this PR refactors it (and related functions) s.t. it returns a list of shapes instead. Converstion from autodiff props to number props was done explicitly everywhere (e.g. `prepareState`).

