### PR TITLE
fix: transform polygon/polyline points to screen space

### DIFF
--- a/packages/core/src/renderer/AttrHelper.ts
+++ b/packages/core/src/renderer/AttrHelper.ts
@@ -3,7 +3,7 @@
  * output SVG properties using the optimized shape properties as input.
  */
 
-import { IColorV, IFloatV, IVectorV, IStrV } from "types/value";
+import { IColorV, IFloatV, IVectorV, IStrV, IPtListV } from "types/value";
 import { Shape } from "types/shape";
 import { toSvgPaintProperty, toScreen, toSvgOpacityProperty } from "utils/Util";
 import { attrMapSvg } from "./AttrMapSvg";
@@ -334,4 +334,20 @@ export const attrFont = (shape: Shape, elem: SVGElement): string[] => {
     "fontWeight",
     "lineHeigh",
   ]; // Return array of input properties programatically mapped
+};
+
+/**
+ * Maps points -> points
+ */
+export const attrPolyPoints = (
+  shape: Shape,
+  canvasSize: [number, number],
+  elem: SVGElement
+): string[] => {
+  const points = shape.properties.points as IPtListV<number>;
+  const pointsTransformed = points.contents.map((p: number[]) =>
+    toScreen(p as [number, number], canvasSize)
+  );
+  elem.setAttribute("points", pointsTransformed.toString());
+  return ["points"];
 };

--- a/packages/core/src/renderer/Polygon.ts
+++ b/packages/core/src/renderer/Polygon.ts
@@ -1,6 +1,7 @@
 import {
   attrAutoFillSvg,
   attrFill,
+  attrPolyPoints,
   attrScale,
   attrStroke,
   attrTitle,
@@ -21,6 +22,7 @@ const Polygon = ({ shape, canvasSize }: ShapeProps): SVGPolygonElement => {
   attrToNotAutoMap.push(...attrStroke(shape, elem));
   attrToNotAutoMap.push(...attrTitle(shape, elem));
   attrToNotAutoMap.push(...attrScale(shape, elem));
+  attrToNotAutoMap.push(...attrPolyPoints(shape, canvasSize, elem));
 
   // Directrly Map across any "unknown" SVG properties
   attrAutoFillSvg(shape, elem, attrToNotAutoMap);

--- a/packages/core/src/renderer/Polyline.ts
+++ b/packages/core/src/renderer/Polyline.ts
@@ -4,6 +4,7 @@ import {
   attrTitle,
   attrAutoFillSvg,
   attrFill,
+  attrPolyPoints,
 } from "./AttrHelper";
 import { ShapeProps } from "./Renderer";
 
@@ -21,6 +22,7 @@ const Polyline = ({ shape, canvasSize }: ShapeProps): SVGPolylineElement => {
   attrToNotAutoMap.push(...attrStroke(shape, elem));
   attrToNotAutoMap.push(...attrTitle(shape, elem));
   attrToNotAutoMap.push(...attrScale(shape, elem));
+  attrToNotAutoMap.push(...attrPolyPoints(shape, canvasSize, elem));
 
   // Directrly Map across any "unknown" SVG properties
   attrAutoFillSvg(shape, elem, attrToNotAutoMap);

--- a/packages/core/src/shapes/Polygon.ts
+++ b/packages/core/src/shapes/Polygon.ts
@@ -1,12 +1,11 @@
 import { constOf } from "engine/Autodiff";
-import { INamed, IStroke, IFill, IScale, IPoly, IShape } from "types/shapes";
+import { IFill, INamed, IPoly, IScale, IShape, IStroke } from "types/shapes";
 import {
   Canvas,
   FloatV,
   PtListV,
   sampleColor,
   sampleNoPaint,
-  sampleStroke,
   sampleZero,
   StrV,
 } from "./Samplers";

--- a/packages/core/src/shapes/Polyline.ts
+++ b/packages/core/src/shapes/Polyline.ts
@@ -4,6 +4,7 @@ import {
   Canvas,
   FloatV,
   PtListV,
+  sampleBlack,
   sampleColor,
   sampleNoPaint,
   sampleStroke,
@@ -17,9 +18,9 @@ export const samplePolyline = (_canvas: Canvas): IPolyline => ({
   style: StrV(""),
   strokeWidth: FloatV(constOf(1)),
   strokeStyle: StrV("solid"),
-  strokeColor: sampleNoPaint(),
+  strokeColor: sampleBlack(),
   strokeDashArray: StrV(""),
-  fillColor: sampleColor(),
+  fillColor: sampleNoPaint(),
   scale: FloatV(constOf(1)),
   points: PtListV(
     [


### PR DESCRIPTION
# Description

Fixes: #724

The `points` property for `Polyline` and `Polygon` are currently passthrough properties. This PR adds `attrPolyPoints` for transforming a list of points to screen coordinates.

# Checklist

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new ESLint warnings

