### PR TITLE
fix: check constructor name match in Style selector

### DIFF
--- a/packages/core/src/compiler/Style.ts
+++ b/packages/core/src/compiler/Style.ts
@@ -113,7 +113,7 @@ import { randFloat } from "utils/Util";
 import { checkTypeConstructor, isDeclaredSubtype } from "./Domain";
 
 const log = consola
-  .create({ level: LogLevel.Info })
+  .create({ level: LogLevel.Warn })
   .withScope("Style Compiler");
 const clone = rfdc({ proto: false, circles: false });
 

--- a/packages/core/src/compiler/Style.ts
+++ b/packages/core/src/compiler/Style.ts
@@ -113,7 +113,7 @@ import { randFloat } from "utils/Util";
 import { checkTypeConstructor, isDeclaredSubtype } from "./Domain";
 
 const log = consola
-  .create({ level: LogLevel.Warn })
+  .create({ level: LogLevel.Info })
   .withScope("Style Compiler");
 const clone = rfdc({ proto: false, circles: false });
 
@@ -1129,6 +1129,17 @@ const isSubtypeArrow = (
   ); // Covariant in return type
 };
 
+/**
+ * Match Substance and Style selector constructor expressions on 3 ccnditions:
+ * - If the names of the constructors are the same
+ * - If the substituted args match with the original in number and value
+ * - If the argument types are matching w.r.t. contravariance
+ *
+ * @param varEnv the environment
+ * @param subE the Substance constructor expr
+ * @param styE the substituted Style constructor expr
+ * @returns if the two exprs match
+ */
 const exprsMatchArr = (
   varEnv: Env,
   subE: ApplyConstructor,
@@ -1156,6 +1167,7 @@ const exprsMatchArr = (
   const styVarArgs = styE.args.map(exprToVar);
 
   return (
+    subE.name.value === styE.name.value &&
     isSubtypeArrow(subArrTypes, styArrTypes, varEnv) &&
     _.zip(subVarArgs, styVarArgs).every(([a1, a2]) =>
       varsEq(a1 as Identifier, a2 as Identifier)
@@ -2912,7 +2924,6 @@ const genState = (trans: Translation): Result<State, StyleErrors> => {
     rng: undefined as any,
     policyParams: undefined as any,
     oConfig: undefined as any,
-    selectorMatches: undefined as any,
     varyingMap: {} as any, // TODO: Should this be empty?
 
     canvas: getCanvas(trans),
@@ -3178,7 +3189,6 @@ export const compileStyle = (
     return err(toStyleErrors(selErrs));
   }
 
-  // Leaving these logs in because they are still useful for debugging, but TODO: remove them
   log.info("selEnvs", selEnvs);
 
   // Find substitutions (`find_substs_prog`)

--- a/packages/core/src/types/state.ts
+++ b/packages/core/src/types/state.ts
@@ -19,7 +19,6 @@ export interface IState {
   objFns: Fn[];
   constrFns: Fn[];
   rng: prng;
-  selectorMatches: any; // TODO: types
   policyParams: any; // TODO: types
   oConfig: any; // TODO: types
   pendingPaths: Path[];


### PR DESCRIPTION
# Description

Fixes #756 

As reported in #756, the Style selector matching algorithm incorrectly matches constructors with the same arguments. The reason is that it doesn't check if the constructor names are actually the same before proceeding to checking the argument types and values.

# Implementation strategy and design decisions

Add an additional condition in `exprsMatchArr` and documented the matching conditions.

# Examples with steps to reproduce them

See #756.
