### PR TITLE
fix: use empty string as the default label and check autolabel statements

### DIFF
--- a/packages/core/src/compiler/Style.ts
+++ b/packages/core/src/compiler/Style.ts
@@ -2008,27 +2008,24 @@ const insertNames = (trans: Translation): Translation => {
 const insertLabels = (trans: Translation, labels: LabelMap): void => {
   for (const labelData of labels) {
     const [name, label] = labelData;
-    if (label.isJust()) {
-      const labelString = label.value;
-      const labelValue: TagExpr<VarAD> = {
-        tag: "Done",
-        contents: {
-          tag: "StrV",
-          contents: labelString,
-        },
+    const labelValue: TagExpr<VarAD> = {
+      tag: "Done",
+      contents: {
+        tag: "StrV",
+        contents: label,
+      },
+    };
+    const labelExpr: FieldExpr<VarAD> = {
+      tag: "FExpr",
+      contents: labelValue,
+    };
+    const fieldDict = trans.trMap[name];
+    if (fieldDict !== undefined) {
+      fieldDict[LABEL_FIELD] = labelExpr;
+    } else {
+      trans[name] = {
+        [LABEL_FIELD]: labelExpr,
       };
-      const labelExpr: FieldExpr<VarAD> = {
-        tag: "FExpr",
-        contents: labelValue,
-      };
-      const fieldDict = trans.trMap[name];
-      if (fieldDict !== undefined) {
-        fieldDict[LABEL_FIELD] = labelExpr;
-      } else {
-        trans[name] = {
-          [LABEL_FIELD]: labelExpr,
-        };
-      }
     }
   }
 };

--- a/packages/core/src/compiler/Substance.test.ts
+++ b/packages/core/src/compiler/Substance.test.ts
@@ -154,9 +154,7 @@ NoLabel D, E
         ["E", ""],
       ];
       const labelMap = res.value[0].labels;
-      expected.map(([id, value]) =>
-        expect(labelMap.get(id)!.unwrapOr("")).toEqual(value)
-      );
+      expected.map(([id, value]) => expect(labelMap.get(id)!).toEqual(value));
     } else {
       fail("Unexpected error when processing labels: " + showError(res.error));
     }

--- a/packages/core/src/compiler/Substance.ts
+++ b/packages/core/src/compiler/Substance.ts
@@ -32,6 +32,7 @@ import {
   TypeConsApp,
 } from "types/substance";
 import {
+  all,
   andThen,
   argLengthMismatch,
   deconstructNonconstructor,
@@ -103,21 +104,26 @@ export const compileSubstance = (
   }
 };
 
-const initEnv = (ast: SubProg): SubstanceEnv => ({
+const initEnv = (ast: SubProg, env: Env): SubstanceEnv => ({
   exprEqualities: [],
   predEqualities: [],
   bindings: Map<string, SubExpr>(),
-  labels: Map<string, Maybe<string>>(),
+  labels: Map<string, string>(
+    [...env.vars.keys()].map((id: string) => [id, EMPTY_LABEL])
+  ),
   predicates: [],
   ast,
 });
 
 //#region Postprocessing
+
+const EMPTY_LABEL = "";
+
 export const postprocessSubstance = (prog: SubProg, env: Env): SubstanceEnv => {
   // post process all statements
-  const subEnv = initEnv(prog);
+  const subEnv = initEnv(prog, env);
   return prog.statements.reduce(
-    (e, stmt) => postprocessStmt(stmt, env, e),
+    (e, stmt) => processLabelStmt(stmt, env, e),
     subEnv
   );
 };
@@ -133,7 +139,7 @@ const toSubDecl = (idString: string, decl: TypeConstructor): Decl => ({
   name: dummyIdentifier(idString, "SyntheticSubstance"),
 });
 
-const postprocessStmt = (
+const processLabelStmt = (
   stmt: SubStmt,
   env: Env,
   subEnv: SubstanceEnv
@@ -142,7 +148,7 @@ const postprocessStmt = (
     case "AutoLabel": {
       if (stmt.option.tag === "DefaultLabels") {
         const [...ids] = env.vars.keys();
-        const newLabels: LabelMap = Map(ids.map((id) => [id, Maybe.just(id)]));
+        const newLabels: LabelMap = Map(ids.map((id) => [id, id]));
         return {
           ...subEnv,
           labels: newLabels,
@@ -150,7 +156,7 @@ const postprocessStmt = (
       } else {
         const ids = stmt.option.variables;
         const newLabels: LabelMap = subEnv.labels.merge(
-          ids.map((id) => [id.value, Maybe.just(id.value)])
+          ids.map((id) => [id.value, id.value])
         );
         return {
           ...subEnv,
@@ -162,13 +168,13 @@ const postprocessStmt = (
       const { variable, label } = stmt;
       return {
         ...subEnv,
-        labels: subEnv.labels.set(variable.value, Maybe.just(label.contents)),
+        labels: subEnv.labels.set(variable.value, label.contents),
       };
     }
     case "NoLabel": {
       const ids = stmt.args;
       const newLabels: LabelMap = subEnv.labels.merge(
-        ids.map((id) => [id.value, Maybe.nothing()])
+        ids.map((id) => [id.value, EMPTY_LABEL])
       );
       return {
         ...subEnv,
@@ -290,8 +296,16 @@ const checkStmt = (stmt: SubStmt, env: Env): CheckerResult => {
       const rightOk = checkPredicate(right, env);
       return every(leftOk, rightOk);
     }
-    case "AutoLabel":
-      return ok(env); // NOTE: no checking required
+    case "AutoLabel": {
+      if (stmt.option.tag === "DefaultLabels") return ok(env);
+      // NOTE: no checking required
+      else {
+        const varsOk = every(
+          ...stmt.option.variables.map((v) => checkVar(v, env))
+        );
+        return andThen(([_, e]) => ok(e), varsOk);
+      }
+    }
     case "LabelDecl":
       return andThen(([_, e]) => ok(e), checkVar(stmt.variable, env));
     case "NoLabel":

--- a/packages/core/src/types/substance.ts
+++ b/packages/core/src/types/substance.ts
@@ -1,10 +1,9 @@
-import { Maybe } from "utils/Error";
 import { IStringLit, ASTNode, Identifier } from "./ast";
 import { Env, TypeConstructor } from "./domain";
 import { Map } from "immutable";
 
 export type SubRes = [SubstanceEnv, Env];
-export type LabelMap = Map<string, Maybe<string>>;
+export type LabelMap = Map<string, string>;
 export interface SubstanceEnv {
   exprEqualities: [SubExpr, SubExpr][];
   predEqualities: [ApplyPredicate, ApplyPredicate][];


### PR DESCRIPTION
# Description

Related issue/PR: #752 

When `NoLabel` is used or no labeling statements exist for a Substance variable, the current system doesn't insert a `label` field for that variable in the `Translation`. This often causes expected errors. In this PR, we change the default to __empty strings as default labels__ even when there's no labeling statements. 

# Implementation strategy and design decisions

* #752 also uncovers a bug in the Substance checker: we didn't check the variables of statements like `AutoLabel A, B, C`. Added the checking in the Substance checker.
* Changed Substance postprocessing to insert default `""` labels for every variable and insert `""` for `NoLabel` statements

# Examples with steps to reproduce them



