### PR TITLE
feat: `maximal` and `minimal` objectives

### DIFF
--- a/packages/core/src/contrib/Objectives.ts
+++ b/packages/core/src/contrib/Objectives.ts
@@ -30,6 +30,16 @@ import { VarAD } from "types/ad";
 // Do not require shape quaries, operate directly with `VarAD` parameters.
 export const objDictSimple = {
   /**
+   * Encourage the input value to be close to negative infinity
+   */
+  minimal: (x: VarAD) => x,
+
+  /**
+   * Encourage the input value to be close to infinity
+   */
+  maximal: (x: VarAD) => neg(x),
+
+  /**
    * Encourage the inputs to have the same value: `(x - y)^2`
    */
   equal: (x: VarAD, y: VarAD) => squared(sub(x, y)),


### PR DESCRIPTION
# Description

@keenancrane mentioned a repeated pattern of `encourage equal(<some value>, 0)`. After some discussion, we decided to add `maximal` and `minimal` for sending single values to inf or -inf. This is similar to saying "minimize" and "maximize" in optimization problems.