### PR TITLE
fix: Remove Rectangle Rotation BBox logic

### DIFF
--- a/packages/core/src/engine/BBox.ts
+++ b/packages/core/src/engine/BBox.ts
@@ -250,7 +250,6 @@ export const bboxFromRect = ({
   height,
   center,
   strokeWidth,
-  rotation,
 }: IRectangle): BBox => {
   // https://github.com/penrose/penrose/issues/715
   if (!isPt2(center.contents)) {
@@ -260,12 +259,10 @@ export const bboxFromRect = ({
   }
 
   // rx just rounds the corners, doesn't change the bbox
-  return bboxFromRotatedRect(
-    center.contents,
-    width.contents,
-    height.contents,
-    rotation.contents,
-    strokeWidth.contents
+  return bbox(
+    add(width.contents, strokeWidth.contents),
+    add(height.contents, strokeWidth.contents),
+    center.contents
   );
 };
 


### PR DESCRIPTION
# Description

This PR removes rectangle rotation due to performance issues in testing, particularly with testing in CI due to the heavy use of rectangles in the test suite.  Rotation of rectangles is presently less important than performance.

# Checklist

- [X] I have commented my code, particularly in hard-to-understand areas
- [X] My changes generate no new warnings
- [X] My code follows the style guidelines of this project (e.g.: no ESLint warnings)

# Open questions

The performance issue behind rectangle rotation will need to be investigated and the functionality re-introduced into the codebase.
