### PR TITLE
fix: circle-rectangle interactions

### DIFF
--- a/packages/core/src/contrib/ConstraintsUtils.ts
+++ b/packages/core/src/contrib/ConstraintsUtils.ts
@@ -89,11 +89,11 @@ export const overlappingRectlikeCircle = (
   const box1 = bboxFromShape([t1, s1]);
   const box2 = bboxFromShape([t2, s2]);
   // Get the Minkowski difference of inner rectangle
-  const innerPadding = sub(padding, box2.width);
+  const innerPadding = sub(padding, s2.r.contents);
   const [bottomLeft, topRight] = rectangleDifference(box1, box2, innerPadding);
   // Return the signed distance
   const innerSDF = rectangleSignedDistance(bottomLeft, topRight);
-  return sub(innerSDF, box2.width);
+  return sub(innerSDF, s2.r.contents);
 };
 
 /**

--- a/packages/core/src/contrib/__testfixtures__/TestShapes.input.ts
+++ b/packages/core/src/contrib/__testfixtures__/TestShapes.input.ts
@@ -33,6 +33,7 @@ export const _circles = [
   { center: [0, 0], r: 100 },
   { center: [200, 0], r: 100 },
   { center: [0, 300], r: 100 },
+  { center: [0, 200], r: 100 },
 ].map((x) =>
   makeCircle(canvas, {
     r: FloatV(constOf(x.r)),

--- a/packages/core/src/contrib/__tests__/Constraints.test.ts
+++ b/packages/core/src/contrib/__tests__/Constraints.test.ts
@@ -225,7 +225,13 @@ describe("general constraints", () => {
     ["Rectangle", "Line", 150, _rectangles[0], _lines[2]],
     ["Rectangle", "Polygon", 150, _rectangles[3], _polygons[1]],
     ["Rectangle", "Polygon", 150, _rectangles[1], _polygons[2]],
-    ["Circle", "Rectangle", 100 * (Math.SQRT2 - 1) / Math.SQRT2 + 10, _circles[4], _rectangles[2]],
+    [
+      "Circle",
+      "Rectangle",
+      (100 * (Math.SQRT2 - 1)) / Math.SQRT2 + 10,
+      _circles[4],
+      _rectangles[2],
+    ],
   ])(
     "overlapping %p and %p with padding %p",
     (
@@ -322,7 +328,13 @@ describe("general constraints", () => {
     ["Circle", "Rectangle", 100, _circles[1], _rectangles[3]],
     ["Circle", "Circle", 100, _circles[1], _circles[3]],
     ["Line", "Line", 100, _lines[1], _lines[2]],
-    ["Circle", "Rectangle", 100 * (Math.SQRT2 - 1) / Math.SQRT2, _circles[4], _rectangles[2]],
+    [
+      "Circle",
+      "Rectangle",
+      (100 * (Math.SQRT2 - 1)) / Math.SQRT2,
+      _circles[4],
+      _rectangles[2],
+    ],
   ])(
     "touching %p and %p with padding %p",
     (

--- a/packages/core/src/contrib/__tests__/Constraints.test.ts
+++ b/packages/core/src/contrib/__tests__/Constraints.test.ts
@@ -225,6 +225,7 @@ describe("general constraints", () => {
     ["Rectangle", "Line", 150, _rectangles[0], _lines[2]],
     ["Rectangle", "Polygon", 150, _rectangles[3], _polygons[1]],
     ["Rectangle", "Polygon", 150, _rectangles[1], _polygons[2]],
+    ["Circle", "Rectangle", 100 * (Math.SQRT2 - 1) / Math.SQRT2 + 10, _circles[4], _rectangles[2]],
   ])(
     "overlapping %p and %p with padding %p",
     (
@@ -264,6 +265,7 @@ describe("general constraints", () => {
     ["Line", "Polygon", 0, _lines[0], _polygons[3]],
     ["Rectangle", "Polygon", 0, _rectangles[1], _polygons[3]],
     ["Rectangle", "Line", 0, _rectangles[2], _lines[2]],
+    ["Circle", "Rectangle", 0, _circles[3], _rectangles[2]],
     // With padding
     ["Rectangle", "Rectangle", 10, _rectangles[1], _rectangles[3]],
     ["Rectangle", "Circle", 10, _rectangles[1], _circles[3]],
@@ -320,8 +322,9 @@ describe("general constraints", () => {
     ["Circle", "Rectangle", 100, _circles[1], _rectangles[3]],
     ["Circle", "Circle", 100, _circles[1], _circles[3]],
     ["Line", "Line", 100, _lines[1], _lines[2]],
+    ["Circle", "Rectangle", 100 * (Math.SQRT2 - 1) / Math.SQRT2, _circles[4], _rectangles[2]],
   ])(
-    "%p and %p at distance %p",
+    "touching %p and %p with padding %p",
     (
       shapeType0: string,
       shapeType1: string,


### PR DESCRIPTION
# Description

Related issue/PR: #810

Fixing regression introduced by #810. Labels in example `examples/set-theory-domain` (`npx roger watch nested.sub venn.sty setTheory.dsl`) were not optimized correctly. This PR fixes the issue and adds test cases to `Constraints.test.ts`.

# Checklist

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new ESLint warnings
