### PR TITLE
feat: Handle strokeWidth in bbox

### DIFF
--- a/packages/core/src/renderer/ShapeDef.test.ts
+++ b/packages/core/src/renderer/ShapeDef.test.ts
@@ -37,6 +37,8 @@ const getShape = async (shapeSty: string): Promise<ShapeAD> => {
 const circleSty = `Circle {
   r: 100
   center: (42, 121)
+  strokeWidth: 50
+  strokeColor: rgba(0, 0, 0, 1) -- Circle strokeColor is noPaint by default
 }
 `;
 
@@ -44,6 +46,8 @@ const ellipseSty = `Ellipse {
   rx: 200
   ry: 100
   center: (42, 121)
+  strokeWidth: 50
+  strokeColor: rgba(0, 0, 0, 1) -- Ellipse strokeColor is noPaint by default
 }
 `;
 
@@ -51,6 +55,8 @@ const rectSty = `Rectangle {
   center: (0, 0)
   w: 150
   h: 200
+  strokeWidth: 50
+  strokeColor: rgba(0, 0, 0, 1) -- Rectangle strokeColor is noPaint by default
 }
 `;
 
@@ -59,6 +65,8 @@ const calloutStyNoPadding = `Callout {
   w: 100
   h: 100
   anchor: (100, -200)
+  strokeWidth: 10
+  strokeColor: rgba(0, 0, 0, 1) -- Callout strokeColor is noPaint by default
 }
 `;
 
@@ -68,6 +76,8 @@ const calloutStyPadding = `Callout {
   h: 100
   anchor: (100, -200)
   padding: 20
+  strokeWidth: 10
+  strokeColor: rgba(0, 0, 0, 1) -- Callout strokeColor is noPaint by default
 }
 `;
 
@@ -97,6 +107,8 @@ const squareSty = `Square {
   side: 50
   center: (30, 70)
   rotation: 30
+  strokeWidth: 10
+  strokeColor: rgba(0, 0, 0, 1) -- Square strokeColor is noPaint by default
 }
 `;
 
@@ -155,8 +167,8 @@ describe("ShapeDef", () => {
       h,
       center: [x, y],
     } = ShapeDef.circleDef.bbox(shape.properties);
-    expect(numOf(w)).toBeCloseTo(200);
-    expect(numOf(h)).toBeCloseTo(200);
+    expect(numOf(w)).toBeCloseTo(250);
+    expect(numOf(h)).toBeCloseTo(250);
     expect(numOf(x)).toBeCloseTo(42);
     expect(numOf(y)).toBeCloseTo(121);
   });
@@ -168,8 +180,8 @@ describe("ShapeDef", () => {
       h,
       center: [x, y],
     } = ShapeDef.ellipseDef.bbox(shape.properties);
-    expect(numOf(w)).toBeCloseTo(400);
-    expect(numOf(h)).toBeCloseTo(200);
+    expect(numOf(w)).toBeCloseTo(450);
+    expect(numOf(h)).toBeCloseTo(250);
     expect(numOf(x)).toBeCloseTo(42);
     expect(numOf(y)).toBeCloseTo(121);
   });
@@ -181,8 +193,8 @@ describe("ShapeDef", () => {
       h,
       center: [x, y],
     } = ShapeDef.rectDef.bbox(shape.properties);
-    expect(numOf(w)).toBeCloseTo(150);
-    expect(numOf(h)).toBeCloseTo(200);
+    expect(numOf(w)).toBeCloseTo(200);
+    expect(numOf(h)).toBeCloseTo(250);
     expect(numOf(x)).toBeCloseTo(0);
     expect(numOf(y)).toBeCloseTo(0);
   });
@@ -194,8 +206,8 @@ describe("ShapeDef", () => {
       h,
       center: [x, y],
     } = ShapeDef.calloutDef.bbox(shape.properties);
-    expect(numOf(w)).toBeCloseTo(215);
-    expect(numOf(h)).toBeCloseTo(165);
+    expect(numOf(w)).toBeCloseTo(225);
+    expect(numOf(h)).toBeCloseTo(175);
     expect(numOf(x)).toBeCloseTo(-7.5);
     expect(numOf(y)).toBeCloseTo(-117.5);
   });
@@ -207,8 +219,8 @@ describe("ShapeDef", () => {
       h,
       center: [x, y],
     } = ShapeDef.calloutDef.bbox(shape.properties);
-    expect(numOf(w)).toBeCloseTo(210);
-    expect(numOf(h)).toBeCloseTo(160);
+    expect(numOf(w)).toBeCloseTo(220);
+    expect(numOf(h)).toBeCloseTo(170);
     expect(numOf(x)).toBeCloseTo(-5);
     expect(numOf(y)).toBeCloseTo(-120);
   });
@@ -285,8 +297,8 @@ describe("ShapeDef", () => {
       h,
       center: [x, y],
     } = ShapeDef.squareDef.bbox(shape.properties);
-    expect(numOf(w)).toBeCloseTo(68.301);
-    expect(numOf(h)).toBeCloseTo(68.301);
+    expect(numOf(w)).toBeCloseTo(81.962);
+    expect(numOf(h)).toBeCloseTo(81.962);
     expect(numOf(x)).toBeCloseTo(14.151);
     expect(numOf(y)).toBeCloseTo(60.849);
   });

--- a/packages/core/src/renderer/ShapeDef.ts
+++ b/packages/core/src/renderer/ShapeDef.ts
@@ -193,27 +193,39 @@ const bboxFromRotatedRect = (
   center: Pt2,
   w: VarAD,
   h: VarAD,
-  clockwise: VarAD
+  clockwise: VarAD,
+  strokeWidth: VarAD
 ): BBox.BBox => {
   const counterclockwise = neg(clockwise);
-  const top = ops.vrot([w, constOf(0)], counterclockwise);
-  const left = ops.vrot([constOf(0), neg(h)], counterclockwise);
+  const down = ops.vrot([constOf(0), constOf(-1)], counterclockwise);
+  const right = ops.rot90(down);
 
-  const topLeft: Pt2 = [
-    sub(center[0], div(w, constOf(2))),
-    add(center[1], div(h, constOf(2))),
-  ];
+  const width = add(w, strokeWidth);
+  const height = add(h, strokeWidth);
+  const top = ops.vmul(width, right);
+  const left = ops.vmul(height, down);
+
+  const topLeft = ops.vsub(
+    [sub(center[0], div(w, constOf(2))), add(center[1], div(h, constOf(2)))],
+    ops.vmul(div(strokeWidth, constOf(2)), ops.vadd(down, right))
+  );
   const topRight = ops.vadd(topLeft, top);
   const botLeft = ops.vadd(topLeft, left);
   const botRight = ops.vadd(topRight, left);
-  if (!(isPt2(topRight) && isPt2(botLeft) && isPt2(botRight))) {
+  if (
+    !(isPt2(topLeft) && isPt2(topRight) && isPt2(botLeft) && isPt2(botRight))
+  ) {
     throw new Error("ops.vadd did not preserve dimension");
   }
 
   return bboxFromPoints([topLeft, topRight, botLeft, botRight]);
 };
 
-const bboxFromCircle = ({ r, center }: Properties<VarAD>): BBox.BBox => {
+const bboxFromCircle = ({
+  r,
+  center,
+  strokeWidth,
+}: Properties<VarAD>): BBox.BBox => {
   // https://github.com/penrose/penrose/issues/701
   if (r.tag !== "FloatV") {
     throw new Error(`bboxFromCircle expected r to be FloatV, but got ${r.tag}`);
@@ -228,8 +240,13 @@ const bboxFromCircle = ({ r, center }: Properties<VarAD>): BBox.BBox => {
       `bboxFromCircle expected center to be Pt2, but got length ${center.contents.length}`
     );
   }
+  if (strokeWidth.tag !== "FloatV") {
+    throw new Error(
+      `bboxFromCircle expected strokeWidth to be FloatV, but got ${strokeWidth.tag}`
+    );
+  }
 
-  const diameter = mul(constOf(2), r.contents);
+  const diameter = add(mul(constOf(2), r.contents), strokeWidth.contents);
   return BBox.bbox(diameter, diameter, center.contents);
 };
 
@@ -250,7 +267,12 @@ export const circleDef: ShapeDef = {
   bbox: bboxFromCircle,
 };
 
-const bboxFromEllipse = ({ rx, ry, center }: Properties<VarAD>): BBox.BBox => {
+const bboxFromEllipse = ({
+  rx,
+  ry,
+  center,
+  strokeWidth,
+}: Properties<VarAD>): BBox.BBox => {
   // https://github.com/penrose/penrose/issues/701
   if (rx.tag !== "FloatV") {
     throw new Error(
@@ -272,10 +294,19 @@ const bboxFromEllipse = ({ rx, ry, center }: Properties<VarAD>): BBox.BBox => {
       `bboxFromEllipse expected center to be Pt2, but got length ${center.contents.length}`
     );
   }
+  if (strokeWidth.tag !== "FloatV") {
+    throw new Error(
+      `bboxFromEllipse expected strokeWidth to be FloatV, but got ${strokeWidth.tag}`
+    );
+  }
 
   const dx = mul(constOf(2), rx.contents);
   const dy = mul(constOf(2), ry.contents);
-  return BBox.bbox(dx, dy, center.contents);
+  return BBox.bbox(
+    add(dx, strokeWidth.contents),
+    add(dy, strokeWidth.contents),
+    center.contents
+  );
 };
 
 export const ellipseDef: ShapeDef = {
@@ -297,7 +328,12 @@ export const ellipseDef: ShapeDef = {
   bbox: bboxFromEllipse,
 };
 
-const bboxFromRect = ({ w, h, center }: Properties<VarAD>): BBox.BBox => {
+const bboxFromRect = ({
+  w,
+  h,
+  center,
+  strokeWidth,
+}: Properties<VarAD>): BBox.BBox => {
   // https://github.com/penrose/penrose/issues/701
   if (w.tag !== "FloatV") {
     throw new Error(`bboxFromRect expected w to be FloatV, but got ${w.tag}`);
@@ -315,9 +351,18 @@ const bboxFromRect = ({ w, h, center }: Properties<VarAD>): BBox.BBox => {
       `bboxFromRect expected center to be Pt2, but got length ${center.contents.length}`
     );
   }
+  if (strokeWidth.tag !== "FloatV") {
+    throw new Error(
+      `bboxFromRect expected strokeWidth to be FloatV, but got ${strokeWidth.tag}`
+    );
+  }
 
   // rx just rounds the corners, doesn't change the bbox
-  return BBox.bbox(w.contents, h.contents, center.contents);
+  return BBox.bbox(
+    add(w.contents, strokeWidth.contents),
+    add(h.contents, strokeWidth.contents),
+    center.contents
+  );
 };
 
 export const rectDef: ShapeDef = {
@@ -345,6 +390,7 @@ const bboxFromCallout = ({
   w,
   h,
   padding,
+  strokeWidth,
 }: Properties<VarAD>): BBox.BBox => {
   // https://github.com/penrose/penrose/issues/701
   if (anchor.tag !== "VectorV") {
@@ -382,6 +428,11 @@ const bboxFromCallout = ({
       `bboxFromCallout expected padding to be FloatV, but got ${padding.tag}`
     );
   }
+  if (strokeWidth.tag !== "FloatV") {
+    throw new Error(
+      `bboxFromRect expected strokeWidth to be FloatV, but got ${strokeWidth.tag}`
+    );
+  }
 
   // below adapted from makeCallout function in renderer/Callout.ts
 
@@ -404,7 +455,11 @@ const bboxFromCallout = ({
   const height = sub(maxY, minY);
   const cx = div(add(minX, maxX), constOf(2));
   const cy = div(add(minY, maxY), constOf(2));
-  return BBox.bbox(width, height, [cx, cy]);
+  return BBox.bbox(
+    add(width, strokeWidth.contents),
+    add(height, strokeWidth.contents),
+    [cx, cy]
+  );
 };
 
 export const calloutDef: ShapeDef = {
@@ -545,7 +600,8 @@ const bboxFromRectlike = ({
     center.contents,
     w.contents,
     h.contents,
-    rotation.contents
+    rotation.contents,
+    constOf(0)
   );
 };
 
@@ -614,6 +670,7 @@ const bboxFromSquare = ({
   center,
   side,
   rotation,
+  strokeWidth,
 }: Properties<VarAD>): BBox.BBox => {
   // https://github.com/penrose/penrose/issues/701
   if (center.tag !== "VectorV") {
@@ -636,6 +693,11 @@ const bboxFromSquare = ({
       `bboxFromSquare expected rotation to be FloatV, but got ${rotation.tag}`
     );
   }
+  if (strokeWidth.tag !== "FloatV") {
+    throw new Error(
+      `bboxFromSquare expected strokeWidth to be FloatV, but got ${strokeWidth.tag}`
+    );
+  }
 
   // rx rounds the corners, so we could use it to give a smaller bbox if both
   // that and rotation are nonzero, but we don't account for that here
@@ -644,7 +706,8 @@ const bboxFromSquare = ({
     center.contents,
     side.contents,
     side.contents,
-    rotation.contents
+    rotation.contents,
+    strokeWidth.contents
   );
 };
 


### PR DESCRIPTION
# Description

Mostly resolves https://github.com/penrose/penrose/pull/698#issuecomment-1002015939

This PR accounts for the `strokeWidth` property when computing bounding boxes, as per @keenancrane's suggestion:

> So, let's consider what happens to the size of a shape if you stroke it by a stroke of width w. Giving a closed path a width w is equivalent to sweeping a circle of radius w/2 along that path. Hence, no matter which points are the extreme points along the path, the bounding box will need to grow by w/2 in all directions (top/bottom/left/right). So, just add w to both the bounding box width and height.

The only shape for which this PR does not use that strategy is `Square`, because in that case it is more correct to add half the `strokeWidth` in all directions _before_ doing the rotation instead of after.

The following shapes are accounted for:

- `Circle`
- `Ellipse`
- `Rectangle`
- `Callout`*
- `Square`

The one(s) marked with an asterisk * have newly introduced imprecision:

<img width="882" alt="Screen Shot 2021-12-28 at 9 12 25 AM" src="https://user-images.githubusercontent.com/8246041/147574975-6481de99-9c0e-4579-91ff-17d1a29c9bbd.png">

The following shapes did not need to be accounted for:

- `Image`
- `Text`
- `Line`
- `Arrow`

And finally, the following shapes should ideally be accounted for, but are not in this PR for various reasons:

- `Polygon`/`FreeformPolygon`/`Polyline` because https://github.com/penrose/penrose/issues/724
- `PathString` because currently its bbox implementation just uses its `w` and `h` properties and ignores `data`
- `Path` because currently its bbox implementation already has a lot of imprecision for Bézier curves and for arcs

# Checklist

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] New and existing tests pass locally using `yarn test`
- [x] I ran `yarn docs` and there were no errors when generating the HTML site
- [x] My code follows the style guidelines of this project (e.g.: no ESLint warnings)