### PR TITLE
ci: Set env.CI to false in the entire build job

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,6 +7,8 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    env:
+      CI: false # TODO: eliminate warnings so we don't have to do this
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -24,8 +26,6 @@ jobs:
         run: yarn
       - name: Run all builds
         run: yarn build
-        env:
-          CI: false # TODO: eliminate warnings so we don't have to do this
       - name: Run all tests
         run: yarn test
       - name: Make test report dir


### PR DESCRIPTION
Still trying to fix the GitHub Actions canary release: https://github.com/penrose/penrose/runs/4743970903?check_suite_focus=true