### PR TITLE
chore: Use Prettier in VS Code

### DIFF
--- a/penrose.code-workspace
+++ b/penrose.code-workspace
@@ -59,7 +59,13 @@
     "[jsonc]": {
       "editor.defaultFormatter": "esbenp.prettier-vscode"
     },
+    "[markdown]": {
+      "editor.defaultFormatter": "esbenp.prettier-vscode"
+    },
     "[typescript]": {
+      "editor.defaultFormatter": "esbenp.prettier-vscode"
+    },
+    "[typescriptreact]": {
       "editor.defaultFormatter": "esbenp.prettier-vscode"
     },
     "files.insertFinalNewline": false,

--- a/penrose.code-workspace
+++ b/penrose.code-workspace
@@ -47,7 +47,7 @@
     }
   ],
   "settings": {
-    "[html]": {
+    "[css]": {
       "editor.defaultFormatter": "esbenp.prettier-vscode"
     },
     "[javascript]": {
@@ -56,10 +56,10 @@
     "[json]": {
       "editor.defaultFormatter": "esbenp.prettier-vscode"
     },
-    "[jsonc]": {
+    "[markdown]": {
       "editor.defaultFormatter": "esbenp.prettier-vscode"
     },
-    "[markdown]": {
+    "[scss]": {
       "editor.defaultFormatter": "esbenp.prettier-vscode"
     },
     "[typescript]": {

--- a/penrose.code-workspace
+++ b/penrose.code-workspace
@@ -47,6 +47,21 @@
     }
   ],
   "settings": {
+    "[html]": {
+      "editor.defaultFormatter": "esbenp.prettier-vscode"
+    },
+    "[javascript]": {
+      "editor.defaultFormatter": "esbenp.prettier-vscode"
+    },
+    "[json]": {
+      "editor.defaultFormatter": "esbenp.prettier-vscode"
+    },
+    "[jsonc]": {
+      "editor.defaultFormatter": "esbenp.prettier-vscode"
+    },
+    "[typescript]": {
+      "editor.defaultFormatter": "esbenp.prettier-vscode"
+    },
     "files.insertFinalNewline": false,
     "files.trimFinalNewlines": false,
     "files.trimTrailingWhitespace": false,


### PR DESCRIPTION
This PR sets the VS Code formatter to [Prettier](https://github.com/prettier/prettier-vscode) for all the languages to which it seems to apply:

https://github.com/penrose/penrose/blob/d99c216255522b25b0a85baf395060baf86bfcb6/package.json#L22-L23