### PR TITLE
feat: Use C-style syntax for Domain arglists

### DIFF
--- a/examples/existential-graph-domain/existential-graph.dsl
+++ b/examples/existential-graph-domain/existential-graph.dsl
@@ -1,12 +1,12 @@
 type Graph
 type Variable
 
-predicate not : Graph  g1
-predicate and : Graph g1 * Graph g2
-function if : Graph * Graph -> Graph
-function or : Graph * Graph -> Graph
+predicate not(Graph g1)
+predicate and(Graph g1, Graph g2)
+function if(Graph, Graph) -> Graph
+function or(Graph, Graph) -> Graph
 
-predicate equal: Variable v1 * Variable v2
-predicate invisibleGraph: Graph p1
-predicate some : Variable * Graph * Graph
-predicate all : Variable * Graph * Graph
+predicate equal(Variable v1, Variable v2)
+predicate invisibleGraph(Graph p1)
+predicate some(Variable, Graph, Graph)
+predicate all(Variable, Graph, Graph)

--- a/examples/geometry-domain/geometry.dsl
+++ b/examples/geometry-domain/geometry.dsl
@@ -22,73 +22,73 @@ Rectangle <: Quadrilateral
 
 -- ~~~~~~~~~~~~~~~~ CONSTRUCTORS ~~~~~~~~~~~~~~~~
 -- Lines and Points
-constructor MkSegment : Point p * Point q -> Segment
-constructor MkRay : Point base * Point direction -> Ray
-constructor MkLine : Point p * Point q -> Line
-constructor MkMidpoint : Linelike l -> Point
+constructor MkSegment(Point p, Point q) -> Segment
+constructor MkRay(Point base, Point direction) -> Ray
+constructor MkLine(Point p, Point q) -> Line
+constructor MkMidpoint(Linelike l) -> Point
 
 -- Angles
-constructor InteriorAngle : Point p * Point q * Point r -> Angle
+constructor InteriorAngle(Point p, Point q, Point r) -> Angle
 
 -- Polygons/Shapes
-constructor MkTriangle : Point p * Point q * Point r -> Triangle
-constructor MkRectangle : Point p * Point q * Point r * Point s -> Rectangle
-constructor MkQuadrilateral : Point p * Point q * Point r * Point s -> Quadrilateral
-constructor MkCircleR : Point center * Point radius -> Circle
--- constructor MkCircleD : Point diam1 * Point diam2 -> Circle  -- TODO can be reimplemented when #621 is resolved
+constructor MkTriangle(Point p, Point q, Point r) -> Triangle
+constructor MkRectangle(Point p, Point q, Point r, Point s) -> Rectangle
+constructor MkQuadrilateral(Point p, Point q, Point r, Point s) -> Quadrilateral
+constructor MkCircleR(Point center, Point radius) -> Circle
+-- constructor MkCircleD(Point diam1, Point diam2) -> Circle  -- TODO can be reimplemented when #621 is resolved
 
 -- ~~~~~~~~~~~~~~~~ FUNCTIONS ~~~~~~~~~~~~~~~~
 -- Lines and Points
-function Bisector : Angle -> Ray
-function PerpendicularBisector : Segment * Point -> Segment
-function PerpendicularBisectorLabelPts : Segment * Point * Point -> Segment -- same as PerpendicularBisector but it takes a segment + 2 points as args for labeling
+function Bisector(Angle) -> Ray
+function PerpendicularBisector(Segment, Point) -> Segment
+function PerpendicularBisectorLabelPts(Segment, Point, Point) -> Segment -- same as PerpendicularBisector but it takes a segment + 2 points as args for labeling
 
 -- Polygons/Shapes
-function MidSegment : Triangle * Point * Point -> Segment
-function Radius : Circle c * Point p -> Segment
-function Chord : Circle c * Point p * Point q -> Segment
-function Diameter : Circle c * Point p * Point q -> Segment
+function MidSegment(Triangle, Point, Point) -> Segment
+function Radius(Circle c, Point p) -> Segment
+function Chord(Circle c, Point p, Point q) -> Segment
+function Diameter(Circle c, Point p, Point q) -> Segment
 
 -- Unimplemented
--- function Sum : Angle * Angle -> Angle
--- function Intersection : Linelike * Linelike -> Point
--- function Altitude : Triangle * Angle -> Segment
--- function Endpoint : Segment -> Point
+-- function Sum(Angle, Angle) -> Angle
+-- function Intersection(Linelike, Linelike) -> Point
+-- function Altitude(Triangle, Angle) -> Segment
+-- function Endpoint(Segment) -> Point
 
 -- ~~~~~~~~~~~~~~~~ PREDICATES ~~~~~~~~~~~~~~~~
 -- Lines and Points
-predicate On : Point * Linelike
-predicate In : Point * Plane
-predicate Midpoint : Linelike * Point
-predicate Collinear : Point * Point * Point
-predicate ParallelMarker1 : Linelike * Linelike
-predicate EqualLengthMarker1 : Linelike * Linelike
-predicate EqualLengthMarker2 : Linelike * Linelike -- TODO implement, blocked
-predicate EqualLengthMarker3 : Linelike * Linelike -- TODO implement, blocked
-predicate EqualLength : Linelike * Linelike 
-predicate Parallel : Linelike * Linelike
+predicate On(Point, Linelike)
+predicate In(Point, Plane)
+predicate Midpoint(Linelike, Point)
+predicate Collinear(Point, Point, Point)
+predicate ParallelMarker1(Linelike, Linelike)
+predicate EqualLengthMarker1(Linelike, Linelike)
+predicate EqualLengthMarker2(Linelike, Linelike) -- TODO implement, blocked
+predicate EqualLengthMarker3(Linelike, Linelike) -- TODO implement, blocked
+predicate EqualLength(Linelike, Linelike )
+predicate Parallel(Linelike, Linelike)
 
 -- Angles
-predicate RightMarked : Angle
-predicate RightUnmarked : Angle
-predicate AngleBisector : Angle * Linelike
-predicate EqualAngleMarker1 : Angle * Angle
-predicate EqualAngleMarker2 : Angle * Angle
-predicate EqualAngleMarker3 : Angle * Angle
-predicate EqualAngle : Angle * Angle
+predicate RightMarked(Angle)
+predicate RightUnmarked(Angle)
+predicate AngleBisector(Angle, Linelike)
+predicate EqualAngleMarker1(Angle, Angle)
+predicate EqualAngleMarker2(Angle, Angle)
+predicate EqualAngleMarker3(Angle, Angle)
+predicate EqualAngle(Angle, Angle)
 
 -- Polygons/Shapes
-predicate Parallelogram : Quadrilateral
-predicate OnCircle : Circle * Point
-predicate CircleCenter : Circle * Point
-predicate Incenter : Point * Triangle
-predicate Orthocenter : Point * Triangle
-predicate Centroid : Point * Triangle
-predicate Circumcenter : Point * Triangle
+predicate Parallelogram(Quadrilateral)
+predicate OnCircle(Circle, Point)
+predicate CircleCenter(Circle, Point)
+predicate Incenter(Point, Triangle)
+predicate Orthocenter(Point, Triangle)
+predicate Centroid(Point, Triangle)
+predicate Circumcenter(Point, Triangle)
 
 -- Unimplemented
-predicate Supplementary : Angle -- TODO broken
--- predicate Perpendicular : Linelike * Linelike
+predicate Supplementary(Angle) -- TODO broken
+-- predicate Perpendicular(Linelike, Linelike
 
 
 

--- a/examples/graph-domain/graph-theory-extended.dsl
+++ b/examples/graph-domain/graph-theory-extended.dsl
@@ -28,10 +28,10 @@ Face <: Graph
 Path <: Graph
 Cycle <: Graph
 
-constructor MkGraph : List(Vertex) vertices * List(Edge) edges -> Graph
-constructor MkEdge : Vertex from * Vertex to -> Edge
-constructor MkUndirectedEdge : Vertex from * Vertex to -> UndirectedEdge
-constructor MkDirectedEdge : Vertex from * Vertex to -> DirectedEdge 
+constructor MkGraph(List(Vertex) vertices, List(Edge) edges) -> Graph
+constructor MkEdge(Vertex from, Vertex to) -> Edge
+constructor MkUndirectedEdge(Vertex from, Vertex to) -> UndirectedEdge
+constructor MkDirectedEdge(Vertex from, Vertex to) -> DirectedEdge 
 
 operator Union : Graph G1 * Graph G2 -> Graph
 operator Product : Graph G1 * Graph G2 -> Graph
@@ -39,14 +39,14 @@ operator Neighbors : Vertex v -> List(Vertex)
 operator FindFace : Graph G -> Face
 operator FindVertex : Graph G -> Vertex
 
-predicate SelectedV : Vertex v
-predicate SelectedE : Edge e
-predicate Colored : Graph G
-predicate FullyConnected : Graph G
-predicate Bipartite : Graph G
-predicate SmallerDegree : Vertex v1 * Vertex v2
-predicate InV : Vertex v * Graph G
-predicate InE : Edge e * Graph G
-predicate InF : Face f * Graph G
+predicate SelectedV(Vertex v)
+predicate SelectedE(Edge e)
+predicate Colored(Graph G)
+predicate FullyConnected(Graph G)
+predicate Bipartite(Graph G)
+predicate SmallerDegree(Vertex v1, Vertex v2)
+predicate InV(Vertex v, Graph G)
+predicate InE(Edge e, Graph G)
+predicate InF(Face f, Graph G)
 
 -- TODO syntactic sugar

--- a/examples/graph-domain/graph-theory.dsl
+++ b/examples/graph-domain/graph-theory.dsl
@@ -9,20 +9,20 @@ type Path
 Face <: Graph
 Path <: Graph
 
-constructor MkEdge : Vertex from * Vertex to -> Edge
+constructor MkEdge(Vertex from, Vertex to) -> Edge
 
 -- COMBAK: Add lists
--- constructor MkGraph : List(Vertex) vertices * List(Edge) edges -> Graph
--- operator Neighbors : Vertex v -> List(Vertex)
+-- constructor MkGraph(List(Vertex) vertices, List(Edge) edges) -> Graph
+-- operator Neighbors(Vertex v) -> List(Vertex)
 
-predicate Directed : Edge e
-predicate Undirected : Edge e
+predicate Directed(Edge e)
+predicate Undirected(Edge e)
 
-predicate SelectedV : Vertex v
-predicate SelectedE : Edge e
+predicate SelectedV(Vertex v)
+predicate SelectedE(Edge e)
 
--- predicate InV : Vertex v * Graph G
--- predicate InE : Edge e * Graph G
--- predicate InF : Face f * Graph G
+-- predicate InV(Vertex v, Graph G)
+-- predicate InE(Edge e, Graph G)
+-- predicate InF(Face f, Graph G)
 
 -- TODO syntactic sugar

--- a/examples/hyperbolic-domain/hyperbolic.dsl
+++ b/examples/hyperbolic-domain/hyperbolic.dsl
@@ -6,10 +6,10 @@ type Horocycle
 
 IdealPoint <: Point
 
-predicate In: Point * HyperbolicPlane
-predicate IsCenter: IdealPoint * Horocycle
+predicate In(Point, HyperbolicPlane)
+predicate IsCenter(IdealPoint, Horocycle)
 
-constructor MakeSegment: Point endpoint1 * Point endpoint2 -> Segment
+constructor MakeSegment(Point endpoint1, Point endpoint2) -> Segment
 
 notation "{ a, b }" ~ "MakeSegment( a, b )"
 notation "p ∈ H" ~ "In( p, H )"

--- a/examples/linear-algebra-domain/linear-algebra-test.dsl
+++ b/examples/linear-algebra-domain/linear-algebra-test.dsl
@@ -5,21 +5,21 @@ type Vector
 type LinearMap
 
 -- Operators
-function neg: Vector v -> Vector
-function scale: Scalar c * Vector v -> Vector cv
-function addV: Vector * Vector -> Vector
-function addS: Scalar s1 * Scalar s2 -> Scalar
-function norm: Vector v -> Scalar
-function innerProduct: Vector * Vector -> Scalar
-function determinant: Vector * Vector -> Scalar
-function apply: LinearMap f * Vector -> Vector
+function neg(Vector v) -> Vector
+function scale(Scalar c, Vector v) -> Vector cv
+function addV(Vector, Vector) -> Vector
+function addS(Scalar s1, Scalar s2) -> Scalar
+function norm(Vector v) -> Scalar
+function innerProduct(Vector, Vector) -> Scalar
+function determinant(Vector, Vector) -> Scalar
+function apply(LinearMap f, Vector) -> Vector
 
 -- Predicates
-predicate In: Vector * VectorSpace V
-predicate From: LinearMap V * VectorSpace domain * VectorSpace codomain
-predicate Not: Prop p1
-predicate Orthogonal: Vector v1 * Vector v2
-predicate Unit: Vector v
+predicate In(Vector, VectorSpace V)
+predicate From(LinearMap V, VectorSpace domain, VectorSpace codomain)
+predicate Not(Prop p1)
+predicate Orthogonal(Vector v1, Vector v2)
+predicate Unit(Vector v)
 
 -- Syntactic sugar
 notation "det(v1, v2)" ~ "determinant(v1, v2)"

--- a/examples/linear-algebra-domain/linear-algebra.dsl
+++ b/examples/linear-algebra-domain/linear-algebra.dsl
@@ -5,23 +5,23 @@ type Vector
 type LinearMap
 
 -- Operators
-function neg: Vector v -> Vector
-function scale: Scalar c * Vector v -> Vector cv
-function addV: Vector * Vector -> Vector
-function addS: Scalar s1 * Scalar s2 -> Scalar
-function norm: Vector v -> Scalar
-function innerProduct: Vector * Vector -> Scalar
-function determinant: Vector * Vector -> Scalar
-function apply: LinearMap f * Vector -> Vector
+function neg(Vector v) -> Vector
+function scale(Scalar c, Vector v) -> Vector cv
+function addV(Vector, Vector) -> Vector
+function addS(Scalar s1, Scalar s2) -> Scalar
+function norm(Vector v) -> Scalar
+function innerProduct(Vector, Vector) -> Scalar
+function determinant(Vector, Vector) -> Scalar
+function apply(LinearMap f, Vector) -> Vector
 
 -- Predicates
-predicate In: Vector * VectorSpace V
-predicate From: LinearMap V * VectorSpace domain * VectorSpace codomain
-predicate Not: Prop p1
-predicate Orthogonal: Vector v1 * Vector v2
-predicate Independent: Vector v1 * Vector v2
-predicate Dependent: Vector v1 * Vector v2
-predicate Unit: Vector v
+predicate In(Vector, VectorSpace V)
+predicate From(LinearMap V, VectorSpace domain, VectorSpace codomain)
+predicate Not(Prop p1)
+predicate Orthogonal(Vector v1, Vector v2)
+predicate Independent(Vector v1, Vector v2)
+predicate Dependent(Vector v1, Vector v2)
+predicate Unit(Vector v)
 
 -- Syntactic sugar
 notation "det(v1, v2)" ~ "determinant(v1, v2)"

--- a/examples/logic-circuit-domain/logic-gates.dsl
+++ b/examples/logic-circuit-domain/logic-gates.dsl
@@ -32,8 +32,8 @@ type NOTGate
 Buffer <: OneInputGate
 NOTGate <: OneInputGate
 
-constructor MakeBuffer : Node IN * Node OUT -> Buffer
-constructor MakeNOTGate : Node IN * Node OUT -> NOTGate
+constructor MakeBuffer(Node IN, Node OUT) -> Buffer
+constructor MakeNOTGate(Node IN, Node OUT) -> NOTGate
 
 type ORGate
 type NORGate
@@ -49,15 +49,15 @@ NANDGate <: TwoInputGate
 XORGate <: TwoInputGate
 XNORGate <: TwoInputGate
 
-constructor MakeORGate : Node IN1 * Node IN2 * Node OUT -> ORGate
-constructor MakeNORGate : Node IN1 * Node IN2 * Node OUT -> NORGate
-constructor MakeANDGate : Node IN1 * Node IN2 * Node OUT -> ANDGate
-constructor MakeNANDGate : Node IN1 * Node IN2 * Node OUT -> NANDGate
-constructor MakeXORGate : Node IN1 * Node IN2 * Node OUT -> XORGate
-constructor MakeXNORGate : Node IN1 * Node IN2 * Node OUT -> XNORGate
+constructor MakeORGate(Node IN1, Node IN2, Node OUT) -> ORGate
+constructor MakeNORGate(Node IN1, Node IN2, Node OUT) -> NORGate
+constructor MakeANDGate(Node IN1, Node IN2, Node OUT) -> ANDGate
+constructor MakeNANDGate(Node IN1, Node IN2, Node OUT) -> NANDGate
+constructor MakeXORGate(Node IN1, Node IN2, Node OUT) -> XORGate
+constructor MakeXNORGate(Node IN1, Node IN2, Node OUT) -> XNORGate
 
 -- Connections
 
 type Connection
 
-constructor MakeConnection : Node A * Node B -> Connection
+constructor MakeConnection(Node A, Node B) -> Connection

--- a/examples/mesh-set-domain/DomainInterop.dsl
+++ b/examples/mesh-set-domain/DomainInterop.dsl
@@ -9,31 +9,31 @@ type Map
 Set <: Type
 Point <: Type
 
-constructor Singleton : Point p -> Set
+constructor Singleton(Point p) -> Set
 
-function Intersection : Set a * Set b -> Set
-function Union : Set a * Set b -> Set
-function Subtraction : Set a * Set b -> Set
-function CartesianProduct : Set a * Set b -> Set
-function Difference : Set a * Set b -> Set
-function Subset : Set a * Set b -> Set
-function AddPoint : Point p * Set s1 -> Set
+function Intersection(Set a, Set b) -> Set
+function Union(Set a, Set b) -> Set
+function Subtraction(Set a, Set b) -> Set
+function CartesianProduct(Set a, Set b) -> Set
+function Difference(Set a, Set b) -> Set
+function Subset(Set a, Set b) -> Set
+function AddPoint(Point p, Set s1) -> Set
 
-predicate From : Map f * Set domain * Set codomain
-predicate Empty : Set s
-predicate Nonempty : Set s
-predicate Intersect : Set s1 * Set s2
-predicate NotIntersecting : Set s1 * Set s2
-predicate IsSubset : Set s1 * Set s2
-predicate NotSubset : Set s1 * Set s2
-predicate PointIn : Set s * Point p
-predicate PointNotIn : Set s * Point p
-predicate Injection : Map m
-predicate Surjection : Map m
-predicate Bijection : Map m
-predicate PairIn : Point * Point * Map
+predicate From(Map f, Set domain, Set codomain)
+predicate Empty(Set s)
+predicate Nonempty(Set s)
+predicate Intersect(Set s1, Set s2)
+predicate NotIntersecting(Set s1, Set s2)
+predicate IsSubset(Set s1, Set s2)
+predicate NotSubset(Set s1, Set s2)
+predicate PointIn(Set s, Point p)
+predicate PointNotIn(Set s, Point p)
+predicate Injection(Map m)
+predicate Surjection(Map m)
+predicate Bijection(Map m)
+predicate PairIn(Point, Point, Map)
 
--- predicate Not : Predicate p
+-- predicate Not(Predicate p)
 
 -- These are new, and should go back in the Set domain
 notation "A ⊂ B" ~ "IsSubset(A, B)"
@@ -62,28 +62,28 @@ Face <: SimplicialSubset
 -- Subcomplex <: SimplicialComplex
 -- TODO: Technically true, but messes up our Style matching
 
-constructor MkEdge : Vertex v1 * Vertex v2 -> Edge
-constructor MkFace : Edge e1 * Edge e2 * Edge e3 -> Face
+constructor MkEdge(Vertex v1, Vertex v2) -> Edge
+constructor MkFace(Edge e1, Edge e2, Edge e3) -> Face
 
-function Star: SimplicialSubset s -> SimplicialSubset
-function Closure: SimplicialSubset s -> Subcomplex
-function Link: SimplicialSubset s -> SimplicialSubset
-function SetMinus: SimplicialSubset s * SimplicialSubset t -> SimplicialSubset
-function Boundary: SimplicialSubset s -> SimplicialSubset
--- function Union: SimplicialSubset s * SimplicialSubset t -> SimplicialSubset
+function Star(SimplicialSubset s) -> SimplicialSubset
+function Closure(SimplicialSubset s) -> Subcomplex
+function Link(SimplicialSubset s) -> SimplicialSubset
+function SetMinus(SimplicialSubset s, SimplicialSubset t) -> SimplicialSubset
+function Boundary(SimplicialSubset s) -> SimplicialSubset
+-- function Union(SimplicialSubset s, SimplicialSubset t) -> SimplicialSubset
 
 -- Generic connectivity and selection predicates
-predicate InVE: Vertex v * Edge e
-predicate InEF: Edge e * Face f
+predicate InVE(Vertex v, Edge e)
+predicate InEF(Edge e, Face f)
 
-predicate InVS: Vertex v * SimplicialSubset s
-predicate InES: Edge e * SimplicialSubset s
-predicate InFS: Face f * SimplicialSubset s
+predicate InVS(Vertex v, SimplicialSubset s)
+predicate InES(Edge e, SimplicialSubset s)
+predicate InFS(Face f, SimplicialSubset s)
 
 -- For plugin use
-predicate DeclaredV: Vertex v
-predicate DeclaredE: Edge e
-predicate DeclaredF: Face f
+predicate DeclaredV(Vertex v)
+predicate DeclaredE(Edge e)
+predicate DeclaredF(Face f)
 
 type Object
 Vertex <: Object
@@ -93,7 +93,7 @@ SimplicialSubset <: Object
 SimplicialComplex <: Object
 Subcomplex <: Object
 
-predicate Result: Object o -- The Style only draws objects that are declared as results
+predicate Result(Object o) -- The Style only draws objects that are declared as results
 
 -- Syntactic sugar
 notation "Vertex v ∈ K" ~ "Vertex v; InVS(v, K)"
@@ -109,5 +109,5 @@ notation "{p, q, r}" ~ "MkFace(p, q, r)"
 
 ------------------------------
 
--- predicate Identified: Point * Vertex
-predicate Identified: Type * Type
+-- predicate Identified(Point, Vertex)
+predicate Identified(Type, Type)

--- a/examples/molecules/molecules.dsl
+++ b/examples/molecules/molecules.dsl
@@ -24,6 +24,6 @@ SingleBond <: Bond
 DoubleBond <: Bond
 TripleBond <: Bond
 
-constructor MakeSingleBond : Atom a * Atom b -> SingleBond
-constructor MakeDoubleBond : Atom a * Atom b -> DoubleBond
-constructor MakeTripleBond : Atom a * Atom b -> TripleBond
+constructor MakeSingleBond(Atom a, Atom b) -> SingleBond
+constructor MakeDoubleBond(Atom a, Atom b) -> DoubleBond
+constructor MakeTripleBond(Atom a, Atom b) -> TripleBond

--- a/examples/monoidal-category-domain/monoidal-test.dsl
+++ b/examples/monoidal-category-domain/monoidal-test.dsl
@@ -1,10 +1,10 @@
 type Object
 type Morphism
 
-function tensor : Object * Object -> Object
+function tensor(Object, Object) -> Object
 -- notation “a * b” ~ “tensor(a, b)” -- Could use unicode
 
-predicate ChildOf : Object * Morphism
-predicate NotChildOf : Object * Morphism
+predicate ChildOf(Object, Morphism)
+predicate NotChildOf(Object, Morphism)
 
-constructor join : Object first * Object second -> Morphism
+constructor join(Object first, Object second) -> Morphism

--- a/examples/set-theory-domain/setTheory.dsl
+++ b/examples/set-theory-domain/setTheory.dsl
@@ -2,28 +2,28 @@ type Set
 type Point
 type Map
 
-constructor Singleton : Point p -> Set
+constructor Singleton(Point p) -> Set
 
-function Intersection : Set a * Set b -> Set
-function Union : Set a * Set b -> Set
-function Subtraction : Set a * Set b -> Set
-function CartesianProduct : Set a * Set b -> Set
-function Difference : Set a * Set b -> Set
-function Subset : Set a * Set b -> Set
-function AddPoint : Point p * Set s1 -> Set
+function Intersection(Set a, Set b) -> Set
+function Union(Set a, Set b) -> Set
+function Subtraction(Set a, Set b) -> Set
+function CartesianProduct(Set a, Set b) -> Set
+function Difference(Set a, Set b) -> Set
+function Subset(Set a, Set b) -> Set
+function AddPoint(Point p, Set s1) -> Set
 
-predicate Not : Prop p1
-predicate From : Map f * Set domain * Set codomain
-predicate Empty : Set s
-predicate Intersecting : Set s1 * Set s2
-predicate IsSubset : Set s1 * Set s2
-predicate Equal : Set s1 * Set s2
-predicate PointIn : Set s * Point p
-predicate In : Point p * Set s
-predicate Injection : Map m
-predicate Surjection : Map m
-predicate Bijection : Map m
-predicate PairIn : Point * Point * Map
+predicate Not(Prop p1)
+predicate From(Map f, Set domain, Set codomain)
+predicate Empty(Set s)
+predicate Intersecting(Set s1, Set s2)
+predicate IsSubset(Set s1, Set s2)
+predicate Equal(Set s1, Set s2)
+predicate PointIn(Set s, Point p)
+predicate In(Point p, Set s)
+predicate Injection(Map m)
+predicate Surjection(Map m)
+predicate Bijection(Map m)
+predicate PairIn(Point, Point, Map)
 
 notation "A ⊂ B" ~ "IsSubset(A, B)"
 notation "p ∈ A" ~ "PointIn(A, p)"

--- a/examples/structural-formula/structural-formula.dsl
+++ b/examples/structural-formula/structural-formula.dsl
@@ -34,9 +34,9 @@ Nitrogen <: Atom
 Chlorine <: Atom
 
 -- predicates used to specify bonds between Nodes
-predicate SingleBond: Node n1 * Node n2
-predicate DoubleBond: Node n1 * Node n2
-predicate  IonicBond: Node n1 * Node n2
+predicate SingleBond(Node n1, Node n2)
+predicate DoubleBond(Node n1, Node n2)
+predicate  IonicBond(Node n1, Node n2)
 
 -- a Molecule is a collection of Atoms, or more generally,
 -- Nodes, held together by bonds.  It is not essential to
@@ -45,19 +45,19 @@ predicate  IonicBond: Node n1 * Node n2
 -- and/or grouping reactants/products.
 type Molecule
 
-predicate Contains: Molecule m * Node n
+predicate Contains(Molecule m, Node n)
 
 -- these predicates are used to delineate reactants and
 -- produces in a chemical equation
-predicate IsReactant: Molecule m
-predicate IsProduct: Molecule m
+predicate IsReactant(Molecule m)
+predicate IsProduct(Molecule m)
 
 -- a reaction involving all reactants and products
 type Reaction
 
 -- predicates to mark the type of reaction
-predicate     IsNetForward: Reaction r
-predicate IsStoichiometric: Reaction r
-predicate    IsEquilibrium: Reaction r
-predicate  IsBidirectional: Reaction r
+predicate     IsNetForward(Reaction r)
+predicate IsStoichiometric(Reaction r)
+predicate    IsEquilibrium(Reaction r)
+predicate  IsBidirectional(Reaction r)
 

--- a/packages/core/src/analysis/SubstanceAnalysis.test.ts
+++ b/packages/core/src/analysis/SubstanceAnalysis.test.ts
@@ -22,9 +22,9 @@ import {
 const domain = `
 type Set
 type Point
-predicate IsSubset: Set * Set
-predicate Equal: Set * Set
-function Subset : Set a * Set b -> Set
+predicate IsSubset(Set, Set)
+predicate Equal(Set, Set)
+function Subset(Set a, Set b) -> Set
 `;
 const env: Env = compileDomain(domain).unsafelyUnwrap();
 

--- a/packages/core/src/compiler/Domain.test.ts
+++ b/packages/core/src/compiler/Domain.test.ts
@@ -82,11 +82,11 @@ type Real
 type Interval
 type OpenInterval
 type ClosedInterval
-constructor Cons ['X] : 'X head * List('X) tail -> List('X)
-constructor Nil['X] -> List('X)
-constructor CreateInterval: Real left * Real right -> Interval
-constructor CreateOpenInterval: Real left * Real right -> OpenInterval
-constructor CreateClosedInterval: Real left * Real right -> ClosedInterval
+constructor Cons ['X] ('X head, List('X) tail) -> List('X)
+constructor Nil['X]() -> List('X)
+constructor CreateInterval(Real left, Real right) -> Interval
+constructor CreateOpenInterval(Real left, Real right) -> OpenInterval
+constructor CreateClosedInterval(Real left, Real right) -> ClosedInterval
     `;
     const res = compileDomain(prog);
     const types = [
@@ -111,17 +111,17 @@ constructor CreateClosedInterval: Real left * Real right -> ClosedInterval
 type Map
 type Set
 type Point
-predicate Not : Prop p1
-predicate From : Map f * Set domain * Set codomain
-predicate Empty : Set s
-predicate Intersecting : Set s1 * Set s2
-predicate IsSubset : Set s1 * Set s2
-predicate PointIn : Set s * Point p
-predicate In : Point p * Set s
-predicate Injection : Map m
-predicate Surjection : Map m
-predicate Bijection : Map m
-predicate PairIn : Point * Point * Map
+predicate Not(Prop p1)
+predicate From(Map f, Set domain, Set codomain)
+predicate Empty(Set s)
+predicate Intersecting(Set s1, Set s2)
+predicate IsSubset(Set s1, Set s2)
+predicate PointIn(Set s, Point p)
+predicate In(Point p, Set s)
+predicate Injection(Map m)
+predicate Surjection(Map m)
+predicate Bijection(Map m)
+predicate PairIn(Point, Point, Map)
     `;
     const res = compileDomain(prog);
     const types = ["Map", "Set", "Point"];
@@ -168,13 +168,13 @@ type Set
   });
   test("Type not found", () => {
     const prog = `
-constructor Cons ['X] : 'X head * List('X) tail -> List('X)
+constructor Cons ['X] ('X head, List('X) tail) -> List('X)
     `;
     expectErrorOf(prog, "TypeNotFound");
   });
   test("type var not found", () => {
     const prog = `
-  constructor Cons ['X] : 'Z head * List('Y) tail -> List('X)
+  constructor Cons ['X] ('Z head, List('Y) tail) -> List('X)
     `;
     expectErrorOf(prog, "TypeVarNotFound");
   });

--- a/packages/core/src/compiler/Substance.test.ts
+++ b/packages/core/src/compiler/Substance.test.ts
@@ -40,17 +40,17 @@ type List('T)
 type Tuple('T, 'U)
 type Point
 OpenSet <: Set
-constructor Subset: Set A * Set B -> Set
-constructor Intersection: Set A * Set B -> Set
-constructor Cons ['X] : 'X head * List('X) tail -> List('X)
-constructor Nil['X] -> List('X)
-constructor CreateTuple['T, 'U] : 'T fst * 'U snd -> Tuple('T, 'U)
-function AddPoint : Point p * Set s1 -> Set
-predicate Not : Prop p1
-predicate Both : Prop p1 * Prop p2
-predicate Empty : Set s
-predicate Intersecting : Set s1 * Set s2
-predicate IsSubset : Set s1 * Set s2
+constructor Subset(Set A, Set B) -> Set
+constructor Intersection(Set A, Set B) -> Set
+constructor Cons ['X] ('X head, List('X) tail) -> List('X)
+constructor Nil['X]() -> List('X)
+constructor CreateTuple['T, 'U]('T fst, 'U snd) -> Tuple('T, 'U)
+function AddPoint(Point p, Set s1) -> Set
+predicate Not(Prop p1)
+predicate Both(Prop p1, Prop p2)
+predicate Empty(Set s)
+predicate Intersecting(Set s1, Set s2)
+predicate IsSubset(Set s1, Set s2)
 `;
 
 const domainProgWithPrelude = `
@@ -61,17 +61,17 @@ type List('T)
 type Tuple('T, 'U)
 type Point
 OpenSet <: Set
-constructor Subset: Set A * Set B -> Set
-constructor Intersection: Set A * Set B -> Set
-constructor Cons ['X] : 'X head * List('X) tail -> List('X)
-constructor Nil['X] -> List('X)
-constructor CreateTuple['T, 'U] : 'T fst * 'U snd -> Tuple('T, 'U)
-function AddPoint : Point p * Set s1 -> Set
-predicate Not : Prop p1
-predicate Both : Prop p1 * Prop p2
-predicate Empty : Set s
-predicate Intersecting : Set s1 * Set s2
-predicate IsSubset : Set s1 * Set s2
+constructor Subset(Set A, Set B) -> Set
+constructor Intersection(Set A, Set B) -> Set
+constructor Cons ['X] ('X head, List('X) tail) -> List('X)
+constructor Nil['X]() -> List('X)
+constructor CreateTuple['T, 'U]('T fst, 'U snd) -> Tuple('T, 'U)
+function AddPoint(Point p, Set s1) -> Set
+predicate Not(Prop p1)
+predicate Both(Prop p1, Prop p2)
+predicate Empty(Set s)
+predicate Intersecting(Set s1, Set s2)
+predicate IsSubset(Set s1, Set s2)
 value X: Set
 `;
 
@@ -386,7 +386,7 @@ v := Subset(A, B) -- error
     const env = envOrError(domainProg);
     const prog = `
 -- type Tuple('T, 'U)
--- constructor CreateTuple['T, 'U] : 'T fst * 'U snd -> Tuple('T, 'U)
+-- constructor CreateTuple['T, 'U]('T fst, 'U snd) -> Tuple('T, 'U)
 List(Set) nil
 Tuple(Set, Set) t -- Maybe an error?
 t := CreateTuple(nil, nil) -- Definitely an error

--- a/packages/core/src/parser/Domain.ne
+++ b/packages/core/src/parser/Domain.ne
@@ -40,24 +40,20 @@ const nodeData = (children: ASTNode[]) => ({
 
 # Macros
 
-sepBy1[ITEM, SEP] -> $ITEM (_ $SEP _ $ITEM):* $SEP:? {% 
-  d => { 
-    const [first, rest] = [d[0], d[1]];
-    if(rest.length > 0) {
-      const restNodes = rest.map((ts: any[]) => ts[3]);
-      return concat(first, ...restNodes);
-    } else return first;
+sepBy1[ITEM, SEP] -> $ITEM (_ $SEP _ $ITEM):* _ $SEP:? {%
+  ([first, rest]) => {
+    const restNodes = rest.map((ts: any[]) => ts[3]);
+    return concat(first, ...restNodes);
   }
 %}
 
-sepBy[ITEM, SEP] -> $ITEM:? (_ $SEP _ $ITEM):* {% 
-  d => { 
-    const [first, rest] = [d[0], d[1]];
-    if(!first) return [];
-    if(rest.length > 0) {
-      const restNodes = rest.map(ts => ts[3]);
-      return concat(first, ...restNodes);
-    } else return first;
+sepBy[ITEM, SEP] -> ($ITEM _ $SEP _):* $ITEM:? {%
+  ([rest, last]) => {
+    const nodes = rest.map((ts: any[]) => ts[0]);
+    if (last) {
+      nodes.push(last);
+    }
+    return concat.apply(null, nodes);
   }
 %}
 
@@ -214,8 +210,7 @@ type_params_list
 type_params -> sepBy1[type_var, ","] {% ([d]) => d %}
 
 args_list 
-  -> null {% d => [] %}
-  |  _ ":" _ sepBy1[arg, "*"] {% ([, , , d]): Arg[] => flatten(d) %}
+  -> _ "(" _ sepBy[arg, ","] _ ")" {% ([, , , d]): Arg[] => flatten(d) %}
 arg -> type (__ var):? {% 
   ([type, v]): Arg => {
     const variable = v ? v[1] : undefined;
@@ -228,8 +223,7 @@ arg -> type (__ var):? {%
   }
 %}
 named_args_list 
-  -> null {% d => [] %}
-  |  _ ":" _ sepBy1[named_arg, "*"] {% ([, , , d]): Arg[] => flatten(d) %}
+  -> _ "(" _ sepBy[named_arg, ","] _ ")" {% ([, , , d]): Arg[] => flatten(d) %}
 named_arg -> type __ var {% 
   ([type, , variable]): Arg => ({
      ...nodeData([type, variable]),

--- a/packages/core/src/parser/Domain.ne
+++ b/packages/core/src/parser/Domain.ne
@@ -40,22 +40,7 @@ const nodeData = (children: ASTNode[]) => ({
 
 # Macros
 
-sepBy1[ITEM, SEP] -> $ITEM (_ $SEP _ $ITEM):* _ $SEP:? {%
-  ([first, rest]) => {
-    const restNodes = rest.map((ts: any[]) => ts[3]);
-    return concat(first, ...restNodes);
-  }
-%}
-
-sepBy[ITEM, SEP] -> ($ITEM _ $SEP _):* $ITEM:? {%
-  ([rest, last]) => {
-    const nodes = rest.map((ts: any[]) => ts[0]);
-    if (last) {
-      nodes.push(last);
-    }
-    return concat.apply(null, nodes);
-  }
-%}
+@include "macros.ne"
 
 # Main grammar
 

--- a/packages/core/src/parser/DomainParser.test.ts
+++ b/packages/core/src/parser/DomainParser.test.ts
@@ -53,12 +53,12 @@ describe("Common", () => {
 type Set -- inline comments\r
 -- type Point 
 type ParametrizedSet ('T, 'U)\r\n
-predicate From : Map f * Set domain * Set codomain\n
+predicate From(Map f, Set domain, Set codomain)\n
 /* Multi-line comments
 type ParametrizedSet ('T, 'U)
-predicate From : Map f * Set domain * Set codomain
+predicate From(Map f, Set domain, Set codomain)
 */
-predicate From : Map f * Set domain * Set codomain
+predicate From(Map f, Set domain, Set codomain)
     `;
     const { results } = parser.feed(prog);
     sameASTs(results);
@@ -69,27 +69,27 @@ predicate From : Map f * Set domain * Set codomain
 type Set -- inline comments
 -- type Point 
 type ParametrizedSet ('T, 'U)
-predicate From : Map f * Set domain * Set codomain
+predicate From(Map f, Set domain, Set codomain)
 /* Multi-line comments
 type ParametrizedSet ('T, 'U)
-predicate From : Map f * Set domain * Set codomain
+predicate From(Map f, Set domain, Set codomain)
 */
-predicate From : Map f * Set domain * Set codomain
-function Intersection : Set a * Set b -> Set
-function Union : Set a * Set b -> Set c
-function Subtraction : Set a * Set b -> Set
-function CartesianProduct : Set a * Set b -> Set
-function Difference : Set a * Set b -> Set
-function Subset : Set a * Set b -> Set
-function AddPoint : Point p * Set s1 -> Set
+predicate From(Map f, Set domain, Set codomain)
+function Intersection(Set a, Set b) -> Set
+function Union(Set a, Set b) -> Set c
+function Subtraction(Set a, Set b) -> Set
+function CartesianProduct(Set a, Set b) -> Set
+function Difference(Set a, Set b) -> Set
+function Subset(Set a, Set b) -> Set
+function AddPoint(Point p, Set s1) -> Set
 -- with type params
-function AddV['V] : Vector('V) v1 *Vector('V) v2 -> Vector('V)
-function Norm['V] : Vector('V) v1 -> Scalar
+function AddV['V](Vector('V) v1, Vector('V) v2) -> Vector('V)
+function Norm['V](Vector('V) v1) -> Scalar
 -- edge case
-function Empty -> Scalar
+function Empty() -> Scalar
 -- generics
-constructor Cons ['X] : 'X head * List('X) tail -> List('X)
-constructor Nil['X] -> List('X)
+constructor Cons ['X] ('X head, List('X) tail) -> List('X)
+constructor Nil['X]() -> List('X)
 notation "A ⊂ B" ~ "IsSubset(A, B)"
 notation "p ∈ A" ~ "PointIn(A, p)"
 notation "p ∉ A" ~ "PointNotIn(A, p)"
@@ -122,17 +122,17 @@ type ParametrizedSet3 ( 'T,    'V)
   test("predicate decls", () => {
     const prog = `
 -- comments
-predicate Not : Prop p1
-predicate From : Map f * Set domain * Set codomain
-predicate Empty : Set s
-predicate Intersecting : Set s1 * Set s2
-predicate IsSubset : Set s1 * Set s2
-predicate PointIn : Set s * Point p
-predicate In : Point p * Set s
-predicate Injection : Map m
-predicate Surjection : Map m
-predicate Bijection : Map m
-predicate PairIn : Point * Point * Map
+predicate Not(Prop p1)
+predicate From(Map f, Set domain, Set codomain)
+predicate Empty(Set s)
+predicate Intersecting(Set s1, Set s2)
+predicate IsSubset(Set s1, Set s2)
+predicate PointIn(Set s, Point p)
+predicate In(Point p, Set s)
+predicate Injection(Map m)
+predicate Surjection(Map m)
+predicate Bijection(Map m)
+predicate PairIn(Point, Point, Map)
     `;
     const { results } = parser.feed(prog);
     sameASTs(results);
@@ -140,18 +140,18 @@ predicate PairIn : Point * Point * Map
   test("function decls", () => {
     const prog = `
 -- comments
-function Intersection : Set a * Set b -> Set
-function Union : Set a * Set b -> Set c
-function Subtraction : Set a * Set b -> Set
-function CartesianProduct : Set a * Set b -> Set
-function Difference : Set a * Set b -> Set
-function Subset : Set a * Set b -> Set
-function AddPoint : Point p * Set s1 -> Set
+function Intersection(Set a, Set b) -> Set
+function Union(Set a, Set b) -> Set c
+function Subtraction(Set a, Set b) -> Set
+function CartesianProduct(Set a, Set b) -> Set
+function Difference(Set a, Set b) -> Set
+function Subset(Set a, Set b) -> Set
+function AddPoint(Point p, Set s1) -> Set
 -- with type params
-function AddV['V] : Vector('V) v1 *Vector('V) v2 -> Vector('V)
-function Norm['V] : Vector('V) v1 -> Scalar
+function AddV['V](Vector('V) v1, Vector('V) v2) -> Vector('V)
+function Norm['V](Vector('V) v1) -> Scalar
 -- edge case
-function Empty -> Scalar
+function Empty() -> Scalar
     `;
     const { results } = parser.feed(prog);
     sameASTs(results);
@@ -159,16 +159,16 @@ function Empty -> Scalar
   test("constructor decls", () => {
     const prog = `
   -- real program
-  constructor CreateInterval: Real left * Real right -> Interval
-  constructor CreateOpenInterval: Real left * Real right -> OpenInterval
-  constructor CreateClosedInterval: Real left * Real right -> ClosedInterval
-  constructor CreateLeftClopenInterval: Real left * Real right -> LeftClopenInterval
-  constructor CreateRightClopenInterval: Real left * Real right -> RightClopenInterval
-  constructor CreateFunction: Set s1 * Set s2 -> Function
-  constructor Pt: Real x * Real y -> Point
+  constructor CreateInterval(Real left, Real right) -> Interval
+  constructor CreateOpenInterval(Real left, Real right) -> OpenInterval
+  constructor CreateClosedInterval(Real left, Real right) -> ClosedInterval
+  constructor CreateLeftClopenInterval(Real left, Real right) -> LeftClopenInterval
+  constructor CreateRightClopenInterval(Real left, Real right) -> RightClopenInterval
+  constructor CreateFunction(Set s1, Set s2) -> Function
+  constructor Pt(Real x, Real y) -> Point
   -- generics
-  constructor Cons ['X] : 'X head * List('X) tail -> List('X)
-  constructor Nil['X] -> List('X)
+  constructor Cons ['X] ('X head, List('X) tail) -> List('X)
+  constructor Nil['X]() -> List('X)
       `;
     const { results } = parser.feed(prog);
     sameASTs(results);

--- a/packages/core/src/parser/Style.ne
+++ b/packages/core/src/parser/Style.ne
@@ -109,27 +109,7 @@ const binop = (op: BinaryOp, left: Expr, right: Expr): IBinOp => ({
 
 # Macros
 
-# TODO: factor out sepEndBy
-sepBy1[ITEM, SEP] -> $ITEM (_ $SEP _ $ITEM):* $SEP:? {% 
-  d => { 
-    const [first, rest] = [d[0], d[1]];
-    if(rest.length > 0) {
-      const restNodes = rest.map((ts: any[]) => ts[3]);
-      return concat(first, ...restNodes);
-    } else return first;
-  }
-%}
-
-sepBy[ITEM, SEP] -> $ITEM:? (_ $SEP _ $ITEM):* {% 
-  d => { 
-    const [first, rest] = [d[0], d[1]];
-    if(!first) return [];
-    if(rest.length > 0) {
-      const restNodes = rest.map(ts => ts[3]);
-      return concat(first, ...restNodes);
-    } else return first;
-  }
-%}
+@include "macros.ne"
 
 ################################################################################
 # Style Grammar

--- a/packages/core/src/parser/Substance.ne
+++ b/packages/core/src/parser/Substance.ne
@@ -42,26 +42,7 @@ const nodeData = (children: ASTNode[]) => ({
 
 # Macros
 
-sepBy1[ITEM, SEP] -> $ITEM (_ $SEP _ $ITEM):* $SEP:? {% 
-  d => { 
-    const [first, rest] = [d[0], d[1]];
-    if(rest.length > 0) {
-      const restNodes = rest.map((ts: any[]) => ts[3]);
-      return concat(first, ...restNodes);
-    } else return first;
-  }
-%}
-
-sepBy[ITEM, SEP] -> $ITEM:? (_ $SEP _ $ITEM):* {% 
-  d => { 
-    const [first, rest] = [d[0], d[1]];
-    if(!first) return [];
-    if(rest.length > 0) {
-      const restNodes = rest.map((ts: any[]) => ts[3]);
-      return concat(first, ...restNodes);
-    } else return first;
-  }
-%}
+@include "macros.ne"
 
 # Main grammar
 

--- a/packages/core/src/parser/macros.ne
+++ b/packages/core/src/parser/macros.ne
@@ -1,0 +1,16 @@
+sepBy1[ITEM, SEP] -> $ITEM (_ $SEP _ $ITEM):* (_ $SEP):? {%
+  ([first, rest]) => {
+    const restNodes = rest.map((ts: any[]) => ts[3]);
+    return concat(first, ...restNodes);
+  }
+%}
+
+sepBy[ITEM, SEP] -> ($ITEM _ $SEP _):* $ITEM:? {%
+  ([rest, last]) => {
+    const nodes = rest.map((ts: any[]) => ts[0]);
+    if (last) {
+      nodes.push(last);
+    }
+    return concat.apply(null, nodes);
+  }
+%}

--- a/packages/core/src/parser/macros.ne
+++ b/packages/core/src/parser/macros.ne
@@ -5,12 +5,9 @@ sepBy1[ITEM, SEP] -> $ITEM (_ $SEP _ $ITEM):* (_ $SEP):? {%
   }
 %}
 
-sepBy[ITEM, SEP] -> ($ITEM _ $SEP _):* $ITEM:? {%
-  ([rest, last]) => {
-    const nodes = rest.map((ts: any[]) => ts[0]);
-    if (last) {
-      nodes.push(last);
-    }
-    return concat.apply(null, nodes);
+sepBy[ITEM, SEP] -> null {% d => [] %} | $ITEM (_ $SEP _ $ITEM):* (_ $SEP):? {%
+  ([first, rest]) => {
+    const restNodes = rest.map((ts: any[]) => ts[3]);
+    return concat(first, ...restNodes);
   }
 %}

--- a/packages/core/src/parser/macros.ne
+++ b/packages/core/src/parser/macros.ne
@@ -5,9 +5,11 @@ sepBy1[ITEM, SEP] -> $ITEM (_ $SEP _ $ITEM):* (_ $SEP):? {%
   }
 %}
 
-sepBy[ITEM, SEP] -> null {% d => [] %} | $ITEM (_ $SEP _ $ITEM):* (_ $SEP):? {%
-  ([first, rest]) => {
-    const restNodes = rest.map((ts: any[]) => ts[3]);
-    return concat(first, ...restNodes);
-  }
-%}
+sepBy[ITEM, SEP] 
+  -> null {% d => [] %} 
+  | $ITEM (_ $SEP _ $ITEM):* (_ $SEP):? {%
+    ([first, rest]) => {
+      const restNodes = rest.map((ts: any[]) => ts[3]);
+      return concat(first, ...restNodes);
+    }
+  %}

--- a/packages/core/src/synthesis/Search.test.ts
+++ b/packages/core/src/synthesis/Search.test.ts
@@ -72,28 +72,28 @@ type Set
 type Point
 type Map
 
-constructor Singleton : Point p -> Set
+constructor Singleton(Point p) -> Set
 
-function Intersection : Set a * Set b -> Set
-function Union : Set a * Set b -> Set
-function Subtraction : Set a * Set b -> Set
-function CartesianProduct : Set a * Set b -> Set
-function Difference : Set a * Set b -> Set
-function Subset : Set a * Set b -> Set
-function AddPoint : Point p * Set s1 -> Set
+function Intersection(Set a, Set b) -> Set
+function Union(Set a, Set b) -> Set
+function Subtraction(Set a, Set b) -> Set
+function CartesianProduct(Set a, Set b) -> Set
+function Difference(Set a, Set b) -> Set
+function Subset(Set a, Set b) -> Set
+function AddPoint(Point p, Set s1) -> Set
 
-predicate Not : Prop p1
-predicate From : Map f * Set domain * Set codomain
-predicate Empty : Set s
-predicate Intersecting : Set s1 * Set s2
-predicate IsSubset : Set s1 * Set s2
-predicate Equal : Set s1 * Set s2
-predicate PointIn : Set s * Point p
-predicate In : Point p * Set s
-predicate Injection : Map m
-predicate Surjection : Map m
-predicate Bijection : Map m
-predicate PairIn : Point * Point * Map
+predicate Not(Prop p1)
+predicate From(Map f, Set domain, Set codomain)
+predicate Empty(Set s)
+predicate Intersecting(Set s1, Set s2)
+predicate IsSubset(Set s1, Set s2)
+predicate Equal(Set s1, Set s2)
+predicate PointIn(Set s, Point p)
+predicate In(Point p, Set s)
+predicate Injection(Map m)
+predicate Surjection(Map m)
+predicate Bijection(Map m)
+predicate PairIn(Point, Point, Map)
 `;
 
 const substanceSrc = `

--- a/packages/core/src/synthesis/Synthesizer.test.ts
+++ b/packages/core/src/synthesis/Synthesizer.test.ts
@@ -53,8 +53,8 @@ const initSynth = (
 };
 
 const domain = `type Set
-function Intersection : Set a * Set b -> Set
-function Subset : Set a * Set b -> Set`;
+function Intersection(Set a, Set b) -> Set
+function Subset(Set a, Set b) -> Set`;
 const env: Env = compileDomain(domain).unsafelyUnwrap();
 
 describe("Synthesizer Operations", () => {

--- a/packages/synthesizer/__tests__/geometry.dsl
+++ b/packages/synthesizer/__tests__/geometry.dsl
@@ -34,52 +34,52 @@ type Plane
 -- TODO: optional naming for constructors
 
 -- TODO: rename to MakeSegment and MakeTriangle (etc.) everywhere
-constructor MkSegment : Point p * Point q -> Segment
--- constructor MkRay : Point base * Point direction -> Ray
--- constructor MkLine : Point p * Point q -> Point
+constructor MkSegment(Point p, Point q) -> Segment
+-- constructor MkRay(Point base, Point direction) -> Ray
+-- constructor MkLine(Point p, Point q) -> Point
 
--- constructor InteriorAngle : Linelike l * Linelike m -> Angle
-constructor InteriorAngle : Point p * Point q * Point r -> Angle
-constructor TriangleVertex : Point p * Point q * Point r -> Angle
+-- constructor InteriorAngle(Linelike l, Linelike m -> Angle
+constructor InteriorAngle(Point p, Point q, Point r) -> Angle
+constructor TriangleVertex(Point p, Point q, Point r) -> Angle
 
-constructor MkTriangle : Point p * Point q * Point r -> Triangle
--- constructor MkTriangleL : Linelike l * Linelike m * Linelike n -> Triangle
--- constructor MkCircleR : Point center * Point radius -> Circle
--- constructor MkCircleD : Point diam1 * Point diam2 -> Circle
--- constructor MkSquareP : Point p * Point q * Point r * Point s -> Square
--- constructor MkSquare : Point p * Point q * Point r * Point s -> Square -- Assuming the first two points are the segment of a triangle
-constructor MkRectangle : Point p * Point q * Point r * Point s -> Rectangle
+constructor MkTriangle(Point p, Point q, Point r) -> Triangle
+-- constructor MkTriangleL(Linelike l, Linelike m, Linelike n) -> Triangle
+-- constructor MkCircleR(Point center, Point radius) -> Circle
+-- constructor MkCircleD(Point diam1, Point diam2) -> Circle
+-- constructor MkSquareP(Point p, Point q, Point r, Point s) -> Square
+-- constructor MkSquare(Point p, Point q, Point r, Point s) -> Square -- Assuming the first two points are the segment of a triangle
+constructor MkRectangle(Point p, Point q, Point r, Point s) -> Rectangle
 
 -- -- TODO: subtyping on the return types
--- function Midpoint : Linelike -> Point
--- function Bisector : Angle -> Ray
--- function PerpendicularBisector : Linelike -> Ray
-function Sum : Angle * Angle -> Angle
--- function Intersection : Linelike * Linelike -> Point
--- function Altitude : Triangle * Angle -> Segment
--- function Endpoint : Segment -> Point
+-- function Midpoint(Linelike) -> Point
+-- function Bisector(Angle) -> Ray
+-- function PerpendicularBisector(Linelike) -> Ray
+function Sum(Angle, Angle) -> Angle
+-- function Intersection(Linelike, Linelike) -> Point
+-- function Altitude(Triangle, Angle) -> Segment
+-- function Endpoint(Segment) -> Point
 
-predicate Acute : Angle
-predicate Obtuse : Angle
-predicate Right : Angle
--- predicate On : Point * Linelike
-predicate In : Point * Plane
-predicate Not : Prop
--- predicate Parallel : Linelike * Linelike
--- predicate Perpendicular : Linelike * Linelike
--- predicate EquilateralT : Triangle
--- predicate RightT : Triangle
-predicate Scalene : Triangle
--- predicate Similar : Triangle * Triangle
--- predicate Disjoint : Set * Set
-predicate Collinear : Point * Point * Point
-predicate EqualAngleMarker1 : Angle * Angle
-predicate EqualAngleMarker2 : Angle * Angle
-predicate EqualLengthMarker : Segment * Segment
-predicate EqualAngle : Angle * Angle
-predicate EqualLength : Segment * Segment 
-predicate RightMarked : Angle
-predicate RightUnmarked : Angle
+predicate Acute(Angle)
+predicate Obtuse(Angle)
+predicate Right(Angle)
+-- predicate On(Point, Linelike)
+predicate In(Point, Plane)
+predicate Not(Prop)
+-- predicate Parallel(Linelike, Linelike)
+-- predicate Perpendicular(Linelike, Linelike)
+-- predicate EquilateralT(Triangle)
+-- predicate RightT(Triangle)
+predicate Scalene(Triangle)
+-- predicate Similar(Triangle, Triangle)
+-- predicate Disjoint(Set, Set)
+predicate Collinear(Point, Point, Point)
+predicate EqualAngleMarker1(Angle, Angle)
+predicate EqualAngleMarker2(Angle, Angle)
+predicate EqualLengthMarker(Segment, Segment)
+predicate EqualAngle(Angle, Angle)
+predicate EqualLength(Segment, Segment)
+predicate RightMarked(Angle)
+predicate RightUnmarked(Angle)
 
 
 -- notation "{p, q}" ~ "MkSegment(p, q)"

--- a/packages/synthesizer/__tests__/setTheory.dsl
+++ b/packages/synthesizer/__tests__/setTheory.dsl
@@ -2,28 +2,28 @@ type Set
 type Point
 type Map
 
-constructor Singleton : Point p -> Set
+constructor Singleton(Point p) -> Set
 
-function Intersection : Set a * Set b -> Set
-function Union : Set a * Set b -> Set
-function Subtraction : Set a * Set b -> Set
-function CartesianProduct : Set a * Set b -> Set
-function Difference : Set a * Set b -> Set
-function Subset : Set a * Set b -> Set
-function AddPoint : Point p * Set s1 -> Set
+function Intersection(Set a, Set b) -> Set
+function Union(Set a, Set b) -> Set
+function Subtraction(Set a, Set b) -> Set
+function CartesianProduct(Set a, Set b) -> Set
+function Difference(Set a, Set b) -> Set
+function Subset(Set a, Set b) -> Set
+function AddPoint(Point p, Set s1) -> Set
 
-predicate Not : Prop p1
-predicate From : Map f * Set domain * Set codomain
-predicate Empty : Set s
-predicate Intersecting : Set s1 * Set s2
-predicate IsSubset : Set s1 * Set s2
-predicate Equal : Set s1 * Set s2
-predicate PointIn : Set s * Point p
-predicate In : Point p * Set s
-predicate Injection : Map m
-predicate Surjection : Map m
-predicate Bijection : Map m
-predicate PairIn : Point * Point * Map
+predicate Not(Prop p1)
+predicate From(Map f, Set domain, Set codomain)
+predicate Empty(Set s)
+predicate Intersecting(Set s1, Set s2)
+predicate IsSubset(Set s1, Set s2)
+predicate Equal(Set s1, Set s2)
+predicate PointIn(Set s, Point p)
+predicate In(Point p, Set s)
+predicate Injection(Map m)
+predicate Surjection(Map m)
+predicate Bijection(Map m)
+predicate PairIn(Point, Point, Map)
 
 notation "A ⊂ B" ~ "IsSubset(A, B)"
 notation "p ∈ A" ~ "PointIn(A, p)"

--- a/packages/synthesizer/__tests__/spec.dsl
+++ b/packages/synthesizer/__tests__/spec.dsl
@@ -2,25 +2,25 @@ type Set
 -- type Point
 -- type Map
 
--- constructor Singleton : Point p -> Set
+-- constructor Singleton(Point p) -> Set
 
--- function Intersection : Set a * Set b -> Set
--- function Union : Set a * Set b -> Set
--- function Subtraction : Set a * Set b -> Set
--- function CartesianProduct : Set a * Set b -> Set
--- function Difference : Set a * Set b -> Set
--- function Subset : Set a * Set b -> Set
--- function AddPoint : Point p * Set s1 -> Set
+-- function Intersection(Set a, Set b) -> Set
+-- function Union(Set a, Set b) -> Set
+-- function Subtraction(Set a, Set b) -> Set
+-- function CartesianProduct(Set a, Set b) -> Set
+-- function Difference(Set a, Set b) -> Set
+-- function Subset(Set a, Set b) -> Set
+-- function AddPoint(Point p, Set s1) -> Set
 
--- predicate Not : Prop p1
--- predicate From : Map f * Set domain * Set codomain
--- predicate Empty : Set s
--- predicate Intersecting : Set s1 * Set s2
-predicate IsSubset : Set s1 * Set s2
--- predicate Equal : Set s1 * Set s2
--- predicate PointIn : Set s * Point p
--- predicate In : Point p * Set s
--- predicate Injection : Map m
--- predicate Surjection : Map m
--- predicate Bijection : Map m
--- predicate PairIn : Point * Point * Map
+-- predicate Not(Prop p1)
+-- predicate From(Map f, Set domain, Set codomain)
+-- predicate Empty(Set s)
+-- predicate Intersecting(Set s1, Set s2)
+predicate IsSubset(Set s1, Set s2)
+-- predicate Equal(Set s1, Set s2)
+-- predicate PointIn(Set s, Point p)
+-- predicate In(Point p, Set s)
+-- predicate Injection(Map m)
+-- predicate Surjection(Map m)
+-- predicate Bijection(Map m)
+-- predicate PairIn(Point, Point, Map)


### PR DESCRIPTION
# Description

Resolves #312. That issue only gives examples for `predicate`, and only mentions that and `function`, but this PR also updates the syntax for `constructor`.

A few things I noticed:

- Previously we had a special case for zero args, where no colon would be used. Now that we delimit the arglist with parentheses, I removed that special case for greater consistency.
- I'm a bit confused about the syntax for what look like generics? They seem to use round parentheses in the `type` declaration, then square brackets when listing them before the arglist for a `constructor`, then round parentheses again in the actual arglist. Those latter parentheses are a bit less readable with the new arglist syntax in my opinion, but not terrible; still, it seems like it may be a better idea to make them all square brackets?
- While most (all?) of `examples/` seems to be checked by `packages/core/src/__tests__/overall.test.ts`, which is run as part of `yarn test` from the repo root, the same does not seem to be true of `packages/synthesizer/__tests__/*.dsl`.
- I made use of local search-and-replace to do these example replacements a bit faster, but it was still a fairly manual process. I seem to remember @keenancrane previously mentioning in a conversation with @wodeni that it would be nice to have tools to systematically update all our examples when we update syntax.

# Implementation strategy and design decisions

The `sepBy1` and `sepBy` macros previously had some bugs, which this PR fixes:

- `sepBy1` previously forbid whitespace between the last item and its trailing separator
- `sepBy` previously forbid a trailing separator
- `sepBy` previously allowed a leading separator
- `sepBy` previously allowed leading whitespace, which could cause ambiguity

They were also duplicated across all three of our preexisting nearley files, so this PR extracts their definitions out into a new `packages/core/src/parser/macros.ne` file. Previously Substance was the only language to use `sepBy` (the other two languages only used `sepBy1`), so it had a fix for a bug in that macro definition which would have caused a compile error if the macro were used in either of the other languages. Other than that, the duplicated macro definitions were already all the same.

# Checklist

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] New and existing tests pass locally using `yarn test`
- [x] I ran `yarn docs` and there were no errors when generating the HTML site
- [x] My code follows the style guidelines of this project (e.g.: no ESLint warnings)

# Open questions

- Do we actually _want_ `sepBy1` and `sepBy` to allow trailing separators?