### PR TITLE
feat: Allow Greek letters in style identifiers

### DIFF
--- a/examples/fancy-text/fancy-text.sty
+++ b/examples/fancy-text/fancy-text.sty
@@ -87,6 +87,7 @@ forall Point p {
 forall Point p; Point q {
    vec2 x = p.icon.center
    vec2 y = q.icon.center
-   encourage equal( 200000./normsq(x-y), 0. )
+   Δ = x-y
+   encourage equal( 200000./normsq(Δ), 0. )
 }
 

--- a/packages/core/src/parser/Style.ne
+++ b/packages/core/src/parser/Style.ne
@@ -36,11 +36,11 @@ const styleTypes: string[] =
 const lexer = moo.compile({
   ...basicSymbols,
   identifier: {
-    // Allow alpha, numbers, underscores.  But an identified name:
+    // Allow latin/greek upper/lower characters, numbers, underscores.  An identified name:
     //  - May not begin with a number (ending with a number is ok)
-    //  - May be a single alpha character or underscore
+    //  - May be a single latin/greek upper/lower character or underscore
     //  - May begin or end with an underscore
-    match: /[A-Za-z_][A-Za-z_0-9]*/,
+    match: /[A-Za-z_\u0374-\u03FF][A-Za-z_0-9\u0374-\u03FF]*/,
     type: moo.keywords({
       // NOTE: the next line add type annotation keywords into the keyword set and thereby forbidding users to use keywords like `shape`
       // "type-keyword": styleTypes, 


### PR DESCRIPTION
# Description

Closes #794

This PR adds the ability to use Greek letters in style identifiers.

# Implementation strategy and design decisions

Adapted style identifier regex to allow Greek characters in positions 1-n.

# Examples with steps to reproduce them

Run the fancy-text example, which now includes a Greek identifier.

# Checklist

- [X] I have commented my code, particularly in hard-to-understand areas
- [X] My changes generate no new warnings
- [X] My code follows the style guidelines of this project (e.g.: no ESLint warnings)

# Open questions

None.