### PR TITLE
ci: Enforce no ESLint errors

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,6 +28,16 @@ jobs:
         name: Publish canary release
         run: yarn publish:canary --yes
 
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Install packages
+        uses: ./.github/actions/packages
+      - name: Lint
+        run: yarn lint
+
   storybook:
     runs-on: ubuntu-latest
     defaults:

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "build:ide": "lerna run build --stream --scope=@penrose/core --scope=@penrose/panels",
     "test": "lerna run test --stream",
     "docs": "lerna run docs --stream",
+    "lint": "lerna run lint --stream",
     "lerna": "lerna",
     "new-version": "lerna version --conventional-commits --create-release github -m \"chore(release): publish %s [ci skip]\"",
     "new-version:prerelease": "lerna version --conventional-prerelease",

--- a/packages/core/.eslintrc.js
+++ b/packages/core/.eslintrc.js
@@ -37,5 +37,10 @@ module.exports = {
     "import/no-cycle": 2,
     "no-fallthrough": 2,
   },
-  ignorePatterns: ["**/*.test.ts", "**/*.test.tsx"],
+  ignorePatterns: [
+    "**/*.input.ts",
+    "**/*.output.ts",
+    "**/*.test.ts",
+    "**/*.test.tsx",
+  ],
 };

--- a/packages/core/.eslintrc.js
+++ b/packages/core/.eslintrc.js
@@ -38,9 +38,12 @@ module.exports = {
     "no-fallthrough": 2,
   },
   ignorePatterns: [
-    "**/*.input.ts",
-    "**/*.output.ts",
     "**/*.test.ts",
     "**/*.test.tsx",
+    "src/__testfixtures__/transformtest.input.ts",
+    "src/__testfixtures__/transformtest.output.ts",
+    "src/parser/DomainParser.ts",
+    "src/parser/StyleParser.ts",
+    "src/parser/SubstanceParser.ts",
   ],
 };

--- a/packages/core/src/engine/EngineUtils.ts
+++ b/packages/core/src/engine/EngineUtils.ts
@@ -897,6 +897,7 @@ export const findExpr = (
         case "FExpr":
           return fieldExpr.contents;
       }
+      break; // dead code to please ESLint
     }
 
     case "PropertyPath": {
@@ -935,6 +936,7 @@ export const findExpr = (
           return propRes;
         }
       }
+      break; // dead code to please ESLint
     }
 
     case "AccessPath": {

--- a/packages/core/src/engine/Evaluator.ts
+++ b/packages/core/src/engine/Evaluator.ts
@@ -416,12 +416,13 @@ export const evalExpr = (
               contents: argVals.map(toVecVal),
             } as ILListV<VarAD>,
           };
+        } else {
+          throw Error("unknown tag");
         }
       } else {
         console.error("list elems", argVals);
         throw Error("unsupported element in list");
       }
-      break; // dead code to please ESLint
     }
 
     case "ListAccess": {

--- a/packages/core/src/engine/Evaluator.ts
+++ b/packages/core/src/engine/Evaluator.ts
@@ -421,6 +421,7 @@ export const evalExpr = (
         console.error("list elems", argVals);
         throw Error("unsupported element in list");
       }
+      break; // dead code to please ESLint
     }
 
     case "ListAccess": {

--- a/packages/core/src/renderer/Staging.ts
+++ b/packages/core/src/renderer/Staging.ts
@@ -60,7 +60,7 @@ const getStateFromObjArrAndLocalState = (
   arr: StringObjPair[],
   state: State
 ): State => {
-  let shapeNamesToInclude = arr.map((elem) => {
+  const shapeNamesToInclude = arr.map((elem) => {
     return elem[0];
   });
 

--- a/packages/core/src/utils/Error.ts
+++ b/packages/core/src/utils/Error.ts
@@ -375,6 +375,7 @@ canvas {
         case "wrong type":
           return `Canvas ${error.attr} must be a numeric literal, but it has type ${error.type}.`;
       }
+      break; // dead code to please ESLint
     }
 
     // ----- END TRANSLATION VALIDATION ERRORS


### PR DESCRIPTION
# Description

This PR does the following:

- Add a `lint` script to our root `package.json` which runs `lint` in any packages that include it (currently just `core` and `browser-ui`, both of which just run ESLint)
- Add a `lint` job to our Build workflow in CI which runs `yarn lint`
- Eliminate all ESLint _errors_, so the `lint` job passes

# Checklist

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new ESLint warnings

# Open questions

- Get rid of ESLint _warnings_ too