### PR TITLE
fix: GitHub Actions canary release

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -55,6 +55,8 @@ jobs:
       - if: github.event_name != 'pull_request'
         name: Authenticate with registry
         run: echo "//registry.npmjs.org/:_authToken=$NPM_TOKEN" > ~/penrose/.npmrc
+        env:
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
       - if: github.event_name != 'pull_request'
         name: Publish canary release
         run: sudo yarn publish:canary --yes

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Run all builds
         run: yarn build
         env:
-          CI: false # TODO: don't do this
+          CI: false # TODO: eliminate warnings so we don't have to do this
       - name: Run all tests
         run: yarn test
       - name: Make test report dir

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -54,7 +54,7 @@ jobs:
           path: packages/core/coverage
       - if: github.event_name != 'pull_request'
         name: Authenticate with registry
-        run: echo "//registry.npmjs.org/:_authToken=$NPM_TOKEN" > ~/penrose/.npmrc
+        run: echo "//registry.npmjs.org/:_authToken=$NPM_TOKEN" > .npmrc
         env:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
       - if: github.event_name != 'pull_request'


### PR DESCRIPTION
This PR includes a couple additional commits that I meant to include in #755 but forgot. It also fixes another bug in the "Authenticate with registry" step that I didn't notice before but did notice after CI failed on `main`:

- https://github.com/penrose/penrose/runs/4742741785?check_suite_focus=true