### PR TITLE
fix: empty label check in Style selector

### DIFF
--- a/packages/core/src/compiler/Style.ts
+++ b/packages/core/src/compiler/Style.ts
@@ -1310,7 +1310,7 @@ const relMatchesProg = (
       if (fieldDesc) {
         // NOTE: empty labels have a specific `NoLabel` type, so even if the entry exists, no existing field descriptors will match on it.
         return label.type === fieldDesc;
-      } else return true;
+      } else return label.value.length > 0;
     } else {
       return false;
     }


### PR DESCRIPTION
# Description

Fix: #787 

When there's no field descriptor in the field selector pattern, the Style compiler incorrectly assumes the return must be true if there's an entry in the label map. However, there's the possibility of empty strings, so we need to explicitly check if the string is empty.

# Implementation strategy and design decisions

Add string length check in `relMatchesProg`.

# Example

https://500d1995.penrose-panes.pages.dev/gist/6a441188eb78ca88e7d495449cee2f1d