### PR TITLE
ci: Fix canary release

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,3 +49,4 @@ examples/plugins/alloy/__temp.als__
 temp.als
 .*.sw*
 packages/panels/public/app.js.map
+.npmrc

--- a/packages/browser-ui/tsconfig.json
+++ b/packages/browser-ui/tsconfig.json
@@ -4,10 +4,16 @@
     "outDir": "build/dist",
     "module": "esnext",
     "target": "es5",
-    "lib": ["es5", "es6", "es7", "esnext", "dom"],
+    "lib": [
+      "es5",
+      "es6",
+      "es7",
+      "esnext",
+      "dom"
+    ],
     "sourceMap": true,
     "allowJs": true,
-    "jsx": "react",
+    "jsx": "react-jsx",
     "moduleResolution": "node",
     "rootDir": "src",
     "forceConsistentCasingInFileNames": true,
@@ -21,15 +27,24 @@
     "noUnusedLocals": false,
     "skipLibCheck": true,
     "downlevelIteration": true,
-    "types": ["react", "jest", "node", "tslib"],
-    "typeRoots": ["node_modules/@types"],
+    "types": [
+      "react",
+      "jest",
+      "node",
+      "tslib"
+    ],
+    "typeRoots": [
+      "node_modules/@types"
+    ],
     "esModuleInterop": true,
     "isolatedModules": true,
     "noEmit": true,
     "strict": true,
     "noFallthroughCasesInSwitch": true
   },
-  "include": ["src"],
+  "include": [
+    "src"
+  ],
   "exclude": [
     "node_modules",
     "build",
@@ -43,7 +58,9 @@
     "src/setupTests.ts"
   ],
   "typedocOptions": {
-    "inputFiles": ["./src"],
+    "inputFiles": [
+      "./src"
+    ],
     "mode": "modules",
     "out": "doc",
     "exclude": [


### PR DESCRIPTION
# Description

It seems that upgrading TypeScript in #798 broke CI again: https://github.com/penrose/penrose/runs/4766221596?check_suite_focus=true

```
lerna ERR! EUNCOMMIT Working tree has uncommitted changes, please commit or remove the following changes before continuing:
lerna ERR! EUNCOMMIT  M packages/browser-ui/tsconfig.json
lerna ERR! EUNCOMMIT ?? .npmrc
```

So this PR attempts to fix those errors by doing the following:

- Update `packages/browser-ui/tsconfig.json` by running `yarn build` locally and committing that
- Add `.npmrc` to `.gitignore`

# Checklist

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] My code follows the style guidelines of this project (e.g.: no ESLint warnings)