### PR TITLE
chore: Use a .code-workspace instead of .vscode/ folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,9 +32,7 @@ node_modules/
 build/
 .tmp/
 _region_.tex
-/.vscode/*
-!/.vscode/extensions.json
-!/.vscode/settings.json
+.vscode/
 out*.txt
 penrose-ide/
 *.prof

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,7 +1,0 @@
-{
-  "recommendations": [
-    "esbenp.prettier-vscode",
-    "folke.vscode-monorepo-workspace",
-    "penrose.penrose-vs"
-  ]
-}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,4 +1,0 @@
-{
-  "files.insertFinalNewline": false,
-  "files.trimFinalNewlines": false
-}

--- a/penrose.code-workspace
+++ b/penrose.code-workspace
@@ -1,0 +1,54 @@
+{
+  "extensions": {
+    "recommendations": [
+      "dbaeumer.vscode-eslint",
+      "esbenp.prettier-vscode",
+      "folke.vscode-monorepo-workspace",
+      "karyfoundation.nearley",
+      "penrose.penrose-vs"
+    ]
+  },
+  "folders": [
+    {
+      "name": "✨ penrose",
+      "path": "."
+    },
+    {
+      "name": "📦 @penrose/automator",
+      "path": "packages/automator"
+    },
+    {
+      "name": "📦 @penrose/browser-ui",
+      "path": "packages/browser-ui"
+    },
+    {
+      "name": "📦 @penrose/components",
+      "path": "packages/components"
+    },
+    {
+      "name": "📦 @penrose/core",
+      "path": "packages/core"
+    },
+    {
+      "name": "📦 @penrose/panels",
+      "path": "packages/panels"
+    },
+    {
+      "name": "📦 @penrose/roger",
+      "path": "packages/roger"
+    },
+    {
+      "name": "📦 @penrose/synthesizer",
+      "path": "packages/synthesizer"
+    },
+    {
+      "name": "📦 @penrose/synthesizer-ui",
+      "path": "packages/synthesizer-ui"
+    }
+  ],
+  "settings": {
+    "files.insertFinalNewline": false,
+    "files.trimFinalNewlines": false,
+    "files.trimTrailingWhitespace": false
+  }
+}


### PR DESCRIPTION
When using the [Monorepo Workspace](https://marketplace.visualstudio.com/items?itemName=folke.vscode-monorepo-workspace) extension which we use for Penrose, a `*.code-workspace` file is automatically created to keep track of all the workspace folders (i.e. the root plus everything under `packages/`, when using standard [Lerna](https://lerna.js.org/) conventions).

So far, I had been simply keeping this in `~/penrose.code-workspace`, but earlier this morning I realized that using a `*.code-workspace` file causes everything in this repository's `.vscode/settings.json` file to be ignored. Then I learned that those [settings](https://code.visualstudio.com/docs/editor/multi-root-workspaces#_settings) can actually be given in the `*.code-workspace` file itself, along with [extension recommendations](https://code.visualstudio.com/docs/editor/multi-root-workspaces#_extension-recommendations).

Thus, I'm opening this PR to undo the `.vscode/` folder added by #649 and #661, and replace it with a `penrose.code-workspace` file, including the additional extensions suggested in #729, as well as setting `files.trimTrailingWhitespace` to `false` because, for instance, `packages/core/src/parser/Domain.ne` has a lot of trailing whitespace.