### PR TITLE
feat: Allow subtypes inline

### DIFF
--- a/examples/geometry-domain/geometry.dsl
+++ b/examples/geometry-domain/geometry.dsl
@@ -1,24 +1,18 @@
 -- ~~~~~~~~~~~~~~~~ TYPES ~~~~~~~~~~~~~~~~
 type Point
 type Linelike
-type Ray
-type Line
-type Segment
+type Ray <: Linelike
+type Line <: Linelike
+type Segment <: Linelike
 
 type Angle
 
 type Triangle
-type Rectangle
 type Quadrilateral
+type Rectangle <: Quadrilateral
 type Circle
 
 type Plane
-
--- ~~~~~~~~~~~~~~~~ SUBTYPES ~~~~~~~~~~~~~~~~
-Ray <: Linelike
-Line <: Linelike
-Segment <: Linelike
-Rectangle <: Quadrilateral
 
 -- ~~~~~~~~~~~~~~~~ CONSTRUCTORS ~~~~~~~~~~~~~~~~
 -- Lines and Points

--- a/examples/graph-domain/graph-theory-extended.dsl
+++ b/examples/graph-domain/graph-theory-extended.dsl
@@ -8,25 +8,15 @@ type Edge
 type Graph
 
 -- Subtypes
-type UndirectedEdge
-type DirectedEdge
-type UndirectedGraph
-type DirectedGraph
-type Tree
-type BinaryTree
-type Face
-type Path
-type Cycle
-
-UndirectedEdge <: Edge
-DirectedEdge <: Edge
-UndirectedGraph <: Graph
-DirectedGraph <: Graph
-Tree <: Graph
-BinaryTree <: Tree
-Face <: Graph
-Path <: Graph
-Cycle <: Graph
+type UndirectedEdge <: Edge
+type DirectedEdge <: Edge
+type UndirectedGraph <: Graph
+type DirectedGraph <: Graph
+type Tree <: Graph
+type BinaryTree <: Tree
+type Face <: Graph
+type Path <: Graph
+type Cycle <: Graph
 
 constructor MkGraph : List(Vertex) vertices * List(Edge) edges -> Graph
 constructor MkEdge : Vertex from * Vertex to -> Edge

--- a/examples/graph-domain/graph-theory.dsl
+++ b/examples/graph-domain/graph-theory.dsl
@@ -3,11 +3,8 @@ type Edge
 type Graph
 
 -- Subtypes
-type Face
-type Path
-
-Face <: Graph
-Path <: Graph
+type Face <: Graph
+type Path <: Graph
 
 constructor MkEdge : Vertex from * Vertex to -> Edge
 

--- a/examples/hyperbolic-domain/hyperbolic.dsl
+++ b/examples/hyperbolic-domain/hyperbolic.dsl
@@ -1,10 +1,8 @@
 type HyperbolicPlane
 type Point
-type IdealPoint
+type IdealPoint <: Point
 type Segment
 type Horocycle
-
-IdealPoint <: Point
 
 predicate In: Point * HyperbolicPlane
 predicate IsCenter: IdealPoint * Horocycle

--- a/examples/logic-circuit-domain/logic-gates.dsl
+++ b/examples/logic-circuit-domain/logic-gates.dsl
@@ -2,52 +2,33 @@
 
 type Node
 
-type InputNode
-type OutputNode
-
-InputNode <: Node
-OutputNode <: Node
+type InputNode <: Node
+type OutputNode <: Node
 
 -- Gates
 
 type Component
 
-type SplitComponent
-type Gate
+type SplitComponent <: Component
+type Gate <: Component
 
-SplitComponent <: Component
-Gate <: Component
-
-type OneInputGate
-type TwoInputGate
-
-OneInputGate <: Gate
-TwoInputGate <: Gate
+type OneInputGate <: Gate
+type TwoInputGate <: Gate
 
 constructor MakeSplitComponent : Node IN * Node OUT1 * Node OUT2 -> SplitComponent
 
-type Buffer
-type NOTGate
-
-Buffer <: OneInputGate
-NOTGate <: OneInputGate
+type Buffer <: OneInputGate
+type NOTGate <: OneInputGate
 
 constructor MakeBuffer : Node IN * Node OUT -> Buffer
 constructor MakeNOTGate : Node IN * Node OUT -> NOTGate
 
-type ORGate
-type NORGate
-type ANDGate
-type NANDGate
-type XORGate
-type XNORGate
-
-ORGate <: TwoInputGate
-NORGate <: TwoInputGate
-ANDGate <: TwoInputGate
-NANDGate <: TwoInputGate
-XORGate <: TwoInputGate
-XNORGate <: TwoInputGate
+type ORGate <: TwoInputGate
+type NORGate <: TwoInputGate
+type ANDGate <: TwoInputGate
+type NANDGate <: TwoInputGate
+type XORGate <: TwoInputGate
+type XNORGate <: TwoInputGate
 
 constructor MakeORGate : Node IN1 * Node IN2 * Node OUT -> ORGate
 constructor MakeNORGate : Node IN1 * Node IN2 * Node OUT -> NORGate

--- a/examples/mesh-set-domain/DomainInterop.dsl
+++ b/examples/mesh-set-domain/DomainInterop.dsl
@@ -2,12 +2,9 @@ type Type
 
 -- | Set domain program
 
-type Set
-type Point
+type Set <: Type
+type Point <: Type
 type Map
-
-Set <: Type
-Point <: Type
 
 constructor Singleton : Point p -> Set
 
@@ -43,19 +40,13 @@ notation "p ∉ A" ~ "PointNotIn(A, p)"
 ------------------------------
 -- | Mesh domain program
 
-type Vertex
-type Edge
-type Face
+type Vertex <: Type
+type Edge <: Type
+type Face <: Type
 type SimplicialSubset -- Subset of a mesh; might not be a simplicial complex
-type SimplicialComplex -- Mesh := SimplicialComplex(2); simplicial complex
-type Subcomplex -- (V, E, F) linked to a mesh; is a simplicial complex
+type SimplicialComplex <: SimplicialSubset -- Mesh := SimplicialComplex(2); simplicial complex
+type Subcomplex <: SimplicialSubset -- (V, E, F) linked to a mesh; is a simplicial complex
 
-Vertex <: Type
-Edge <: Type
-Face <: Type
-
-SimplicialComplex <: SimplicialSubset
-Subcomplex <: SimplicialSubset
 Vertex <: Subcomplex -- TODO: plugin doesn't deal w/ this
 Edge <: SimplicialSubset
 Face <: SimplicialSubset

--- a/examples/molecules/molecules.dsl
+++ b/examples/molecules/molecules.dsl
@@ -2,27 +2,18 @@
 
 type Atom
 
-type Carbon
-type Hydrogen
-type Oxygen
-type Nitrogen
-
-Carbon <: Atom
-Hydrogen <: Atom
-Oxygen <: Atom
-Nitrogen <: Atom
+type Carbon <: Atom
+type Hydrogen <: Atom
+type Oxygen <: Atom
+type Nitrogen <: Atom
 
 -- Bonds
 
 type Bond
 
-type SingleBond
-type DoubleBond
-type TripleBond
-
-SingleBond <: Bond
-DoubleBond <: Bond
-TripleBond <: Bond
+type SingleBond <: Bond
+type DoubleBond <: Bond
+type TripleBond <: Bond
 
 constructor MakeSingleBond : Atom a * Atom b -> SingleBond
 constructor MakeDoubleBond : Atom a * Atom b -> DoubleBond

--- a/examples/structural-formula/structural-formula.dsl
+++ b/examples/structural-formula/structural-formula.dsl
@@ -11,27 +11,19 @@ type Node
 
 -- a FunctionalGroup represents a collection of atoms
 -- in the same molecule (such as an alcohol or ester)
-type FunctionalGroup
-FunctionalGroup <: Node
+type FunctionalGroup <: Node
 
 -- an Atom represents a single atom within a larger
 -- molecule (or as an isolated ion)
-type Atom
-Atom <: Node
+type Atom <: Node
 
 -- specific types of atoms (more could be added here)
-type Hydrogen
-type Carbon
-type Nitrogen
-type Oxygen
-type Sodium
-type Chlorine
-Hydrogen <: Atom
-  Carbon <: Atom
-Nitrogen <: Atom
-  Oxygen <: Atom
-  Sodium <: Atom
-Chlorine <: Atom
+type Hydrogen <: Atom
+type   Carbon <: Atom
+type Nitrogen <: Atom
+type   Oxygen <: Atom
+type   Sodium <: Atom
+type Chlorine <: Atom
 
 -- predicates used to specify bonds between Nodes
 predicate SingleBond: Node n1 * Node n2

--- a/packages/core/src/compiler/Domain.test.ts
+++ b/packages/core/src/compiler/Domain.test.ts
@@ -46,10 +46,9 @@ describe("Common", () => {
     const prog = `
   type A
   type B
-  type C
+  type C <: B
   type D
   type E
-  C <: B
   B <: A
   value varA: A
   value varB: B

--- a/packages/core/src/parser/Domain.ne
+++ b/packages/core/src/parser/Domain.ne
@@ -92,13 +92,14 @@ statement
   |  subtype     {% id %}
 
 # not to be confused with `type`, defined below
-type_decl -> "type" __ identifier (_ "(" _ type_params _ ")"):? {%
-  ([typ, , name, ps]): TypeDecl => {
+type_decl -> "type" __ identifier (_ "(" _ type_params _ ")"):? (_ "<:" _ sepBy1[type, ","]):? {%
+  ([typ, , name, ps, sub]): TypeDecl => {
     const params = ps ? ps[3] : [];
+    const superTypes = sub ? sub[3] : [];
     return { 
-      ...nodeData([name, ...params]),
+      ...nodeData([name, ...params, ...superTypes]),
       ...rangeBetween(typ, name),
-      tag: "TypeDecl", name, params
+      tag: "TypeDecl", name, params, superTypes
     };
   }
 %}

--- a/packages/core/src/parser/Domain.ne
+++ b/packages/core/src/parser/Domain.ne
@@ -83,7 +83,7 @@ statements
     |  _ statement _c_ nl statements {% d => [d[1], ...d[4]] %}
 
 statement 
-  -> type        {% id %}
+  -> type_decl   {% id %}
   |  predicate   {% id %}
   |  function    {% id %}
   |  constructor_decl {% id %}
@@ -91,7 +91,8 @@ statement
   |  notation    {% id %}
   |  subtype     {% id %}
 
-type -> "type" __ identifier (_ "(" _ type_params _ ")"):? {%
+# not to be confused with `type`, defined below
+type_decl -> "type" __ identifier (_ "(" _ type_params _ ")"):? {%
   ([typ, , name, ps]): TypeDecl => {
     const params = ps ? ps[3] : [];
     return { 

--- a/packages/core/src/parser/DomainParser.test.ts
+++ b/packages/core/src/parser/DomainParser.test.ts
@@ -115,6 +115,9 @@ type Point
 -- type ParametrizedSet1 () -- this is not okay
 type ParametrizedSet2 ('T)
 type ParametrizedSet3 ( 'T,    'V)
+-- inline subtype
+type Nonempty <: Set
+type SmallerSet <: Point, Set
     `;
     const { results } = parser.feed(prog);
     sameASTs(results);

--- a/packages/core/src/types/domain.ts
+++ b/packages/core/src/types/domain.ts
@@ -47,6 +47,7 @@ export interface TypeDecl extends ASTNode {
   tag: "TypeDecl";
   name: Identifier;
   params: TypeVar[];
+  superTypes: Type[];
 }
 
 export interface PredicateDecl extends ASTNode {


### PR DESCRIPTION
# Description

Resolves #722.

# Implementation strategy and design decisions

The first commit in this PR renamed the `type` `statement` rule to `type_decl`, because previously it was being combined with the other `type` rule below, which would have caused ambiguous parsing after adding the syntax extension this PR adds.

I'm not sure why `SubTypeDecl`'s fields are `Type` instead of `TypeConstructor` since the compiler throws an error if they aren't the latter, but I've kept that the same in this PR.

# Examples with steps to reproduce them

This PR updates most things in `examples/` to use the more concise syntax.

# Checklist

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] New and existing tests pass locally using `yarn test`
- [x] I ran `yarn docs` and there were no errors when generating the HTML site
- [x] My code follows the style guidelines of this project (e.g.: no ESLint warnings)

# Open questions

- Should we even keep around `SubTypeDecl` at all? (Note: a few places in `examples/` still use it.)
- Currently this PR only allows the comma syntax (for specifying multiple supertypes) in `TypeDecl`, not `SubTypeDecl`; should that syntax be allowed in the latter as well?
- Should the `subType`, `superType`, and `superTypes` fields have their types changed from `Type` to `TypeConstructor`?