### PR TITLE
feat: Exterior algebra

### DIFF
--- a/examples/exterior-algebra/exterior-algebra.dsl
+++ b/examples/exterior-algebra/exterior-algebra.dsl
@@ -2,8 +2,8 @@ type Scalar
 
 type kVector
 type Vector <: kVector
-type biVector <: kVector
+type Bivector <: kVector
 
 function Scale( Scalar, Vector ) -> Vector
 function Add( Vector, Vector ) -> Vector
-function Wedge( Vector, Vector ) -> biVector
+function Wedge( Vector, Vector ) -> Bivector

--- a/examples/exterior-algebra/exterior-algebra.dsl
+++ b/examples/exterior-algebra/exterior-algebra.dsl
@@ -1,0 +1,9 @@
+type Scalar
+
+type kVector
+type Vector <: kVector
+type biVector <: kVector
+
+function Scale( Scalar, Vector ) -> Vector
+function Add( Vector, Vector ) -> Vector
+function Wedge( Vector, Vector ) -> biVector

--- a/examples/exterior-algebra/exterior-algebra.dsl
+++ b/examples/exterior-algebra/exterior-algebra.dsl
@@ -1,9 +1,13 @@
 type Scalar
 
+-- define vectors and bivectors as subtypes of a base k-vector type
 type kVector
 type Vector <: kVector
 type Bivector <: kVector
 
+-- some basic operations on k-vectors
 function Scale( Scalar, Vector ) -> Vector
 function Add( Vector, Vector ) -> Vector
 function Wedge( Vector, Vector ) -> Bivector
+
+-- (more can be added here ) --

--- a/examples/exterior-algebra/exterior-algebra.sty
+++ b/examples/exterior-algebra/exterior-algebra.sty
@@ -56,15 +56,22 @@ where v has label {
       fontSize: Global.fontSize
       fontFamily: Global.fontFamily
    }
+   -- keep the label on the canvas
+   ensure contains( Global.box, v.labelText )
 }
 
-forall biVector w; Vector u; Vector v
+forall Bivector w; Vector u; Vector v
 where w := Wedge(u,v) {
+
+   -- pick a random brightly-saturated color for this bivector
+   scalar w.hue = ?
+   color w.solidColor = hsva( w.hue, 100, 80, 1 )
+   color w.clearColor = hsva( w.hue, 100, 80, .2 )
 
    -- draw a parallelogram with sides u,v
    shape w.icon = Path {
       d: pathFromPoints("closed", [ (0,0), u.p, u.p+v.p, v.p ])
-      fillColor: Colors.clearGreen
+      fillColor: w.clearColor
       strokeColor: none()
    }
    -- keep the parallelogram on the canvas
@@ -89,10 +96,11 @@ where w := Wedge(u,v) {
    scalar R = .75 * minWidth/2. -- radius
    vec2 x0 = w.c + R*unit(u.p-v.p) -- arc start
    vec2 x1 = w.c + R*unit(v.p-u.p) -- arc end
+   scalar cw = .5*sign( cross2D(u.p,v.p) ) + .5 -- clockwise (1) or not (0)
    shape w.marker = Path {
-      d: arc( "open", x0, x1, (R,R), 0., 0, 0 )
+      d: arc( "open", x0, x1, (R,R), 0., 0, cw )
       fillColor: none()
-      strokeColor: Colors.darkGreen
+      strokeColor: w.solidColor
       strokeWidth: .75*Global.lineThickness
       startArrowhead: true
       arrowheadSize: .5
@@ -100,12 +108,12 @@ where w := Wedge(u,v) {
 }
 
 -- draw a label for the bivector if it has one
-forall biVector v
+forall Bivector w
 where v has label {
-   v.labelText = Equation {
-      string: v.label
-      center: v.c -- marker center
-      fillColor: Colors.darkGreen
+   w.labelText = Equation {
+      string: w.label
+      center: w.c -- marker center
+      fillColor: w.solidColor
       fontSize: Global.fontSize
       fontFamily: Global.fontFamily
    }

--- a/examples/exterior-algebra/exterior-algebra.sty
+++ b/examples/exterior-algebra/exterior-algebra.sty
@@ -1,0 +1,113 @@
+canvas {
+   width = 240
+   height = 180
+}
+
+Colors {
+   color black = rgba(0,0,0,1)
+   color white = rgba(1,1,1,1)
+   color clearGray = rgba(0,0,0,.2)
+   color clearGreen = rgba(0,.6,0,.2)
+   color darkGreen = rgba(0,.6,0,1.)
+}
+
+Global {
+   shape box = Rectangle {
+      center: (0,0)
+      width: canvas.width
+      height: canvas.height
+      fillColor: none()
+      strokeColor: Colors.clearGray
+      strokeWidth: 1
+   }
+
+   scalar lineThickness = 1.5
+   scalar fontSize = "6pt"
+   string fontFamily = "Linux Libertine"
+}
+
+forall Vector v {
+
+   -- declare a point whose location will be
+   -- determined via optimization
+   v.p = (?,?)
+
+   -- draw an arrow to p
+   v.icon = Line {
+      start: (0,0)
+      end: v.p
+      strokeColor: Colors.black
+      strokeWidth: Global.lineThickness
+      strokeLineCap: "round"
+      endArrowhead: true
+      arrowheadSize: .5
+   }
+   -- keep the arrow on the canvas
+   ensure contains( Global.box, v.icon)
+}
+
+-- draw a label for the vector if it has one
+forall Vector v
+where v has label {
+   v.labelText = Equation {
+      string: v.label
+      center: v.p + 4.*unit(v.p)
+      fillColor: Colors.black
+      fontSize: Global.fontSize
+      fontFamily: Global.fontFamily
+   }
+}
+
+forall biVector w; Vector u; Vector v
+where w := Wedge(u,v) {
+
+   -- draw a parallelogram with sides u,v
+   shape w.icon = Path {
+      d: pathFromPoints("closed", [ (0,0), u.p, u.p+v.p, v.p ])
+      fillColor: Colors.clearGreen
+      strokeColor: none()
+   }
+   -- keep the parallelogram on the canvas
+   ensure contains( Global.box, w.icon )
+
+   -- try to make sure the parallelogram is a reasonable size
+   scalar area = abs( cross2D( u.p, v.p ))
+   scalar canvasArea = canvas.width * canvas.height
+   encourage greaterThan( area, canvasArea/10. )
+
+   -- compute the minimum width of the parallelogram
+   -- by projecting each vector onto the unit normal
+   -- of the other
+   vec2 nu = unit( rot90(u.p) )
+   vec2 nv = unit( rot90(v.p) )
+   scalar wu = abs( dot( nu, v.p ))
+   scalar wv = abs( dot( nv, u.p ))
+   scalar minWidth = min( wu, wv )
+
+   -- draw an orientation marker
+   scalar w.c = (u.p+v.p)/2. -- center
+   scalar R = .75 * minWidth/2. -- radius
+   vec2 x0 = w.c + R*unit(u.p-v.p) -- arc start
+   vec2 x1 = w.c + R*unit(v.p-u.p) -- arc end
+   shape w.marker = Path {
+      d: arc( "open", x0, x1, (R,R), 0., 0, 0 )
+      fillColor: none()
+      strokeColor: Colors.darkGreen
+      strokeWidth: .75*Global.lineThickness
+      startArrowhead: true
+      arrowheadSize: .5
+   }
+}
+
+-- draw a label for the bivector if it has one
+forall biVector v
+where v has label {
+   v.labelText = Equation {
+      string: v.label
+      center: v.c -- marker center
+      fillColor: Colors.darkGreen
+      fontSize: Global.fontSize
+      fontFamily: Global.fontFamily
+   }
+}
+

--- a/examples/exterior-algebra/exterior-algebra.sty
+++ b/examples/exterior-algebra/exterior-algebra.sty
@@ -1,17 +1,20 @@
+-- define the size of the drawing
 canvas {
    width = 240
    height = 180
 }
 
+-- define some colors re-used throughout
 Colors {
    color black = rgba(0,0,0,1)
    color white = rgba(1,1,1,1)
    color clearGray = rgba(0,0,0,.2)
-   color clearGreen = rgba(0,.6,0,.2)
-   color darkGreen = rgba(0,.6,0,1.)
 }
 
 Global {
+
+   -- draw a box around the canvas (this box will 
+   -- also be used to constrain shapes to the canvas)
    shape box = Rectangle {
       center: (0,0)
       width: canvas.width
@@ -21,11 +24,15 @@ Global {
       strokeWidth: 1
    }
 
+   -- some additional parameters to get consistent styling throughout
    scalar lineThickness = 1.5
    scalar fontSize = "6pt"
    string fontFamily = "Linux Libertine"
 }
 
+-- for each Vector declared in the .sub program, this match will
+-- get executed once to draw a little widget for that vector, and
+-- set up any associated constraints
 forall Vector v {
 
    -- declare a point whose location will be
@@ -60,10 +67,14 @@ where v has label {
    ensure contains( Global.box, v.labelText )
 }
 
+-- draw a bivector that has been defined as the wedge of two
+-- vectors as a little parallelogram
 forall Bivector w; Vector u; Vector v
 where w := Wedge(u,v) {
 
    -- pick a random brightly-saturated color for this bivector
+   -- (these colors will be re-used in subsequent rules, which
+   -- why we define them up-front and associate them with w)
    scalar w.hue = ?
    color w.solidColor = hsva( w.hue, 100, 80, 1 )
    color w.clearColor = hsva( w.hue, 100, 80, .2 )

--- a/examples/exterior-algebra/exterior-algebra.sub
+++ b/examples/exterior-algebra/exterior-algebra.sub
@@ -1,0 +1,7 @@
+Vector a, b, c
+biVector u := Wedge(a,b)
+biVector v := Wedge(b,c)
+
+AutoLabel All
+Label u $a \wedge b$
+Label v $b \wedge c$

--- a/examples/exterior-algebra/exterior-algebra.sub
+++ b/examples/exterior-algebra/exterior-algebra.sub
@@ -1,6 +1,6 @@
 Vector a, b, c
-biVector u := Wedge(a,b)
-biVector v := Wedge(b,c)
+Bivector u := Wedge(a,b)
+Bivector v := Wedge(b,c)
 
 AutoLabel All
 Label u $a \wedge b$

--- a/examples/exterior-algebra/run
+++ b/examples/exterior-algebra/run
@@ -1,0 +1,2 @@
+npx roger watch exterior-algebra.sub exterior-algebra.sty exterior-algebra.dsl
+

--- a/util/vim/syntax/sty.vim
+++ b/util/vim/syntax/sty.vim
@@ -21,7 +21,7 @@ syn keyword styTodo TODO FIXME XXX NOTE
 syn match styComment "--.*$" contains=styTodo,@Spell
 
 " Types and values
-syn keyword styTypes scalar rgba vec2 vec3 constraint objective
+syn keyword styTypes scalar color rgba vec2 vec3 constraint objective
 syn match styString "\"[^"]*\""
 
 " Highlight as a keyword only if preceded by

--- a/util/vim/syntax/sty.vim
+++ b/util/vim/syntax/sty.vim
@@ -21,7 +21,7 @@ syn keyword styTodo TODO FIXME XXX NOTE
 syn match styComment "--.*$" contains=styTodo,@Spell
 
 " Types and values
-syn keyword styTypes scalar rgba vec2 vec3
+syn keyword styTypes scalar rgba vec2 vec3 constraint objective
 syn match styString "\"[^"]*\""
 
 " Highlight as a keyword only if preceded by

--- a/util/vim/syntax/sub.vim
+++ b/util/vim/syntax/sub.vim
@@ -8,7 +8,7 @@ if exists("b:current_syntax")
 endif
 
 " Keywords
-syn keyword subKeywords Label AutoLabel All None
+syn keyword subKeywords Label AutoLabel NoLabel All None
 
 " Comments
 syn keyword subTodo TODO FIXME XXX NOTE


### PR DESCRIPTION
# Description

Adds a stub of a domain for depicting operations on k-vectors from [exterior algebra](https://en.wikipedia.org/wiki/Exterior_algebra) (also known as Grassmann algebra, which is a building block for [Clifford algebra](https://en.wikipedia.org/wiki/Clifford_algebra), [geometric algebra](https://en.wikipedia.org/wiki/Geometric_algebra), and [exterior calculus](https://en.wikipedia.org/wiki/Exterior_calculus)).

**Example:**

![image](https://user-images.githubusercontent.com/3604525/148968810-b9e8b623-166e-446f-93e8-c2b904b3bae2.png)

# Checklist

- [X] I have commented my code, particularly in hard-to-understand areas
- [X] My changes generate no new warnings
- [X] My code follows the style guidelines of this project (e.g.: no ESLint warnings)
