### PR TITLE
fix: show animation when optimizing with configurable autostep size

### DIFF
--- a/packages/browser-ui/src/App.tsx
+++ b/packages/browser-ui/src/App.tsx
@@ -72,7 +72,7 @@ class App extends React.Component<any, ICanvasState> {
     settings: {
       autostep: false,
       showInspector: true,
-      autoStepSize: 10000
+      autoStepSize: 50
     }
   };
   public readonly buttons = React.createRef<ButtonBar>();
@@ -102,7 +102,7 @@ class App extends React.Component<any, ICanvasState> {
     this.renderCanvas(canvasState);
     const { settings } = this.state;
     if (settings.autostep && !stateConverged(canvasState)) {
-      await this.stepUntilConvergence();
+      await this.step(this.state.settings.autoStepSize);
     }
   };
   public downloadSVG = (): void => {
@@ -157,10 +157,10 @@ class App extends React.Component<any, ICanvasState> {
     }
   };
 
-  public step = (): void => {
+  public step = (numSteps: number): void => {
     if (this.state.data) {
       try {
-        const stepped = stepState(this.state.data, 1);
+        const stepped = stepState(this.state.data, numSteps);
         void this.onCanvasState(stepped);
       } catch (e) {
         const error: PenroseError = {

--- a/packages/browser-ui/src/ui/ButtonBar.tsx
+++ b/packages/browser-ui/src/ui/ButtonBar.tsx
@@ -15,7 +15,7 @@ interface IProps {
   downloadSVG?(): void;
   downloadState?(): void;
   autoStepToggle?(): void;
-  step(): void;
+  step(numSteps: number): void;
   stepUntilConvergence(): void;
   resample(): void;
   reconnect(): void;
@@ -37,7 +37,7 @@ class ButtonBar extends React.Component<IProps> {
       showInspector,
       files,
       connected,
-      reconnect,
+      reconnect
     } = this.props;
     return (
       <div style={{ display: "flex", justifyContent: "middle" }}>
@@ -46,7 +46,7 @@ class ButtonBar extends React.Component<IProps> {
             autostep {autostep ? "(on)" : "(off)"}
           </button>
         )}
-        <button onClick={step}>x1 optimization step</button>
+        <button onClick={() => step(1)}>x1 optimization step</button>
         <button onClick={stepUntilConvergence}>step until convergence</button>
         <button
           onClick={resample}
@@ -76,7 +76,7 @@ class ButtonBar extends React.Component<IProps> {
                 ? "#55de55"
                 : initial
                 ? "#4286f4"
-                : "#ff9d23",
+                : "#ff9d23"
           }}
         />
         <div
@@ -84,7 +84,7 @@ class ButtonBar extends React.Component<IProps> {
             display: "inline-block",
             marginLeft: "1em",
             color: "#303030",
-            fontSize: "14px",
+            fontSize: "14px"
           }}
         >
           {files === null


### PR DESCRIPTION
# Description

Initially suggested by @keenancrane: the number of steps the optimizer takes when auto-stepping should be configurable in `browser-ui`. A smaller step size shows more of the optimization process as "animation", but will take longer to converge due to repeated evaluation. This PR updates the default step size to `50` for a good balance: 

![venn-stepsize-5](https://user-images.githubusercontent.com/11740102/148835558-7e61d99a-bef4-4e3f-a4f7-a9334a7a9cbc.gif)

If `autoStepSize === 1`:

![venn-stepsize-1](https://user-images.githubusercontent.com/11740102/148835529-c02fa69c-7dd9-418a-993a-eb718e94a65c.gif)

