### PR TITLE
refactor: tweak linear algebra Style example

### DIFF
--- a/examples/linear-algebra-domain/linear-algebra-paper-simple.sty
+++ b/examples/linear-algebra-domain/linear-algebra-paper-simple.sty
@@ -1,6 +1,6 @@
 canvas {
-  width = 800
-  height = 700
+  width = 400
+  height = 500
 }
 
 const {
@@ -12,254 +12,215 @@ const {
   scalar repelWeight = 0.7
   scalar arrowheadSize = 0.7
   scalar lineThickness = 2.
-  int intForTesting = 1
-  bool boolForTesting = true
-
   string fontFamily = "Palatino"
   string fontSize = "22.5px"
 }
 
 C {
-    color black = rgba(0.,0.,0.,1.)
-    color white = rgba(1., 1., 1., 1.)
-    color lightBlue = rgba(1e-1, 0.1, 0.9, 1.0)
-    -- Note: we don't currently support color accessors r,g,b
-    -- darkBlue = rgba(lightBlue.r / 2., lightBlue.g / 2., lightBlue.b / 2., 0.5)
-    color darkGray = rgba(0.4, 0.4, 0.4, 1.)
-    color gray = rgba(0.6, 0.6, 0.6, 1.)
-    color green = rgba(0., 0.8, 0., 1.)
-    color none = none()
-}
-
--- Just some weird definitions to test parser. Not used in rest of program
-testing {
-  -- COMBAK: Test that plugins still run
-  -- pluginVar = "ddg"["a"]["length"]
-        x = { 1, {2, 3} }
-        y = [-2., const.perpLen, const.markerPadding + 3]
-        a = (-1.0, ?)
-        a1 = (-1.0, 2.) + (1e5, 2.0)
-        m = (a, (-1., 2.))
-        v = (a + (2., 900.))  / (4.0 + 3.)
-        -- z = Colors.black.g
-        asum = a[1] + a[0]
-        -- Currently not supported: indexing a vector or list by a variable
-        -- c = 0
-        -- b = 1
-        -- msum = m[1][0] + m[c][b]
-        nv = -v
-        -- t1 = x[1][b]
-
-        -- test parser access of matrix
-        -- test0 = f(0)[1]
-        -- test1 = makeMatrix((1, 0.0, 5.0), (-1, -9., -4.))[2][0]
-        -- test2 = (makeVector(-1, 3.0) + (3.4, 2.1))[0]
+  color black = rgba(0.,0.,0.,1.)
+  color white = rgba(1., 1., 1., 1.)
+  color lightBlue = rgba(1e-1, 0.1, 0.9, 1.0)
+  -- Note: we don't currently support color accessors r,g,b
+  -- darkBlue = rgba(lightBlue.r / 2., lightBlue.g / 2., lightBlue.b / 2., 0.5)
+  color darkGray = rgba(0.4, 0.4, 0.4, 1.)
+  color gray = rgba(0.6, 0.6, 0.6, 1.)
+  color green = rgba(0., 0.8, 0., 1.)
+  color none = none()
 }
 
 forall VectorSpace U {
-    scalar axisSize = const.vectorSpaceSize / 2.0 -- This should get promoted to float
-    vec2 U.origin = (0., 0.)
-    vec2 o = U.origin
-    color U.axisColor = C.gray
+  scalar axisSize = const.vectorSpaceSize / 2.0 -- This should get promoted to float
+  vec2 U.origin = (0., 0.)
+  vec2 o = U.origin
+  color U.axisColor = C.gray
 
-    shape U.background = Rectangle {
-        center : U.origin
-        width : const.vectorSpaceSize
-        height : const.vectorSpaceSize
-        fillColor : rgba(.95,.95,.95,1.)
-        strokeColor : C.none
-        -- strokeWidth : 2.0
-    }
+  shape U.background = Rectangle {
+    center : U.origin
+    width : const.vectorSpaceSize
+    height : const.vectorSpaceSize
+    fillColor : rgba(.95,.95,.95,1.)
+    strokeColor : C.none
+  }
 
-    shape U.xAxis = Line {
-        start : (o[0] - 1.1*axisSize, o[1]) -- TODO This gets mis-parsed as a matrix access
-          end : (o[0] + 1.1*axisSize, o[1])
-        strokeWidth : const.lineThickness
-        style : "solid"
-        strokeColor : U.axisColor
-        -- startArrowhead: true
-        -- endArrowhead: true
-        arrowheadSize : const.arrowheadSize * 2.
-    }
+  shape U.xAxis = Line {
+    start : (o[0] - 1.1*axisSize, o[1]) -- TODO This gets mis-parsed as a matrix access
+    end : (o[0] + 1.1*axisSize, o[1])
+    strokeWidth : const.lineThickness
+    style : "solid"
+    strokeColor : U.axisColor
+  --   startArrowhead: true
+  --   endArrowhead: true
+    arrowheadSize : const.arrowheadSize
+  }
 
-    shape U.yAxis = Line {
-           start : (o[0], o[1] - 1.1*axisSize)
-             end : (o[0], o[1] + 1.1*axisSize)
-       strokeWidth : const.lineThickness
-           style : "solid"
-           strokeColor : U.axisColor
-           -- startArrowhead: true
-           -- endArrowhead: true
-        arrowheadSize : const.arrowheadSize * 2.
-    }
+  shape U.yAxis = Line {
+    start : (o[0], o[1] - 1.1*axisSize)
+    end : (o[0], o[1] + 1.1*axisSize)
+    strokeWidth : const.lineThickness
+    style : "solid"
+    strokeColor : U.axisColor
+    -- startArrowhead: true
+    -- endArrowhead: true
+    arrowheadSize : const.arrowheadSize
+  }
 
-    shape U.text = Text {
-        fontSize : const.fontSize
-        fontFamily : const.fontFamily
-        fontStyle : "italic"
-        string : U.label
-        center : (U.origin[0] + .8*axisSize, U.origin[1] + .8*axisSize)
-        fillColor : U.axisColor
-    }
+  shape U.text = Text {
+    fontSize : const.fontSize
+    fontFamily : const.fontFamily
+    fontStyle : "italic"
+    string : U.label
+    center : (U.origin[0] + .8*axisSize, U.origin[1] + .8*axisSize)
+    fillColor : U.axisColor
+  }
 
-    layer U.xAxis above U.yAxis
-    layer U.background below U.yAxis
-    layer U.text above U.background
-    layer U.text below U.yAxis
+  layer U.xAxis above U.yAxis
+  layer U.background below U.yAxis
+  layer U.text above U.background
+  layer U.text below U.yAxis
 }
 
 forall Vector u; VectorSpace U
 where In(u,U) {
 
-   shape u.arrow = Line {
-      start : U.origin
-      end : (?, ?)
-      strokeWidth : 3.0
-      strokeColor : C.lightBlue
-      endArrowhead : true
-      arrowheadSize : const.arrowheadSize
-   }
+  shape u.arrow = Line {
+    start : U.origin
+    end : (?, ?)
+    strokeWidth : 3.0
+    strokeColor : C.lightBlue
+    endArrowhead : true
+    arrowheadSize : const.arrowheadSize
+  }
 
-   shape u.text = Text {
-      center: u.arrow.end * 1.15
-      fontSize: const.fontSize
-      fontFamily: const.fontFamily
-      fontWeight: "bold"
-      string: u.label
-      fillColor: u.arrow.strokeColor
-   }
+  shape u.text = Text {
+    center: u.arrow.end * 1.15
+    fontSize: const.fontSize
+    fontFamily: const.fontFamily
+    fontWeight: "bold"
+    string: u.label
+    fillColor: u.arrow.strokeColor
+  }
 
-   shape u.stroke = Text {
-      center: u.text.center
-      fontSize: u.text.fontSize
-      fontFamily: u.text.fontFamily
-      fontWeight: "bold"
-      string: u.label
-      fillColor: C.white
-      strokeColor: C.white
-      strokeWidth: 8.
-   }
+  shape u.stroke = Text {
+    center: u.text.center
+    fontSize: u.text.fontSize
+    fontFamily: u.text.fontFamily
+    fontWeight: "bold"
+    string: u.label
+    fillColor: C.white
+    strokeColor: C.white
+    strokeWidth: 8.
+  }
 
-   vec2 u.vector = u.arrow.end - u.arrow.start -- Vector sugar for subtraction
+  vec2 u.vector = u.arrow.end - u.arrow.start -- Vector sugar for subtraction
 
-   ensure contains(U.background, u.arrow)
-   --ensure contains(U.background, u.text)
-   --ensure atDist(u.arrow, u.text, 15.0)
-   ensure minSize(u.arrow)
+  ensure contains(U.background, u.arrow)
+  ensure contains(U.background, u.text)
+  ensure minSize(u.arrow)
 
-   layer u.stroke above u.arrow
-   layer u.arrow above U.xAxis
-   layer u.text above U.xAxis
-   layer u.text above U.yAxis
-   layer u.text above U.xAxis
+  layer u.stroke above u.arrow
+  layer u.arrow above U.xAxis
+  layer u.text above U.xAxis
+  layer u.text above U.yAxis
+  layer u.text above U.xAxis
 }
 
 -- draw all labels above all arrows, to improve legibility
 forall Vector u; Vector v {
-   layer u.stroke above v.arrow
-   layer v.stroke above u.arrow
+  layer u.stroke above v.arrow
+  layer v.stroke above u.arrow
 }
 
 forall Vector u; Vector v
 with VectorSpace U
 where Orthogonal(u, v); In(u, U); In(v, U) {
-      startR = u.arrow.start -- TODO: Do we want destructuring syntax like vec2[] [startR, endR] = [u.arrow.start, u.arrow.end]
-      endR = u.arrow.end
-      startL = v.arrow.start
-      endL = v.arrow.end
-      dirR = normalize(endR - startR)  -- Syntax sugar for vectors (better in Style because JS doesn't allow it!)
-      dirL = normalize(endL - startL)
-      ptL = startR + const.perpLen * dirL
-      ptR = startR + const.perpLen * dirR
-      ptLR = ptL + const.perpLen * dirR
-      pts = [startR, ptL, ptLR, ptR]
+  startR = u.arrow.start
+  endR = u.arrow.end
+  startL = v.arrow.start
+  endL = v.arrow.end
+  dirR = normalize(endR - startR)  
+  dirL = normalize(endL - startL)
+  ptL = startR + const.perpLen * dirL
+  ptR = startR + const.perpLen * dirR
+  ptLR = ptL + const.perpLen * dirR
+  pts = [startR, ptL, ptLR, ptR]
 
-      -- toPath = functions.pathFromPoints -- COMBAK: Add ability to alias function names
+  -- Draw perpendicular mark -- NOTE: local shapes should still be drawn
+  perpMark = Path {
+    d : pathFromPoints("closed", pts)
+    strokeWidth : 2.0
+    strokeColor : C.black
+    fillColor : C.white
+  }
 
-      -- Draw perpendicular mark -- NOTE: local shapes should still be drawn
-      perpMark = Path {
-           d : pathFromPoints("closed", pts)
-           strokeWidth : 2.0
-           strokeColor : C.black
-           fillColor : C.white
-      }
+  ensure equal(dot(u.vector, v.vector), 0.0) 
 
-      -- Make sure vectors are orthogonal (use ensure?)
-      -- eq = functions.equal
-      encourage equal(dot(u.vector, v.vector), 0.0) -- NOTE: Have to import Penrose fns
+  layer v.arrow above perpMark
+  layer u.arrow above perpMark
+  layer perpMark above U.xAxis
 
--- COMBAK: Test parsing the expressions that involve local vars 
-      layer v.arrow above perpMark
-      layer u.arrow above perpMark
-      layer perpMark above U.xAxis
-
-   shape labelText = Text {
-      string: "orthogonal"
-      center: (0.,-.6*V.background.width)
-      fontFamily: const.fontFamily
-      fontSize: "18px"
-      fontWeight: "bold"
-      fillColor: C.black
-   }
+  shape labelText = Text {
+    string: "orthogonal"
+    center: (0.,-.6*V.background.width)
+    fontFamily: const.fontFamily
+    fontSize: "18px"
+    fontWeight: "bold"
+    fillColor: C.black
+  }
 }
 
 forall Vector v
 with VectorSpace U; Vector w
 where In(v, U); Unit(v); Orthogonal(v, w) {
-      -- Usually, the unit vector shouldn't need to know about orthogonal vectors
-      -- but we need to position the unit mark so it doesn't overlap with the "inside" of the two vectors
+  -- Usually, the unit vector shouldn't need to know about orthogonal vectors
+  -- but we need to position the unit mark so it doesn't overlap with the "inside" of the two vectors
 
-      strokeWidth = 2.0
-      padding = 15.0 -- COMBAK: What is this?
-      -- toPath = functions.pathFromPoints -- COMBAK
+  strokeWidth = 2.0
+  padding = 15.0 
 
-      -- The start and end of the body of the unit marker line
-      -- NOTE: We need to have lists of vectors
-      dir = normalize(w.arrow.end - w.arrow.start)
-      normal = -dir
-      markStart = v.arrow.start + padding * normal
-      markEnd = v.arrow.end + padding * normal
-      v.markerLine = [markStart, markEnd]
+  -- The start and end of the body of the unit marker line
+  -- NOTE: We need to have lists of vectors
+  dir = normalize(w.arrow.end - w.arrow.start)
+  normal = -dir
+  markStart = v.arrow.start + padding * normal
+  markEnd = v.arrow.end + padding * normal
+  v.markerLine = [markStart, markEnd]
 
-      v.unitMarkerLine = Path {
-          d : pathFromPoints("open", v.markerLine)
-          -- strokeWidth : strokeWidth
-          strokeColor : C.black
-          fillColor : C.none
-      }
+  v.unitMarkerLine = Path {
+    d : pathFromPoints("open", v.markerLine)
+    strokeColor : C.black
+    fillColor : C.none
+  }
 
-      -- Could use normal instead, just doing this to demonstrate how to use matrices
-      mat2x2 rot90CW = ((0., 1.), (-1., 0.))
-      vec2 markNormal = mul(rot90CW, normalize(v.arrow.end - v.arrow.start)) -- TODO: Do we want syntactic sugar for matrix-vector multiplication? Or a better name?
-      scalar c = const.barSize
-      vec2 halfvec = c * markNormal
+  -- Could use normal instead, just doing this to demonstrate how to use matrices
+  mat2x2 rot90CW = ((0., 1.), (-1., 0.))
+  vec2 markNormal = mul(rot90CW, normalize(v.arrow.end - v.arrow.start)) 
+  scalar c = const.barSize
+  vec2 halfvec = c * markNormal
 
-      v.unitMarkerEnd1 = Path {
-          d : pathFromPoints("open", [markStart - halfvec, markStart + halfvec]) -- TODO: Can we infer this type if it's written anonymously?
-          -- strokeWidth : strokeWidth
-          strokeColor : C.black
-          fillColor : C.none
-      }
+  v.unitMarkerEnd1 = Path {
+    d : pathFromPoints("open", [markStart - halfvec, markStart + halfvec]) 
+    strokeColor : C.black
+    fillColor : C.none
+  }
 
-      v.unitMarkerEnd2 = Path {
-          d : pathFromPoints("open", [markEnd - halfvec, markEnd + halfvec])
-          -- strokeWidth : strokeWidth
-          strokeColor : C.black
-          fillColor : C.none
-      }
+  v.unitMarkerEnd2 = Path {
+    d : pathFromPoints("open", [markEnd - halfvec, markEnd + halfvec])
+    strokeColor : C.black
+    fillColor : C.none
+  }
 
-      vec2 midpointLoc = (v.markerLine[0] + v.markerLine[1]) / 2.
-      vec2 labelPos = midpointLoc + const.markerPadding * normal
+  vec2 midpointLoc = (v.markerLine[0] + v.markerLine[1]) / 2.
+  vec2 labelPos = midpointLoc + const.markerPadding * normal
 
-      v.unitMarkerText = Equation {
-          fontSize : const.fontSize
-          string : "1"
-          center : labelPos
-          fillColor : C.black
-      }
+  v.unitMarkerText = Equation {
+    fontSize : const.fontSize
+    string : "1"
+    center : labelPos
+    fillColor : C.black
+  }
 
-      layer v.unitMarkerLine above U.xAxis
-      layer v.unitMarkerLine above U.yAxis
+  layer v.unitMarkerLine above U.xAxis
+  layer v.unitMarkerLine above U.yAxis
 }
 
 -- If two vectors are linearly dependent, make
@@ -267,45 +228,45 @@ where In(v, U); Unit(v); Orthogonal(v, w) {
 -- signed are of the parallelogram with sides u,v
 forall Vector u; Vector v
 where Dependent(u,v) {
-   vec2 x = u.arrow.end
-   vec2 y = v.arrow.end
-   scalar A = cross2D(x,y)
-   ensure equal( A, 0. )
+  vec2 x = u.arrow.end
+  vec2 y = v.arrow.end
+  scalar A = cross2D(x,y)
+  ensure equal( A, 0. )
 
-   shape labelText = Text {
-      string: "linearly dependent"
-      center: (0.,-.6*V.background.width)
-      fontFamily: const.fontFamily
-      fontSize: "18px"
-      fontWeight: "bold"
-      fillColor: C.black
-   }
+  shape labelText = Text {
+    string: "linearly dependent"
+    center: (0.,-.6*V.background.width)
+    fontFamily: const.fontFamily
+    fontSize: "18px"
+    fontWeight: "bold"
+    fillColor: C.black
+  }
 }
 
 -- If two vectors are linearly independent, make
 -- sure they're not parallel
 forall Vector u; Vector v; VectorSpace V
 where Independent(u, v); In(v,V) {
-   vec2 x = u.arrow.end
-   vec2 y = v.arrow.end
-   ensure inRange( angleBetween(x,y), .25*MathPI(), .75*MathPI() )
+  vec2 x = u.arrow.end
+  vec2 y = v.arrow.end
+  ensure inRange( angleBetween(x,y), .25*MathPI(), .75*MathPI() )
 
-   shape labelText = Text {
-      string: "linearly independent"
-      center: (0.,-.6*V.background.width)
-      fontFamily: const.fontFamily
-      fontSize: "18px"
-      fontWeight: "bold"
-      fillColor: C.black
-   }
+  shape labelText = Text {
+    string: "linearly independent"
+    center: (0.,-.6*V.background.width)
+    fontFamily: const.fontFamily
+    fontSize: "18px"
+    fontWeight: "bold"
+    fillColor: C.black
+  }
 }
 
 forall Vector `u` {
-       override `u`.arrow.strokeColor = C.green
+  override `u`.arrow.strokeColor = C.green
 }
 
 forall Vector `x2` {
-       override `x2`.arrow.strokeColor = C.green
+  override `x2`.arrow.strokeColor = C.green
 }
 
 


### PR DESCRIPTION
# Description

This PR fixes some small issues `linear-algebra-paper-simple.sty`:

* Change to `ensure` the dot product to be zero for `Orthogonal` vectors
* File formatting. Mostly tab size. Original is very inconsistent.
* Remove testing code and stray comments.

# Examples with steps to reproduce them

`roger watch twoVectorsPerp-unsugared.sub linear-algebra-paper-simple.sty linear-algebra.dsl`

![image](https://user-images.githubusercontent.com/11740102/151026304-6576352a-e1da-4026-9cec-d2e4017b0553.png)


# Checklist

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new ESLint warnings
