### PR TITLE
fix: Upgrade TypeScript for roger prepack

### DIFF
--- a/packages/roger/package.json
+++ b/packages/roger/package.json
@@ -24,7 +24,7 @@
     "eslint-config-oclif-typescript": "^0.1.0",
     "globby": "^10.0.2",
     "ts-node": "^8.10.2",
-    "typescript": "^3.9.7"
+    "typescript": "^4.1.3"
   },
   "engines": {
     "node": ">=8.0.0"


### PR DESCRIPTION
Continuing to try to fix the GitHub Actions canary release: https://github.com/penrose/penrose/runs/4743590685?check_suite_focus=true