### PR TITLE
feat: Math functions

### DIFF
--- a/MathTODO.md
+++ b/MathTODO.md
@@ -1,0 +1,50 @@
+These functions are provided by the JavaScript Math Object.  Here's their status in Penrose.
+
+| JavaScript  | Autodiff.ts | Functions.ts | Notes
+|-------------|-------------|--------------|-------
+| `abs(x)`    | `absVal(x)` | `abs`        |
+| `acos(x)`   | `acos(x)`   | TODO         |
+| `acosh(x)`  | TODO        | TODO         |
+| `asin(x)`   | `asin(x)`   | TODO         |
+| `asinh(x)`  | TODO        | TODO         |
+| `atan(x)`   | TODO        | TODO         |
+| `atan2(y,x)`| `atan2(y,x)`| TODO         |
+| `atanh(x)`  | TODO        | TODO         |
+| `cbrt(x)`   | TODO        | TODO         |
+| `ceil(x)`   | TODO        | TODO         |
+| `cos(x)`    | `cos(x)`    | `cos(x)`     |
+| `cosh(x)`   | TODO        | TODO         |
+| `exp(x)`    | TODO        | TODO         |
+| `expm1(x)`  | TODO        | TODO         |
+| `floor(x)`  | TODO        | TODO         |
+| `fround(x)` | TODO        | TODO         |
+| `hypot(x)`  | TODO        | TODO         |
+| `log(x)`    | TODO        | TODO         |
+| `log2(x)`   | TODO        | TODO         |
+| `log10(x)`  | TODO        | TODO         |
+| `log1p(x)`  | TODO        | TODO         |
+| `max(x,...)`| `max(x,y)`  | `max(x,y)`   |
+| `min(x,...)`| `min(x,y)`  | `min(x,y)`   |
+| `pow(x, y)` | TODO        | TODO         |
+| `random()`  | TODO        | TODO         |
+| `round(x)`  | TODO        | TODO         |
+| `sign(x)`   | TODO        | `sgn(x)`     | Not provided as a differentiable function, since the derivative is zero almost everywhere.
+| `sin(x)`    | `sin(x)`    | `sin(x)`     |
+| `sinh(x)`   | TODO        | TODO         |
+| `sqrt(x)`   | `sqrt(x)`   | `sqrt(x)`    |
+| `tan(x)`    | TODO        | TODO         |
+| `tanh(x)`   | TODO        | TODO         |
+| `trunc(x)`  | TODO        | TODO         |
+
+The JavaScript Math object also provides some standard mathematical constants, as static properties.  In Style we provide these constants as static functions that return a constant value.  (These are all listed as NA in `Autodiff.ts`, since there is no reason to differentiate a constant.)
+
+| JavaScript  | Autodiff.ts | Functions.ts | Notes
+|-------------|-------------|--------------|-------
+| `E`         | NA          | TODO         |
+| `LN2`       | NA          | TODO         |
+| `LN10`      | NA          | TODO         |
+| `LOG2E`     | NA          | TODO         |
+| `LOG10E`    | NA          | TODO         |
+| `PI`        | NA          | TODO         |
+| `SQRT1_2`   | NA          | TODO         |
+| `SQRT2`     | NA          | TODO         |

--- a/packages/core/src/contrib/Functions.ts
+++ b/packages/core/src/contrib/Functions.ts
@@ -19,6 +19,7 @@ import {
   asin,
   asinh,
   atan,
+  atan2,
   atanh,
   cbrt,
   cos,
@@ -288,6 +289,16 @@ export const compDict = {
      return {
         tag: "FloatV",
         contents: atan(x),
+     };
+  },
+  
+  /**
+  * Return `atan2(y,x)`.
+  */
+  atan2: (x: VarAD,y: VarAD): IFloatV<VarAD> => {
+     return {
+        tag: "FloatV",
+        contents: atan2(y,x),
      };
   },
   
@@ -1053,6 +1064,28 @@ export const compDict = {
    */
   vdistsq: (v: VarAD[], w: VarAD[]): IFloatV<VarAD> => {
     return { tag: "FloatV", contents: ops.vdistsq(v, w) };
+  },
+
+  // ------ Mathematical constants
+
+  /**
+   * Base e of the natural logarithm.
+   */
+  MathE: (): IFloatV<VarAD> => {
+    return {
+      tag: "FloatV",
+      contents: constOf(2.718281828459045),
+    };
+  },
+
+  /**
+   * Ratio of the circumference of a circle to its diameter.
+   */
+  MathPI: (): IFloatV<VarAD> => {
+    return {
+      tag: "FloatV",
+      contents: constOf(3.141592653589793),
+    };
   },
 
   // ------ Geometry/graphics utils

--- a/packages/core/src/contrib/Functions.ts
+++ b/packages/core/src/contrib/Functions.ts
@@ -5,9 +5,6 @@ import {
   add,
   addN,
   constOf,
-  cos,
-  acos,
-  asin,
   div,
   gt,
   ifCond,
@@ -17,7 +14,25 @@ import {
   neg,
   numOf,
   ops,
+  acosh,
+  acos,
+  asin,
+  asinh,
+  atan,
+  atanh,
+  cbrt,
+  cos,
+  cosh,
+  exp,
+  expm1,
+  ln,
+  log2,
+  log10,
+  log1p,
   sin,
+  sinh,
+  tan,
+  tanh,
   sqrt,
   sub,
   variableAD,
@@ -227,25 +242,193 @@ export const compDict = {
   },
 
   /**
-   * Return the cosine of input `rad` (in radians).
+   * Return `acosh(x)`.
    */
-  cos: (rad: VarAD): IFloatV<VarAD> => {
-    // Accepts radians
-    return {
-      tag: "FloatV",
-      contents: cos(rad),
-    };
+  acosh: (x: VarAD): IFloatV<VarAD> => {
+     return {
+        tag: "FloatV",
+        contents: acosh(x),
+     };
   },
-
+  
   /**
-   * Return the sine of input `rad` (in radians).
+  * Return `acos(x)`.
+  */
+  acos: (x: VarAD): IFloatV<VarAD> => {
+     return {
+        tag: "FloatV",
+        contents: acos(x),
+     };
+  },
+  
+  /**
+  * Return `asin(x)`.
+  */
+  asin: (x: VarAD): IFloatV<VarAD> => {
+     return {
+        tag: "FloatV",
+        contents: asin(x),
+     };
+  },
+  
+  /**
+  * Return `asinh(x)`.
+  */
+  asinh: (x: VarAD): IFloatV<VarAD> => {
+     return {
+        tag: "FloatV",
+             contents: asinh(x),
+     };
+  },
+  
+  /**
+  * Return `atan(x)`.
+  */
+  atan: (x: VarAD): IFloatV<VarAD> => {
+     return {
+        tag: "FloatV",
+        contents: atan(x),
+     };
+  },
+  
+  /**
+  * Return `atanh(x)`.
+  */
+  atanh: (x: VarAD): IFloatV<VarAD> => {
+     return {
+        tag: "FloatV",
+        contents: atanh(x),
+     };
+  },
+  
+  /**
+  * Return `cbrt(x)`.
+  */
+  cbrt: (x: VarAD): IFloatV<VarAD> => {
+     return {
+        tag: "FloatV",
+        contents: cbrt(x),
+     };
+  },
+  
+  /**
+  * Return `cos(x)`.
+  */
+  cos: (x: VarAD): IFloatV<VarAD> => {
+     return {
+        tag: "FloatV",
+        contents: cos(x),
+     };
+  },
+  
+  /**
+  * Return `cosh(x)`.
+  */
+  cosh: (x: VarAD): IFloatV<VarAD> => {
+     return {
+        tag: "FloatV",
+        contents: cosh(x),
+     };
+  },
+  
+  /**
+  * Return `exp(x)`.
+  */
+  exp: (x: VarAD): IFloatV<VarAD> => {
+     return {
+        tag: "FloatV",
+        contents: exp(x),
+     };
+  },
+  
+  /**
+  * Return `expm1(x)`.
+  */
+  expm1: (x: VarAD): IFloatV<VarAD> => {
+     return {
+        tag: "FloatV",
+        contents: expm1(x),
+     };
+  },
+  
+  /**
+  * Return `log(x)`.
+  */
+  log: (x: VarAD): IFloatV<VarAD> => {
+     return {
+        tag: "FloatV",
+        contents: ln(x),
+     };
+  },
+  
+  /**
+  * Return `log2(x)`.
+  */
+  log2: (x: VarAD): IFloatV<VarAD> => {
+     return {
+        tag: "FloatV",
+        contents: log2(x),
+     };
+  },
+  
+  /**
+  * Return `log10(x)`.
+  */
+  log10: (x: VarAD): IFloatV<VarAD> => {
+     return {
+        tag: "FloatV",
+             contents: log10(x),
+     };
+  },
+  
+  /**
+  * Return `log1p(x)`.
+  */
+  log1p: (x: VarAD): IFloatV<VarAD> => {
+     return {
+        tag: "FloatV",
+        contents: log1p(x),
+     };
+  },
+  
+  /**
+  * Return `sin(x)`.
+  */
+  sin: (x: VarAD): IFloatV<VarAD> => {
+     return {
+        tag: "FloatV",
+        contents: sin(x),
+     };
+  },
+  
+  /**
+  * Return `sinh(x)`.
+  */
+  sinh: (x: VarAD): IFloatV<VarAD> => {
+     return {
+        tag: "FloatV",
+        contents: sinh(x),
+     };
+  },
+  
+  /**
+  * Return `tan(x)`.
+  */
+  tan: (x: VarAD): IFloatV<VarAD> => {
+     return {
+        tag: "FloatV",
+        contents: tan(x),
+     };
+  },
+  
+  /**
+   * Return `tanh(x)`.
    */
-  sin: (rad: VarAD): IFloatV<VarAD> => {
-    // Accepts radians
-    return {
-      tag: "FloatV",
-      contents: sin(rad),
-    };
+  tanh: (x: VarAD): IFloatV<VarAD> => {
+     return {
+        tag: "FloatV",
+        contents: tanh(x),
+     };
   },
 
   /**

--- a/packages/core/src/contrib/Functions.ts
+++ b/packages/core/src/contrib/Functions.ts
@@ -16,6 +16,7 @@ import {
   neg,
   numOf,
   ops,
+  pow,
   acosh,
   acos,
   asin,
@@ -424,6 +425,16 @@ export const compDict = {
      return {
         tag: "FloatV",
         contents: log1p(x),
+     };
+  },
+
+  /**
+  * Return `pow(x,y)`.
+  */
+  pow: (x: VarAD,y: VarAD): IFloatV<VarAD> => {
+     return {
+        tag: "FloatV",
+        contents: pow(x,y),
      };
   },
 

--- a/packages/core/src/contrib/Functions.ts
+++ b/packages/core/src/contrib/Functions.ts
@@ -4,8 +4,10 @@ import {
   absVal,
   add,
   addN,
+  ceil,
   constOf,
   div,
+  floor,
   gt,
   ifCond,
   max,
@@ -30,10 +32,13 @@ import {
   log2,
   log10,
   log1p,
+  round,
+  sign,
   sin,
   sinh,
   tan,
   tanh,
+  trunc,
   sqrt,
   sub,
   variableAD,
@@ -321,6 +326,16 @@ export const compDict = {
         contents: cbrt(x),
      };
   },
+
+  /**
+   * Return `ceil(x)`.
+   */
+  ceil: (x: VarAD): IFloatV<VarAD> => {
+     return {
+        tag: "FloatV",
+        contents: ceil(x),
+     };
+  },
   
   /**
   * Return `cos(x)`.
@@ -363,6 +378,16 @@ export const compDict = {
   },
   
   /**
+  * Return `floor(x)`.
+  */
+  floor: (x: VarAD): IFloatV<VarAD> => {
+     return {
+        tag: "FloatV",
+        contents: floor(x),
+     };
+  },
+  
+  /**
   * Return `log(x)`.
   */
   log: (x: VarAD): IFloatV<VarAD> => {
@@ -399,6 +424,26 @@ export const compDict = {
      return {
         tag: "FloatV",
         contents: log1p(x),
+     };
+  },
+
+  /**
+  * Return `round(x)`.
+  */
+  round: (x: VarAD): IFloatV<VarAD> => {
+     return {
+        tag: "FloatV",
+        contents: round(x),
+     };
+  },
+  
+  /**
+  * Return `sign(x)`.
+  */
+  sign: (x: VarAD): IFloatV<VarAD> => {
+     return {
+        tag: "FloatV",
+        contents: sign(x),
      };
   },
   
@@ -439,6 +484,16 @@ export const compDict = {
      return {
         tag: "FloatV",
         contents: tanh(x),
+     };
+  },
+
+  /**
+  * Return `trunc(x)`.
+  */
+  trunc: (x: VarAD): IFloatV<VarAD> => {
+     return {
+        tag: "FloatV",
+        contents: trunc(x),
      };
   },
 
@@ -1005,13 +1060,6 @@ export const compDict = {
    */
   abs: (x: VarAD): IFloatV<VarAD> => {
     return { tag: "FloatV", contents: absVal(x) };
-  },
-
-  /**
-   * Return the sign of the number `x`.
-   */
-  sgn: (x: VarAD): IFloatV<VarAD> => {
-    return { tag: "FloatV", contents: div(x,absVal(x)) };
   },
 
   /**

--- a/packages/core/src/engine/Autodiff.ts
+++ b/packages/core/src/engine/Autodiff.ts
@@ -495,135 +495,6 @@ export const atan2 = (y: VarAD, x: VarAD, isCompNode = true): VarAD => {
 // --- Unary ops
 
 /**
- * Return `sin(v)`.
- */
-export const sin = (v: VarAD, isCompNode = true): VarAD => {
-  const z = variableAD(Math.sin(v.val), "sin");
-  z.isCompNode = isCompNode;
-
-  if (isCompNode) {
-    const node = just(cos(v, false));
-    v.parents.push({ node: z, sensitivityNode: node });
-
-    z.children.push({ node: v, sensitivityNode: node });
-  } else {
-    v.parentsGrad.push({ node: z, sensitivityNode: none });
-
-    z.childrenGrad.push({ node: v, sensitivityNode: none });
-  }
-
-  return z;
-};
-
-/**
- * Return `cos(v)`.
- */
-export const cos = (v: VarAD, isCompNode = true): VarAD => {
-  const z = variableAD(Math.cos(v.val), "cos");
-  z.isCompNode = isCompNode;
-
-  if (isCompNode) {
-    // construct the derivative
-    // d/dx cos(x) = -sin(x)
-    const node = just(neg(sin(v, false), false));
-    v.parents.push({ node: z, sensitivityNode: node });
-
-    z.children.push({ node: v, sensitivityNode: node });
-  } else {
-    v.parentsGrad.push({ node: z, sensitivityNode: none });
-
-    z.childrenGrad.push({ node: v, sensitivityNode: none });
-  }
-
-  return z;
-};
-
-/**
- * Returns the arc cosine of x (in radians).
- * Assumes that x is in the range [-1,1], and produces the
- * unique value y in the range [0,pi] such that cos(y) = x.
- */
-export const acos = (x: VarAD, isCompNode = true): VarAD => {
-  const y = variableAD(Math.acos(x.val), "acos");
-  y.isCompNode = isCompNode;
-
-  if (isCompNode) {
-
-    // construct the derivative
-    // d/dx acos(x) = -1/sqrt(1-x^2)
-    const node = just(
-       neg(
-          div(
-             gvarOf(1.0),
-             sub(
-                gvarOf(1.0),
-                mul(
-                   x,
-                   x,
-                   false
-                ),
-                false
-             ),
-             false
-          ),
-          false
-       )
-    );
-
-    x.parents.push({ node: y, sensitivityNode: node });
-
-    y.children.push({ node: x, sensitivityNode: node });
-  } else {
-    x.parentsGrad.push({ node: y, sensitivityNode: none });
-
-    y.childrenGrad.push({ node: x, sensitivityNode: none });
-  }
-
-  return y;
-};
-
-/**
- * Returns the arc sine of x (in radians).
- * Assumes that x is in the range [-1,1], and produces the
- * unique value y in the range [-pi/2,pi/2] such that sin(y) = x.
- */
-export const asin = (x: VarAD, isCompNode = true): VarAD => {
-  const y = variableAD(Math.asin(x.val), "asin");
-  y.isCompNode = isCompNode;
-
-  if (isCompNode) {
-
-    // construct the derivative
-    // d/dx asin(x) = 1/sqrt(1-x^2)
-    const node = just(
-       div(
-          gvarOf(1.0),
-          sub(
-             gvarOf(1.0),
-             mul(
-                x,
-                x,
-                false
-             ),
-             false
-          ),
-          false
-       ),
-    );
-
-    x.parents.push({ node: y, sensitivityNode: node });
-
-    y.children.push({ node: x, sensitivityNode: node });
-  } else {
-    x.parentsGrad.push({ node: y, sensitivityNode: none });
-
-    y.childrenGrad.push({ node: x, sensitivityNode: none });
-  }
-
-  return y;
-};
-
-/**
  * Return `-v`.
  */
 export const neg = (v: VarAD, isCompNode = true): VarAD => {
@@ -673,6 +544,7 @@ export const sqrt = (v: VarAD, isCompNode = true): VarAD => {
   const z = variableAD(Math.sqrt(v.val), "sqrt");
   z.isCompNode = isCompNode;
 
+  // XXX Looks like this is for debugging?
   const dzDv = (arg: "unit"): number => {
     if (v.val < 0) {
       log.trace(`negative arg ${v.val} in sqrt`);
@@ -750,6 +622,369 @@ export const absVal = (v: VarAD, isCompNode = true): VarAD => {
 
   return z;
 };
+
+/**
+ * Return `acosh(v)`.
+ */
+export const acosh = (x: VarAD, isCompNode = true): VarAD => {
+  const y = variableAD(Math.acosh(x.val), "acosh");
+  y.isCompNode = isCompNode;
+
+  if (isCompNode) {
+    const node = just(div(gvarOf(1.0),mul(sqrt(sub(x,gvarOf(1.0),false),false),sqrt(add(x,gvarOf(1.0),false),false),false),false));
+    x.parents.push({ node: y, sensitivityNode: node });
+    y.children.push({ node: x, sensitivityNode: node });
+  } else {
+    x.parentsGrad.push({ node: y, sensitivityNode: none });
+    y.childrenGrad.push({ node: x, sensitivityNode: none });
+  }
+
+  return y;
+};
+
+/**
+ * Return `acos(v)`.
+ */
+export const acos = (x: VarAD, isCompNode = true): VarAD => {
+  const y = variableAD(Math.acos(x.val), "acos");
+  y.isCompNode = isCompNode;
+
+  if (isCompNode) {
+    const node = just(neg(div(gvarOf(1.0),sqrt(sub(gvarOf(1.0),mul(x,x,false),false),false),false),false));
+    x.parents.push({ node: y, sensitivityNode: node });
+    y.children.push({ node: x, sensitivityNode: node });
+  } else {
+    x.parentsGrad.push({ node: y, sensitivityNode: none });
+    y.childrenGrad.push({ node: x, sensitivityNode: none });
+  }
+
+  return y;
+};
+
+/**
+ * Return `asin(v)`.
+ */
+export const asin = (x: VarAD, isCompNode = true): VarAD => {
+  const y = variableAD(Math.asin(x.val), "asin");
+  y.isCompNode = isCompNode;
+
+  if (isCompNode) {
+    const node = just(div(gvarOf(1.0),sqrt(sub(gvarOf(1.0),mul(x,x,false),false),false),false));
+    x.parents.push({ node: y, sensitivityNode: node });
+    y.children.push({ node: x, sensitivityNode: node });
+  } else {
+    x.parentsGrad.push({ node: y, sensitivityNode: none });
+    y.childrenGrad.push({ node: x, sensitivityNode: none });
+  }
+
+  return y;
+};
+
+/**
+ * Return `asinh(v)`.
+ */
+export const asinh = (x: VarAD, isCompNode = true): VarAD => {
+  const y = variableAD(Math.asinh(x.val), "asinh");
+  y.isCompNode = isCompNode;
+
+  if (isCompNode) {
+    const node = just(div(gvarOf(1.0),sqrt(add(gvarOf(1.0),mul(x,x,false),false),false),false));
+    x.parents.push({ node: y, sensitivityNode: node });
+    y.children.push({ node: x, sensitivityNode: node });
+  } else {
+    x.parentsGrad.push({ node: y, sensitivityNode: none });
+    y.childrenGrad.push({ node: x, sensitivityNode: none });
+  }
+
+  return y;
+};
+
+/**
+ * Return `atan(v)`.
+ */
+export const atan = (x: VarAD, isCompNode = true): VarAD => {
+  const y = variableAD(Math.atan(x.val), "atan");
+  y.isCompNode = isCompNode;
+
+  if (isCompNode) {
+    const node = just(div(gvarOf(1.0),add(gvarOf(1.0),mul(x,x,false),false),false));
+    x.parents.push({ node: y, sensitivityNode: node });
+    y.children.push({ node: x, sensitivityNode: node });
+  } else {
+    x.parentsGrad.push({ node: y, sensitivityNode: none });
+    y.childrenGrad.push({ node: x, sensitivityNode: none });
+  }
+
+  return y;
+};
+
+/**
+ * Return `atanh(v)`.
+ */
+export const atanh = (x: VarAD, isCompNode = true): VarAD => {
+  const y = variableAD(Math.atanh(x.val), "atanh");
+  y.isCompNode = isCompNode;
+
+  if (isCompNode) {
+    const node = just(div(gvarOf(1.0),sub(gvarOf(1.0),mul(x,x,false),false),false));
+    x.parents.push({ node: y, sensitivityNode: node });
+    y.children.push({ node: x, sensitivityNode: node });
+  } else {
+    x.parentsGrad.push({ node: y, sensitivityNode: none });
+    y.childrenGrad.push({ node: x, sensitivityNode: none });
+  }
+
+  return y;
+};
+
+/**
+ * Return `cbrt(v)`.
+ */
+export const cbrt = (x: VarAD, isCompNode = true): VarAD => {
+  const y = variableAD(Math.cbrt(x.val), "cbrt");
+  y.isCompNode = isCompNode;
+
+  if (isCompNode) {
+    const node = just(div(gvarOf(1.0),mul(gvarOf(3.0),squared(cbrt(x,false),false),false),false));
+    x.parents.push({ node: y, sensitivityNode: node });
+    y.children.push({ node: x, sensitivityNode: node });
+  } else {
+    x.parentsGrad.push({ node: y, sensitivityNode: none });
+    y.childrenGrad.push({ node: x, sensitivityNode: none });
+  }
+
+  return y;
+};
+
+/**
+ * Return `cos(v)`.
+ */
+export const cos = (x: VarAD, isCompNode = true): VarAD => {
+  const y = variableAD(Math.cos(x.val), "cos");
+  y.isCompNode = isCompNode;
+
+  if (isCompNode) {
+    const node = just(neg(sin(x,false),false));
+    x.parents.push({ node: y, sensitivityNode: node });
+    y.children.push({ node: x, sensitivityNode: node });
+  } else {
+    x.parentsGrad.push({ node: y, sensitivityNode: none });
+    y.childrenGrad.push({ node: x, sensitivityNode: none });
+  }
+
+  return y;
+};
+
+/**
+ * Return `cosh(v)`.
+ */
+export const cosh = (x: VarAD, isCompNode = true): VarAD => {
+  const y = variableAD(Math.cosh(x.val), "cosh");
+  y.isCompNode = isCompNode;
+
+  if (isCompNode) {
+    const node = just(sinh(x,false));
+    x.parents.push({ node: y, sensitivityNode: node });
+    y.children.push({ node: x, sensitivityNode: node });
+  } else {
+    x.parentsGrad.push({ node: y, sensitivityNode: none });
+    y.childrenGrad.push({ node: x, sensitivityNode: none });
+  }
+
+  return y;
+};
+
+/**
+ * Return `exp(v)`.
+ */
+export const exp = (x: VarAD, isCompNode = true): VarAD => {
+  const y = variableAD(Math.exp(x.val), "exp");
+  y.isCompNode = isCompNode;
+
+  if (isCompNode) {
+    const node = just(exp(x,false));
+    x.parents.push({ node: y, sensitivityNode: node });
+    y.children.push({ node: x, sensitivityNode: node });
+  } else {
+    x.parentsGrad.push({ node: y, sensitivityNode: none });
+    y.childrenGrad.push({ node: x, sensitivityNode: none });
+  }
+
+  return y;
+};
+
+/**
+ * Return `expm1(v)`.
+ */
+export const expm1 = (x: VarAD, isCompNode = true): VarAD => {
+  const y = variableAD(Math.expm1(x.val), "expm1");
+  y.isCompNode = isCompNode;
+
+  if (isCompNode) {
+    const node = just(exp(x,false));
+    x.parents.push({ node: y, sensitivityNode: node });
+    y.children.push({ node: x, sensitivityNode: node });
+  } else {
+    x.parentsGrad.push({ node: y, sensitivityNode: none });
+    y.childrenGrad.push({ node: x, sensitivityNode: none });
+  }
+
+  return y;
+};
+
+/**
+ * Return the natural logarithm `ln(v)` (i.e., log base e).
+ */
+export const ln = (x: VarAD, isCompNode = true): VarAD => {
+  const y = variableAD(Math.log(x.val), "log");
+  y.isCompNode = isCompNode;
+
+  if (isCompNode) {
+    const node = just(div(gvarOf(1.0),x,false));
+    x.parents.push({ node: y, sensitivityNode: node });
+    y.children.push({ node: x, sensitivityNode: node });
+  } else {
+    x.parentsGrad.push({ node: y, sensitivityNode: none });
+    y.childrenGrad.push({ node: x, sensitivityNode: none });
+  }
+
+  return y;
+};
+
+/**
+ * Return `log2(v)`.
+ */
+export const log2 = (x: VarAD, isCompNode = true): VarAD => {
+  const y = variableAD(Math.log2(x.val), "log2");
+  y.isCompNode = isCompNode;
+
+  if (isCompNode) {
+    const node = just(div(gvarOf(1.0),mul(x,gvarOf(0.6931471805599453),false),false));
+    x.parents.push({ node: y, sensitivityNode: node });
+    y.children.push({ node: x, sensitivityNode: node });
+  } else {
+    x.parentsGrad.push({ node: y, sensitivityNode: none });
+    y.childrenGrad.push({ node: x, sensitivityNode: none });
+  }
+
+  return y;
+};
+
+/**
+ * Return `log10(v)`.
+ */
+export const log10 = (x: VarAD, isCompNode = true): VarAD => {
+  const y = variableAD(Math.log10(x.val), "log10");
+  y.isCompNode = isCompNode;
+
+  if (isCompNode) {
+    const node = just(div(gvarOf(1.0),mul(x,gvarOf(2.302585092994046),false),false));
+    x.parents.push({ node: y, sensitivityNode: node });
+    y.children.push({ node: x, sensitivityNode: node });
+  } else {
+    x.parentsGrad.push({ node: y, sensitivityNode: none });
+    y.childrenGrad.push({ node: x, sensitivityNode: none });
+  }
+
+  return y;
+};
+
+/**
+ * Return `log1p(v)`.
+ */
+export const log1p = (x: VarAD, isCompNode = true): VarAD => {
+  const y = variableAD(Math.log1p(x.val), "log1p");
+  y.isCompNode = isCompNode;
+
+  if (isCompNode) {
+    const node = just(div(gvarOf(1.0),add(gvarOf(1.0),x,false),false));
+    x.parents.push({ node: y, sensitivityNode: node });
+    y.children.push({ node: x, sensitivityNode: node });
+  } else {
+    x.parentsGrad.push({ node: y, sensitivityNode: none });
+    y.childrenGrad.push({ node: x, sensitivityNode: none });
+  }
+
+  return y;
+};
+
+/**
+ * Return `sin(v)`.
+ */
+export const sin = (x: VarAD, isCompNode = true): VarAD => {
+  const y = variableAD(Math.sin(x.val), "sin");
+  y.isCompNode = isCompNode;
+
+  if (isCompNode) {
+    const node = just(cos(x,false));
+    x.parents.push({ node: y, sensitivityNode: node });
+    y.children.push({ node: x, sensitivityNode: node });
+  } else {
+    x.parentsGrad.push({ node: y, sensitivityNode: none });
+    y.childrenGrad.push({ node: x, sensitivityNode: none });
+  }
+
+  return y;
+};
+
+/**
+ * Return `sinh(v)`.
+ */
+export const sinh = (x: VarAD, isCompNode = true): VarAD => {
+  const y = variableAD(Math.sinh(x.val), "sinh");
+  y.isCompNode = isCompNode;
+
+  if (isCompNode) {
+    const node = just(cosh(x,false));
+    x.parents.push({ node: y, sensitivityNode: node });
+    y.children.push({ node: x, sensitivityNode: node });
+  } else {
+    x.parentsGrad.push({ node: y, sensitivityNode: none });
+    y.childrenGrad.push({ node: x, sensitivityNode: none });
+  }
+
+  return y;
+};
+
+/**
+ * Return `tan(v)`.
+ */
+export const tan = (x: VarAD, isCompNode = true): VarAD => {
+  const y = variableAD(Math.tan(x.val), "tan");
+  y.isCompNode = isCompNode;
+
+  if (isCompNode) {
+    const node = just(squared(div(gvarOf(1.0),cos(x,false),false),false));
+    x.parents.push({ node: y, sensitivityNode: node });
+    y.children.push({ node: x, sensitivityNode: node });
+  } else {
+    x.parentsGrad.push({ node: y, sensitivityNode: none });
+    y.childrenGrad.push({ node: x, sensitivityNode: none });
+  }
+
+  return y;
+};
+
+/**
+ * Return `tanh(v)`.
+ */
+export const tanh = (x: VarAD, isCompNode = true): VarAD => {
+  const y = variableAD(Math.tanh(x.val), "tanh");
+  y.isCompNode = isCompNode;
+
+  if (isCompNode) {
+    const node = just(squared(div(gvarOf(1.0),cosh(x,false),false),false));
+    x.parents.push({ node: y, sensitivityNode: node });
+    y.children.push({ node: x, sensitivityNode: node });
+  } else {
+    x.parentsGrad.push({ node: y, sensitivityNode: none });
+    y.childrenGrad.push({ node: x, sensitivityNode: none });
+  }
+
+  return y;
+};
+
+
 // ------- Discontinuous / noGrad ops
 
 /**
@@ -956,17 +1191,62 @@ const opMap = {
   min: {
     fn: (x: number, y: number): number => Math.min(x, y),
   },
-  sin: {
-    fn: (x: number): number => Math.sin(x),
-  },
-  cos: {
-    fn: (x: number): number => Math.cos(x),
-  },
-  asin: {
-    fn: (x: number): number => Math.asin(x),
+  acosh: {
+     fn: (x: number): number => Math.acosh(x),
   },
   acos: {
-    fn: (x: number): number => Math.acos(x),
+     fn: (x: number): number => Math.acos(x),
+  },
+  asin: {
+     fn: (x: number): number => Math.asin(x),
+  },
+  asinh: {
+     fn: (x: number): number => Math.asinh(x),
+  },
+  atan: {
+     fn: (x: number): number => Math.atan(x),
+  },
+  atanh: {
+     fn: (x: number): number => Math.atanh(x),
+  },
+  cbrt: {
+     fn: (x: number): number => Math.cbrt(x),
+  },
+  cos: {
+     fn: (x: number): number => Math.cos(x),
+  },
+  cosh: {
+     fn: (x: number): number => Math.cosh(x),
+  },
+  exp: {
+     fn: (x: number): number => Math.exp(x),
+  },
+  expm1: {
+     fn: (x: number): number => Math.expm1(x),
+  },
+  ln: {
+     fn: (x: number): number => Math.log(x),
+  },
+  log2: {
+     fn: (x: number): number => Math.log2(x),
+  },
+  log10: {
+     fn: (x: number): number => Math.log10(x),
+  },
+  log1p: {
+     fn: (x: number): number => Math.log1p(x),
+  },
+  sin: {
+     fn: (x: number): number => Math.sin(x),
+  },
+  sinh: {
+     fn: (x: number): number => Math.sinh(x),
+  },
+  tan: {
+     fn: (x: number): number => Math.tan(x),
+  },
+  tanh: {
+     fn: (x: number): number => Math.tanh(x),
   },
   "- (unary)": {
     fn: (x: number): number => -x,
@@ -1484,14 +1764,44 @@ const traverseGraph = (i: number, z: IVarAD, setting: string): any => {
       stmt = `const ${parName} = ${childName} * ${childName};`;
     } else if (z.op === "sqrt") {
       stmt = `const ${parName} = Math.sqrt(${childName});`;
-    } else if (z.op === "sin") {
-      stmt = `const ${parName} = Math.sin(${childName});`;
-    } else if (z.op === "cos") {
-      stmt = `const ${parName} = Math.cos(${childName});`;
-    } else if (z.op === "asin") {
-      stmt = `const ${parName} = Math.asin(${childName});`;
+    } else if (z.op === "acosh") {
+      stmt = `const ${parName} = Math.acosh(${childName});`;
     } else if (z.op === "acos") {
       stmt = `const ${parName} = Math.acos(${childName});`;
+    } else if (z.op === "asin") {
+      stmt = `const ${parName} = Math.asin(${childName});`;
+    } else if (z.op === "asinh") {
+      stmt = `const ${parName} = Math.asinh(${childName});`;
+    } else if (z.op === "atan") {
+      stmt = `const ${parName} = Math.atan(${childName});`;
+    } else if (z.op === "atanh") {
+      stmt = `const ${parName} = Math.atanh(${childName});`;
+    } else if (z.op === "cbrt") {
+      stmt = `const ${parName} = Math.cbrt(${childName});`;
+    } else if (z.op === "cos") {
+      stmt = `const ${parName} = Math.cos(${childName});`;
+    } else if (z.op === "cosh") {
+      stmt = `const ${parName} = Math.cosh(${childName});`;
+    } else if (z.op === "exp") {
+      stmt = `const ${parName} = Math.exp(${childName});`;
+    } else if (z.op === "expm1") {
+      stmt = `const ${parName} = Math.expm1(${childName});`;
+    } else if (z.op === "log") {
+      stmt = `const ${parName} = Math.log(${childName});`;
+    } else if (z.op === "log2") {
+      stmt = `const ${parName} = Math.log2(${childName});`;
+    } else if (z.op === "log10") {
+      stmt = `const ${parName} = Math.log10(${childName});`;
+    } else if (z.op === "log1p") {
+      stmt = `const ${parName} = Math.log1p(${childName});`;
+    } else if (z.op === "sin") {
+      stmt = `const ${parName} = Math.sin(${childName});`;
+    } else if (z.op === "sinh") {
+      stmt = `const ${parName} = Math.sinh(${childName});`;
+    } else if (z.op === "tan") {
+      stmt = `const ${parName} = Math.tan(${childName});`;
+    } else if (z.op === "tanh") {
+      stmt = `const ${parName} = Math.tanh(${childName});`;
     } else if (z.op === "+ list") {
       // TODO: Get rid of unary +
       stmt = `const ${parName} = ${childName};`;

--- a/packages/core/src/engine/Autodiff.ts
+++ b/packages/core/src/engine/Autodiff.ts
@@ -624,7 +624,7 @@ export const absVal = (v: VarAD, isCompNode = true): VarAD => {
 };
 
 /**
- * Return `acosh(v)`.
+ * Return `acosh(x)`.
  */
 export const acosh = (x: VarAD, isCompNode = true): VarAD => {
   const y = variableAD(Math.acosh(x.val), "acosh");
@@ -643,7 +643,7 @@ export const acosh = (x: VarAD, isCompNode = true): VarAD => {
 };
 
 /**
- * Return `acos(v)`.
+ * Return `acos(x)`.
  */
 export const acos = (x: VarAD, isCompNode = true): VarAD => {
   const y = variableAD(Math.acos(x.val), "acos");
@@ -662,7 +662,7 @@ export const acos = (x: VarAD, isCompNode = true): VarAD => {
 };
 
 /**
- * Return `asin(v)`.
+ * Return `asin(x)`.
  */
 export const asin = (x: VarAD, isCompNode = true): VarAD => {
   const y = variableAD(Math.asin(x.val), "asin");
@@ -681,7 +681,7 @@ export const asin = (x: VarAD, isCompNode = true): VarAD => {
 };
 
 /**
- * Return `asinh(v)`.
+ * Return `asinh(x)`.
  */
 export const asinh = (x: VarAD, isCompNode = true): VarAD => {
   const y = variableAD(Math.asinh(x.val), "asinh");
@@ -700,7 +700,7 @@ export const asinh = (x: VarAD, isCompNode = true): VarAD => {
 };
 
 /**
- * Return `atan(v)`.
+ * Return `atan(x)`.
  */
 export const atan = (x: VarAD, isCompNode = true): VarAD => {
   const y = variableAD(Math.atan(x.val), "atan");
@@ -719,7 +719,7 @@ export const atan = (x: VarAD, isCompNode = true): VarAD => {
 };
 
 /**
- * Return `atanh(v)`.
+ * Return `atanh(x)`.
  */
 export const atanh = (x: VarAD, isCompNode = true): VarAD => {
   const y = variableAD(Math.atanh(x.val), "atanh");
@@ -738,7 +738,7 @@ export const atanh = (x: VarAD, isCompNode = true): VarAD => {
 };
 
 /**
- * Return `cbrt(v)`.
+ * Return `cbrt(x)`.
  */
 export const cbrt = (x: VarAD, isCompNode = true): VarAD => {
   const y = variableAD(Math.cbrt(x.val), "cbrt");
@@ -757,7 +757,26 @@ export const cbrt = (x: VarAD, isCompNode = true): VarAD => {
 };
 
 /**
- * Return `cos(v)`.
+ * Return `ceil(x)`.
+ */
+export const ceil = (x: VarAD, isCompNode = true): VarAD => {
+  const y = variableAD(Math.ceil(x.val), "ceil");
+  y.isCompNode = isCompNode;
+
+  if (isCompNode) {
+    const node = just(gvarOf(0.0));
+    x.parents.push({ node: y, sensitivityNode: node });
+    y.children.push({ node: x, sensitivityNode: node });
+  } else {
+    x.parentsGrad.push({ node: y, sensitivityNode: none });
+    y.childrenGrad.push({ node: x, sensitivityNode: none });
+  }
+
+  return y;
+};
+
+/**
+ * Return `cos(x)`.
  */
 export const cos = (x: VarAD, isCompNode = true): VarAD => {
   const y = variableAD(Math.cos(x.val), "cos");
@@ -776,7 +795,7 @@ export const cos = (x: VarAD, isCompNode = true): VarAD => {
 };
 
 /**
- * Return `cosh(v)`.
+ * Return `cosh(x)`.
  */
 export const cosh = (x: VarAD, isCompNode = true): VarAD => {
   const y = variableAD(Math.cosh(x.val), "cosh");
@@ -795,7 +814,7 @@ export const cosh = (x: VarAD, isCompNode = true): VarAD => {
 };
 
 /**
- * Return `exp(v)`.
+ * Return `exp(x)`.
  */
 export const exp = (x: VarAD, isCompNode = true): VarAD => {
   const y = variableAD(Math.exp(x.val), "exp");
@@ -814,7 +833,7 @@ export const exp = (x: VarAD, isCompNode = true): VarAD => {
 };
 
 /**
- * Return `expm1(v)`.
+ * Return `expm1(x)`.
  */
 export const expm1 = (x: VarAD, isCompNode = true): VarAD => {
   const y = variableAD(Math.expm1(x.val), "expm1");
@@ -822,6 +841,25 @@ export const expm1 = (x: VarAD, isCompNode = true): VarAD => {
 
   if (isCompNode) {
     const node = just(exp(x,false));
+    x.parents.push({ node: y, sensitivityNode: node });
+    y.children.push({ node: x, sensitivityNode: node });
+  } else {
+    x.parentsGrad.push({ node: y, sensitivityNode: none });
+    y.childrenGrad.push({ node: x, sensitivityNode: none });
+  }
+
+  return y;
+};
+
+/**
+ * Return `floor(x)`.
+ */
+export const floor = (x: VarAD, isCompNode = true): VarAD => {
+  const y = variableAD(Math.floor(x.val), "floor");
+  y.isCompNode = isCompNode;
+
+  if (isCompNode) {
+    const node = just(gvarOf(0.0));
     x.parents.push({ node: y, sensitivityNode: node });
     y.children.push({ node: x, sensitivityNode: node });
   } else {
@@ -852,7 +890,7 @@ export const ln = (x: VarAD, isCompNode = true): VarAD => {
 };
 
 /**
- * Return `log2(v)`.
+ * Return `log2(x)`.
  */
 export const log2 = (x: VarAD, isCompNode = true): VarAD => {
   const y = variableAD(Math.log2(x.val), "log2");
@@ -871,7 +909,7 @@ export const log2 = (x: VarAD, isCompNode = true): VarAD => {
 };
 
 /**
- * Return `log10(v)`.
+ * Return `log10(x)`.
  */
 export const log10 = (x: VarAD, isCompNode = true): VarAD => {
   const y = variableAD(Math.log10(x.val), "log10");
@@ -890,7 +928,7 @@ export const log10 = (x: VarAD, isCompNode = true): VarAD => {
 };
 
 /**
- * Return `log1p(v)`.
+ * Return `log1p(x)`.
  */
 export const log1p = (x: VarAD, isCompNode = true): VarAD => {
   const y = variableAD(Math.log1p(x.val), "log1p");
@@ -909,7 +947,45 @@ export const log1p = (x: VarAD, isCompNode = true): VarAD => {
 };
 
 /**
- * Return `sin(v)`.
+ * Return `round(x)`.
+ */
+export const round = (x: VarAD, isCompNode = true): VarAD => {
+  const y = variableAD(Math.round(x.val), "round");
+  y.isCompNode = isCompNode;
+
+  if (isCompNode) {
+    const node = just(gvarOf(0.0));
+    x.parents.push({ node: y, sensitivityNode: node });
+    y.children.push({ node: x, sensitivityNode: node });
+  } else {
+    x.parentsGrad.push({ node: y, sensitivityNode: none });
+    y.childrenGrad.push({ node: x, sensitivityNode: none });
+  }
+
+  return y;
+};
+
+/**
+ * Return `sign(x)`.
+ */
+export const sign = (x: VarAD, isCompNode = true): VarAD => {
+  const y = variableAD(Math.sign(x.val), "sign");
+  y.isCompNode = isCompNode;
+
+  if (isCompNode) {
+    const node = just(gvarOf(0.0));
+    x.parents.push({ node: y, sensitivityNode: node });
+    y.children.push({ node: x, sensitivityNode: node });
+  } else {
+    x.parentsGrad.push({ node: y, sensitivityNode: none });
+    y.childrenGrad.push({ node: x, sensitivityNode: none });
+  }
+
+  return y;
+};
+
+/**
+ * Return `sin(x)`.
  */
 export const sin = (x: VarAD, isCompNode = true): VarAD => {
   const y = variableAD(Math.sin(x.val), "sin");
@@ -928,7 +1004,7 @@ export const sin = (x: VarAD, isCompNode = true): VarAD => {
 };
 
 /**
- * Return `sinh(v)`.
+ * Return `sinh(x)`.
  */
 export const sinh = (x: VarAD, isCompNode = true): VarAD => {
   const y = variableAD(Math.sinh(x.val), "sinh");
@@ -947,7 +1023,7 @@ export const sinh = (x: VarAD, isCompNode = true): VarAD => {
 };
 
 /**
- * Return `tan(v)`.
+ * Return `tan(x)`.
  */
 export const tan = (x: VarAD, isCompNode = true): VarAD => {
   const y = variableAD(Math.tan(x.val), "tan");
@@ -966,7 +1042,7 @@ export const tan = (x: VarAD, isCompNode = true): VarAD => {
 };
 
 /**
- * Return `tanh(v)`.
+ * Return `tanh(x)`.
  */
 export const tanh = (x: VarAD, isCompNode = true): VarAD => {
   const y = variableAD(Math.tanh(x.val), "tanh");
@@ -984,6 +1060,24 @@ export const tanh = (x: VarAD, isCompNode = true): VarAD => {
   return y;
 };
 
+/**
+ * Return `trunc(x)`.
+ */
+export const trunc = (x: VarAD, isCompNode = true): VarAD => {
+  const y = variableAD(Math.trunc(x.val), "trunc");
+  y.isCompNode = isCompNode;
+
+  if (isCompNode) {
+    const node = just(gvarOf(0.0));
+    x.parents.push({ node: y, sensitivityNode: node });
+    y.children.push({ node: x, sensitivityNode: node });
+  } else {
+    x.parentsGrad.push({ node: y, sensitivityNode: none });
+    y.childrenGrad.push({ node: x, sensitivityNode: none });
+  }
+
+  return y;
+};
 
 // ------- Discontinuous / noGrad ops
 
@@ -1212,6 +1306,9 @@ const opMap = {
   cbrt: {
      fn: (x: number): number => Math.cbrt(x),
   },
+  ceil: {
+     fn: (x: number): number => Math.ceil(x),
+  },
   cos: {
      fn: (x: number): number => Math.cos(x),
   },
@@ -1223,6 +1320,9 @@ const opMap = {
   },
   expm1: {
      fn: (x: number): number => Math.expm1(x),
+  },
+  floor: {
+     fn: (x: number): number => Math.floor(x),
   },
   ln: {
      fn: (x: number): number => Math.log(x),
@@ -1236,6 +1336,12 @@ const opMap = {
   log1p: {
      fn: (x: number): number => Math.log1p(x),
   },
+  round: {
+     fn: (x: number): number => Math.round(x),
+  },
+  sign: {
+     fn: (x: number): number => Math.sign(x),
+  },
   sin: {
      fn: (x: number): number => Math.sin(x),
   },
@@ -1247,6 +1353,9 @@ const opMap = {
   },
   tanh: {
      fn: (x: number): number => Math.tanh(x),
+  },
+  trunc: {
+     fn: (x: number): number => Math.trunc(x),
   },
   "- (unary)": {
     fn: (x: number): number => -x,
@@ -1778,6 +1887,8 @@ const traverseGraph = (i: number, z: IVarAD, setting: string): any => {
       stmt = `const ${parName} = Math.atanh(${childName});`;
     } else if (z.op === "cbrt") {
       stmt = `const ${parName} = Math.cbrt(${childName});`;
+    } else if (z.op === "ceil") {
+      stmt = `const ${parName} = Math.ceil(${childName});`;
     } else if (z.op === "cos") {
       stmt = `const ${parName} = Math.cos(${childName});`;
     } else if (z.op === "cosh") {
@@ -1786,6 +1897,8 @@ const traverseGraph = (i: number, z: IVarAD, setting: string): any => {
       stmt = `const ${parName} = Math.exp(${childName});`;
     } else if (z.op === "expm1") {
       stmt = `const ${parName} = Math.expm1(${childName});`;
+    } else if (z.op === "floor") {
+      stmt = `const ${parName} = Math.floor(${childName});`;
     } else if (z.op === "log") {
       stmt = `const ${parName} = Math.log(${childName});`;
     } else if (z.op === "log2") {
@@ -1794,6 +1907,10 @@ const traverseGraph = (i: number, z: IVarAD, setting: string): any => {
       stmt = `const ${parName} = Math.log10(${childName});`;
     } else if (z.op === "log1p") {
       stmt = `const ${parName} = Math.log1p(${childName});`;
+    } else if (z.op === "round") {
+      stmt = `const ${parName} = Math.round(${childName});`;
+    } else if (z.op === "sign") {
+      stmt = `const ${parName} = Math.sign(${childName});`;
     } else if (z.op === "sin") {
       stmt = `const ${parName} = Math.sin(${childName});`;
     } else if (z.op === "sinh") {
@@ -1802,6 +1919,8 @@ const traverseGraph = (i: number, z: IVarAD, setting: string): any => {
       stmt = `const ${parName} = Math.tan(${childName});`;
     } else if (z.op === "tanh") {
       stmt = `const ${parName} = Math.tanh(${childName});`;
+    } else if (z.op === "trunc") {
+      stmt = `const ${parName} = Math.trunc(${childName});`;
     } else if (z.op === "+ list") {
       // TODO: Get rid of unary +
       stmt = `const ${parName} = ${childName};`;

--- a/util/ad/GenerateCode.pl
+++ b/util/ad/GenerateCode.pl
@@ -1,0 +1,14 @@
+#!/usr/bin/perl
+
+open( IN, "<derivatives.txt" ) or die "Need to run GenerateDerivatives.nb first!\n";
+
+while( <IN> )
+{
+   # grab the function name
+   s/([^:]+):\s*//;
+   print $_
+
+   # TODO perform substitutions
+}
+
+close( IN );

--- a/util/ad/GenerateDerivatives.nb
+++ b/util/ad/GenerateDerivatives.nb
@@ -10,10 +10,10 @@
 NotebookFileLineBreakTest
 NotebookFileLineBreakTest
 NotebookDataPosition[       158,          7]
-NotebookDataLength[      8514,        238]
-NotebookOptionsPosition[      7690,        217]
-NotebookOutlinePosition[      8055,        233]
-CellTagsIndexPosition[      8012,        230]
+NotebookDataLength[      7528,        218]
+NotebookOptionsPosition[      7078,        201]
+NotebookOutlinePosition[      7443,        217]
+CellTagsIndexPosition[      7400,        214]
 WindowFrame->Normal*)
 
 (* Beginning of Notebook Content *)
@@ -43,8 +43,12 @@ Cell[BoxData[{
    SuperscriptBox["x", "y"]}], ";"}], "\[IndentingNewLine]", 
  RowBox[{
   RowBox[{
-   RowBox[{"Powyx", "[", "x_", "]"}], ":=", 
-   SuperscriptBox["y", "x"]}], ";"}], "\[IndentingNewLine]", 
+   RowBox[{
+    RowBox[{"Powyx", "[", "x_", "]"}], ":=", 
+    SuperscriptBox["y", "x"]}], ";"}], "\[IndentingNewLine]", 
+  RowBox[{"(*", " ", 
+   RowBox[{"Mathematica", " ", "function", " ", "names"}], " ", 
+   "*)"}]}], "\[IndentingNewLine]", 
  RowBox[{
   RowBox[{
    RowBox[{"functions", "=", 
@@ -53,60 +57,88 @@ Cell[BoxData[{
      "ArcCosh", ",", "ArcSinh", ",", "ArcTan", ",", "ArcTanh", ",", "Cbrt", 
       ",", "Cosh", ",", "Exp", ",", "Expm1", ",", "Log", ",", "Log2", ",", 
       "Log10", ",", "Log1p", ",", "Powxy", ",", "Powyx", ",", "Sinh", ",", 
-      "Tan", ",", "Tanh"}], "}"}]}], ";"}], 
-  "\[IndentingNewLine]"}], "\[IndentingNewLine]", 
- RowBox[{
-  RowBox[{"Print", "[", "\"\<functions:\>\"", "]"}], 
-  ";"}], "\[IndentingNewLine]", 
- RowBox[{"functions", "\[IndentingNewLine]"}], "\[IndentingNewLine]", 
- RowBox[{
-  RowBox[{"Print", "[", "\"\<derivatives:\>\"", "]"}], 
-  ";"}], "\[IndentingNewLine]", 
+      "Tan", ",", "Tanh"}], "}"}]}], ";"}], "\[IndentingNewLine]", 
+  RowBox[{"(*", " ", 
+   RowBox[{"JavaScript", " ", "Math", " ", "function", " ", "names"}], " ", 
+   "*)"}]}], "\[IndentingNewLine]", 
  RowBox[{
   RowBox[{
-   RowBox[{"(", 
+   RowBox[{"names", "=", 
+    RowBox[{"{", 
+     RowBox[{
+     "\"\<acosh\>\"", ",", "\"\<asinh\>\"", ",", "\"\<atan\>\"", ",", 
+      "\"\<atanh\>\"", ",", "\"\<cbrt\>\"", ",", "\"\<cosh\>\"", ",", 
+      "\"\<exp\>\"", ",", "\"\<expm1\>\"", ",", "\"\<log\>\"", ",", 
+      "\"\<log2\>\"", ",", "\"\<log10\>\"", ",", "\"\<log1p\>\"", ",", 
+      "\"\<pow\>\"", ",", "\"\<pow\>\"", ",", "\"\<sinh\>\"", ",", 
+      "\"\<tan\>\"", ",", "\"\<tanh\>\""}], "}"}]}], ";"}], 
+  "\[IndentingNewLine]", "\n", 
+  RowBox[{"(*", " ", 
+   RowBox[{"Display", " ", "derivatives"}], " ", 
+   "*)"}]}], "\[IndentingNewLine]", 
+ RowBox[{
+  RowBox[{
+   RowBox[{
+    RowBox[{"(", 
+     RowBox[{
+      SubscriptBox["\[PartialD]", "x"], 
+      RowBox[{"(", 
+       RowBox[{"#", "[", "x", "]"}], ")"}]}], ")"}], "&"}], "/@", 
+   "functions"}], "\[IndentingNewLine]", "\[IndentingNewLine]", 
+  RowBox[{"(*", " ", 
+   RowBox[{
+   "Write", " ", "derivatives", " ", "as", " ", "plain", " ", "text", " ", 
+    "in", " ", "functional", " ", 
+    RowBox[{"form", "."}]}], " ", "*)"}]}], "\[IndentingNewLine]", 
+ RowBox[{
+  RowBox[{"SetDirectory", "[", 
+   RowBox[{"NotebookDirectory", "[", "]"}], "]"}], 
+  ";"}], "\[IndentingNewLine]", 
+ RowBox[{
+  RowBox[{"file", "=", 
+   RowBox[{"OpenWrite", "[", "\"\<derivatives.txt\>\"", "]"}]}], 
+  ";"}], "\[IndentingNewLine]", 
+ RowBox[{
+  RowBox[{"For", "[", 
+   RowBox[{
+    RowBox[{"i", "=", "1"}], ",", 
+    RowBox[{"i", "\[LessEqual]", 
+     RowBox[{"Length", "[", "functions", "]"}]}], ",", 
+    RowBox[{"i", "++"}], ",", "\[IndentingNewLine]", 
     RowBox[{
-     SubscriptBox["\[PartialD]", "x"], 
-     RowBox[{"(", 
-      RowBox[{"#", "[", "x", "]"}], ")"}]}], ")"}], "&"}], "/@", 
-  "functions"}]}], "Input",
+     RowBox[{"WriteString", "[", 
+      RowBox[{"file", ",", 
+       RowBox[{
+        RowBox[{
+        "names", "\[LeftDoubleBracket]", "i", "\[RightDoubleBracket]"}], 
+        "<>", "\"\<: \>\""}]}], "]"}], ";", "\[IndentingNewLine]", 
+     RowBox[{"WriteString", "[", 
+      RowBox[{"file", ",", 
+       RowBox[{
+        RowBox[{"ToString", "[", 
+         RowBox[{"FullForm", "[", 
+          RowBox[{
+           SubscriptBox["\[PartialD]", "x"], 
+           RowBox[{
+            RowBox[{"(", 
+             RowBox[{
+             "functions", "\[LeftDoubleBracket]", "i", 
+              "\[RightDoubleBracket]"}], ")"}], "[", "x", "]"}]}], "]"}], 
+         "]"}], "<>", "\"\<\\n\>\""}]}], "]"}], ";"}]}], 
+   "\[IndentingNewLine]", "]"}], ";"}], "\[IndentingNewLine]", 
+ RowBox[{
+  RowBox[{"Close", "[", "file", "]"}], ";"}]}], "Input",
  CellChangeTimes->{{3.8498776733966007`*^9, 3.849877707123211*^9}, {
   3.849877761145133*^9, 3.84987795055476*^9}, {3.8498780555965776`*^9, 
   3.8498780608356323`*^9}, {3.849878101854938*^9, 3.849878114853664*^9}, {
   3.849878209688684*^9, 3.849878245414351*^9}, {3.849878298787912*^9, 
   3.849878350615507*^9}, {3.849878409088463*^9, 3.849878420874947*^9}, {
   3.8498784914012337`*^9, 3.849878640649445*^9}, {3.849878681758749*^9, 
-  3.8498787259745693`*^9}},
+  3.8498787259745693`*^9}, {3.849878994174678*^9, 3.849879006352531*^9}, {
+  3.849879305530075*^9, 3.849879338594101*^9}, {3.849879378915772*^9, 
+  3.849879422589959*^9}},
  CellLabel->
-  "In[286]:=",ExpressionUUID->"c7a4d10f-a759-47ef-93fd-2c4a358c0e03"],
-
-Cell[BoxData["\<\"functions:\"\>"], "Print",
- CellChangeTimes->{{3.8498786986301537`*^9, 3.849878726938965*^9}},
- CellLabel->
-  "During evaluation of \
-In[286]:=",ExpressionUUID->"81964357-8b23-494b-a416-9b8860f99442"],
-
-Cell[BoxData[
- RowBox[{"{", 
-  RowBox[{
-  "ArcCosh", ",", "ArcSinh", ",", "ArcTan", ",", "ArcTanh", ",", "Cbrt", ",", 
-   "Cosh", ",", "Exp", ",", "Expm1", ",", "Log", ",", "Log2", ",", "Log10", 
-   ",", "Log1p", ",", "Powxy", ",", "Powyx", ",", "Sinh", ",", "Tan", ",", 
-   "Tanh"}], "}"}]], "Output",
- CellChangeTimes->{{3.849877823254277*^9, 3.849877867527458*^9}, {
-   3.849877932865683*^9, 3.849877951202083*^9}, 3.8498781152756157`*^9, 
-   3.849878246371073*^9, {3.849878321907565*^9, 3.849878351027482*^9}, {
-   3.849878410218278*^9, 3.849878421593227*^9}, {3.849878493731399*^9, 
-   3.849878498187255*^9}, {3.8498785759967012`*^9, 3.849878641271357*^9}, {
-   3.849878698632161*^9, 3.8498787269404182`*^9}},
- CellLabel->
-  "Out[293]=",ExpressionUUID->"06fdcc75-d02c-4500-a914-5271b9aa03e0"],
-
-Cell[BoxData["\<\"derivatives:\"\>"], "Print",
- CellChangeTimes->{{3.8498786986301537`*^9, 3.8498787269415283`*^9}},
- CellLabel->
-  "During evaluation of \
-In[286]:=",ExpressionUUID->"a71b8978-b8d7-4def-a161-616dd3720778"],
+  "In[323]:=",ExpressionUUID->"c7a4d10f-a759-47ef-93fd-2c4a358c0e03"],
 
 Cell[BoxData[
  RowBox[{"{", 
@@ -161,59 +193,11 @@ Cell[BoxData[
    3.849878246371073*^9, {3.849878321907565*^9, 3.849878351027482*^9}, {
    3.849878410218278*^9, 3.849878421593227*^9}, {3.849878493731399*^9, 
    3.849878498187255*^9}, {3.8498785759967012`*^9, 3.849878641271357*^9}, {
-   3.849878698632161*^9, 3.849878726943058*^9}},
+   3.849878698632161*^9, 3.8498787269404182`*^9}, 3.84987901049017*^9, {
+   3.849879406217231*^9, 3.849879423571478*^9}},
  CellLabel->
-  "Out[295]=",ExpressionUUID->"73f3ad27-478c-4da2-9d8f-edfffb001d75"]
-}, Open  ]],
-
-Cell[BoxData[
- RowBox[{
-  RowBox[{"(*", " ", 
-   RowBox[{
-   "Evaluate", " ", "this", " ", "cell", " ", "to", " ", "write", " ", 
-    "derivatives", " ", "as", " ", "plain", " ", 
-    RowBox[{"text", "."}]}], " ", "*)"}], "\[IndentingNewLine]", 
-  RowBox[{
-   RowBox[{
-    RowBox[{"file", "=", 
-     RowBox[{"OpenWrite", "[", "\"\<derivatives.txt\>\"", "]"}]}], ";"}], 
-   "\[IndentingNewLine]", 
-   RowBox[{
-    RowBox[{"For", "[", 
-     RowBox[{
-      RowBox[{"i", "=", "1"}], ",", 
-      RowBox[{"i", "\[LessEqual]", 
-       RowBox[{"Length", "[", "functions", "]"}]}], ",", 
-      RowBox[{"i", "++"}], ",", "\[IndentingNewLine]", 
-      RowBox[{
-       RowBox[{"WriteString", "[", 
-        RowBox[{"file", ",", 
-         RowBox[{
-          RowBox[{"ToString", "[", 
-           RowBox[{"FullForm", "[", 
-            RowBox[{
-            "functions", "\[LeftDoubleBracket]", "i", 
-             "\[RightDoubleBracket]"}], "]"}], "]"}], "<>", "\"\<\\n\>\""}]}],
-         "]"}], ";", "\[IndentingNewLine]", 
-       RowBox[{"WriteString", "[", 
-        RowBox[{"file", ",", 
-         RowBox[{
-          RowBox[{"ToString", "[", 
-           RowBox[{"FullForm", "[", 
-            RowBox[{
-             SubscriptBox["\[PartialD]", "x"], 
-             RowBox[{
-              RowBox[{"(", 
-               RowBox[{
-               "functions", "\[LeftDoubleBracket]", "i", 
-                "\[RightDoubleBracket]"}], ")"}], "[", "x", "]"}]}], "]"}], 
-           "]"}], "<>", "\"\<\\n\>\""}]}], "]"}], ";"}]}], 
-     "\[IndentingNewLine]", "]"}], ";"}], "\[IndentingNewLine]", 
-   RowBox[{
-    RowBox[{"Close", "[", "file", "]"}], ";"}]}]}]], "Input",
- CellChangeTimes->{{3.8498787075835257`*^9, 3.849878717207244*^9}},
- CellLabel->
-  "In[283]:=",ExpressionUUID->"30321297-cca0-49c8-a68b-140c9ee60d56"]
+  "Out[330]=",ExpressionUUID->"cd1ca178-49e9-4b1e-aa07-ae6929f300c2"]
+}, Open  ]]
 },
 WindowSize->{1315, 870},
 WindowMargins->{{4, Automatic}, {Automatic, 4}},
@@ -233,13 +217,9 @@ CellTagsIndex->{}
 (*NotebookFileOutline
 Notebook[{
 Cell[CellGroupData[{
-Cell[580, 22, 2174, 58, 574, "Input",ExpressionUUID->"c7a4d10f-a759-47ef-93fd-2c4a358c0e03"],
-Cell[2757, 82, 218, 4, 47, "Print",ExpressionUUID->"81964357-8b23-494b-a416-9b8860f99442"],
-Cell[2978, 88, 797, 14, 131, "Output",ExpressionUUID->"06fdcc75-d02c-4500-a914-5271b9aa03e0"],
-Cell[3778, 104, 222, 4, 47, "Print",ExpressionUUID->"a71b8978-b8d7-4def-a161-616dd3720778"],
-Cell[4003, 110, 1876, 55, 206, "Output",ExpressionUUID->"73f3ad27-478c-4da2-9d8f-edfffb001d75"]
-}, Open  ]],
-Cell[5894, 168, 1792, 47, 328, "Input",ExpressionUUID->"30321297-cca0-49c8-a68b-140c9ee60d56"]
+Cell[580, 22, 4530, 118, 1025, "Input",ExpressionUUID->"c7a4d10f-a759-47ef-93fd-2c4a358c0e03"],
+Cell[5113, 142, 1949, 56, 206, "Output",ExpressionUUID->"cd1ca178-49e9-4b1e-aa07-ae6929f300c2"]
+}, Open  ]]
 }
 ]
 *)

--- a/util/ad/GenerateDerivatives.nb
+++ b/util/ad/GenerateDerivatives.nb
@@ -1,0 +1,246 @@
+(* Content-type: application/vnd.wolfram.mathematica *)
+
+(*** Wolfram Notebook File ***)
+(* http://www.wolfram.com/nb *)
+
+(* CreatedBy='Mathematica 12.0' *)
+
+(*CacheID: 234*)
+(* Internal cache information:
+NotebookFileLineBreakTest
+NotebookFileLineBreakTest
+NotebookDataPosition[       158,          7]
+NotebookDataLength[      8514,        238]
+NotebookOptionsPosition[      7690,        217]
+NotebookOutlinePosition[      8055,        233]
+CellTagsIndexPosition[      8012,        230]
+WindowFrame->Normal*)
+
+(* Beginning of Notebook Content *)
+Notebook[{
+
+Cell[CellGroupData[{
+Cell[BoxData[{
+ RowBox[{
+  RowBox[{
+   RowBox[{"Cbrt", "[", "x_", "]"}], ":=", 
+   SuperscriptBox["x", 
+    RowBox[{"1", "/", "3"}]]}], ";"}], "\[IndentingNewLine]", 
+ RowBox[{
+  RowBox[{
+   RowBox[{"Expm1", "[", "x_", "]"}], ":=", 
+   RowBox[{
+    SuperscriptBox["\[ExponentialE]", "x"], "-", "1"}]}], 
+  ";"}], "\[IndentingNewLine]", 
+ RowBox[{
+  RowBox[{
+   RowBox[{"Log1p", "[", "x_", "]"}], ":=", 
+   RowBox[{"Log", "[", 
+    RowBox[{"1", "+", "x"}], "]"}]}], ";"}], "\[IndentingNewLine]", 
+ RowBox[{
+  RowBox[{
+   RowBox[{"Powxy", "[", "x_", "]"}], ":=", 
+   SuperscriptBox["x", "y"]}], ";"}], "\[IndentingNewLine]", 
+ RowBox[{
+  RowBox[{
+   RowBox[{"Powyx", "[", "x_", "]"}], ":=", 
+   SuperscriptBox["y", "x"]}], ";"}], "\[IndentingNewLine]", 
+ RowBox[{
+  RowBox[{
+   RowBox[{"functions", "=", 
+    RowBox[{"{", 
+     RowBox[{
+     "ArcCosh", ",", "ArcSinh", ",", "ArcTan", ",", "ArcTanh", ",", "Cbrt", 
+      ",", "Cosh", ",", "Exp", ",", "Expm1", ",", "Log", ",", "Log2", ",", 
+      "Log10", ",", "Log1p", ",", "Powxy", ",", "Powyx", ",", "Sinh", ",", 
+      "Tan", ",", "Tanh"}], "}"}]}], ";"}], 
+  "\[IndentingNewLine]"}], "\[IndentingNewLine]", 
+ RowBox[{
+  RowBox[{"Print", "[", "\"\<functions:\>\"", "]"}], 
+  ";"}], "\[IndentingNewLine]", 
+ RowBox[{"functions", "\[IndentingNewLine]"}], "\[IndentingNewLine]", 
+ RowBox[{
+  RowBox[{"Print", "[", "\"\<derivatives:\>\"", "]"}], 
+  ";"}], "\[IndentingNewLine]", 
+ RowBox[{
+  RowBox[{
+   RowBox[{"(", 
+    RowBox[{
+     SubscriptBox["\[PartialD]", "x"], 
+     RowBox[{"(", 
+      RowBox[{"#", "[", "x", "]"}], ")"}]}], ")"}], "&"}], "/@", 
+  "functions"}]}], "Input",
+ CellChangeTimes->{{3.8498776733966007`*^9, 3.849877707123211*^9}, {
+  3.849877761145133*^9, 3.84987795055476*^9}, {3.8498780555965776`*^9, 
+  3.8498780608356323`*^9}, {3.849878101854938*^9, 3.849878114853664*^9}, {
+  3.849878209688684*^9, 3.849878245414351*^9}, {3.849878298787912*^9, 
+  3.849878350615507*^9}, {3.849878409088463*^9, 3.849878420874947*^9}, {
+  3.8498784914012337`*^9, 3.849878640649445*^9}, {3.849878681758749*^9, 
+  3.8498787259745693`*^9}},
+ CellLabel->
+  "In[286]:=",ExpressionUUID->"c7a4d10f-a759-47ef-93fd-2c4a358c0e03"],
+
+Cell[BoxData["\<\"functions:\"\>"], "Print",
+ CellChangeTimes->{{3.8498786986301537`*^9, 3.849878726938965*^9}},
+ CellLabel->
+  "During evaluation of \
+In[286]:=",ExpressionUUID->"81964357-8b23-494b-a416-9b8860f99442"],
+
+Cell[BoxData[
+ RowBox[{"{", 
+  RowBox[{
+  "ArcCosh", ",", "ArcSinh", ",", "ArcTan", ",", "ArcTanh", ",", "Cbrt", ",", 
+   "Cosh", ",", "Exp", ",", "Expm1", ",", "Log", ",", "Log2", ",", "Log10", 
+   ",", "Log1p", ",", "Powxy", ",", "Powyx", ",", "Sinh", ",", "Tan", ",", 
+   "Tanh"}], "}"}]], "Output",
+ CellChangeTimes->{{3.849877823254277*^9, 3.849877867527458*^9}, {
+   3.849877932865683*^9, 3.849877951202083*^9}, 3.8498781152756157`*^9, 
+   3.849878246371073*^9, {3.849878321907565*^9, 3.849878351027482*^9}, {
+   3.849878410218278*^9, 3.849878421593227*^9}, {3.849878493731399*^9, 
+   3.849878498187255*^9}, {3.8498785759967012`*^9, 3.849878641271357*^9}, {
+   3.849878698632161*^9, 3.8498787269404182`*^9}},
+ CellLabel->
+  "Out[293]=",ExpressionUUID->"06fdcc75-d02c-4500-a914-5271b9aa03e0"],
+
+Cell[BoxData["\<\"derivatives:\"\>"], "Print",
+ CellChangeTimes->{{3.8498786986301537`*^9, 3.8498787269415283`*^9}},
+ CellLabel->
+  "During evaluation of \
+In[286]:=",ExpressionUUID->"a71b8978-b8d7-4def-a161-616dd3720778"],
+
+Cell[BoxData[
+ RowBox[{"{", 
+  RowBox[{
+   FractionBox["1", 
+    RowBox[{
+     SqrtBox[
+      RowBox[{
+       RowBox[{"-", "1"}], "+", "x"}]], " ", 
+     SqrtBox[
+      RowBox[{"1", "+", "x"}]]}]], ",", 
+   FractionBox["1", 
+    SqrtBox[
+     RowBox[{"1", "+", 
+      SuperscriptBox["x", "2"]}]]], ",", 
+   FractionBox["1", 
+    RowBox[{"1", "+", 
+     SuperscriptBox["x", "2"]}]], ",", 
+   FractionBox["1", 
+    RowBox[{"1", "-", 
+     SuperscriptBox["x", "2"]}]], ",", 
+   FractionBox["1", 
+    RowBox[{"3", " ", 
+     SuperscriptBox["x", 
+      RowBox[{"2", "/", "3"}]]}]], ",", 
+   RowBox[{"Sinh", "[", "x", "]"}], ",", 
+   SuperscriptBox["\[ExponentialE]", "x"], ",", 
+   SuperscriptBox["\[ExponentialE]", "x"], ",", 
+   FractionBox["1", "x"], ",", 
+   FractionBox["1", 
+    RowBox[{"x", " ", 
+     RowBox[{"Log", "[", "2", "]"}]}]], ",", 
+   FractionBox["1", 
+    RowBox[{"x", " ", 
+     RowBox[{"Log", "[", "10", "]"}]}]], ",", 
+   FractionBox["1", 
+    RowBox[{"1", "+", "x"}]], ",", 
+   RowBox[{
+    SuperscriptBox["x", 
+     RowBox[{
+      RowBox[{"-", "1"}], "+", "y"}]], " ", "y"}], ",", 
+   RowBox[{
+    SuperscriptBox["y", "x"], " ", 
+    RowBox[{"Log", "[", "y", "]"}]}], ",", 
+   RowBox[{"Cosh", "[", "x", "]"}], ",", 
+   SuperscriptBox[
+    RowBox[{"Sec", "[", "x", "]"}], "2"], ",", 
+   SuperscriptBox[
+    RowBox[{"Sech", "[", "x", "]"}], "2"]}], "}"}]], "Output",
+ CellChangeTimes->{{3.849877823254277*^9, 3.849877867527458*^9}, {
+   3.849877932865683*^9, 3.849877951202083*^9}, 3.8498781152756157`*^9, 
+   3.849878246371073*^9, {3.849878321907565*^9, 3.849878351027482*^9}, {
+   3.849878410218278*^9, 3.849878421593227*^9}, {3.849878493731399*^9, 
+   3.849878498187255*^9}, {3.8498785759967012`*^9, 3.849878641271357*^9}, {
+   3.849878698632161*^9, 3.849878726943058*^9}},
+ CellLabel->
+  "Out[295]=",ExpressionUUID->"73f3ad27-478c-4da2-9d8f-edfffb001d75"]
+}, Open  ]],
+
+Cell[BoxData[
+ RowBox[{
+  RowBox[{"(*", " ", 
+   RowBox[{
+   "Evaluate", " ", "this", " ", "cell", " ", "to", " ", "write", " ", 
+    "derivatives", " ", "as", " ", "plain", " ", 
+    RowBox[{"text", "."}]}], " ", "*)"}], "\[IndentingNewLine]", 
+  RowBox[{
+   RowBox[{
+    RowBox[{"file", "=", 
+     RowBox[{"OpenWrite", "[", "\"\<derivatives.txt\>\"", "]"}]}], ";"}], 
+   "\[IndentingNewLine]", 
+   RowBox[{
+    RowBox[{"For", "[", 
+     RowBox[{
+      RowBox[{"i", "=", "1"}], ",", 
+      RowBox[{"i", "\[LessEqual]", 
+       RowBox[{"Length", "[", "functions", "]"}]}], ",", 
+      RowBox[{"i", "++"}], ",", "\[IndentingNewLine]", 
+      RowBox[{
+       RowBox[{"WriteString", "[", 
+        RowBox[{"file", ",", 
+         RowBox[{
+          RowBox[{"ToString", "[", 
+           RowBox[{"FullForm", "[", 
+            RowBox[{
+            "functions", "\[LeftDoubleBracket]", "i", 
+             "\[RightDoubleBracket]"}], "]"}], "]"}], "<>", "\"\<\\n\>\""}]}],
+         "]"}], ";", "\[IndentingNewLine]", 
+       RowBox[{"WriteString", "[", 
+        RowBox[{"file", ",", 
+         RowBox[{
+          RowBox[{"ToString", "[", 
+           RowBox[{"FullForm", "[", 
+            RowBox[{
+             SubscriptBox["\[PartialD]", "x"], 
+             RowBox[{
+              RowBox[{"(", 
+               RowBox[{
+               "functions", "\[LeftDoubleBracket]", "i", 
+                "\[RightDoubleBracket]"}], ")"}], "[", "x", "]"}]}], "]"}], 
+           "]"}], "<>", "\"\<\\n\>\""}]}], "]"}], ";"}]}], 
+     "\[IndentingNewLine]", "]"}], ";"}], "\[IndentingNewLine]", 
+   RowBox[{
+    RowBox[{"Close", "[", "file", "]"}], ";"}]}]}]], "Input",
+ CellChangeTimes->{{3.8498787075835257`*^9, 3.849878717207244*^9}},
+ CellLabel->
+  "In[283]:=",ExpressionUUID->"30321297-cca0-49c8-a68b-140c9ee60d56"]
+},
+WindowSize->{1315, 870},
+WindowMargins->{{4, Automatic}, {Automatic, 4}},
+Magnification:>2. Inherited,
+FrontEndVersion->"12.0 for Mac OS X x86 (64-bit) (April 8, 2019)",
+StyleDefinitions->"Default.nb"
+]
+(* End of Notebook Content *)
+
+(* Internal cache information *)
+(*CellTagsOutline
+CellTagsIndex->{}
+*)
+(*CellTagsIndex
+CellTagsIndex->{}
+*)
+(*NotebookFileOutline
+Notebook[{
+Cell[CellGroupData[{
+Cell[580, 22, 2174, 58, 574, "Input",ExpressionUUID->"c7a4d10f-a759-47ef-93fd-2c4a358c0e03"],
+Cell[2757, 82, 218, 4, 47, "Print",ExpressionUUID->"81964357-8b23-494b-a416-9b8860f99442"],
+Cell[2978, 88, 797, 14, 131, "Output",ExpressionUUID->"06fdcc75-d02c-4500-a914-5271b9aa03e0"],
+Cell[3778, 104, 222, 4, 47, "Print",ExpressionUUID->"a71b8978-b8d7-4def-a161-616dd3720778"],
+Cell[4003, 110, 1876, 55, 206, "Output",ExpressionUUID->"73f3ad27-478c-4da2-9d8f-edfffb001d75"]
+}, Open  ]],
+Cell[5894, 168, 1792, 47, 328, "Input",ExpressionUUID->"30321297-cca0-49c8-a68b-140c9ee60d56"]
+}
+]
+*)
+

--- a/util/ad/MathTODO.md
+++ b/util/ad/MathTODO.md
@@ -3,38 +3,38 @@ These functions are provided by the JavaScript Math Object.  Here's their status
 | JavaScript  | Autodiff.ts | Functions.ts | Notes
 |-------------|-------------|--------------|-------
 | `abs(x)`    | `absVal(x)` | `abs`        |
-| `acos(x)`   | `acos(x)`   | TODO         |
-| `acosh(x)`  | TODO        | TODO         |
-| `asin(x)`   | `asin(x)`   | TODO         |
-| `asinh(x)`  | TODO        | TODO         |
-| `atan(x)`   | TODO        | TODO         |
+| `acos(x)`   | `acos(x)`   | `acos(x)`    |
+| `acosh(x)`  | `acosh(x)`  | `acosh(x)`   |
+| `asin(x)`   | `asin(x)`   | `asin(x)`    |
+| `asinh(x)`  | `asinh(x)`  | `asinh(x)`   |
+| `atan(x)`   | `atan(x)`   | `atan(x)`    |
 | `atan2(y,x)`| `atan2(y,x)`| TODO         |
-| `atanh(x)`  | TODO        | TODO         |
-| `cbrt(x)`   | TODO        | TODO         |
-| `ceil(x)`   | TODO        | TODO         | Not provided as a differentiable function, since the derivative is zero almost everywhere.
+| `atanh(x)`  | `atanh(x)`  | `atanh(x)`   |
+| `cbrt(x)`   | `cbrt(x)`   | `cbrt(x)`    |
+| `ceil(x)`   | NA          | TODO         | Not provided as a differentiable function, since the derivative is zero almost everywhere.
 | `cos(x)`    | `cos(x)`    | `cos(x)`     |
-| `cosh(x)`   | TODO        | TODO         |
-| `exp(x)`    | TODO        | TODO         |
-| `expm1(x)`  | TODO        | TODO         |
-| `floor(x)`  | TODO        | TODO         | Not provided as a differentiable function, since the derivative is zero almost everywhere.
-| `fround(x)` | TODO        | TODO         | Not provided as a differentiable function, since the derivative is zero almost everywhere.
+| `cosh(x)`   | `cosh(x)`   | `cosh(x)`    |
+| `exp(x)`    | `exp(x)`    | `exp(x)`     |
+| `expm1(x)`  | `expm1(x)`  | `expm1(x)`   |
+| `floor(x)`  | NA          | TODO         | Not provided as a differentiable function, since the derivative is zero almost everywhere.
+| `fround(x)` | NA          | TODO         | Not provided as a differentiable function, since the derivative is zero almost everywhere.
 | `hypot(x)`  | TODO        | TODO         |
-| `log(x)`    | TODO        | TODO         |
-| `log2(x)`   | TODO        | TODO         |
-| `log10(x)`  | TODO        | TODO         |
-| `log1p(x)`  | TODO        | TODO         |
+| `log(x)`    | `ln(x)`     | `log(x)`     | The name `log` conflicts with the error log in `Autodiff.ts`, but is still exposed as `log` in `Functions.ts`.
+| `log2(x)`   | `log2(x)`   | `log2(x)`    |
+| `log10(x)`  | `log10(x)`  | `log10(x)`   |
+| `log1p(x)`  | `log1p(x)`  | `log1p(x)`   |
 | `max(x,...)`| `max(x,y)`  | `max(x,y)`   |
 | `min(x,...)`| `min(x,y)`  | `min(x,y)`   |
 | `pow(x, y)` | TODO        | TODO         |
-| `random()`  | TODO        | TODO         |
-| `round(x)`  | TODO        | TODO         | Not provided as a differentiable function, since the derivative is zero almost everywhere.
-| `sign(x)`   | TODO        | `sgn(x)`     | Not provided as a differentiable function, since the derivative is zero almost everywhere.
+| `random()`  | NA          | NA           | Can't differentiate in, and semantics are a bit unclear in the context of a Style program.
+| `round(x)`  | NA          | TODO         | Not provided as a differentiable function, since the derivative is zero almost everywhere.
+| `sign(x)`   | NA          | `sgn(x)`     | Not provided as a differentiable function, since the derivative is zero almost everywhere.
 | `sin(x)`    | `sin(x)`    | `sin(x)`     |
-| `sinh(x)`   | TODO        | TODO         |
+| `sinh(x)`   | `sinh(x)`   | `sinh(x)`    |
 | `sqrt(x)`   | `sqrt(x)`   | `sqrt(x)`    |
-| `tan(x)`    | TODO        | TODO         |
-| `tanh(x)`   | TODO        | TODO         |
-| `trunc(x)`  | TODO        | TODO         |
+| `tan(x)`    | `tan(x)`    | `tan(x)`     |
+| `tanh(x)`   | `tanh(x)`   | `tanh(x)`    |
+| `trunc(x)`  | NA          | TODO         | Not provided as a differentiable function, since the derivative is zero almost everywhere.
 
 The JavaScript Math object also provides some standard mathematical constants, as static properties.  In Style we provide these constants as static functions that return a constant value.  (These are all listed as NA in `Autodiff.ts`, since there is no reason to differentiate a constant.)
 

--- a/util/ad/MathTODO.md
+++ b/util/ad/MathTODO.md
@@ -17,14 +17,14 @@ These functions are provided by the JavaScript Math Object.  Here's their status
 | `exp(x)`    | `exp(x)`    | `exp(x)`     |
 | `expm1(x)`  | `expm1(x)`  | `expm1(x)`   |
 | `floor(x)`  | `floor(x)`  | `floor(x)`   | Derivative is zero almost everywhere.
-| `hypot(x)`  | TODO        | TODO         |
+| `hypot(x)`  | `vnorm(v)`  | `norm(v)`    | Not implemented using JavaScript `Math.hypot()`.
 | `log(x)`    | `ln(x)`     | `log(x)`     | The name `log` conflicts with the error log in `Autodiff.ts`, but is still exposed as `log` in `Functions.ts`.
 | `log2(x)`   | `log2(x)`   | `log2(x)`    |
 | `log10(x)`  | `log10(x)`  | `log10(x)`   |
 | `log1p(x)`  | `log1p(x)`  | `log1p(x)`   |
 | `max(x,...)`| `max(x,y)`  | `max(x,y)`   |
 | `min(x,...)`| `min(x,y)`  | `min(x,y)`   |
-| `pow(x, y)` | TODO        | TODO         |
+| `pow(x, y)` | `pow(x, y)` | `pow(x, y)`  |
 | `random()`  | NA          | NA           | Can't differentiate in, and semantics are a bit unclear in the context of a Style program.
 | `round(x)`  | `round(x)`  | `round(x)`   | Derivative is zero almost everywhere.
 | `sign(x)`   | `sign(x)`   | `sign(x)`    | Derivative is zero almost everywhere.

--- a/util/ad/MathTODO.md
+++ b/util/ad/MathTODO.md
@@ -11,13 +11,12 @@ These functions are provided by the JavaScript Math Object.  Here's their status
 | `atan2(y,x)`| `atan2(y,x)`| `atan2(y,x)` |
 | `atanh(x)`  | `atanh(x)`  | `atanh(x)`   |
 | `cbrt(x)`   | `cbrt(x)`   | `cbrt(x)`    |
-| `ceil(x)`   | NA          | TODO         | Not provided as a differentiable function, since the derivative is zero almost everywhere.
+| `ceil(x)`   | `ceil(x)`   | `ceil(x)`    | Derivative is zero almost everywhere.
 | `cos(x)`    | `cos(x)`    | `cos(x)`     |
 | `cosh(x)`   | `cosh(x)`   | `cosh(x)`    |
 | `exp(x)`    | `exp(x)`    | `exp(x)`     |
 | `expm1(x)`  | `expm1(x)`  | `expm1(x)`   |
-| `floor(x)`  | NA          | TODO         | Not provided as a differentiable function, since the derivative is zero almost everywhere.
-| `fround(x)` | NA          | TODO         | Not provided as a differentiable function, since the derivative is zero almost everywhere.
+| `floor(x)`  | `floor(x)`  | `floor(x)`   | Derivative is zero almost everywhere.
 | `hypot(x)`  | TODO        | TODO         |
 | `log(x)`    | `ln(x)`     | `log(x)`     | The name `log` conflicts with the error log in `Autodiff.ts`, but is still exposed as `log` in `Functions.ts`.
 | `log2(x)`   | `log2(x)`   | `log2(x)`    |
@@ -27,14 +26,14 @@ These functions are provided by the JavaScript Math Object.  Here's their status
 | `min(x,...)`| `min(x,y)`  | `min(x,y)`   |
 | `pow(x, y)` | TODO        | TODO         |
 | `random()`  | NA          | NA           | Can't differentiate in, and semantics are a bit unclear in the context of a Style program.
-| `round(x)`  | NA          | TODO         | Not provided as a differentiable function, since the derivative is zero almost everywhere.
-| `sign(x)`   | NA          | `sgn(x)`     | Not provided as a differentiable function, since the derivative is zero almost everywhere.
+| `round(x)`  | `round(x)`  | `round(x)`   | Derivative is zero almost everywhere.
+| `sign(x)`   | `sign(x)`   | `sign(x)`    | Derivative is zero almost everywhere.
 | `sin(x)`    | `sin(x)`    | `sin(x)`     |
 | `sinh(x)`   | `sinh(x)`   | `sinh(x)`    |
 | `sqrt(x)`   | `sqrt(x)`   | `sqrt(x)`    |
 | `tan(x)`    | `tan(x)`    | `tan(x)`     |
 | `tanh(x)`   | `tanh(x)`   | `tanh(x)`    |
-| `trunc(x)`  | NA          | TODO         | Not provided as a differentiable function, since the derivative is zero almost everywhere.
+| `trunc(x)`  | `trunc(x)`  | `trunc(x)`   | Derivative is zero almost everywhere.
 
 The JavaScript Math object also provides some standard mathematical constants, as static properties.  In Style we provide these constants as static functions that return a constant value.  (These are all listed as NA in `Autodiff.ts`, since there is no reason to differentiate a constant.)
 

--- a/util/ad/MathTODO.md
+++ b/util/ad/MathTODO.md
@@ -8,7 +8,7 @@ These functions are provided by the JavaScript Math Object.  Here's their status
 | `asin(x)`   | `asin(x)`   | `asin(x)`    |
 | `asinh(x)`  | `asinh(x)`  | `asinh(x)`   |
 | `atan(x)`   | `atan(x)`   | `atan(x)`    |
-| `atan2(y,x)`| `atan2(y,x)`| TODO         |
+| `atan2(y,x)`| `atan2(y,x)`| `atan2(y,x)` |
 | `atanh(x)`  | `atanh(x)`  | `atanh(x)`   |
 | `cbrt(x)`   | `cbrt(x)`   | `cbrt(x)`    |
 | `ceil(x)`   | NA          | TODO         | Not provided as a differentiable function, since the derivative is zero almost everywhere.
@@ -40,11 +40,12 @@ The JavaScript Math object also provides some standard mathematical constants, a
 
 | JavaScript  | Autodiff.ts | Functions.ts | Notes
 |-------------|-------------|--------------|-------
-| `E`         | NA          | TODO         |
-| `LN2`       | NA          | TODO         |
-| `LN10`      | NA          | TODO         |
-| `LOG2E`     | NA          | TODO         |
-| `LOG10E`    | NA          | TODO         |
-| `PI`        | NA          | TODO         |
-| `SQRT1_2`   | NA          | TODO         |
-| `SQRT2`     | NA          | TODO         |
+| `E`         | NA          | `MathE()`    |
+| `LN2`       | NA          | NA           | Can be computed in Style via `log(2.)`.
+| `LN10`      | NA          | NA           | Can be computed in Style via `log(10.)`.
+| `LOG2E`     | NA          | NA           | Can be computed in Style via `log2(MathE())`.
+| `LOG10E`    | NA          | NA           | Can be computed in Style via `log10(MathE())`.
+| `PI`        | NA          | `MathPI()`   |
+| `SQRT1_2`   | NA          | NA           | Can be computed in Style via `sqrt(.5)`.
+| `SQRT2`     | NA          | NA           | Can be computed in Style via `sqrt(2.)`.
+

--- a/util/ad/MathTODO.md
+++ b/util/ad/MathTODO.md
@@ -11,13 +11,13 @@ These functions are provided by the JavaScript Math Object.  Here's their status
 | `atan2(y,x)`| `atan2(y,x)`| TODO         |
 | `atanh(x)`  | TODO        | TODO         |
 | `cbrt(x)`   | TODO        | TODO         |
-| `ceil(x)`   | TODO        | TODO         |
+| `ceil(x)`   | TODO        | TODO         | Not provided as a differentiable function, since the derivative is zero almost everywhere.
 | `cos(x)`    | `cos(x)`    | `cos(x)`     |
 | `cosh(x)`   | TODO        | TODO         |
 | `exp(x)`    | TODO        | TODO         |
 | `expm1(x)`  | TODO        | TODO         |
-| `floor(x)`  | TODO        | TODO         |
-| `fround(x)` | TODO        | TODO         |
+| `floor(x)`  | TODO        | TODO         | Not provided as a differentiable function, since the derivative is zero almost everywhere.
+| `fround(x)` | TODO        | TODO         | Not provided as a differentiable function, since the derivative is zero almost everywhere.
 | `hypot(x)`  | TODO        | TODO         |
 | `log(x)`    | TODO        | TODO         |
 | `log2(x)`   | TODO        | TODO         |
@@ -27,7 +27,7 @@ These functions are provided by the JavaScript Math Object.  Here's their status
 | `min(x,...)`| `min(x,y)`  | `min(x,y)`   |
 | `pow(x, y)` | TODO        | TODO         |
 | `random()`  | TODO        | TODO         |
-| `round(x)`  | TODO        | TODO         |
+| `round(x)`  | TODO        | TODO         | Not provided as a differentiable function, since the derivative is zero almost everywhere.
 | `sign(x)`   | TODO        | `sgn(x)`     | Not provided as a differentiable function, since the derivative is zero almost everywhere.
 | `sin(x)`    | `sin(x)`    | `sin(x)`     |
 | `sinh(x)`   | TODO        | TODO         |

--- a/util/ad/README.md
+++ b/util/ad/README.md
@@ -1,0 +1,3 @@
+This directory contains tools to generate autodiff code from functions expressed via Mathematica.
+
+Evaluating the notebook `GenerateDerivatves.nb` will compute derivatives for all functions in the list `functions`, and write these derivatives as plain text to `derivatives.txt`.  Executing the Perl script `GenerateCode.pl` then transforms this file into TypeScript code that can be added to `Autodiff.ts`.


### PR DESCRIPTION
# Description

Related issue/PR: # (issue/PR)

This PR makes essentially all of the library functions from JavaScript Math available in Style (as well as the autodiff engine).  Up until now, math library functions have been made available in Style on an as-needed basis.  As a result, Style programmers have needed to pause and implement such functions.  This PR hopefully provides all the low-level functions that will "ever" be needed (…ok, there's always something else someone wants!).

In particular, this table lists the functions provided by the JavaScript Math Object, and the corresponding functions in the autodiff engine/Style.

| JavaScript  | Autodiff.ts | Functions.ts | Notes
|-------------|-------------|--------------|-------
| `abs(x)`    | `absVal(x)` | `abs`        |
| `acos(x)`   | `acos(x)`   | `acos(x)`    |
| `acosh(x)`  | `acosh(x)`  | `acosh(x)`   |
| `asin(x)`   | `asin(x)`   | `asin(x)`    |
| `asinh(x)`  | `asinh(x)`  | `asinh(x)`   |
| `atan(x)`   | `atan(x)`   | `atan(x)`    |
| `atan2(y,x)`| `atan2(y,x)`| `atan2(y,x)` |
| `atanh(x)`  | `atanh(x)`  | `atanh(x)`   |
| `cbrt(x)`   | `cbrt(x)`   | `cbrt(x)`    |
| `ceil(x)`   | `ceil(x)`   | `ceil(x)`    | Derivative is zero almost everywhere.
| `cos(x)`    | `cos(x)`    | `cos(x)`     |
| `cosh(x)`   | `cosh(x)`   | `cosh(x)`    |
| `exp(x)`    | `exp(x)`    | `exp(x)`     |
| `expm1(x)`  | `expm1(x)`  | `expm1(x)`   |
| `floor(x)`  | `floor(x)`  | `floor(x)`   | Derivative is zero almost everywhere.
| `hypot(x)`  | `vnorm(v)`  | `norm(v)`    | Not implemented using JavaScript `Math.hypot()`.
| `log(x)`    | `ln(x)`     | `log(x)`     | The name `log` conflicts with the error log in `Autodiff.ts`, but is still exposed as `log` in `Functions.ts`.
| `log2(x)`   | `log2(x)`   | `log2(x)`    |
| `log10(x)`  | `log10(x)`  | `log10(x)`   |
| `log1p(x)`  | `log1p(x)`  | `log1p(x)`   |
| `max(x,...)`| `max(x,y)`  | `max(x,y)`   |
| `min(x,...)`| `min(x,y)`  | `min(x,y)`   |
| `pow(x, y)` | `pow(x, y)` | `pow(x, y)`  |
| `random()`  | NA          | NA           | Can't differentiate in, and semantics are a bit unclear in the context of a Style program.
| `round(x)`  | `round(x)`  | `round(x)`   | Derivative is zero almost everywhere.
| `sign(x)`   | `sign(x)`   | `sign(x)`    | Derivative is zero almost everywhere.
| `sin(x)`    | `sin(x)`    | `sin(x)`     |
| `sinh(x)`   | `sinh(x)`   | `sinh(x)`    |
| `sqrt(x)`   | `sqrt(x)`   | `sqrt(x)`    |
| `tan(x)`    | `tan(x)`    | `tan(x)`     |
| `tanh(x)`   | `tanh(x)`   | `tanh(x)`    |
| `trunc(x)`  | `trunc(x)`  | `trunc(x)`   | Derivative is zero almost everywhere.

The JavaScript Math object also provides some standard mathematical constants, as static properties.  In Style we now provide the most basic constants (e and pi) as static functions that return a constant value.  Other functions can be evaluated using functions now available in Style; unlike a low-level numerical library, there is no performance impact here since these values will anyway be precomputed and stored by the compiler prior to optimization.  (Constants are also listed as NA in `Autodiff.ts`, since there is no reason to differentiate a constant.)

| JavaScript  | Autodiff.ts | Functions.ts | Notes
|-------------|-------------|--------------|-------
| `E`         | NA          | `MathE()`    |
| `LN2`       | NA          | NA           | Can be computed in Style via `log(2.)`.
| `LN10`      | NA          | NA           | Can be computed in Style via `log(10.)`.
| `LOG2E`     | NA          | NA           | Can be computed in Style via `log2(MathE())`.
| `LOG10E`    | NA          | NA           | Can be computed in Style via `log10(MathE())`.
| `PI`        | NA          | `MathPI()`   |
| `SQRT1_2`   | NA          | NA           | Can be computed in Style via `sqrt(.5)`.
| `SQRT2`     | NA          | NA           | Can be computed in Style via `sqrt(2.)`.

# Implementation strategy and design decisions

Derivative expressions were obtained via _Mathematica_ and converted into code systematically (e.g., by scripts/macros).  Some functions were omitted, such as `Math.fround`, since they pertain to low-level numerical issues (e.g., different bit depths) that are not relevant in Style programs.

# Examples with steps to reproduce them

I'm pretty confident everything works ok, but it would be nice to have some unit tests.  I'm not sure how to best evaluate unit tests for atomic functions (versus full-blown Penrose programs that get run through `roger`).

# Checklist

- [X] I have commented my code, particularly in hard-to-understand areas
- [X] My changes generate no new warnings
- [X] New and existing tests pass locally using `yarn test`
- [X] I ran `yarn docs` and there were no errors when generating the HTML site
- [X] My code follows the style guidelines of this project (e.g.: no ESLint warnings)

# Open questions

Currently the mathematical constants e and pi are made available to Style programmers via the functions `MathE()` and `MathPI()` (defined in `Functions.ts`).  This convention is a bit nonstandard, but currently we have (as far as I know) no other way to make universal constants available in Style.
