### PR TITLE
feat: Line polygon constraints

### DIFF
--- a/packages/core/src/contrib/Constraints.ts
+++ b/packages/core/src/contrib/Constraints.ts
@@ -5,6 +5,7 @@ import {
   constOfIf,
   max,
   min,
+  minN,
   mul,
   neg,
   ops,
@@ -28,6 +29,7 @@ import {
   overlappingCircles,
   overlappingPolygons,
   overlappingRectlikeCircle,
+  overlappingPolygonLinelike,
   overlappingAABBs,
   containsCircles,
   containsCircleRectlike,
@@ -151,6 +153,11 @@ const constrDictGeneral = {
       return overlappingCircles([t1, s1], [t2, s2], constOfIf(padding));
     else if (t1 === "Polygon" && t2 === "Polygon")
       return overlappingPolygons([t1, s1], [t2, s2], constOfIf(padding));
+    // Polygon x Linelike
+    else if (t1 === "Polygon" && shapedefs[t2].isLinelike)
+      return overlappingPolygonLinelike([t1, s1], [t2, s2], constOfIf(padding));
+    else if (shapedefs[t1].isLinelike && t2 === "Polygon")
+      return overlappingPolygonLinelike([t2, s2], [t1, s1], constOfIf(padding));
     // Rectlike x Circle
     else if (shapedefs[t1].isRectlike && t2 === "Circle")
       return overlappingRectlikeCircle([t1, s1], [t2, s2], constOfIf(padding));

--- a/packages/core/src/contrib/Constraints.ts
+++ b/packages/core/src/contrib/Constraints.ts
@@ -146,14 +146,19 @@ const constrDictGeneral = {
     [t2, s2]: [string, any],
     padding = 0.0
   ) => {
+    // Same shapes
     if (shapedefs[t1].isLinelike && shapedefs[t2].isLinelike)
       return overlappingLines([t1, s1], [t2, s2], constOfIf(padding));
     else if (t1 === "Circle" && t2 === "Circle")
       return overlappingCircles([t1, s1], [t2, s2], constOfIf(padding));
     else if (t1 === "Polygon" && t2 === "Polygon")
       return overlappingPolygons([t1, s1], [t2, s2], constOfIf(padding));
-    if (shapedefs[t1].isRectlike && t2 === "Circle")
+    // Rectlike x Circle
+    else if (shapedefs[t1].isRectlike && t2 === "Circle")
       return overlappingRectlikeCircle([t1, s1], [t2, s2], constOfIf(padding));
+    else if (t1 === "Circle" && shapedefs[t2].isRectlike)
+      return overlappingRectlikeCircle([t2, s2], [t1, s1], constOfIf(padding));
+    // Default to bounding boxes
     else {
       // TODO: After compilation time fix (issue #652), replace by:
       // return overlappingAABBsMinkowski([t1, s1], [t2, s2], constOfIf(padding));

--- a/packages/core/src/contrib/Constraints.ts
+++ b/packages/core/src/contrib/Constraints.ts
@@ -30,6 +30,7 @@ import {
   overlappingPolygons,
   overlappingRectlikeCircle,
   overlappingPolygonLinelike,
+  overlappingRectlikeLinelike,
   overlappingAABBs,
   containsCircles,
   containsCircleRectlike,
@@ -78,7 +79,7 @@ const constrDictSimple = {
     // [if len2 <= len1,] require that (l2 > l1) & (r2 < r1)
     return add(constrDictSimple.lessThanSq(l1, l2), constrDictSimple.lessThanSq(r2, r1));
   },
-  
+
   /**
    * Make scalar `c` disjoint from a range `left, right`.
    */
@@ -158,6 +159,11 @@ const constrDictGeneral = {
       return overlappingPolygonLinelike([t1, s1], [t2, s2], constOfIf(padding));
     else if (shapedefs[t1].isLinelike && t2 === "Polygon")
       return overlappingPolygonLinelike([t2, s2], [t1, s1], constOfIf(padding));
+    // Rectlike x Linelike 
+    else if (shapedefs[t1].isRectlike && shapedefs[t2].isLinelike)
+      return overlappingRectlikeLinelike([t1, s1], [t2, s2], constOfIf(padding));
+    else if (shapedefs[t1].isLinelike && shapedefs[t2].isRectlike)
+      return overlappingRectlikeLinelike([t2, s2], [t1, s1], constOfIf(padding));
     // Rectlike x Circle
     else if (shapedefs[t1].isRectlike && t2 === "Circle")
       return overlappingRectlikeCircle([t1, s1], [t2, s2], constOfIf(padding));

--- a/packages/core/src/contrib/Constraints.ts
+++ b/packages/core/src/contrib/Constraints.ts
@@ -32,8 +32,6 @@ import {
   containsCircles,
   containsCircleRectlike,
   containsRectlikeCircle,
-  containsSquareCircle,
-  containsSquareLinelike,
   containsAABBs,
 } from "contrib/ConstraintsUtils";
 import { VarAD } from "types/ad";
@@ -202,12 +200,8 @@ const constrDictGeneral = {
       return containsCircles([t1, s1], [t2, s2], constOfIf(padding));
     else if (t1 === "Circle" && shapedefs[t2].isRectlike)
       return containsCircleRectlike([t1, s1], [t2, s2], constOfIf(padding));
-    else if (shapedefs[t1].isRectlike && t1 !== "Square" && t2 === "Circle")
+    else if (shapedefs[t1].isRectlike && t2 === "Circle")
       return containsRectlikeCircle([t1, s1], [t2, s2], constOfIf(padding));
-    else if (t1 === "Square" && t2 === "Circle")
-      return containsSquareCircle([t1, s1], [t2, s2], constOfIf(padding));
-    else if (t1 === "Square" && shapedefs[t2].isLinelike)
-      return containsSquareLinelike([t1, s1], [t2, s2], constOfIf(padding));
     else
       return containsAABBs([t1, s1], [t2, s2], constOfIf(padding));
   },

--- a/packages/core/src/contrib/Constraints.ts
+++ b/packages/core/src/contrib/Constraints.ts
@@ -177,7 +177,7 @@ const constrDictGeneral = {
       return overlappingRectlikeCircle([t1, s1], [t2, s2], constOfIf(padding));
     else if (t1 === "Circle" && shapedefs[t2].isRectlike)
       return overlappingRectlikeCircle([t2, s2], [t1, s1], constOfIf(padding));
-    // Rectlike x Circle
+    // Circle x Line
     else if (t1 === "Circle" && t2 === "Line")
       return overlappingCircleLine([t1, s1], [t2, s2], constOfIf(padding));
     else if (t1 === "Line" && t2 === "Circle")

--- a/packages/core/src/contrib/ConstraintsUtils.ts
+++ b/packages/core/src/contrib/ConstraintsUtils.ts
@@ -21,6 +21,13 @@ import {
 import { shapeCenter, bboxFromShape } from "contrib/Queries";
 import { VarAD } from "types/ad";
 import * as BBox from "engine/BBox";
+import { Circle } from "shapes/Circle";
+import { Polygon } from "shapes/Polygon";
+import { Rectangle } from "shapes/Rectangle";
+import { Text } from "shapes/Text";
+import { Equation } from "shapes/Equation";
+import { Image } from "shapes/Image";
+import { Line } from "shapes/Line";
 
 // -------- Ovelapping helpers
 
@@ -28,8 +35,8 @@ import * as BBox from "engine/BBox";
  * Require that shape `s1` overlaps shape `s2` with some padding `padding`.
  */
 export const overlappingLines = (
-  [, s1]: [string, any],
-  [, s2]: [string, any],
+  [, s1]: [string, Line],
+  [, s2]: [string, Line],
   padding: VarAD = constOf(0.0)
 ): VarAD => {
   const oneSimplex1 = { points: { contents: [s1.start.contents, s1.end.contents] } };
@@ -41,8 +48,8 @@ export const overlappingLines = (
  * Require that shape `s1` overlaps shape `s2` with some padding `padding`.
  */
 export const overlappingCircles = (
-  [t1, s1]: [string, any],
-  [t2, s2]: [string, any],
+  [t1, s1]: [string, Circle],
+  [t2, s2]: [string, Circle],
   padding: VarAD = constOf(0.0)
 ): VarAD => {
   const d = ops.vdist(shapeCenter([t1, s1]), shapeCenter([t2, s2]));
@@ -54,8 +61,8 @@ export const overlappingCircles = (
  * Require that shape `s1` overlaps shape `s2` with some padding `padding`.
  */
 export const overlappingPolygons = (
-  [, s1]: [string, any],
-  [, s2]: [string, any],
+  [, s1]: [string, Polygon],
+  [, s2]: [string, Polygon],
   padding: VarAD = constOf(0.0)
 ): VarAD => {
   const cp1 = convexPartitions(s1.points.contents);
@@ -70,9 +77,9 @@ export const overlappingPolygons = (
 /**
  * Require that shape `s1` overlaps shape `s2` with some padding `padding`.
  */
- export const overlappingRectlikeCircle = (
-  [t1, s1]: [string, any],
-  [t2, s2]: [string, any],
+export const overlappingRectlikeCircle = (
+  [t1, s1]: [string, Rectangle | Text | Equation | Image],
+  [t2, s2]: [string, Circle],
   padding: VarAD = constOf(0.0)
 ): VarAD => {
   const s1BBox = bboxFromShape([t1, s1]);
@@ -126,8 +133,8 @@ export const overlappingAABBs = (
  * Require that a shape `s1` contains another shape `s2`.
  */
 export const containsCircles = (
-  [t1, s1]: [string, any],
-  [t2, s2]: [string, any],
+  [t1, s1]: [string, Circle],
+  [t2, s2]: [string, Circle],
   padding: VarAD = constOf(0.0)
 ): VarAD => {
   const d = ops.vdist(shapeCenter([t1, s1]), shapeCenter([t2, s2]));
@@ -142,8 +149,8 @@ export const containsCircles = (
  * Require that a shape `s1` contains another shape `s2`.
  */
 export const containsCircleRectlike = (
-  [t1, s1]: [string, any],
-  [t2, s2]: [string, any],
+  [t1, s1]: [string, Circle],
+  [t2, s2]: [string, Rectangle | Text | Equation | Image],
   padding: VarAD = constOf(0.0)
 ): VarAD => {
   // TODO: Remake using Minkowski penalties
@@ -157,8 +164,8 @@ export const containsCircleRectlike = (
  * Require that a shape `s1` contains another shape `s2`.
  */
 export const containsRectlikeCircle = (
-  [, s1]: [string, any],
-  [, s2]: [string, any],
+  [, s1]: [string, Rectangle | Text | Equation | Image],
+  [, s2]: [string, Circle],
   padding: VarAD = constOf(0.0)
 ): VarAD => {
   // TODO: Remake using Minkowski penalties

--- a/packages/core/src/contrib/ConstraintsUtils.ts
+++ b/packages/core/src/contrib/ConstraintsUtils.ts
@@ -7,7 +7,6 @@ import {
   ops,
   sub,
   mul,
-  div,
   min,
   max,
   minN,
@@ -22,7 +21,6 @@ import {
 import { shapeCenter, bboxFromShape } from "contrib/Queries";
 import { VarAD } from "types/ad";
 import * as BBox from "engine/BBox";
-import { linePts } from "utils/OtherUtils";
 
 // -------- Ovelapping helpers
 
@@ -105,7 +103,6 @@ export const overlappingAABBsMinkowski = (
   return sub(e1, e2);
 };
 
-
 /**
  * Require that shape `s1` overlaps shape `s2` with some padding `padding`.
  * To be DEPRACATED - replace by `overlappingAABBsMinkowski` after issue #652.
@@ -184,44 +181,6 @@ export const containsRectlikeCircle = (
     sub(absVal(sub(cx, rx)), sub(sub(halfW, r), padding)),
     sub(absVal(sub(cy, ry)), sub(sub(halfH, r), padding))
   );
-};
-
-/**
- * Require that a shape `s1` contains another shape `s2`.
- */
-export const containsSquareCircle = (
-  [, s1]: [string, any],
-  [t2, s2]: [string, any],
-  padding: VarAD = constOf(0.0)
-): VarAD => {
-  // TODO: Remake using Minkowski penalties
-
-  // dist (outerx, outery) (innerx, innery) - (0.5 * outer.side - inner.radius)
-  const sq = s1.center.contents;
-  const d = ops.vdist(sq, shapeCenter([t2, s2]));
-  return sub(d, sub(mul(constOf(0.5), s1.side.contents), s2.r.contents));
-};
-
-/**
- * Require that a shape `s1` contains another shape `s2`.
- */
-export const containsSquareLinelike = (
-  [t1, s1]: [string, any],
-  [, s2]: [string, any],
-  padding: VarAD = constOf(0.0)
-): VarAD => {
-  // TODO: Remake using Minkowski penalties
-  const [[startX, startY], [endX, endY]] = linePts(s2);
-  const [x, y] = shapeCenter([t1, s1]);
-  const r = div(s1.side.contents, constOf(2.0));
-  const [lx, ly] = [mul(sub(x, r), padding), mul(sub(y, r), padding)];
-  const [rx, ry] = [mul(add(x, r), padding), mul(add(y, r), padding)];
-  return addN([
-    mul(sub(startX, lx), sub(startX, rx)),
-    mul(sub(startY, ly), sub(startY, ry)),
-    mul(sub(endX, lx), sub(endX, rx)),
-    mul(sub(endY, ly), sub(endY, ry))
-  ]);
 };
 
 /**

--- a/packages/core/src/contrib/ConstraintsUtils.ts
+++ b/packages/core/src/contrib/ConstraintsUtils.ts
@@ -106,6 +106,28 @@ export const overlappingPolygonLinelike = (
 /**
  * Require that shape `s1` overlaps shape `s2` with some padding `padding`.
  */
+export const overlappingRectlikeLinelike = (
+  [t1, s1]: [string, Rectangle | Text | Equation | Image],
+  [t2, s2]: [string, Line],
+  padding: VarAD = constOf(0.0)
+): VarAD => {
+  // Treat Rectlike object as a polygon
+  const bbox = bboxFromShape([t1, s1]);
+  const corners = BBox.corners(bbox);
+  const rectPoints = [
+    corners.topRight, 
+    corners.topLeft, 
+    corners.bottomLeft, 
+    corners.bottomRight
+  ];
+  // Treat line segment as a degenerate polygon (1-simplex)
+  const oneSimplexPoints = [s2.start.contents, s2.end.contents];
+  return overlappingPolygonPoints(rectPoints, oneSimplexPoints, padding);
+};
+
+/**
+ * Require that shape `s1` overlaps shape `s2` with some padding `padding`.
+ */
 export const overlappingAABBsMinkowski = (
   [t1, s1]: [string, any],
   [t2, s2]: [string, any],

--- a/packages/core/src/contrib/ConstraintsUtils.ts
+++ b/packages/core/src/contrib/ConstraintsUtils.ts
@@ -130,8 +130,8 @@ export const overlappingRectlikeLinelike = (
  * Require that shape `s1` overlaps shape `s2` with some padding `padding`.
  */
 export const overlappingCircleLine = (
-  [t1, s1]: [string, any],
-  [t2, s2]: [string, any],
+  [t1, s1]: [string, Circle],
+  [t2, s2]: [string, Line],
   padding: VarAD = constOf(0.0)
 ): VarAD => {
   // collect constants

--- a/packages/core/src/contrib/Minkowski.ts
+++ b/packages/core/src/contrib/Minkowski.ts
@@ -141,3 +141,23 @@ export const convexPartitions = (p: VarAD[][]): VarAD[][][] => {
   // See e.g.: https://doc.cgal.org/Manual/3.2/doc_html/cgal_manual/Partition_2/Chapter_main.html#Section_9.3
   return [p];
 };
+
+/**
+ * Overlapping constraint function for polygon points with padding `padding`.
+ * @param polygonPoints1 Sequence of points defining a polygon.
+ * @param polygonPoints2 Sequence of points defining a polygon.
+ * @param padding Padding applied to one of the polygons.
+ */
+export const overlappingPolygonPoints = (
+  polygonPoints1: VarAD[][],
+  polygonPoints2: VarAD[][],
+  padding: VarAD = constOf(0.0)
+): VarAD => {
+  const cp1 = convexPartitions(polygonPoints1);
+  const cp2 = convexPartitions(polygonPoints2.map((p: VarAD[]) => ops.vneg(p)));
+  return maxN(
+    cp1.map((p1) => minN(
+      cp2.map((p2) => convexPolygonMinkowskiSDF(p1, p2, padding))
+    ))
+  );
+};


### PR DESCRIPTION
# Description

Related PRs: #648, #751 and #791

Added constraints for `Linelike`x`Polygon` and `Linelike`x`Rectlike` shape combinations. Added shape typing to `ConstraintsUtils.ts`. Unified Minkowski penalties interface for polygons.

# Checklist

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] My code follows the style guidelines of this project (e.g.: no ESLint warnings)