### PR TITLE
chore: Remove husky and its pre-push hook

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,17 +25,11 @@
   },
   "devDependencies": {
     "cross-env": "^7.0.3",
-    "husky": "^7.0.4",
     "lerna": "^3.22.1",
     "prettier": "2.2.1",
     "pretty-quick": "^3.1.0",
     "rimraf": "^3.0.2",
     "typescript": "^4.1.3"
-  },
-  "husky": {
-    "hooks": {
-      "pre-push": "yarn test && pretty-quick --staged"
-    }
   },
   "workspaces": {
     "packages": [

--- a/yarn.lock
+++ b/yarn.lock
@@ -11747,11 +11747,6 @@ humanize-ms@^1.2.1:
   dependencies:
     ms "^2.0.0"
 
-husky@^7.0.4:
-  version "7.0.4"
-  resolved "https://registry.yarnpkg.com/husky/-/husky-7.0.4.tgz#242048245dc49c8fb1bf0cc7cfb98dd722531535"
-  integrity sha512-vbaCKN2QLtP/vD4yvs6iz6hBEo6wkSzs8HpRah1Z6aGmF2KW5PdYuAd7uX5a+OyBZHBhd+TFLqgjUgytQr4RvQ==
-
 hyperlinker@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/hyperlinker/-/hyperlinker-1.0.0.tgz#23dc9e38a206b208ee49bc2d6c8ef47027df0c0e"


### PR DESCRIPTION
This PR removes our pre-push hook; it's unnecessary because

- `main` is protected so we can't push to it directly, and
- PRs can't be merged until they pass CI.