### PR TITLE
fix: Document the fact that rot90 is counterclockwise

### DIFF
--- a/packages/core/src/contrib/Functions.ts
+++ b/packages/core/src/contrib/Functions.ts
@@ -782,7 +782,7 @@ export const compDict = {
   // ------ Geometry/graphics utils
 
   /**
-   * Rotate a 2D vector `v` by 90 degrees clockwise.
+   * Rotate a 2D vector `v` by 90 degrees counterclockwise.
    */
   rot90: (v: VarAD[]) => {
     if (v.length !== 2) {
@@ -837,7 +837,7 @@ const perpPathFlat = (
 };
 
 /**
- * Rotate a 2D point `[x, y]` by 90 degrees clockwise.
+ * Rotate a 2D point `[x, y]` by 90 degrees counterclockwise.
  */
 const rot90 = ([x, y]: Pt2): Pt2 => {
   return [neg(y), x];

--- a/packages/core/src/engine/Autodiff.ts
+++ b/packages/core/src/engine/Autodiff.ts
@@ -1065,7 +1065,7 @@ export const ops = {
   },
 
   /**
-   * Rotate a 2D point `[x, y]` by 90 degrees clockwise.
+   * Rotate a 2D point `[x, y]` by 90 degrees counterclockwise.
    */
   rot90: ([x, y]: VarAD[]): VarAD[] => {
     return [neg(y), x];

--- a/packages/core/src/utils/Util.ts
+++ b/packages/core/src/utils/Util.ts
@@ -491,7 +491,7 @@ export const ops = {
   },
 
   /**
-   * Rotate a 2D point `[x, y]` by 90 degrees clockwise.
+   * Rotate a 2D point `[x, y]` by 90 degrees counterclockwise.
    */
   rot90: ([x, y]: number[]): number[] => {
     return [-y, x];


### PR DESCRIPTION
# Description

Previously the documentation for `rot90` said that it rotates a point/vector clockwise. As far as I can tell, this is incorrect, so this PR modifies the documentation to say that it rotates counterclockwise.

# Checklist

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] New and existing tests pass locally using `yarn test`
- [x] I ran `yarn docs` and there were no errors when generating the HTML site
- [x] My code follows the style guidelines of this project (e.g.: no ESLint warnings)