### PR TITLE
feat: check existence and type of labels in Style selectors

### DIFF
--- a/packages/core/src/compiler/Style.test.ts
+++ b/packages/core/src/compiler/Style.test.ts
@@ -7,7 +7,6 @@ import {
   parseSubstance,
 } from "compiler/Substance";
 import * as fs from "fs";
-import { Graph } from "graphlib";
 import _ from "lodash";
 import * as path from "path";
 import { Either } from "types/common";
@@ -408,7 +407,7 @@ describe("Compiler", () => {
     const errorStyProgs = {
       // ------ Selector errors (from Substance)
       SelectorVarMultipleDecl: [`forall Set x; Set x { }`],
-      SelectorFieldNotSupported: [`forall Set x where x has randomfield`],
+      SelectorFieldNotSupported: [`forall Set x where x has randomfield { }`],
 
       // COMBAK: Style doesn't throw parse error if the program is just "forall Point `A`"... instead it fails inside compileStyle with an undefined selector environment
       SelectorDeclTypeMismatch: [`forall Point \`A\` { }`],

--- a/packages/core/src/compiler/Style.test.ts
+++ b/packages/core/src/compiler/Style.test.ts
@@ -408,6 +408,7 @@ describe("Compiler", () => {
     const errorStyProgs = {
       // ------ Selector errors (from Substance)
       SelectorVarMultipleDecl: [`forall Set x; Set x { }`],
+      SelectorFieldNotSupported: [`forall Set x where x has randomfield`],
 
       // COMBAK: Style doesn't throw parse error if the program is just "forall Point `A`"... instead it fails inside compileStyle with an undefined selector environment
       SelectorDeclTypeMismatch: [`forall Point \`A\` { }`],

--- a/packages/core/src/compiler/Style.ts
+++ b/packages/core/src/compiler/Style.ts
@@ -23,8 +23,8 @@ import {
   insertGPI,
   isPath,
   isTagExpr,
-  propertiesNotOf,
   propertiesOf,
+  propertiesNotOf,
 } from "engine/EngineUtils";
 import { alg, Edge, Graph } from "graphlib";
 import _ from "lodash";
@@ -66,6 +66,7 @@ import {
   PropertyDecl,
   RelationPattern,
   RelBind,
+  RelField,
   RelPred,
   Selector,
   SelExpr,
@@ -102,7 +103,15 @@ import {
   Translation,
   Value,
 } from "types/value";
-import { err, isErr, ok, parseError, Result, toStyleErrors } from "utils/Error";
+import {
+  err,
+  isErr,
+  ok,
+  parseError,
+  Result,
+  selectorFieldNotSupported,
+  toStyleErrors,
+} from "utils/Error";
 import { prettyPrintPath } from "utils/OtherUtils";
 import { randFloat } from "utils/Util";
 import { checkTypeConstructor, isDeclaredSubtype } from "./Domain";
@@ -275,12 +284,30 @@ const ppRelPred = (r: RelPred): string => {
   const name = r.name.value;
   return `${name}(${args})`;
 };
+const ppRelField = (r: RelField): string => {
+  const name = r.name.contents.value;
+  const field = r.field.value;
+  const fieldDesc = r.fieldDescriptor;
+  if (!fieldDesc) return `${name} has ${field}`;
+  else {
+    switch (fieldDesc) {
+      case "MathLabel":
+        return `${name} has math ${field}`;
+      case "TextLabel":
+        return `${name} has text ${field}`;
+      case "NoLabel":
+        return `${name} has empty ${field}`;
+    }
+  }
+};
 
 export const ppRel = (r: RelationPattern): string => {
   if (r.tag === "RelBind") {
     return ppRelBind(r);
   } else if (r.tag === "RelPred") {
     return ppRelPred(r);
+  } else if (r.tag === "RelField") {
+    return ppRelField(r);
   } else throw Error("unknown tag");
 };
 
@@ -400,58 +427,73 @@ const checkDeclPatternsAndMakeEnv = (
 // Judgment 4. G |- |S_r ok
 const checkRelPattern = (varEnv: Env, rel: RelationPattern): StyleErrors => {
   // rule Bind-Context
-  if (rel.tag === "RelBind") {
-    // TODO: use checkSubStmt here (and in paper)?
-    // TODO: make sure the ill-typed bind selectors fail here (after Sub statics is fixed)
-    // G |- B : T1
-    const res1 = checkVar(rel.id.contents, varEnv);
+  switch (rel.tag) {
+    case "RelBind": {
+      // TODO: use checkSubStmt here (and in paper)?
+      // TODO: make sure the ill-typed bind selectors fail here (after Sub statics is fixed)
+      // G |- B : T1
+      const res1 = checkVar(rel.id.contents, varEnv);
 
-    // TODO(error)
-    if (isErr(res1)) {
-      const subErr1: SubstanceError = res1.error;
-      // TODO(error): Do we need to wrap this error further, or is returning SubstanceError with no additional Style info ok?
-      // return ["substance typecheck error in B"];
-      return [{ tag: "TaggedSubstanceError", error: subErr1 }];
+      // TODO(error)
+      if (isErr(res1)) {
+        const subErr1: SubstanceError = res1.error;
+        // TODO(error): Do we need to wrap this error further, or is returning SubstanceError with no additional Style info ok?
+        // return ["substance typecheck error in B"];
+        return [{ tag: "TaggedSubstanceError", error: subErr1 }];
+      }
+
+      const [vtype, env1] = res1.value;
+
+      // G |- E : T2
+      const res2 = checkExpr(toSubExpr(varEnv, rel.expr), varEnv);
+
+      // TODO(error)
+      if (isErr(res2)) {
+        const subErr2: SubstanceError = res2.error;
+        return [{ tag: "TaggedSubstanceError", error: subErr2 }];
+        // return ["substance typecheck error in E"];
+      }
+
+      const [etype, env2] = res2.value;
+
+      // T1 = T2
+      const typesEq = isDeclaredSubtype(vtype, etype, varEnv);
+
+      // TODO(error) -- improve message
+      if (!typesEq) {
+        return [
+          { tag: "SelectorRelTypeMismatch", varType: vtype, exprType: etype },
+        ];
+        // return ["types not equal"];
+      }
+
+      return [];
     }
-
-    const [vtype, env1] = res1.value;
-
-    // G |- E : T2
-    const res2 = checkExpr(toSubExpr(varEnv, rel.expr), varEnv);
-
-    // TODO(error)
-    if (isErr(res2)) {
-      const subErr2: SubstanceError = res2.error;
-      return [{ tag: "TaggedSubstanceError", error: subErr2 }];
-      // return ["substance typecheck error in E"];
+    case "RelPred": {
+      // rule Pred-Context
+      // G |- Q : Prop
+      const res = checkPredicate(toSubPred(rel), varEnv);
+      if (isErr(res)) {
+        const subErr3: SubstanceError = res.error;
+        return [{ tag: "TaggedSubstanceError", error: subErr3 }];
+        // return ["substance typecheck error in Pred"];
+      }
+      return [];
     }
-
-    const [etype, env2] = res2.value;
-
-    // T1 = T2
-    const typesEq = isDeclaredSubtype(vtype, etype, varEnv);
-
-    // TODO(error) -- improve message
-    if (!typesEq) {
-      return [
-        { tag: "SelectorRelTypeMismatch", varType: vtype, exprType: etype },
-      ];
-      // return ["types not equal"];
+    case "RelField": {
+      // check if the Substance name exists
+      const nameOk = checkVar(rel.name.contents, varEnv);
+      if (isErr(nameOk)) {
+        const subErr1: SubstanceError = nameOk.error;
+        return [{ tag: "TaggedSubstanceError", error: subErr1 }];
+      }
+      // check if the field is supported. Currently, we only support matching on `label`
+      if (rel.field.value !== "label")
+        return [selectorFieldNotSupported(rel.name, rel.field)];
+      else {
+        return [];
+      }
     }
-
-    return [];
-  } else if (rel.tag === "RelPred") {
-    // rule Pred-Context
-    // G |- Q : Prop
-    const res = checkPredicate(toSubPred(rel), varEnv);
-    if (isErr(res)) {
-      const subErr3: SubstanceError = res.error;
-      return [{ tag: "TaggedSubstanceError", error: subErr3 }];
-      // return ["substance typecheck error in Pred"];
-    }
-    return [];
-  } else {
-    throw Error("unknown tag");
   }
 };
 
@@ -687,20 +729,29 @@ export const substituteRel = (
   subst: Subst,
   rel: RelationPattern
 ): RelationPattern => {
-  if (rel.tag === "RelBind") {
-    // theta(B := E) |-> theta(B) := theta(E)
-    return {
-      ...rel,
-      id: substituteBform({ tag: "Nothing" }, subst, rel.id),
-      expr: substituteExpr(subst, rel.expr),
-    };
-  } else if (rel.tag === "RelPred") {
-    // theta(Q([a]) = Q([theta(a)])
-    return {
-      ...rel,
-      args: rel.args.map((arg) => substitutePredArg(subst, arg)),
-    };
-  } else throw Error("unknown tag");
+  switch (rel.tag) {
+    case "RelBind": {
+      // theta(B := E) |-> theta(B) := theta(E)
+      return {
+        ...rel,
+        id: substituteBform({ tag: "Nothing" }, subst, rel.id),
+        expr: substituteExpr(subst, rel.expr),
+      };
+    }
+    case "RelPred": {
+      // theta(Q([a]) = Q([theta(a)])
+      return {
+        ...rel,
+        args: rel.args.map((arg) => substitutePredArg(subst, arg)),
+      };
+    }
+    case "RelField": {
+      return {
+        ...rel,
+        name: substituteBform({ tag: "Nothing" }, subst, rel.name),
+      };
+    }
+  }
 };
 
 // Applies a substitution to a list of relational statement theta([|S_r])
@@ -1247,9 +1298,25 @@ const relMatchesProg = (
   subProg: SubProg,
   rel: RelationPattern
 ): boolean => {
-  return subProg.statements.some((line) =>
-    relMatchesLine(typeEnv, subEnv, line, rel)
-  );
+  if (rel.tag === "RelField") {
+    // the current pattern matches on a Style field
+    const subName = rel.name.contents.value;
+    const fieldDesc = rel.fieldDescriptor;
+    const label = subEnv.labels.get(subName);
+
+    if (label) {
+      // check if the label type matches with the descriptor
+      if (fieldDesc) {
+        return label.type === fieldDesc;
+      } else return true;
+    } else {
+      return false;
+    }
+  } else {
+    return subProg.statements.some((line) =>
+      relMatchesLine(typeEnv, subEnv, line, rel)
+    );
+  }
 };
 
 // Judgment 15. b |- [S] <| [|S_r]
@@ -2016,7 +2083,7 @@ const insertLabels = (trans: Translation, labels: LabelMap): void => {
       tag: "Done",
       contents: {
         tag: "StrV",
-        contents: label,
+        contents: label.value,
       },
     };
     const labelExpr: FieldExpr<VarAD> = {

--- a/packages/core/src/compiler/Style.ts
+++ b/packages/core/src/compiler/Style.ts
@@ -1307,6 +1307,7 @@ const relMatchesProg = (
     if (label) {
       // check if the label type matches with the descriptor
       if (fieldDesc) {
+        // NOTE: empty labels have a specific `NoLabel` type, so even if the entry exists, no existing field descriptors will match on it.
         return label.type === fieldDesc;
       } else return true;
     } else {

--- a/packages/core/src/compiler/Substance.test.ts
+++ b/packages/core/src/compiler/Substance.test.ts
@@ -140,21 +140,25 @@ describe("Postprocess", () => {
 Set A, B, C, D, E
 AutoLabel All
 Label A $\\vec{A}$
-Label B $B_1$
+Label B "B_1"
 NoLabel D, E
     `;
     const env = envOrError(domainProg);
     const res = compileSubstance(prog, env);
     if (res.isOk()) {
       const expected = [
-        ["A", "\\vec{A}"],
-        ["B", "B_1"],
-        ["C", "C"],
-        ["D", ""],
-        ["E", ""],
+        ["A", "\\vec{A}", "MathLabel"],
+        ["B", "B_1", "TextLabel"],
+        ["C", "C", "MathLabel"],
+        ["D", "", "NoLabel"],
+        ["E", "", "NoLabel"],
       ];
       const labelMap = res.value[0].labels;
-      expected.map(([id, value]) => expect(labelMap.get(id)!).toEqual(value));
+      expected.map(([id, value, type]) => {
+        const label = labelMap.get(id)!;
+        expect(label.value).toEqual(value);
+        expect(label.type).toEqual(type);
+      });
     } else {
       fail("Unexpected error when processing labels: " + showError(res.error));
     }

--- a/packages/core/src/parser/Style.ne
+++ b/packages/core/src/parser/Style.ne
@@ -8,7 +8,7 @@ import * as moo from "moo";
 import { concat, compact, flatten, last } from 'lodash'
 import { basicSymbols, rangeOf, rangeBetween, rangeFrom, nth, convertTokenId } from 'parser/ParserUtil'
 import { ASTNode, Identifier, IStringLit  } from "types/ast";
-import { StyT, DeclPattern, DeclPatterns, RelationPatterns, Namespace, Selector, StyProg, HeaderBlock, RelBind, RelPred, SEFuncOrValCons, SEBind, Block, IAnonAssign, Delete, IOverride, PathAssign, StyType, BindingForm, Path, ILayering, BinaryOp, Expr, IBinOp, SubVar, StyVar, IPropertyPath, IFieldPath, LocalVar, IAccessPath, IUOp, IList, ITuple, IVector, IBoolLit, IVary, IFix, ICompApp, IObjFn, IConstrFn, GPIDecl, PropertyDecl, 
+import { StyT, DeclPattern, DeclPatterns, RelationPatterns, Namespace, Selector, StyProg, HeaderBlock, RelBind, RelField, RelPred, SEFuncOrValCons, SEBind, Block, IAnonAssign, Delete, IOverride, PathAssign, StyType, BindingForm, Path, ILayering, BinaryOp, Expr, IBinOp, SubVar, StyVar, IPropertyPath, IFieldPath, LocalVar, IAccessPath, IUOp, IList, ITuple, IVector, IBoolLit, IVary, IFix, ICompApp, IObjFn, IConstrFn, GPIDecl, PropertyDecl, 
 } from "types/style";
 
 const styleTypes: string[] =
@@ -188,6 +188,7 @@ relation_list -> sepBy1[relation, ";"]  {%
 relation
   -> rel_bind {% id %} 
   |  rel_pred {% id %}
+  |  rel_field {% id %}
 
 rel_bind -> binding_form _ ":=" _ sel_expr {%
   ([id, , , , expr]): RelBind => ({
@@ -204,6 +205,20 @@ rel_pred -> identifier _ "(" pred_arg_list ")" {%
     tag: "RelPred", name, args
   }) 
 %}
+
+rel_field -> binding_form __ "has" __ (field_desc __):? identifier {%
+  ([name, , , , field_desc, field]): RelField => ({
+    ...nodeData(field_desc ? [name, field_desc[0], field] : [name, field]), 
+    ...rangeBetween(name, field),
+    tag: "RelField",
+    fieldDescriptor: field_desc ? field_desc[0] : undefined,
+    name, field, 
+  })
+%}
+
+field_desc 
+  -> "math" {% () => "MathLabel" %} 
+  |  "text" {% () => "TextLabel" %}
 
 sel_expr_list 
   -> _ {% d => [] %}

--- a/packages/core/src/parser/StyleParser.test.ts
+++ b/packages/core/src/parser/StyleParser.test.ts
@@ -155,6 +155,24 @@ as Const
     const { results } = parser.feed(prog);
     sameASTs(results);
   });
+
+  test("label field check", () => {
+    const prog = `
+forall Set A, B
+where IsSubset(A, B); A has math label; B has text label {
+
+}
+    `;
+    const { results } = parser.feed(prog);
+    sameASTs(results);
+    const whereClauses = results[0].blocks[0].header.where.contents;
+    expect(whereClauses[1].name.contents.value).toEqual("A");
+    expect(whereClauses[1].field.value).toEqual("label");
+    expect(whereClauses[1].fieldDescriptor).toEqual("MathLabel");
+    expect(whereClauses[2].name.contents.value).toEqual("B");
+    expect(whereClauses[2].field.value).toEqual("label");
+    expect(whereClauses[2].fieldDescriptor).toEqual("TextLabel");
+  });
 });
 
 describe("Block Grammar", () => {

--- a/packages/core/src/parser/Substance.ne
+++ b/packages/core/src/parser/Substance.ne
@@ -159,21 +159,25 @@ label_stmt
   |  no_label   {% id %}
   |  auto_label {% id %}
 
-label_decl -> "Label" __ identifier __ tex_literal {%
-  ([kw, , variable, , label]): LabelDecl => ({
-    ...nodeData([variable, label]),
-    ...rangeBetween(rangeOf(kw), label),
-    tag: "LabelDecl", variable, label
-  })
-%}
-
-label_decl -> "Label" __ identifier __ string_lit {%
-  ([kw, , variable, , label]): LabelDecl => ({
-    ...nodeData([variable, label]),
-    ...rangeBetween(rangeOf(kw), label),
-    tag: "LabelDecl", variable, label
-  })
-%}
+label_decl 
+  -> "Label" __ identifier __ tex_literal {%
+    ([kw, , variable, , label]): LabelDecl => ({
+      ...nodeData([variable, label]),
+      ...rangeBetween(rangeOf(kw), label),
+      tag: "LabelDecl", 
+      labelType: "MathLabel",
+      variable, label
+    })
+  %}
+ |  "Label" __ identifier __ string_lit {%
+    ([kw, , variable, , label]): LabelDecl => ({
+      ...nodeData([variable, label]),
+      ...rangeBetween(rangeOf(kw), label),
+      tag: "LabelDecl", 
+      labelType: "TextLabel",
+      variable, label
+    })
+  %}
 
 no_label -> "NoLabel" __ sepBy1[identifier, ","] {%
   ([kw, , args]): NoLabel => ({

--- a/packages/core/src/types/errors.ts
+++ b/packages/core/src/types/errors.ts
@@ -150,6 +150,7 @@ export type StyleError =
   | SelectorVarMultipleDecl
   | SelectorDeclTypeMismatch
   | SelectorRelTypeMismatch
+  | SelectorFieldNotSupported
   | TaggedSubstanceError
   // Block static errors
   | InvalidGPITypeError
@@ -225,6 +226,12 @@ export interface SelectorRelTypeMismatch {
   tag: "SelectorRelTypeMismatch";
   varType: TypeConsApp;
   exprType: TypeConsApp;
+}
+
+export interface SelectorFieldNotSupported {
+  tag: "SelectorFieldNotSupported";
+  name: BindingForm;
+  field: Identifier;
 }
 
 export interface TaggedSubstanceError {

--- a/packages/core/src/types/style.ts
+++ b/packages/core/src/types/style.ts
@@ -3,6 +3,7 @@
 
 import { VarAD } from "./ad";
 import { ASTNode, Identifier, IStringLit } from "./ast";
+import { LabelType } from "./substance";
 
 /** Top level type for Style AST */
 export interface StyProg extends ASTNode {
@@ -50,7 +51,14 @@ export interface DeclPattern extends ASTNode {
   id: BindingForm;
 }
 
-export type RelationPattern = RelBind | RelPred;
+export type RelationPattern = RelBind | RelPred | RelField;
+
+export interface RelField {
+  tag: "RelField";
+  name: BindingForm;
+  field: Identifier;
+  fieldDescriptor?: LabelType;
+}
 
 export interface RelationPatterns extends ASTNode {
   tag: "RelationPatterns";

--- a/packages/core/src/types/substance.ts
+++ b/packages/core/src/types/substance.ts
@@ -3,7 +3,7 @@ import { Env, TypeConstructor } from "./domain";
 import { Map } from "immutable";
 
 export type SubRes = [SubstanceEnv, Env];
-export type LabelMap = Map<string, string>;
+export type LabelMap = Map<string, LabelValue>;
 export interface SubstanceEnv {
   exprEqualities: [SubExpr, SubExpr][];
   predEqualities: [ApplyPredicate, ApplyPredicate][];
@@ -29,6 +29,11 @@ export type SubStmt =
   | AutoLabel
   | NoLabel;
 
+export interface LabelValue {
+  value: string;
+  type: LabelType;
+}
+
 export interface LabelDecl extends ASTNode {
   tag: "LabelDecl";
   variable: Identifier;
@@ -36,7 +41,7 @@ export interface LabelDecl extends ASTNode {
   labelType: LabelType;
 }
 
-export type LabelType = "MathLabel" | "TextLabel";
+export type LabelType = "MathLabel" | "TextLabel" | "NoLabel";
 export interface AutoLabel extends ASTNode {
   tag: "AutoLabel";
   option: LabelOption;

--- a/packages/core/src/types/substance.ts
+++ b/packages/core/src/types/substance.ts
@@ -33,7 +33,10 @@ export interface LabelDecl extends ASTNode {
   tag: "LabelDecl";
   variable: Identifier;
   label: IStringLit;
+  labelType: LabelType;
 }
+
+export type LabelType = "MathLabel" | "TextLabel";
 export interface AutoLabel extends ASTNode {
   tag: "AutoLabel";
   option: LabelOption;

--- a/packages/core/src/utils/Error.ts
+++ b/packages/core/src/utils/Error.ts
@@ -16,6 +16,7 @@ import {
   ParseError,
   PenroseError,
   RuntimeError,
+  SelectorFieldNotSupported,
   StyleError,
   SubstanceError,
   TypeArgLengthMismatch,
@@ -25,6 +26,7 @@ import {
   VarNotFound,
 } from "types/errors";
 import { State } from "types/state";
+import { BindingForm } from "types/style";
 import { Deconstructor, SubExpr } from "types/substance";
 import { prettyPrintPath } from "utils/OtherUtils";
 const {
@@ -200,6 +202,14 @@ export const showError = (
 
     case "SelectorVarMultipleDecl": {
       return `Style pattern statement has already declared the variable ${error.varName.contents.value}`;
+    }
+
+    case "SelectorFieldNotSupported": {
+      return `Cannot match on field ${error.name.contents.value}.${
+        error.field.value
+      } (${loc(
+        error.field
+      )}) because matching on fields is not fully supported. Currently, only "label" can be matched in selectors.`;
     }
 
     case "SelectorDeclTypeMismatch": {
@@ -496,6 +506,15 @@ export const typeArgLengthMismatch = (
   sourceType,
   expectedExpr,
   expectedType,
+});
+
+export const selectorFieldNotSupported = (
+  name: BindingForm,
+  field: Identifier
+): SelectorFieldNotSupported => ({
+  tag: "SelectorFieldNotSupported",
+  name,
+  field,
 });
 
 export const deconstructNonconstructor = (

--- a/packages/panels/src/languages/StyleConfig.ts
+++ b/packages/panels/src/languages/StyleConfig.ts
@@ -48,6 +48,9 @@ const styleCustoms = {
     "override",
     "above",
     "below",
+    "has",
+    "math",
+    "text",
   ],
   types: [
     "scalar",


### PR DESCRIPTION
# Description

Closes #774 

In this PR, we introduce a new Style selector pattern: `X has <math|text> label`. When included in the `where` clause of a selector, the compiler checks if `label` exists and whether it matches with the specified descriptor. Examples:

* `Label x $\vec{x}$` will match with `where x has math label`
* `Label x "xxxx"` will match with `where x has text label`
* Both of the above will match with `where x has label`
* `NoLabel x` will not match with `where x has label` nor `where x has math/text label`

Error handling:
* Only `math` and `text` are valid field descriptors. All others will result in parse errors
* `label` is the only field name allowed, but instead of throwing a parse error, the compiler reports `SelectorFieldNotSupported` error:
```
Cannot match on field x.blah (line 14, column 31 of Style program) because matching on fields is not fully supported. Currently, only "label" can be matched in selectors.
```

# Implementation strategy and design decisions

* Introduce `rel_field` rule in the Style parser
* Add `RelField` type in the Style compiler
* In Substance postprocessing, attach the type of the label to entries in `labelMap`
* In the Style compiler, check for the existence of `x` and the label existence and type during selector matching
* Add tests in Style parser, Substance compiler, and Style compiler

# Examples with steps to reproduce them



# Checklist

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] New and existing tests pass locally using `yarn test`
- [x] I ran `yarn docs` and there were no errors when generating the HTML site
- [x] My code follows the style guidelines of this project (e.g.: no ESLint warnings)

# Open questions

There's no infrastructure for testing selector matching results, so we are not including tests for checking selector matching results.
