### PR TITLE
fix: missing code in top-level `diagram` function

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -104,12 +104,15 @@ export const diagram = async (
   domainProg: string,
   subProg: string,
   styProg: string,
-  node: HTMLElement
+  node: HTMLElement,
+  pathResolver: PathResolver
 ): Promise<void> => {
   const res = compileTrio(domainProg, subProg, styProg);
   if (res.isOk()) {
     const state: State = await prepareState(res.value);
     const optimized = stepUntilConvergenceOrThrow(state);
+    const rendered = await RenderStatic(optimized, pathResolver);
+    node.appendChild(rendered);
   } else {
     throw Error(
       `Error when generating Penrose diagram: ${showError(res.error)}`


### PR DESCRIPTION
# Description

For some reason the `diagram` function in `index.ts` is missing a few line of code, perhaps a side-effect of refactoring. This PR adds the missing lines back.

# Checklist

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new ESLint warnings
