### PR TITLE
ci: Add a nice message about how to run Prettier

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -36,7 +36,17 @@ jobs:
       - name: Install packages
         uses: ./.github/actions/packages
       - name: Format
-        run: yarn format:check
+        run: |
+          if ! yarn format:check; then
+            echo
+            echo 'Run this command from the repository root:'
+            echo
+            echo '    yarn format'
+            echo
+            echo 'Then commit and push to re-run CI.'
+            echo
+            false
+          fi
 
   lint:
     runs-on: ubuntu-latest

--- a/packages/browser-ui/src/inspector/views/CompGraph.tsx
+++ b/packages/browser-ui/src/inspector/views/CompGraph.tsx
@@ -111,8 +111,9 @@ const CompGraph: React.FC<IViewProps> = ({
 
   const [value, setValue] = React.useState("none"); // init value of state to use
 
-  const graphRef: React.RefObject<HTMLDivElement> =
-    React.useRef<HTMLDivElement>(null);
+  const graphRef: React.RefObject<HTMLDivElement> = React.useRef<HTMLDivElement>(
+    null
+  );
 
   React.useEffect(() => {
     if (graphRef.current !== null) {

--- a/packages/browser-ui/src/inspector/views/CompGraph.tsx
+++ b/packages/browser-ui/src/inspector/views/CompGraph.tsx
@@ -111,9 +111,8 @@ const CompGraph: React.FC<IViewProps> = ({
 
   const [value, setValue] = React.useState("none"); // init value of state to use
 
-  const graphRef: React.RefObject<HTMLDivElement> = React.useRef<HTMLDivElement>(
-    null
-  );
+  const graphRef: React.RefObject<HTMLDivElement> =
+    React.useRef<HTMLDivElement>(null);
 
   React.useEffect(() => {
     if (graphRef.current !== null) {


### PR DESCRIPTION
This PR adds a message when our `format` job fails in CI, to tell people how to run Prettier locally. Example: https://github.com/penrose/penrose/runs/4820765638?check_suite_focus=true

```
yarn run v1.22.17
$ prettier . --check
Checking formatting...
[warn] packages/browser-ui/src/inspector/views/CompGraph.tsx
[warn] Code style issues found in the above file(s). Forgot to run Prettier?
error Command failed with exit code 1.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.

Run this command from the repository root:

    yarn format

Then commit and push to re-run CI.

Error: Process completed with exit code 1.
```