### PR TITLE
fix: PointcareDisk.sty missing canvas def

### DIFF
--- a/examples/hyperbolic-domain/PoincareDisk.sty
+++ b/examples/hyperbolic-domain/PoincareDisk.sty
@@ -1,3 +1,8 @@
+canvas {
+   scalar width  = 533.
+   scalar height = 300.
+}
+
 Global {
    scalar width = 800.0
    scalar height = 700.0


### PR DESCRIPTION
# Description

In the hyperbolic domain example set, PointcareDisk.sty lacks a canvas definition.  This PR resolves that issue.

# Checklist

- [X] I have commented my code, particularly in hard-to-understand areas
- [X] My changes generate no new ESLint warnings
