### PR TITLE
feat: allow cycles in partial layer orderings

### DIFF
--- a/examples/set-theory-domain/venn.sty
+++ b/examples/set-theory-domain/venn.sty
@@ -76,3 +76,7 @@ with Set A
 where Not(PointIn(A, p)) {
     ensure disjoint(A.icon, p.icon)
 }
+
+Set `G`, `C` {
+    `G`.icon above `C`.icon
+}

--- a/examples/set-theory-domain/venn.sty
+++ b/examples/set-theory-domain/venn.sty
@@ -76,7 +76,3 @@ with Set A
 where Not(PointIn(A, p)) {
     ensure disjoint(A.icon, p.icon)
 }
-
-Set `G`, `C` {
-    `G`.icon above `C`.icon
-}

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -33,10 +33,12 @@
     "prepack": "yarn build"
   },
   "dependencies": {
+    "@datastructures-js/heap": "^3.2.0",
     "consola": "^2.15.2",
     "eigen": "^0.2.0",
     "fast-memoize": "^2.5.2",
     "graphlib": "^2.1.8",
+    "heap-js": "^2.1.6",
     "immutable": "^4.0.0-rc.12",
     "lodash": "^4.17.15",
     "mathjax-full": "^3.0.1",

--- a/packages/core/src/compiler/Style.test.ts
+++ b/packages/core/src/compiler/Style.test.ts
@@ -79,11 +79,11 @@ describe("Layering computation", () => {
     const res = S.topSortLayering(["A", "B", "C"], partials);
     expect(res).toEqual(["A", "B", "C"]);
   });
-  test("one cycle: A -> B -> C -> B", () => {
+  test("one cycle: A -> B -> C -> A", () => {
     const partials: [string, string][] = [
       ["A", "B"],
       ["B", "C"],
-      ["C", "B"],
+      ["C", "A"],
     ];
     const res = S.topSortLayering(["A", "B", "C"], partials);
     expect(res).toEqual(["A", "B", "C"]);

--- a/packages/core/src/compiler/Style.test.ts
+++ b/packages/core/src/compiler/Style.test.ts
@@ -7,6 +7,7 @@ import {
   parseSubstance,
 } from "compiler/Substance";
 import * as fs from "fs";
+import { Graph } from "graphlib";
 import _ from "lodash";
 import * as path from "path";
 import { Either } from "types/common";
@@ -67,6 +68,51 @@ const canvasPreamble = `canvas {
   height = 700
 }
 `;
+
+describe("Layering computation", () => {
+  // NOTE: again, for each edge (v, w), `v` is __below__ `w`.
+  test("simple layering: A -> B -> C", () => {
+    const partials: [string, string][] = [
+      ["A", "B"],
+      ["B", "C"],
+    ];
+    const res = S.topSortLayering(["A", "B", "C"], partials);
+    expect(res).toEqual(["A", "B", "C"]);
+  });
+  test("one cycle: A -> B -> C -> B", () => {
+    const partials: [string, string][] = [
+      ["A", "B"],
+      ["B", "C"],
+      ["C", "B"],
+    ];
+    const res = S.topSortLayering(["A", "B", "C"], partials);
+    expect(res).toEqual(["A", "B", "C"]);
+  });
+  test("one cycle in tree", () => {
+    const partials: [string, string][] = [
+      ["A", "B"],
+      ["A", "C"],
+      ["B", "D"],
+      ["D", "E"],
+      ["E", "B"],
+      ["C", "F"],
+    ];
+    const res = S.topSortLayering(["A", "B", "C", "D", "E", "F"], partials);
+    expect(res).toEqual(["A", "C", "F", "B", "D", "E"]);
+  });
+  test("one big cycle in tree", () => {
+    const partials: [string, string][] = [
+      ["A", "B"],
+      ["A", "C"],
+      ["B", "D"],
+      ["D", "E"],
+      ["E", "C"],
+      ["C", "F"],
+    ];
+    const res = S.topSortLayering(["A", "B", "C", "D", "E", "F"], partials);
+    expect(res).toEqual(["A", "B", "D", "E", "C", "F"]);
+  });
+});
 
 describe("Compiler", () => {
   // COMBAK: StyleTestData is deprecated. Make the data in the test file later (@hypotext).

--- a/packages/core/src/compiler/Style.ts
+++ b/packages/core/src/compiler/Style.ts
@@ -2768,10 +2768,10 @@ const findNames = (e: Expr, tr: Translation): [string, string] => {
   }
 };
 
-const topSortLayering = (
+export const topSortLayering = (
   allGPINames: string[],
   partialOrderings: [string, string][]
-): MaybeVal<string[]> => {
+): string[] => {
   const layerGraph: Graph = new Graph();
   allGPINames.map((name: string) => layerGraph.setNode(name));
   // topsort will return the most upstream node first. Since `shapeOrdering` is consistent with the SVG drawing order, we assign edges as "below => above".
@@ -2782,7 +2782,7 @@ const topSortLayering = (
   // if there is no cycles, return a global ordering from the top sort result
   if (alg.isAcyclic(layerGraph)) {
     const globalOrdering: string[] = alg.topsort(layerGraph);
-    return { tag: "Just", contents: globalOrdering };
+    return globalOrdering;
   } else {
     const cycles = alg.findCycles(layerGraph);
     const globalOrdering = pseudoTopsort(layerGraph);
@@ -2795,7 +2795,7 @@ const topSortLayering = (
         ", "
       )}`
     );
-    return { tag: "Just", contents: globalOrdering };
+    return globalOrdering;
   }
 };
 
@@ -2808,8 +2808,6 @@ const pseudoTopsort = (graph: Graph): string[] => {
     res.push(node);
     // remove all edges with `node`
     const toRemove = graph.nodeEdges(node);
-    console.log(toRemove);
-
     if (toRemove !== undefined)
       toRemove.forEach((e: Edge) => graph.removeEdge(e));
     // sort the list again by the number of incoming edges
@@ -2837,12 +2835,7 @@ const computeShapeOrdering = (tr: Translation): string[] => {
   ).map((e: [string, Field]): string => getShapeName(e[0], e[1]));
   const shapeOrdering = topSortLayering(allGPINames, partialOrderings);
 
-  // TODO: Errors for labeling
-  if (shapeOrdering.tag === "Nothing") {
-    throw Error("no shape ordering possible from layering");
-  }
-
-  return shapeOrdering.contents;
+  return shapeOrdering;
 };
 
 //#endregion

--- a/packages/core/src/compiler/Style.ts
+++ b/packages/core/src/compiler/Style.ts
@@ -26,7 +26,6 @@ import {
   valueNumberToAutodiffConst,
 } from "engine/EngineUtils";
 import { alg, Edge, Graph } from "graphlib";
-import Heap from "heap-js";
 import _ from "lodash";
 import nearley from "nearley";
 import { lastLocation } from "parser/ParserUtil";

--- a/packages/core/src/compiler/Style.ts
+++ b/packages/core/src/compiler/Style.ts
@@ -25,7 +25,7 @@ import {
   valueNumberToAutodiffConst,
 } from "engine/EngineUtils";
 import { alg, Edge, Graph } from "graphlib";
-import _, { sortBy, uniq } from "lodash";
+import _ from "lodash";
 import nearley from "nearley";
 import { lastLocation } from "parser/ParserUtil";
 import styleGrammar from "parser/StyleParser";
@@ -91,7 +91,6 @@ import {
   TypeConsApp,
 } from "types/substance";
 import {
-  FExpr,
   Field,
   FieldDict,
   FieldExpr,

--- a/yarn.lock
+++ b/yarn.lock
@@ -1980,6 +1980,11 @@
   resolved "https://registry.yarnpkg.com/@csstools/normalize.css/-/normalize.css-10.1.0.tgz#f0950bba18819512d42f7197e56c518aa491cf18"
   integrity sha512-ij4wRiunFfaJxjB0BdrYHIH8FxBJpOwNPhhAcunlmPdXudL1WQV1qoP9un6JsEBAgQH+7UXyyjh0g7jTxXK6tg==
 
+"@datastructures-js/heap@^3.2.0":
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/@datastructures-js/heap/-/heap-3.2.0.tgz#d8fcdbf58c462c8a3f0fdfd9c6a57ca11505321e"
+  integrity sha512-FcU5ZAyb+VIOZz1HABsJUsbJi2ZyUDO7aoe97hq4d3tK3z8nMgwdxf5bO0gafR0ExFi18YTspntqHLzt4XOgnA==
+
 "@discoveryjs/json-ext@^0.5.0":
   version "0.5.3"
   resolved "https://registry.yarnpkg.com/@discoveryjs/json-ext/-/json-ext-0.5.3.tgz#90420f9f9c6d3987f176a19a7d8e764271a2f55d"
@@ -11412,6 +11417,11 @@ he@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/he/-/he-1.2.0.tgz#84ae65fa7eafb165fddb61566ae14baf05664f0f"
   integrity sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==
+
+heap-js@^2.1.6:
+  version "2.1.6"
+  resolved "https://registry.yarnpkg.com/heap-js/-/heap-js-2.1.6.tgz#817021e6d252ad6ba9a11ea65988cc4e6207782d"
+  integrity sha512-xQxyJg7VcgveAZtY0eAu7iCn+2VCqLBkQoz7G4RnOIEsmP82J/LnRdr0I2Mi/pThkP5tviL8yFq5utE3yOPYpQ==
 
 heap@^0.2.6:
   version "0.2.6"


### PR DESCRIPTION
# Description

Fixes #730 

When the partial layer orderings from Style (e.g. `A.text above A.icon`) contain cycles, our system throws an error and refuses to render a diagram since there's no topological ordering of shapes. In this PR, we introduce an approximation of topSort. Instead of failing directly, the system attempts a best-effort algorithm to approximate a global ordering. Here's a brief description from @keenancrane:

![image](https://user-images.githubusercontent.com/11740102/148328029-8a8256aa-be21-401b-b795-88f9db72268c.png)

# Implementation strategy and design decisions

* We do cycle detection in `topSortLayering` and proceed as normal when the graph is a DAG
* Else, we use the new algorithm `pseudoTopsort`
* In `pseudoTopsort`, the heuristic is we always pick the node with the lowest in-degree to avoid breaking the cycles too early. The result tend to preserve most of the intended orderings.
* Added tests to `Style.test.ts`

# Examples with steps to reproduce them

See `Style.test.ts`.

# Checklist

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] New and existing tests pass locally using `yarn test`
- [x] I ran `yarn docs` and there were no errors when generating the HTML site
- [x] My code follows the style guidelines of this project (e.g.: no ESLint warnings)

# Open questions

NOTE: the current implementation can be improved by using a priority queue instead of sorting after each step.
