### PR TITLE
chore: Use parent ignore files in VS Code

### DIFF
--- a/penrose.code-workspace
+++ b/penrose.code-workspace
@@ -49,6 +49,7 @@
   "settings": {
     "files.insertFinalNewline": false,
     "files.trimFinalNewlines": false,
-    "files.trimTrailingWhitespace": false
+    "files.trimTrailingWhitespace": false,
+    "search.useParentIgnoreFiles": true
   }
 }


### PR DESCRIPTION
This PR enables **Search: Use Parent Ignore Files** (added by https://github.com/microsoft/vscode/pull/140022) in our VS Code workspace, preventing gitignored files (e.g. those in `packages/core/build/dist/`) from showing up in search when they shouldn't. Currently this setting is only available in VS Code Insiders, but even for Stable VS Code users, it causes no harm to include it now and will begin to take effect in the next VS Code release that includes this feature.