### PR TITLE
refactor: Prefer undefined over null and MaybeVal

### DIFF
--- a/packages/automator/index.tsx
+++ b/packages/automator/index.tsx
@@ -246,7 +246,7 @@ const singleProcess = async (
     }
 
     // HACK: return empty metadata??
-    return null;
+    return undefined;
   }
 };
 

--- a/packages/browser-ui/src/App.tsx
+++ b/packages/browser-ui/src/App.tsx
@@ -88,26 +88,26 @@ export interface ISettings {
 
 interface ICanvasState {
   currentState: PenroseState | undefined; // NOTE: if the backend is not connected, data will be undefined
-  error: PenroseError | null;
+  error: PenroseError | undefined;
   processedInitial: boolean;
   penroseVersion: string;
   history: PenroseState[];
-  files: FileSocketResult | null;
+  files: FileSocketResult | undefined;
   connected: boolean;
   settings: ISettings;
-  fileSocket: FileSocket | null;
+  fileSocket: FileSocket | undefined;
 }
 
 const socketAddress = "ws://localhost:9160";
 class App extends React.Component<unknown, ICanvasState> {
   public readonly state: ICanvasState = {
     currentState: undefined,
-    fileSocket: null,
-    error: null,
+    fileSocket: undefined,
+    error: undefined,
     history: [],
     processedInitial: false, // TODO: clarify the semantics of this flag
     penroseVersion: "",
-    files: null,
+    files: undefined,
     connected: false,
     settings: {
       autostep: false,
@@ -138,7 +138,7 @@ class App extends React.Component<unknown, ICanvasState> {
       currentState: canvasState,
       // history: [...this.state.history, canvasState],
       processedInitial: true,
-      error: null,
+      error: undefined,
     });
     this.renderCanvas(canvasState);
     const { settings } = this.state;
@@ -357,7 +357,10 @@ class App extends React.Component<unknown, ICanvasState> {
   };
 
   public renderCanvas = async (state: PenroseState): Promise<void> => {
-    if (this.canvasRef.current !== null && this.state.fileSocket !== null) {
+    if (
+      this.canvasRef.current !== null &&
+      this.state.fileSocket !== undefined
+    ) {
       const current = this.canvasRef.current;
       const rendered = await RenderInteractive(
         state,

--- a/packages/browser-ui/src/inspector/Inspector.tsx
+++ b/packages/browser-ui/src/inspector/Inspector.tsx
@@ -10,7 +10,7 @@ import IViewProps from "./views/IViewProps";
 interface IProps {
   currentState: PenroseState | undefined;
   history: PenroseState[];
-  error: PenroseError | null;
+  error: PenroseError | undefined;
   onClose(): void;
   modCanvas(state: PenroseState): void;
   settings: ISettings;
@@ -56,18 +56,10 @@ class Inspector extends React.Component<IProps, IInspectState> {
       setSettings,
       reset,
     } = this.props;
-    /*
-    const currentFrame =
-      history.length === 0
-        ? null
-        : selectedFrame === -1
-        ? history[history.length - 1]
-        : history[selectedFrame];
-    */
     const commonProps: IViewProps = {
       selectFrame: this.selectFrame,
       // frame: currentFrame,
-      frame: currentState ?? null, // HACK: since history is disabled, we pass in the current state so the tab always shows the current state
+      frame: currentState, // HACK: since history is disabled, we pass in the current state so the tab always shows the current state
       frameIndex: selectedFrame,
       history,
       modShapes: modCanvas,

--- a/packages/browser-ui/src/inspector/README.md
+++ b/packages/browser-ui/src/inspector/README.md
@@ -14,7 +14,7 @@ The `../App.tsx` is the source of truth for the history. Every new state is appe
 
 The inspector has an internal state to track which `frame` has been "selected". This is so you can go back in time and see prior `frame`s in `history` if you want. This is tracked by index; but there is a second possible value for the current `frame`: `-1`. The value `-1` corresponds to "most recent `frame` in history", so you can see the _current_ frame all the time, dynamically updating. In the timeline, clicking a frame and clicking it again corresponds to whether you're tracking the most recent frame or clamping to the selected frame (blue outline in the thumbnail).
 
-This interaction model is handy but annoying to deal with when you're implementing a new view. Thus the prop `frame` is provided which always gives the frame that should be inspected in the view, and `null` if none such exist (if the history is empty). You should handle both states with separate empty and populated views, as seen in existing views.
+This interaction model is handy but annoying to deal with when you're implementing a new view. Thus the prop `frame` is provided which always gives the frame that should be inspected in the view, and `undefined` if none such exist (if the history is empty). You should handle both states with separate empty and populated views, as seen in existing views.
 
 ## Adding a view
 

--- a/packages/browser-ui/src/inspector/makeViewBoxes.tsx
+++ b/packages/browser-ui/src/inspector/makeViewBoxes.tsx
@@ -49,7 +49,7 @@ const makeViewBoxes = (
                 shape: { properties, shapeType },
                 labels: [],
                 canvasSize: [w, h],
-                pathResolver: async () => null,
+                pathResolver: async () => undefined,
               });
               setShapeHTML(shape.outerHTML);
             })();

--- a/packages/browser-ui/src/inspector/views/Frames.tsx
+++ b/packages/browser-ui/src/inspector/views/Frames.tsx
@@ -5,7 +5,7 @@ import IViewProps from "./IViewProps";
 class Frames extends React.Component<IViewProps> {
   public render(): JSX.Element {
     const { /*history,*/ frame } = this.props;
-    if (frame === null) {
+    if (frame === undefined) {
       return <p style={{ padding: "1em" }}>empty</p>;
     }
     return (

--- a/packages/browser-ui/src/inspector/views/IViewProps.tsx
+++ b/packages/browser-ui/src/inspector/views/IViewProps.tsx
@@ -7,11 +7,11 @@ export interface IViewProps {
   // Gives access to the full history of frames
   history: PenroseState[];
   // Quick access to the frame being shown
-  frame: PenroseState | null;
+  frame: PenroseState | undefined;
   // Either a valid index in History
   frameIndex: number;
   modShapes(state: PenroseState): void; // todo - null check
-  error: PenroseError | null;
+  error: PenroseError | undefined;
   settings: ISettings;
   setSettings(settings: ISettings): void;
   reset(): void;

--- a/packages/browser-ui/src/inspector/views/Mod.tsx
+++ b/packages/browser-ui/src/inspector/views/Mod.tsx
@@ -37,7 +37,7 @@ class Mod extends React.Component<IViewProps, IState> {
   };
   public render() {
     const { frame } = this.props;
-    if (frame === null) {
+    if (frame === undefined) {
       return <div />;
     }
 

--- a/packages/browser-ui/src/inspector/views/ShapeView.tsx
+++ b/packages/browser-ui/src/inspector/views/ShapeView.tsx
@@ -14,7 +14,7 @@ class ShapeView extends React.Component<IViewProps, IState> {
   };
   public render(): JSX.Element {
     const { frame } = this.props;
-    if (frame === null) {
+    if (frame === undefined) {
       return <div />;
     }
 

--- a/packages/browser-ui/src/inspector/views/Timeline.tsx
+++ b/packages/browser-ui/src/inspector/views/Timeline.tsx
@@ -53,7 +53,7 @@ function Timeline({ frameIndex, history, selectFrame }: IViewProps) {
         const [shapeHTML, setShapeHTML] = useState("");
         useEffect(() => {
           (async () => {
-            const shape = await RenderStatic(frame, async () => null);
+            const shape = await RenderStatic(frame, async () => undefined);
             setShapeHTML(shape.outerHTML);
           })();
         }, []);

--- a/packages/browser-ui/src/ui/ButtonBar.tsx
+++ b/packages/browser-ui/src/ui/ButtonBar.tsx
@@ -6,7 +6,7 @@ interface IProps {
   autostep: boolean;
   initial: boolean;
   showInspector: boolean;
-  files: FileSocketResult | null;
+  files: FileSocketResult | undefined;
   connected: boolean;
 
   toggleInspector?(): void;
@@ -92,7 +92,7 @@ class ButtonBar extends React.Component<IProps> {
             fontSize: "14px",
           }}
         >
-          {files === null
+          {files === undefined
             ? "no files received from server"
             : `sub: ${files.substance.fileName} sty: ${files.style.fileName} dsl: ${files.domain.fileName}`}
         </div>

--- a/packages/browser-ui/src/ui/FileSocket.ts
+++ b/packages/browser-ui/src/ui/FileSocket.ts
@@ -34,7 +34,7 @@ export class FileSocket {
       this.onFiles(parsed);
     }
   };
-  getFile = async (path: string): Promise<string | null> => {
+  getFile = async (path: string): Promise<string | undefined> => {
     return new Promise((resolve /*, reject*/) => {
       this.ws.addEventListener("message", (e) => {
         const parsed = JSON.parse(e.data);

--- a/packages/components/src/fetchPathResolver.ts
+++ b/packages/components/src/fetchPathResolver.ts
@@ -1,10 +1,10 @@
 export default async function fetchResolver(
   path: string
-): Promise<string | null> {
+): Promise<string | undefined> {
   const response = await fetch(path);
   if (!response.ok) {
     console.error(`could not fetch ${path}`);
-    return null;
+    return undefined;
   }
   return await response.text();
 }

--- a/packages/core/src/__tests__/overall.test.ts
+++ b/packages/core/src/__tests__/overall.test.ts
@@ -76,7 +76,7 @@ describe("End-to-end testing of existing diagrams", () => {
 
 describe("Determinism", () => {
   const render = async (state: State): Promise<string> =>
-    (await RenderStatic(state, async () => null)).outerHTML;
+    (await RenderStatic(state, async () => undefined)).outerHTML;
 
   const substance = "Set A, B\nIsSubset(B, A)\nAutoLabel All";
   const style = vennStyle;

--- a/packages/core/src/compiler/Style.ts
+++ b/packages/core/src/compiler/Style.ts
@@ -1460,7 +1460,6 @@ const matchBvar = (
 };
 
 // Judgment 12. G; theta |- S <| |S_o
-// TODO: Not sure why Maybe<Subst> doesn't work in the type signature?
 const matchDeclLine = (
   varEnv: Env,
   line: SubStmt<A>,

--- a/packages/core/src/compiler/Style.ts
+++ b/packages/core/src/compiler/Style.ts
@@ -2779,12 +2779,12 @@ const initProperty = (
   shapeType: ShapeTypeStr,
   propName: string,
   styleSetting: TagExpr<VarAD>
-): TagExpr<VarAD> | null => {
+): TagExpr<VarAD> | undefined => {
   // Property set in Style
   switch (styleSetting.tag) {
     case "OptEval": {
       if (styleSetting.contents.tag === "Vary") {
-        return null;
+        return undefined;
       } else if (styleSetting.contents.tag === "VaryInit") {
         // Initialize the varying variable to the property specified in Style
         return {
@@ -2801,7 +2801,7 @@ const initProperty = (
           // (if only one element is set to ?, then presumably it's set by initializing an access path...? TODO: Check this)
           // TODO: This hardcodes an uninitialized 2D vector to be initialized/inserted
           if (v[0].tag === "Vary" && v[1].tag === "Vary") {
-            return null;
+            return undefined;
           }
         }
         return styleSetting;
@@ -2855,7 +2855,7 @@ const initShape = (
             propName,
             initProperty(stype, propName, propExpr),
           ])
-          .filter(([, x]) => x !== null)
+          .filter(([, x]) => x !== undefined)
       ),
     };
 

--- a/packages/core/src/compiler/Substance.ts
+++ b/packages/core/src/compiler/Substance.ts
@@ -40,7 +40,6 @@ import {
   duplicateName,
   err,
   every,
-  Maybe,
   ok,
   parseError,
   Result,

--- a/packages/core/src/engine/Autodiff.test.ts
+++ b/packages/core/src/engine/Autodiff.test.ts
@@ -135,7 +135,7 @@ const gradGraph1 = (): GradGraphs => {
   const z = mul(b, c);
 
   // Build gradient graph
-  z.gradNode = { tag: "Just", contents: gvarOf(1.0) };
+  z.gradNode = gvarOf(1.0);
   const dx0 = _gradADSymbolic(x0);
   const dx1 = _gradADSymbolic(x1);
 
@@ -143,7 +143,7 @@ const gradGraph1 = (): GradGraphs => {
     inputs: [x0, x1],
     energyOutput: z,
     gradOutputs: [dx0, dx1],
-    weight: { tag: "Nothing" },
+    weight: undefined,
   };
 };
 
@@ -158,7 +158,7 @@ const gradGraph2 = (): GradGraphs => {
   const z = mul(b, c);
 
   // Build gradient graph
-  z.gradNode = { tag: "Just", contents: gvarOf(1.0) };
+  z.gradNode = gvarOf(1.0);
   const dx0 = _gradADSymbolic(x0);
   const dx1 = _gradADSymbolic(x1);
 
@@ -166,7 +166,7 @@ const gradGraph2 = (): GradGraphs => {
     inputs: [x0, x1],
     energyOutput: z,
     gradOutputs: [dx0, dx1],
-    weight: { tag: "Nothing" },
+    weight: undefined,
   };
 };
 
@@ -186,7 +186,7 @@ const gradGraph3 = (): GradGraphs => {
     inputs,
     energyOutput: head,
     gradOutputs: dxs,
-    weight: { tag: "Nothing" },
+    weight: undefined,
   };
 };
 
@@ -205,7 +205,7 @@ const gradGraph4 = (): GradGraphs => {
     inputs,
     energyOutput: head,
     gradOutputs: dxs,
-    weight: { tag: "Nothing" },
+    weight: undefined,
   };
 };
 
@@ -228,7 +228,7 @@ const gradGraph5 = (): GradGraphs => {
     inputs,
     energyOutput: head,
     gradOutputs: dxs,
-    weight: { tag: "Nothing" },
+    weight: undefined,
   };
 };
 
@@ -248,7 +248,7 @@ const gradGraph6 = (): GradGraphs => {
     inputs,
     energyOutput: head,
     gradOutputs: dxs,
-    weight: { tag: "Nothing" },
+    weight: undefined,
   };
 };
 
@@ -270,7 +270,7 @@ const gradGraph7 = (): GradGraphs => {
     inputs,
     energyOutput: head,
     gradOutputs: dxs,
-    weight: { tag: "Nothing" },
+    weight: undefined,
   };
 };
 
@@ -293,7 +293,7 @@ const testGradSymbolic = (testNum: number, graphs: GradGraphs): void => {
   let f;
   let gradGen;
 
-  if (graphs.weight.tag === "Just") {
+  if (graphs.weight !== undefined) {
     // Partially apply with weight
     f = f0(weight);
     gradGen = gradGen0(weight);
@@ -330,7 +330,7 @@ const gradGraph0 = (): GradGraphs => {
   const head = squared(ref);
 
   // Build gradient graph
-  head.gradNode = { tag: "Just", contents: gvarOf(1.0) };
+  head.gradNode = gvarOf(1.0);
   const dRef = _gradADSymbolic(ref);
 
   // Print results
@@ -345,6 +345,6 @@ const gradGraph0 = (): GradGraphs => {
     inputs: [ref],
     energyOutput: head,
     gradOutputs: [dRef],
-    weight: { tag: "Nothing" },
+    weight: undefined,
   };
 };

--- a/packages/core/src/engine/Autodiff.ts
+++ b/packages/core/src/engine/Autodiff.ts
@@ -1239,8 +1239,7 @@ export const energyAndGradCompiled = (
   // Note that this does NOT include the weight (i.e. is called on `xsVars`, not `xsVarsWithWeight`! Because the EP weight is not a degree of freedom)
   const gradGraph = _gradAllSymbolic(energyGraph, xsVars);
 
-  const epWeightNode: VarAD | undefined =
-    weightInfo !== undefined ? weightInfo.epWeightNode : undefined; // Generate energy and gradient without weight
+  const epWeightNode: VarAD | undefined = weightInfo?.epWeightNode; // Generate energy and gradient without weight
 
   const graphs: GradGraphs = {
     inputs: xsVars,

--- a/packages/core/src/engine/Autodiff.ts
+++ b/packages/core/src/engine/Autodiff.ts
@@ -1,9 +1,8 @@
 import * as _ from "lodash";
 import consola, { LogLevel } from "consola";
 import { VarAD, IVarAD, GradGraphs } from "types/ad";
-import { MaybeVal } from "types/common";
 import { WeightInfo } from "types/state";
-import { Queue, fromJust } from "utils/Util";
+import { Queue, safe } from "utils/Util";
 import {
   acos,
   add,
@@ -102,8 +101,8 @@ export const variableAD = (
     childrenAD: [],
     parentsADGrad: [],
     childrenADGrad: [],
-    gradVal: { tag: "Nothing" },
-    gradNode: { tag: "Nothing" },
+    gradVal: undefined,
+    gradNode: undefined,
     index: -100,
     id: -1,
 
@@ -168,8 +167,8 @@ export const makeADInputVars = (xs: number[]): VarAD[] => {
 // do not use outside this file
 export const _gradADSymbolic = (v: VarAD): VarAD => {
   // Already computed/cached the gradient
-  if (v.gradNode.tag === "Just") {
-    return v.gradNode.contents;
+  if (v.gradNode !== undefined) {
+    return v.gradNode;
   }
 
   // Build subgraph
@@ -183,7 +182,7 @@ export const _gradADSymbolic = (v: VarAD): VarAD => {
     res = addN(
       v.parentsAD.map((parent) =>
         mul(
-          fromJust(parent.sensitivityNode),
+          safe(parent.sensitivityNode, "expected VarAD but got undefined"),
           _gradADSymbolic(parent.node),
           false
         )
@@ -193,7 +192,7 @@ export const _gradADSymbolic = (v: VarAD): VarAD => {
   }
 
   // Mark node as done
-  v.gradNode = { tag: "Just", contents: res };
+  v.gradNode = res;
 
   // Result is a gradient
   res.isCompNode = false;
@@ -226,9 +225,11 @@ export const _gradAllSymbolic = (
   energyGraph: VarAD,
   xsVars: VarAD[]
 ): VarAD[] => {
-  energyGraph.gradNode = { tag: "Just", contents: variableAD(1.0) };
+  energyGraph.gradNode = variableAD(1.0);
   const dxs = xsVars.map(_gradADSymbolic); // Computes it per variable, mutating the graph to set cached results and reuse them
-  const gradxs = xsVars.map((x: VarAD) => fromJust(x.gradNode));
+  const gradxs = xsVars.map((x: VarAD) =>
+    safe(x.gradNode, "expected VarAD but got undefined")
+  );
   return gradxs;
 };
 
@@ -250,17 +251,11 @@ export const _gradAllSymbolic = (
 // The point of making the sensitivity nodes here is that when the gradient is computed, each child needs to know what its partial derivative was, which depends on its position (e.g. either the first or second arg in x * y has a different sensitivity). This can't be looked up in, say, a dict
 // You have to build it inline bc it involves references to the variables
 
-export const just = (v: VarAD): MaybeVal<VarAD> => {
-  return { tag: "Just", contents: v };
-};
-
-export const none: MaybeVal<VarAD> = { tag: "Nothing" };
-
 const check = (
   isCompNode: boolean,
   sensitivityNode: VarAD
-): MaybeVal<VarAD> => {
-  return isCompNode ? just(sensitivityNode) : none;
+): VarAD | undefined => {
+  return isCompNode ? sensitivityNode : undefined;
 };
 
 // ------------ Meta / debug ops
@@ -698,7 +693,7 @@ export const fns = {
 export const _genEnergyFn = (
   xs: VarAD[],
   z: IVarAD,
-  weight: MaybeVal<VarAD>
+  weight: VarAD | undefined
 ): any => _genCode(xs, [z], "energy", weight);
 
 // Generate code for multi-output function, given its computational graph and a setting for its outputs
@@ -708,7 +703,7 @@ export const _genCode = (
   inputs: VarAD[],
   outputs: IVarAD[],
   setting: string,
-  weightNode: MaybeVal<VarAD>
+  weightNode: VarAD | undefined
 ): any => {
   let counter = 0;
   let progInputs: string[] = [];
@@ -724,11 +719,11 @@ export const _genCode = (
   );
 
   let inputsNew;
-  logAD.trace("has weight?", weightNode.tag === "Just");
-  if (weightNode.tag === "Nothing") {
+  logAD.trace("has weight?", weightNode !== undefined);
+  if (weightNode === undefined) {
     inputsNew = inputs;
   } else {
-    inputsNew = [weightNode.contents].concat(inputs);
+    inputsNew = [weightNode].concat(inputs);
   }
 
   // Just traverse + name the inputs first (they have no children, so the traversal stops there), then work backward from the outputs
@@ -782,7 +777,7 @@ export const _genCode = (
   logAD.trace("generated f with setting =", setting, "\n", f);
 
   let g;
-  if (weightNode.tag === "Nothing") {
+  if (weightNode === undefined) {
     // So you can call the function without spread
     // hasWeight is for "normal" functions that aren't wrapped in the EP cycle (such as the symbolic gradient unit tests)
     g = (xs: number[]) => f(...xs);
@@ -1188,14 +1183,14 @@ export const clearVisitedNodes = (nodeList: VarAD[]): void => {
 // NOTE that this will zero all the nodes in the graph, including the leaves (such as the stepEP parameters)
 export const clearGraphTopDown = (z: VarAD): void => {
   z.val = 0;
-  z.gradVal = { tag: "Nothing" };
+  z.gradVal = undefined;
   z.childrenAD.forEach((e) => clearGraphTopDown(e.node));
 };
 
 const clearGraphBottomUp = (xs: VarAD[]) => {
   xs.forEach((x) => {
     x.val = 0;
-    x.gradVal = { tag: "Nothing" };
+    x.gradVal = undefined;
     clearGraphBottomUp(x.parentsAD.map((p) => p.node));
   });
 };
@@ -1225,7 +1220,7 @@ export const energyAndGradCompiled = (
   xs: number[],
   xsVars: VarAD[],
   energyGraph: VarAD,
-  weightInfo: MaybeVal<WeightInfo>,
+  weightInfo: WeightInfo | undefined,
   debug = false
 ) => {
   // Zero xsvars vals, gradients, and caching setting
@@ -1233,8 +1228,8 @@ export const energyAndGradCompiled = (
   clearVisitedNodes([energyGraph]);
 
   // Set the weight nodes to have the right weight values (may have been updated at some point during the opt)
-  if (weightInfo.tag === "Just") {
-    setWeights(weightInfo.contents);
+  if (weightInfo !== undefined) {
+    setWeights(weightInfo);
   }
 
   // Set the leaves of the graph to have the new input values
@@ -1244,10 +1239,8 @@ export const energyAndGradCompiled = (
   // Note that this does NOT include the weight (i.e. is called on `xsVars`, not `xsVarsWithWeight`! Because the EP weight is not a degree of freedom)
   const gradGraph = _gradAllSymbolic(energyGraph, xsVars);
 
-  const epWeightNode: MaybeVal<VarAD> =
-    weightInfo.tag === "Just"
-      ? just(weightInfo.contents.epWeightNode)
-      : { tag: "Nothing" }; // Generate energy and gradient without weight
+  const epWeightNode: VarAD | undefined =
+    weightInfo !== undefined ? weightInfo.epWeightNode : undefined; // Generate energy and gradient without weight
 
   const graphs: GradGraphs = {
     inputs: xsVars,

--- a/packages/core/src/engine/AutodiffFunctions.ts
+++ b/packages/core/src/engine/AutodiffFunctions.ts
@@ -1,13 +1,5 @@
 import { VarAD } from "types/ad";
-import {
-  just,
-  none,
-  variableAD,
-  gvarOf,
-  logAD,
-  EPS_DENOM,
-  noGrad,
-} from "./Autodiff";
+import { variableAD, gvarOf, logAD, EPS_DENOM, noGrad } from "./Autodiff";
 import * as _ from "lodash";
 
 /**
@@ -18,17 +10,17 @@ export const add = (v: VarAD, w: VarAD, isCompNode = true): VarAD => {
   z.isCompNode = isCompNode;
 
   if (isCompNode) {
-    v.parentsAD.push({ node: z, sensitivityNode: just(gvarOf(1.0)) });
-    w.parentsAD.push({ node: z, sensitivityNode: just(gvarOf(1.0)) });
+    v.parentsAD.push({ node: z, sensitivityNode: gvarOf(1.0) });
+    w.parentsAD.push({ node: z, sensitivityNode: gvarOf(1.0) });
 
-    z.childrenAD.push({ node: v, sensitivityNode: just(gvarOf(1.0)) });
-    z.childrenAD.push({ node: w, sensitivityNode: just(gvarOf(1.0)) });
+    z.childrenAD.push({ node: v, sensitivityNode: gvarOf(1.0) });
+    z.childrenAD.push({ node: w, sensitivityNode: gvarOf(1.0) });
   } else {
-    v.parentsADGrad.push({ node: z, sensitivityNode: none });
-    w.parentsADGrad.push({ node: z, sensitivityNode: none });
+    v.parentsADGrad.push({ node: z, sensitivityNode: undefined });
+    w.parentsADGrad.push({ node: z, sensitivityNode: undefined });
 
-    z.childrenADGrad.push({ node: v, sensitivityNode: none });
-    z.childrenADGrad.push({ node: w, sensitivityNode: none });
+    z.childrenADGrad.push({ node: v, sensitivityNode: undefined });
+    z.childrenADGrad.push({ node: w, sensitivityNode: undefined });
   }
 
   return z;
@@ -53,13 +45,13 @@ export const addN = (xs: VarAD[], isCompNode = true): VarAD => {
 
     if (isCompNode) {
       for (const x of xs) {
-        x.parentsAD.push({ node: z, sensitivityNode: just(gvarOf(1.0)) });
-        z.childrenAD.push({ node: x, sensitivityNode: just(gvarOf(1.0)) });
+        x.parentsAD.push({ node: z, sensitivityNode: gvarOf(1.0) });
+        z.childrenAD.push({ node: x, sensitivityNode: gvarOf(1.0) });
       }
     } else {
       for (const x of xs) {
-        x.parentsADGrad.push({ node: z, sensitivityNode: none });
-        z.childrenADGrad.push({ node: x, sensitivityNode: none });
+        x.parentsADGrad.push({ node: z, sensitivityNode: undefined });
+        z.childrenADGrad.push({ node: x, sensitivityNode: undefined });
       }
     }
 
@@ -75,17 +67,17 @@ export const mul = (v: VarAD, w: VarAD, isCompNode = true): VarAD => {
   z.isCompNode = isCompNode;
 
   if (isCompNode) {
-    v.parentsAD.push({ node: z, sensitivityNode: just(w) });
-    w.parentsAD.push({ node: z, sensitivityNode: just(v) });
+    v.parentsAD.push({ node: z, sensitivityNode: w });
+    w.parentsAD.push({ node: z, sensitivityNode: v });
 
-    z.childrenAD.push({ node: v, sensitivityNode: just(w) });
-    z.childrenAD.push({ node: w, sensitivityNode: just(v) });
+    z.childrenAD.push({ node: v, sensitivityNode: w });
+    z.childrenAD.push({ node: w, sensitivityNode: v });
   } else {
-    v.parentsADGrad.push({ node: z, sensitivityNode: none });
-    w.parentsADGrad.push({ node: z, sensitivityNode: none });
+    v.parentsADGrad.push({ node: z, sensitivityNode: undefined });
+    w.parentsADGrad.push({ node: z, sensitivityNode: undefined });
 
-    z.childrenADGrad.push({ node: v, sensitivityNode: none });
-    z.childrenADGrad.push({ node: w, sensitivityNode: none });
+    z.childrenADGrad.push({ node: v, sensitivityNode: undefined });
+    z.childrenADGrad.push({ node: w, sensitivityNode: undefined });
   }
 
   return z;
@@ -99,17 +91,17 @@ export const sub = (v: VarAD, w: VarAD, isCompNode = true): VarAD => {
   z.isCompNode = isCompNode;
 
   if (isCompNode) {
-    v.parentsAD.push({ node: z, sensitivityNode: just(gvarOf(1.0)) });
-    w.parentsAD.push({ node: z, sensitivityNode: just(gvarOf(-1.0)) });
+    v.parentsAD.push({ node: z, sensitivityNode: gvarOf(1.0) });
+    w.parentsAD.push({ node: z, sensitivityNode: gvarOf(-1.0) });
 
-    z.childrenAD.push({ node: v, sensitivityNode: just(gvarOf(1.0)) });
-    z.childrenAD.push({ node: w, sensitivityNode: just(gvarOf(-1.0)) });
+    z.childrenAD.push({ node: v, sensitivityNode: gvarOf(1.0) });
+    z.childrenAD.push({ node: w, sensitivityNode: gvarOf(-1.0) });
   } else {
-    v.parentsADGrad.push({ node: z, sensitivityNode: none });
-    w.parentsADGrad.push({ node: z, sensitivityNode: none });
+    v.parentsADGrad.push({ node: z, sensitivityNode: undefined });
+    w.parentsADGrad.push({ node: z, sensitivityNode: undefined });
 
-    z.childrenADGrad.push({ node: v, sensitivityNode: none });
-    z.childrenADGrad.push({ node: w, sensitivityNode: none });
+    z.childrenADGrad.push({ node: v, sensitivityNode: undefined });
+    z.childrenADGrad.push({ node: w, sensitivityNode: undefined });
   }
 
   return z;
@@ -128,10 +120,10 @@ export const div = (v: VarAD, w: VarAD, isCompNode = true): VarAD => {
 
   // grad(v/w) = [1/w, -v/w^2]
   if (isCompNode) {
-    const vnode = just(div(gvarOf(1.0), w, false));
+    const vnode = div(gvarOf(1.0), w, false);
     const w0node = squared(w, false);
     // const w1node = max(epsdg, w0node, false); // TODO: Why does this make it get stuck? w1node is not even used
-    const wnode = just(neg(div(v, w0node, false), false));
+    const wnode = neg(div(v, w0node, false), false);
 
     v.parentsAD.push({ node: z, sensitivityNode: vnode });
     w.parentsAD.push({ node: z, sensitivityNode: wnode });
@@ -139,11 +131,11 @@ export const div = (v: VarAD, w: VarAD, isCompNode = true): VarAD => {
     z.childrenAD.push({ node: v, sensitivityNode: vnode });
     z.childrenAD.push({ node: w, sensitivityNode: wnode });
   } else {
-    v.parentsADGrad.push({ node: z, sensitivityNode: none });
-    w.parentsADGrad.push({ node: z, sensitivityNode: none });
+    v.parentsADGrad.push({ node: z, sensitivityNode: undefined });
+    w.parentsADGrad.push({ node: z, sensitivityNode: undefined });
 
-    z.childrenADGrad.push({ node: v, sensitivityNode: none });
-    z.childrenADGrad.push({ node: w, sensitivityNode: none });
+    z.childrenADGrad.push({ node: v, sensitivityNode: undefined });
+    z.childrenADGrad.push({ node: w, sensitivityNode: undefined });
   }
 
   return z;
@@ -167,17 +159,17 @@ export const max = (v: VarAD, w: VarAD, isCompNode = true): VarAD => {
   // Note also the closure attached to each sensitivityFn, which has references to v and w (which have references to their values)
 
   if (isCompNode) {
-    v.parentsAD.push({ node: z, sensitivityNode: just(vNode) });
-    w.parentsAD.push({ node: z, sensitivityNode: just(wNode) });
+    v.parentsAD.push({ node: z, sensitivityNode: vNode });
+    w.parentsAD.push({ node: z, sensitivityNode: wNode });
 
-    z.childrenAD.push({ node: v, sensitivityNode: just(vNode) });
-    z.childrenAD.push({ node: w, sensitivityNode: just(wNode) });
+    z.childrenAD.push({ node: v, sensitivityNode: vNode });
+    z.childrenAD.push({ node: w, sensitivityNode: wNode });
   } else {
-    v.parentsADGrad.push({ node: z, sensitivityNode: none });
-    w.parentsADGrad.push({ node: z, sensitivityNode: none });
+    v.parentsADGrad.push({ node: z, sensitivityNode: undefined });
+    w.parentsADGrad.push({ node: z, sensitivityNode: undefined });
 
-    z.childrenADGrad.push({ node: v, sensitivityNode: none });
-    z.childrenADGrad.push({ node: w, sensitivityNode: none });
+    z.childrenADGrad.push({ node: v, sensitivityNode: undefined });
+    z.childrenADGrad.push({ node: w, sensitivityNode: undefined });
   }
 
   return z;
@@ -201,17 +193,17 @@ export const min = (v: VarAD, w: VarAD, isCompNode = true): VarAD => {
   // Note also the closure attached to each sensitivityFn, which has references to v and w (which have references to their values)
 
   if (isCompNode) {
-    v.parentsAD.push({ node: z, sensitivityNode: just(vNode) });
-    w.parentsAD.push({ node: z, sensitivityNode: just(wNode) });
+    v.parentsAD.push({ node: z, sensitivityNode: vNode });
+    w.parentsAD.push({ node: z, sensitivityNode: wNode });
 
-    z.childrenAD.push({ node: v, sensitivityNode: just(vNode) });
-    z.childrenAD.push({ node: w, sensitivityNode: just(wNode) });
+    z.childrenAD.push({ node: v, sensitivityNode: vNode });
+    z.childrenAD.push({ node: w, sensitivityNode: wNode });
   } else {
-    v.parentsADGrad.push({ node: z, sensitivityNode: none });
-    w.parentsADGrad.push({ node: z, sensitivityNode: none });
+    v.parentsADGrad.push({ node: z, sensitivityNode: undefined });
+    w.parentsADGrad.push({ node: z, sensitivityNode: undefined });
 
-    z.childrenADGrad.push({ node: v, sensitivityNode: none });
-    z.childrenADGrad.push({ node: w, sensitivityNode: none });
+    z.childrenADGrad.push({ node: v, sensitivityNode: undefined });
+    z.childrenADGrad.push({ node: w, sensitivityNode: undefined });
   }
 
   return z;
@@ -235,13 +227,13 @@ export const maxN = (xs: VarAD[], isCompNode = true): VarAD => {
     if (isCompNode) {
       for (const x of xs) {
         const xNode = ifCond(lt(x, z, false), gvarOf(0.0), gvarOf(1.0), false);
-        x.parentsAD.push({ node: z, sensitivityNode: just(xNode) });
-        z.childrenAD.push({ node: x, sensitivityNode: just(xNode) });
+        x.parentsAD.push({ node: z, sensitivityNode: xNode });
+        z.childrenAD.push({ node: x, sensitivityNode: xNode });
       }
     } else {
       for (const x of xs) {
-        x.parentsADGrad.push({ node: z, sensitivityNode: none });
-        z.childrenADGrad.push({ node: x, sensitivityNode: none });
+        x.parentsADGrad.push({ node: z, sensitivityNode: undefined });
+        z.childrenADGrad.push({ node: x, sensitivityNode: undefined });
       }
     }
     return z;
@@ -266,13 +258,13 @@ export const minN = (xs: VarAD[], isCompNode = true): VarAD => {
     if (isCompNode) {
       for (const x of xs) {
         const xNode = ifCond(gt(x, z, false), gvarOf(0.0), gvarOf(1.0), false);
-        x.parentsAD.push({ node: z, sensitivityNode: just(xNode) });
-        z.childrenAD.push({ node: x, sensitivityNode: just(xNode) });
+        x.parentsAD.push({ node: z, sensitivityNode: xNode });
+        z.childrenAD.push({ node: x, sensitivityNode: xNode });
       }
     } else {
       for (const x of xs) {
-        x.parentsADGrad.push({ node: z, sensitivityNode: none });
-        z.childrenADGrad.push({ node: x, sensitivityNode: none });
+        x.parentsADGrad.push({ node: z, sensitivityNode: undefined });
+        z.childrenADGrad.push({ node: x, sensitivityNode: undefined });
       }
     }
     return z;
@@ -293,8 +285,8 @@ export const atan2 = (y: VarAD, x: VarAD, isCompNode = true): VarAD => {
     // d/dx atan2(y,x) = -y/(x^2 + y^2)
     // d/dy atan2(y,x) =  x/(x^2 + y^2)
     const denom = add(squared(x, false), squared(y, false), false);
-    const xnode = just(div(neg(y, false), denom, false));
-    const ynode = just(div(x, denom, false));
+    const xnode = div(neg(y, false), denom, false);
+    const ynode = div(x, denom, false);
 
     y.parentsAD.push({ node: z, sensitivityNode: ynode });
     x.parentsAD.push({ node: z, sensitivityNode: xnode });
@@ -302,11 +294,11 @@ export const atan2 = (y: VarAD, x: VarAD, isCompNode = true): VarAD => {
     z.childrenAD.push({ node: y, sensitivityNode: ynode });
     z.childrenAD.push({ node: x, sensitivityNode: xnode });
   } else {
-    y.parentsADGrad.push({ node: z, sensitivityNode: none });
-    x.parentsADGrad.push({ node: z, sensitivityNode: none });
+    y.parentsADGrad.push({ node: z, sensitivityNode: undefined });
+    x.parentsADGrad.push({ node: z, sensitivityNode: undefined });
 
-    z.childrenADGrad.push({ node: y, sensitivityNode: none });
-    z.childrenADGrad.push({ node: x, sensitivityNode: none });
+    z.childrenADGrad.push({ node: y, sensitivityNode: undefined });
+    z.childrenADGrad.push({ node: x, sensitivityNode: undefined });
   }
 
   return z;
@@ -320,10 +312,8 @@ export const pow = (x: VarAD, y: VarAD, isCompNode = true): VarAD => {
   z.isCompNode = isCompNode;
 
   if (isCompNode) {
-    const xnode = just(
-      mul(pow(x, sub(y, gvarOf(1.0), false), false), y, false)
-    );
-    const ynode = just(mul(pow(x, y, false), ln(x, false), false));
+    const xnode = mul(pow(x, sub(y, gvarOf(1.0), false), false), y, false);
+    const ynode = mul(pow(x, y, false), ln(x, false), false);
 
     y.parentsAD.push({ node: z, sensitivityNode: ynode });
     x.parentsAD.push({ node: z, sensitivityNode: xnode });
@@ -331,11 +321,11 @@ export const pow = (x: VarAD, y: VarAD, isCompNode = true): VarAD => {
     z.childrenAD.push({ node: y, sensitivityNode: ynode });
     z.childrenAD.push({ node: x, sensitivityNode: xnode });
   } else {
-    y.parentsADGrad.push({ node: z, sensitivityNode: none });
-    x.parentsADGrad.push({ node: z, sensitivityNode: none });
+    y.parentsADGrad.push({ node: z, sensitivityNode: undefined });
+    x.parentsADGrad.push({ node: z, sensitivityNode: undefined });
 
-    z.childrenADGrad.push({ node: y, sensitivityNode: none });
-    z.childrenADGrad.push({ node: x, sensitivityNode: none });
+    z.childrenADGrad.push({ node: y, sensitivityNode: undefined });
+    z.childrenADGrad.push({ node: x, sensitivityNode: undefined });
   }
 
   return z;
@@ -351,13 +341,13 @@ export const neg = (v: VarAD, isCompNode = true): VarAD => {
   z.isCompNode = isCompNode;
 
   if (isCompNode) {
-    v.parentsAD.push({ node: z, sensitivityNode: just(gvarOf(-1.0)) });
+    v.parentsAD.push({ node: z, sensitivityNode: gvarOf(-1.0) });
 
-    z.childrenAD.push({ node: v, sensitivityNode: just(gvarOf(-1.0)) });
+    z.childrenAD.push({ node: v, sensitivityNode: gvarOf(-1.0) });
   } else {
-    v.parentsADGrad.push({ node: z, sensitivityNode: none });
+    v.parentsADGrad.push({ node: z, sensitivityNode: undefined });
 
-    z.childrenADGrad.push({ node: v, sensitivityNode: none });
+    z.childrenADGrad.push({ node: v, sensitivityNode: undefined });
   }
 
   return z;
@@ -371,14 +361,14 @@ export const squared = (v: VarAD, isCompNode = true): VarAD => {
   z.isCompNode = isCompNode;
 
   if (isCompNode) {
-    const node = just(mul(gvarOf(2.0), v, false));
+    const node = mul(gvarOf(2.0), v, false);
     v.parentsAD.push({ node: z, sensitivityNode: node });
 
     z.childrenAD.push({ node: v, sensitivityNode: node });
   } else {
-    v.parentsADGrad.push({ node: z, sensitivityNode: none });
+    v.parentsADGrad.push({ node: z, sensitivityNode: undefined });
 
-    z.childrenADGrad.push({ node: v, sensitivityNode: none });
+    z.childrenADGrad.push({ node: v, sensitivityNode: undefined });
   }
 
   return z;
@@ -410,11 +400,11 @@ export const sqrt = (v: VarAD, isCompNode = true): VarAD => {
       mul(gvarOf(2.0), max(gvarOf(EPS_DENOM), sqrt(v, false), false), false),
       false
     );
-    v.parentsAD.push({ node: z, sensitivityNode: just(gradNode) });
-    z.childrenAD.push({ node: v, sensitivityNode: just(gradNode) });
+    v.parentsAD.push({ node: z, sensitivityNode: gradNode });
+    z.childrenAD.push({ node: v, sensitivityNode: gradNode });
   } else {
-    v.parentsADGrad.push({ node: z, sensitivityNode: none });
-    z.childrenADGrad.push({ node: v, sensitivityNode: none });
+    v.parentsADGrad.push({ node: z, sensitivityNode: undefined });
+    z.childrenADGrad.push({ node: v, sensitivityNode: undefined });
   }
 
   return z;
@@ -430,19 +420,17 @@ export const inverse = (v: VarAD, isCompNode = true): VarAD => {
 
   // -1/(x^2 + epsilon) -- This takes care of the divide-by-zero gradient problem
   if (isCompNode) {
-    const node = just(
-      neg(
-        inverse(add(squared(v, false), gvarOf(EPS_DENOM), false), false),
-        false
-      )
+    const node = neg(
+      inverse(add(squared(v, false), gvarOf(EPS_DENOM), false), false),
+      false
     );
     v.parentsAD.push({ node: z, sensitivityNode: node });
 
     z.childrenAD.push({ node: v, sensitivityNode: node });
   } else {
-    v.parentsADGrad.push({ node: z, sensitivityNode: none });
+    v.parentsADGrad.push({ node: z, sensitivityNode: undefined });
 
-    z.childrenADGrad.push({ node: v, sensitivityNode: none });
+    z.childrenADGrad.push({ node: v, sensitivityNode: undefined });
   }
 
   return z;
@@ -457,16 +445,14 @@ export const absVal = (v: VarAD, isCompNode = true): VarAD => {
 
   if (isCompNode) {
     // x / (|x| + epsilon)
-    const node = just(
-      div(v, add(absVal(v, false), gvarOf(EPS_DENOM), false), false)
-    );
+    const node = div(v, add(absVal(v, false), gvarOf(EPS_DENOM), false), false);
     v.parentsAD.push({ node: z, sensitivityNode: node });
 
     z.childrenAD.push({ node: v, sensitivityNode: node });
   } else {
-    v.parentsADGrad.push({ node: z, sensitivityNode: none });
+    v.parentsADGrad.push({ node: z, sensitivityNode: undefined });
 
-    z.childrenADGrad.push({ node: v, sensitivityNode: none });
+    z.childrenADGrad.push({ node: v, sensitivityNode: undefined });
   }
 
   return z;
@@ -480,22 +466,20 @@ export const acosh = (x: VarAD, isCompNode = true): VarAD => {
   y.isCompNode = isCompNode;
 
   if (isCompNode) {
-    const node = just(
-      div(
-        gvarOf(1.0),
-        mul(
-          sqrt(sub(x, gvarOf(1.0), false), false),
-          sqrt(add(x, gvarOf(1.0), false), false),
-          false
-        ),
+    const node = div(
+      gvarOf(1.0),
+      mul(
+        sqrt(sub(x, gvarOf(1.0), false), false),
+        sqrt(add(x, gvarOf(1.0), false), false),
         false
-      )
+      ),
+      false
     );
     x.parentsAD.push({ node: y, sensitivityNode: node });
     y.childrenAD.push({ node: x, sensitivityNode: node });
   } else {
-    x.parentsADGrad.push({ node: y, sensitivityNode: none });
-    y.childrenADGrad.push({ node: x, sensitivityNode: none });
+    x.parentsADGrad.push({ node: y, sensitivityNode: undefined });
+    y.childrenADGrad.push({ node: x, sensitivityNode: undefined });
   }
 
   return y;
@@ -509,21 +493,19 @@ export const acos = (x: VarAD, isCompNode = true): VarAD => {
   y.isCompNode = isCompNode;
 
   if (isCompNode) {
-    const node = just(
-      neg(
-        div(
-          gvarOf(1.0),
-          sqrt(sub(gvarOf(1.0), mul(x, x, false), false), false),
-          false
-        ),
+    const node = neg(
+      div(
+        gvarOf(1.0),
+        sqrt(sub(gvarOf(1.0), mul(x, x, false), false), false),
         false
-      )
+      ),
+      false
     );
     x.parentsAD.push({ node: y, sensitivityNode: node });
     y.childrenAD.push({ node: x, sensitivityNode: node });
   } else {
-    x.parentsADGrad.push({ node: y, sensitivityNode: none });
-    y.childrenADGrad.push({ node: x, sensitivityNode: none });
+    x.parentsADGrad.push({ node: y, sensitivityNode: undefined });
+    y.childrenADGrad.push({ node: x, sensitivityNode: undefined });
   }
 
   return y;
@@ -537,18 +519,16 @@ export const asin = (x: VarAD, isCompNode = true): VarAD => {
   y.isCompNode = isCompNode;
 
   if (isCompNode) {
-    const node = just(
-      div(
-        gvarOf(1.0),
-        sqrt(sub(gvarOf(1.0), mul(x, x, false), false), false),
-        false
-      )
+    const node = div(
+      gvarOf(1.0),
+      sqrt(sub(gvarOf(1.0), mul(x, x, false), false), false),
+      false
     );
     x.parentsAD.push({ node: y, sensitivityNode: node });
     y.childrenAD.push({ node: x, sensitivityNode: node });
   } else {
-    x.parentsADGrad.push({ node: y, sensitivityNode: none });
-    y.childrenADGrad.push({ node: x, sensitivityNode: none });
+    x.parentsADGrad.push({ node: y, sensitivityNode: undefined });
+    y.childrenADGrad.push({ node: x, sensitivityNode: undefined });
   }
 
   return y;
@@ -562,18 +542,16 @@ export const asinh = (x: VarAD, isCompNode = true): VarAD => {
   y.isCompNode = isCompNode;
 
   if (isCompNode) {
-    const node = just(
-      div(
-        gvarOf(1.0),
-        sqrt(add(gvarOf(1.0), mul(x, x, false), false), false),
-        false
-      )
+    const node = div(
+      gvarOf(1.0),
+      sqrt(add(gvarOf(1.0), mul(x, x, false), false), false),
+      false
     );
     x.parentsAD.push({ node: y, sensitivityNode: node });
     y.childrenAD.push({ node: x, sensitivityNode: node });
   } else {
-    x.parentsADGrad.push({ node: y, sensitivityNode: none });
-    y.childrenADGrad.push({ node: x, sensitivityNode: none });
+    x.parentsADGrad.push({ node: y, sensitivityNode: undefined });
+    y.childrenADGrad.push({ node: x, sensitivityNode: undefined });
   }
 
   return y;
@@ -587,14 +565,16 @@ export const atan = (x: VarAD, isCompNode = true): VarAD => {
   y.isCompNode = isCompNode;
 
   if (isCompNode) {
-    const node = just(
-      div(gvarOf(1.0), add(gvarOf(1.0), mul(x, x, false), false), false)
+    const node = div(
+      gvarOf(1.0),
+      add(gvarOf(1.0), mul(x, x, false), false),
+      false
     );
     x.parentsAD.push({ node: y, sensitivityNode: node });
     y.childrenAD.push({ node: x, sensitivityNode: node });
   } else {
-    x.parentsADGrad.push({ node: y, sensitivityNode: none });
-    y.childrenADGrad.push({ node: x, sensitivityNode: none });
+    x.parentsADGrad.push({ node: y, sensitivityNode: undefined });
+    y.childrenADGrad.push({ node: x, sensitivityNode: undefined });
   }
 
   return y;
@@ -608,14 +588,16 @@ export const atanh = (x: VarAD, isCompNode = true): VarAD => {
   y.isCompNode = isCompNode;
 
   if (isCompNode) {
-    const node = just(
-      div(gvarOf(1.0), sub(gvarOf(1.0), mul(x, x, false), false), false)
+    const node = div(
+      gvarOf(1.0),
+      sub(gvarOf(1.0), mul(x, x, false), false),
+      false
     );
     x.parentsAD.push({ node: y, sensitivityNode: node });
     y.childrenAD.push({ node: x, sensitivityNode: node });
   } else {
-    x.parentsADGrad.push({ node: y, sensitivityNode: none });
-    y.childrenADGrad.push({ node: x, sensitivityNode: none });
+    x.parentsADGrad.push({ node: y, sensitivityNode: undefined });
+    y.childrenADGrad.push({ node: x, sensitivityNode: undefined });
   }
 
   return y;
@@ -629,18 +611,16 @@ export const cbrt = (x: VarAD, isCompNode = true): VarAD => {
   y.isCompNode = isCompNode;
 
   if (isCompNode) {
-    const node = just(
-      div(
-        gvarOf(1.0),
-        mul(gvarOf(3.0), squared(cbrt(x, false), false), false),
-        false
-      )
+    const node = div(
+      gvarOf(1.0),
+      mul(gvarOf(3.0), squared(cbrt(x, false), false), false),
+      false
     );
     x.parentsAD.push({ node: y, sensitivityNode: node });
     y.childrenAD.push({ node: x, sensitivityNode: node });
   } else {
-    x.parentsADGrad.push({ node: y, sensitivityNode: none });
-    y.childrenADGrad.push({ node: x, sensitivityNode: none });
+    x.parentsADGrad.push({ node: y, sensitivityNode: undefined });
+    y.childrenADGrad.push({ node: x, sensitivityNode: undefined });
   }
 
   return y;
@@ -654,12 +634,12 @@ export const ceil = (x: VarAD, isCompNode = true): VarAD => {
   y.isCompNode = isCompNode;
 
   if (isCompNode) {
-    const node = just(gvarOf(0.0));
+    const node = gvarOf(0.0);
     x.parentsAD.push({ node: y, sensitivityNode: node });
     y.childrenAD.push({ node: x, sensitivityNode: node });
   } else {
-    x.parentsADGrad.push({ node: y, sensitivityNode: none });
-    y.childrenADGrad.push({ node: x, sensitivityNode: none });
+    x.parentsADGrad.push({ node: y, sensitivityNode: undefined });
+    y.childrenADGrad.push({ node: x, sensitivityNode: undefined });
   }
 
   return y;
@@ -673,12 +653,12 @@ export const cos = (x: VarAD, isCompNode = true): VarAD => {
   y.isCompNode = isCompNode;
 
   if (isCompNode) {
-    const node = just(neg(sin(x, false), false));
+    const node = neg(sin(x, false), false);
     x.parentsAD.push({ node: y, sensitivityNode: node });
     y.childrenAD.push({ node: x, sensitivityNode: node });
   } else {
-    x.parentsADGrad.push({ node: y, sensitivityNode: none });
-    y.childrenADGrad.push({ node: x, sensitivityNode: none });
+    x.parentsADGrad.push({ node: y, sensitivityNode: undefined });
+    y.childrenADGrad.push({ node: x, sensitivityNode: undefined });
   }
 
   return y;
@@ -692,12 +672,12 @@ export const cosh = (x: VarAD, isCompNode = true): VarAD => {
   y.isCompNode = isCompNode;
 
   if (isCompNode) {
-    const node = just(sinh(x, false));
+    const node = sinh(x, false);
     x.parentsAD.push({ node: y, sensitivityNode: node });
     y.childrenAD.push({ node: x, sensitivityNode: node });
   } else {
-    x.parentsADGrad.push({ node: y, sensitivityNode: none });
-    y.childrenADGrad.push({ node: x, sensitivityNode: none });
+    x.parentsADGrad.push({ node: y, sensitivityNode: undefined });
+    y.childrenADGrad.push({ node: x, sensitivityNode: undefined });
   }
 
   return y;
@@ -711,12 +691,12 @@ export const exp = (x: VarAD, isCompNode = true): VarAD => {
   y.isCompNode = isCompNode;
 
   if (isCompNode) {
-    const node = just(exp(x, false));
+    const node = exp(x, false);
     x.parentsAD.push({ node: y, sensitivityNode: node });
     y.childrenAD.push({ node: x, sensitivityNode: node });
   } else {
-    x.parentsADGrad.push({ node: y, sensitivityNode: none });
-    y.childrenADGrad.push({ node: x, sensitivityNode: none });
+    x.parentsADGrad.push({ node: y, sensitivityNode: undefined });
+    y.childrenADGrad.push({ node: x, sensitivityNode: undefined });
   }
 
   return y;
@@ -730,12 +710,12 @@ export const expm1 = (x: VarAD, isCompNode = true): VarAD => {
   y.isCompNode = isCompNode;
 
   if (isCompNode) {
-    const node = just(exp(x, false));
+    const node = exp(x, false);
     x.parentsAD.push({ node: y, sensitivityNode: node });
     y.childrenAD.push({ node: x, sensitivityNode: node });
   } else {
-    x.parentsADGrad.push({ node: y, sensitivityNode: none });
-    y.childrenADGrad.push({ node: x, sensitivityNode: none });
+    x.parentsADGrad.push({ node: y, sensitivityNode: undefined });
+    y.childrenADGrad.push({ node: x, sensitivityNode: undefined });
   }
 
   return y;
@@ -749,12 +729,12 @@ export const floor = (x: VarAD, isCompNode = true): VarAD => {
   y.isCompNode = isCompNode;
 
   if (isCompNode) {
-    const node = just(gvarOf(0.0));
+    const node = gvarOf(0.0);
     x.parentsAD.push({ node: y, sensitivityNode: node });
     y.childrenAD.push({ node: x, sensitivityNode: node });
   } else {
-    x.parentsADGrad.push({ node: y, sensitivityNode: none });
-    y.childrenADGrad.push({ node: x, sensitivityNode: none });
+    x.parentsADGrad.push({ node: y, sensitivityNode: undefined });
+    y.childrenADGrad.push({ node: x, sensitivityNode: undefined });
   }
 
   return y;
@@ -768,12 +748,12 @@ export const ln = (x: VarAD, isCompNode = true): VarAD => {
   y.isCompNode = isCompNode;
 
   if (isCompNode) {
-    const node = just(div(gvarOf(1.0), x, false));
+    const node = div(gvarOf(1.0), x, false);
     x.parentsAD.push({ node: y, sensitivityNode: node });
     y.childrenAD.push({ node: x, sensitivityNode: node });
   } else {
-    x.parentsADGrad.push({ node: y, sensitivityNode: none });
-    y.childrenADGrad.push({ node: x, sensitivityNode: none });
+    x.parentsADGrad.push({ node: y, sensitivityNode: undefined });
+    y.childrenADGrad.push({ node: x, sensitivityNode: undefined });
   }
 
   return y;
@@ -787,14 +767,16 @@ export const log2 = (x: VarAD, isCompNode = true): VarAD => {
   y.isCompNode = isCompNode;
 
   if (isCompNode) {
-    const node = just(
-      div(gvarOf(1.0), mul(x, gvarOf(0.6931471805599453), false), false)
+    const node = div(
+      gvarOf(1.0),
+      mul(x, gvarOf(0.6931471805599453), false),
+      false
     );
     x.parentsAD.push({ node: y, sensitivityNode: node });
     y.childrenAD.push({ node: x, sensitivityNode: node });
   } else {
-    x.parentsADGrad.push({ node: y, sensitivityNode: none });
-    y.childrenADGrad.push({ node: x, sensitivityNode: none });
+    x.parentsADGrad.push({ node: y, sensitivityNode: undefined });
+    y.childrenADGrad.push({ node: x, sensitivityNode: undefined });
   }
 
   return y;
@@ -808,14 +790,16 @@ export const log10 = (x: VarAD, isCompNode = true): VarAD => {
   y.isCompNode = isCompNode;
 
   if (isCompNode) {
-    const node = just(
-      div(gvarOf(1.0), mul(x, gvarOf(2.302585092994046), false), false)
+    const node = div(
+      gvarOf(1.0),
+      mul(x, gvarOf(2.302585092994046), false),
+      false
     );
     x.parentsAD.push({ node: y, sensitivityNode: node });
     y.childrenAD.push({ node: x, sensitivityNode: node });
   } else {
-    x.parentsADGrad.push({ node: y, sensitivityNode: none });
-    y.childrenADGrad.push({ node: x, sensitivityNode: none });
+    x.parentsADGrad.push({ node: y, sensitivityNode: undefined });
+    y.childrenADGrad.push({ node: x, sensitivityNode: undefined });
   }
 
   return y;
@@ -829,12 +813,12 @@ export const log1p = (x: VarAD, isCompNode = true): VarAD => {
   y.isCompNode = isCompNode;
 
   if (isCompNode) {
-    const node = just(div(gvarOf(1.0), add(gvarOf(1.0), x, false), false));
+    const node = div(gvarOf(1.0), add(gvarOf(1.0), x, false), false);
     x.parentsAD.push({ node: y, sensitivityNode: node });
     y.childrenAD.push({ node: x, sensitivityNode: node });
   } else {
-    x.parentsADGrad.push({ node: y, sensitivityNode: none });
-    y.childrenADGrad.push({ node: x, sensitivityNode: none });
+    x.parentsADGrad.push({ node: y, sensitivityNode: undefined });
+    y.childrenADGrad.push({ node: x, sensitivityNode: undefined });
   }
 
   return y;
@@ -848,12 +832,12 @@ export const round = (x: VarAD, isCompNode = true): VarAD => {
   y.isCompNode = isCompNode;
 
   if (isCompNode) {
-    const node = just(gvarOf(0.0));
+    const node = gvarOf(0.0);
     x.parentsAD.push({ node: y, sensitivityNode: node });
     y.childrenAD.push({ node: x, sensitivityNode: node });
   } else {
-    x.parentsADGrad.push({ node: y, sensitivityNode: none });
-    y.childrenADGrad.push({ node: x, sensitivityNode: none });
+    x.parentsADGrad.push({ node: y, sensitivityNode: undefined });
+    y.childrenADGrad.push({ node: x, sensitivityNode: undefined });
   }
 
   return y;
@@ -867,12 +851,12 @@ export const sign = (x: VarAD, isCompNode = true): VarAD => {
   y.isCompNode = isCompNode;
 
   if (isCompNode) {
-    const node = just(gvarOf(0.0));
+    const node = gvarOf(0.0);
     x.parentsAD.push({ node: y, sensitivityNode: node });
     y.childrenAD.push({ node: x, sensitivityNode: node });
   } else {
-    x.parentsADGrad.push({ node: y, sensitivityNode: none });
-    y.childrenADGrad.push({ node: x, sensitivityNode: none });
+    x.parentsADGrad.push({ node: y, sensitivityNode: undefined });
+    y.childrenADGrad.push({ node: x, sensitivityNode: undefined });
   }
 
   return y;
@@ -886,12 +870,12 @@ export const sin = (x: VarAD, isCompNode = true): VarAD => {
   y.isCompNode = isCompNode;
 
   if (isCompNode) {
-    const node = just(cos(x, false));
+    const node = cos(x, false);
     x.parentsAD.push({ node: y, sensitivityNode: node });
     y.childrenAD.push({ node: x, sensitivityNode: node });
   } else {
-    x.parentsADGrad.push({ node: y, sensitivityNode: none });
-    y.childrenADGrad.push({ node: x, sensitivityNode: none });
+    x.parentsADGrad.push({ node: y, sensitivityNode: undefined });
+    y.childrenADGrad.push({ node: x, sensitivityNode: undefined });
   }
 
   return y;
@@ -905,12 +889,12 @@ export const sinh = (x: VarAD, isCompNode = true): VarAD => {
   y.isCompNode = isCompNode;
 
   if (isCompNode) {
-    const node = just(cosh(x, false));
+    const node = cosh(x, false);
     x.parentsAD.push({ node: y, sensitivityNode: node });
     y.childrenAD.push({ node: x, sensitivityNode: node });
   } else {
-    x.parentsADGrad.push({ node: y, sensitivityNode: none });
-    y.childrenADGrad.push({ node: x, sensitivityNode: none });
+    x.parentsADGrad.push({ node: y, sensitivityNode: undefined });
+    y.childrenADGrad.push({ node: x, sensitivityNode: undefined });
   }
 
   return y;
@@ -924,12 +908,12 @@ export const tan = (x: VarAD, isCompNode = true): VarAD => {
   y.isCompNode = isCompNode;
 
   if (isCompNode) {
-    const node = just(squared(div(gvarOf(1.0), cos(x, false), false), false));
+    const node = squared(div(gvarOf(1.0), cos(x, false), false), false);
     x.parentsAD.push({ node: y, sensitivityNode: node });
     y.childrenAD.push({ node: x, sensitivityNode: node });
   } else {
-    x.parentsADGrad.push({ node: y, sensitivityNode: none });
-    y.childrenADGrad.push({ node: x, sensitivityNode: none });
+    x.parentsADGrad.push({ node: y, sensitivityNode: undefined });
+    y.childrenADGrad.push({ node: x, sensitivityNode: undefined });
   }
 
   return y;
@@ -943,12 +927,12 @@ export const tanh = (x: VarAD, isCompNode = true): VarAD => {
   y.isCompNode = isCompNode;
 
   if (isCompNode) {
-    const node = just(squared(div(gvarOf(1.0), cosh(x, false), false), false));
+    const node = squared(div(gvarOf(1.0), cosh(x, false), false), false);
     x.parentsAD.push({ node: y, sensitivityNode: node });
     y.childrenAD.push({ node: x, sensitivityNode: node });
   } else {
-    x.parentsADGrad.push({ node: y, sensitivityNode: none });
-    y.childrenADGrad.push({ node: x, sensitivityNode: none });
+    x.parentsADGrad.push({ node: y, sensitivityNode: undefined });
+    y.childrenADGrad.push({ node: x, sensitivityNode: undefined });
   }
 
   return y;
@@ -962,12 +946,12 @@ export const trunc = (x: VarAD, isCompNode = true): VarAD => {
   y.isCompNode = isCompNode;
 
   if (isCompNode) {
-    const node = just(gvarOf(0.0));
+    const node = gvarOf(0.0);
     x.parentsAD.push({ node: y, sensitivityNode: node });
     y.childrenAD.push({ node: x, sensitivityNode: node });
   } else {
-    x.parentsADGrad.push({ node: y, sensitivityNode: none });
-    y.childrenADGrad.push({ node: x, sensitivityNode: none });
+    x.parentsADGrad.push({ node: y, sensitivityNode: undefined });
+    y.childrenADGrad.push({ node: x, sensitivityNode: undefined });
   }
 
   return y;
@@ -985,17 +969,17 @@ export const gt = (v: VarAD, w: VarAD, isCompNode = true): VarAD => {
   z.isCompNode = isCompNode;
 
   if (isCompNode) {
-    z.childrenAD.push({ node: v, sensitivityNode: just(noGrad) });
-    z.childrenAD.push({ node: w, sensitivityNode: just(noGrad) });
+    z.childrenAD.push({ node: v, sensitivityNode: noGrad });
+    z.childrenAD.push({ node: w, sensitivityNode: noGrad });
 
-    v.parentsAD.push({ node: z, sensitivityNode: just(noGrad) });
-    w.parentsAD.push({ node: z, sensitivityNode: just(noGrad) });
+    v.parentsAD.push({ node: z, sensitivityNode: noGrad });
+    w.parentsAD.push({ node: z, sensitivityNode: noGrad });
   } else {
-    z.childrenADGrad.push({ node: v, sensitivityNode: none });
-    z.childrenADGrad.push({ node: w, sensitivityNode: none });
+    z.childrenADGrad.push({ node: v, sensitivityNode: undefined });
+    z.childrenADGrad.push({ node: w, sensitivityNode: undefined });
 
-    v.parentsADGrad.push({ node: z, sensitivityNode: none });
-    w.parentsADGrad.push({ node: z, sensitivityNode: none });
+    v.parentsADGrad.push({ node: z, sensitivityNode: undefined });
+    w.parentsADGrad.push({ node: z, sensitivityNode: undefined });
   }
 
   return z;
@@ -1010,17 +994,17 @@ export const lt = (v: VarAD, w: VarAD, isCompNode = true): VarAD => {
   z.isCompNode = isCompNode;
 
   if (isCompNode) {
-    z.childrenAD.push({ node: v, sensitivityNode: just(noGrad) });
-    z.childrenAD.push({ node: w, sensitivityNode: just(noGrad) });
+    z.childrenAD.push({ node: v, sensitivityNode: noGrad });
+    z.childrenAD.push({ node: w, sensitivityNode: noGrad });
 
-    v.parentsAD.push({ node: z, sensitivityNode: just(noGrad) });
-    w.parentsAD.push({ node: z, sensitivityNode: just(noGrad) });
+    v.parentsAD.push({ node: z, sensitivityNode: noGrad });
+    w.parentsAD.push({ node: z, sensitivityNode: noGrad });
   } else {
-    z.childrenADGrad.push({ node: v, sensitivityNode: none });
-    z.childrenADGrad.push({ node: w, sensitivityNode: none });
+    z.childrenADGrad.push({ node: v, sensitivityNode: undefined });
+    z.childrenADGrad.push({ node: w, sensitivityNode: undefined });
 
-    v.parentsADGrad.push({ node: z, sensitivityNode: none });
-    w.parentsADGrad.push({ node: z, sensitivityNode: none });
+    v.parentsADGrad.push({ node: z, sensitivityNode: undefined });
+    w.parentsADGrad.push({ node: z, sensitivityNode: undefined });
   }
 
   return z;
@@ -1036,17 +1020,17 @@ export const eq = (v: VarAD, w: VarAD, isCompNode = true): VarAD => {
   z.isCompNode = isCompNode;
 
   if (isCompNode) {
-    z.childrenAD.push({ node: v, sensitivityNode: just(noGrad) });
-    z.childrenAD.push({ node: w, sensitivityNode: just(noGrad) });
+    z.childrenAD.push({ node: v, sensitivityNode: noGrad });
+    z.childrenAD.push({ node: w, sensitivityNode: noGrad });
 
-    v.parentsAD.push({ node: z, sensitivityNode: just(noGrad) });
-    w.parentsAD.push({ node: z, sensitivityNode: just(noGrad) });
+    v.parentsAD.push({ node: z, sensitivityNode: noGrad });
+    w.parentsAD.push({ node: z, sensitivityNode: noGrad });
   } else {
-    z.childrenADGrad.push({ node: v, sensitivityNode: none });
-    z.childrenADGrad.push({ node: w, sensitivityNode: none });
+    z.childrenADGrad.push({ node: v, sensitivityNode: undefined });
+    z.childrenADGrad.push({ node: w, sensitivityNode: undefined });
 
-    v.parentsADGrad.push({ node: z, sensitivityNode: none });
-    w.parentsADGrad.push({ node: z, sensitivityNode: none });
+    v.parentsADGrad.push({ node: z, sensitivityNode: undefined });
+    w.parentsADGrad.push({ node: z, sensitivityNode: undefined });
   }
 
   return z;
@@ -1060,17 +1044,17 @@ export const and = (v: VarAD, w: VarAD, isCompNode = true): VarAD => {
   z.isCompNode = isCompNode;
 
   if (isCompNode) {
-    z.childrenAD.push({ node: v, sensitivityNode: just(noGrad) });
-    z.childrenAD.push({ node: w, sensitivityNode: just(noGrad) });
+    z.childrenAD.push({ node: v, sensitivityNode: noGrad });
+    z.childrenAD.push({ node: w, sensitivityNode: noGrad });
 
-    v.parentsAD.push({ node: z, sensitivityNode: just(noGrad) });
-    w.parentsAD.push({ node: z, sensitivityNode: just(noGrad) });
+    v.parentsAD.push({ node: z, sensitivityNode: noGrad });
+    w.parentsAD.push({ node: z, sensitivityNode: noGrad });
   } else {
-    z.childrenADGrad.push({ node: v, sensitivityNode: none });
-    z.childrenADGrad.push({ node: w, sensitivityNode: none });
+    z.childrenADGrad.push({ node: v, sensitivityNode: undefined });
+    z.childrenADGrad.push({ node: w, sensitivityNode: undefined });
 
-    v.parentsADGrad.push({ node: z, sensitivityNode: none });
-    w.parentsADGrad.push({ node: z, sensitivityNode: none });
+    v.parentsADGrad.push({ node: z, sensitivityNode: undefined });
+    w.parentsADGrad.push({ node: z, sensitivityNode: undefined });
   }
 
   return z;
@@ -1084,17 +1068,17 @@ export const or = (v: VarAD, w: VarAD, isCompNode = true): VarAD => {
   z.isCompNode = isCompNode;
 
   if (isCompNode) {
-    z.childrenAD.push({ node: v, sensitivityNode: just(noGrad) });
-    z.childrenAD.push({ node: w, sensitivityNode: just(noGrad) });
+    z.childrenAD.push({ node: v, sensitivityNode: noGrad });
+    z.childrenAD.push({ node: w, sensitivityNode: noGrad });
 
-    v.parentsAD.push({ node: z, sensitivityNode: just(noGrad) });
-    w.parentsAD.push({ node: z, sensitivityNode: just(noGrad) });
+    v.parentsAD.push({ node: z, sensitivityNode: noGrad });
+    w.parentsAD.push({ node: z, sensitivityNode: noGrad });
   } else {
-    z.childrenADGrad.push({ node: v, sensitivityNode: none });
-    z.childrenADGrad.push({ node: w, sensitivityNode: none });
+    z.childrenADGrad.push({ node: v, sensitivityNode: undefined });
+    z.childrenADGrad.push({ node: w, sensitivityNode: undefined });
 
-    v.parentsADGrad.push({ node: z, sensitivityNode: none });
-    w.parentsADGrad.push({ node: z, sensitivityNode: none });
+    v.parentsADGrad.push({ node: z, sensitivityNode: undefined });
+    w.parentsADGrad.push({ node: z, sensitivityNode: undefined });
   }
 
   return z;
@@ -1118,21 +1102,21 @@ export const ifCond = (
     const vNode = ifCond(cond, gvarOf(1.0), gvarOf(0.0), false);
     const wNode = ifCond(cond, gvarOf(0.0), gvarOf(1.0), false);
 
-    z.childrenAD.push({ node: cond, sensitivityNode: just(noGrad) });
-    z.childrenAD.push({ node: v, sensitivityNode: just(vNode) });
-    z.childrenAD.push({ node: w, sensitivityNode: just(wNode) });
+    z.childrenAD.push({ node: cond, sensitivityNode: noGrad });
+    z.childrenAD.push({ node: v, sensitivityNode: vNode });
+    z.childrenAD.push({ node: w, sensitivityNode: wNode });
 
-    cond.parentsAD.push({ node: z, sensitivityNode: just(noGrad) });
-    v.parentsAD.push({ node: z, sensitivityNode: just(vNode) });
-    w.parentsAD.push({ node: z, sensitivityNode: just(wNode) });
+    cond.parentsAD.push({ node: z, sensitivityNode: noGrad });
+    v.parentsAD.push({ node: z, sensitivityNode: vNode });
+    w.parentsAD.push({ node: z, sensitivityNode: wNode });
   } else {
-    z.childrenADGrad.push({ node: cond, sensitivityNode: none });
-    z.childrenADGrad.push({ node: v, sensitivityNode: none });
-    z.childrenADGrad.push({ node: w, sensitivityNode: none });
+    z.childrenADGrad.push({ node: cond, sensitivityNode: undefined });
+    z.childrenADGrad.push({ node: v, sensitivityNode: undefined });
+    z.childrenADGrad.push({ node: w, sensitivityNode: undefined });
 
-    cond.parentsADGrad.push({ node: z, sensitivityNode: none });
-    v.parentsADGrad.push({ node: z, sensitivityNode: none });
-    w.parentsADGrad.push({ node: z, sensitivityNode: none });
+    cond.parentsADGrad.push({ node: z, sensitivityNode: undefined });
+    v.parentsADGrad.push({ node: z, sensitivityNode: undefined });
+    w.parentsADGrad.push({ node: z, sensitivityNode: undefined });
   }
 
   return z;

--- a/packages/core/src/engine/EngineUtils.ts
+++ b/packages/core/src/engine/EngineUtils.ts
@@ -76,13 +76,7 @@ export const runtimeValueTypeError = (
 };
 // Generic utils for mapping over values
 export function mapTuple<T, S>(f: (arg: T) => S, t: T[]): S[] {
-  // TODO: Polygon seems to be getting through with null to the frontend with previously working set examples -- not sure why?
-  // TODO: Should do null checks more systematically across the translation
   return t.map((tup) => {
-    if (tup === null) {
-      return (varOf(0.0) as unknown) as S;
-    }
-
     return f(tup);
   });
 }

--- a/packages/core/src/engine/EngineUtils.ts
+++ b/packages/core/src/engine/EngineUtils.ts
@@ -1014,8 +1014,8 @@ export const initConstraintWeight = 10e-3;
 const defaultLbfgsMemSize = 17;
 
 export const defaultLbfgsParams: LbfgsParams = {
-  lastState: { tag: "Nothing" },
-  lastGrad: { tag: "Nothing" },
+  lastState: undefined,
+  lastGrad: undefined,
   s_list: [],
   y_list: [],
   numUnconstrSteps: 0,

--- a/packages/core/src/engine/Optimizer.ts
+++ b/packages/core/src/engine/Optimizer.ts
@@ -685,8 +685,8 @@ const lbfgs = (xs: number[], gradfxs: number[], lbfgsInfo: LbfgsParams) => {
     const grad_fx_k = colVec(gradfxs);
 
     const km1 = lbfgsInfo.numUnconstrSteps;
-    const x_km1 = lbfgsInfo.lastState.contents;
-    const grad_fx_km1 = lbfgsInfo.lastGrad.contents;
+    const x_km1 = lbfgsInfo.lastState;
+    const grad_fx_km1 = lbfgsInfo.lastGrad;
     const ss_km2 = lbfgsInfo.s_list;
     const ys_km2 = lbfgsInfo.y_list;
 

--- a/packages/core/src/engine/Optimizer.ts
+++ b/packages/core/src/engine/Optimizer.ts
@@ -30,7 +30,6 @@ import {
 import * as _ from "lodash";
 import rfdc from "rfdc";
 import { OptInfo, VarAD } from "types/ad";
-import { MaybeVal } from "types/common";
 import {
   Fn,
   FnCached,
@@ -670,16 +669,16 @@ const lbfgs = (xs: number[], gradfxs: number[], lbfgsInfo: LbfgsParams) => {
       gradfxsPreconditioned: gradfxs,
       updatedLbfgsInfo: {
         ...lbfgsInfo,
-        lastState: { tag: "Just" as const, contents: colVec(xs) },
-        lastGrad: { tag: "Just" as const, contents: colVec(gradfxs) },
+        lastState: colVec(xs),
+        lastGrad: colVec(gradfxs),
         s_list: [],
         y_list: [],
         numUnconstrSteps: 1,
       },
     };
   } else if (
-    lbfgsInfo.lastState.tag === "Just" &&
-    lbfgsInfo.lastGrad.tag === "Just"
+    lbfgsInfo.lastState !== undefined &&
+    lbfgsInfo.lastGrad !== undefined
   ) {
     // Our current step is k; the last step is km1 (k_minus_1)
     const x_k = colVec(xs);
@@ -721,8 +720,8 @@ const lbfgs = (xs: number[], gradfxs: number[], lbfgsInfo: LbfgsParams) => {
         gradfxsPreconditioned: gradfxs,
         updatedLbfgsInfo: {
           ...lbfgsInfo,
-          lastState: { tag: "Just" as const, contents: x_k },
-          lastGrad: { tag: "Just" as const, contents: grad_fx_k },
+          lastState: x_k,
+          lastGrad: grad_fx_k,
           s_list: [],
           y_list: [],
           numUnconstrSteps: 1,
@@ -741,8 +740,8 @@ const lbfgs = (xs: number[], gradfxs: number[], lbfgsInfo: LbfgsParams) => {
       gradfxsPreconditioned: vecList(gradPreconditioned),
       updatedLbfgsInfo: {
         ...lbfgsInfo,
-        lastState: { tag: "Just" as const, contents: x_k },
-        lastGrad: { tag: "Just" as const, contents: grad_fx_k },
+        lastState: x_k,
+        lastGrad: grad_fx_k,
         s_list: ss_km1,
         y_list: ys_km1,
         numUnconstrSteps: km1 + 1,
@@ -942,7 +941,7 @@ export const evalEnergyOnCustom = (rng: seedrandom.prng, state: State) => {
     );
 
     // NOTE: This is necessary because we have to state the seed for the autodiff, which is the last output
-    overallEng.gradVal = { tag: "Just" as const, contents: 1.0 };
+    overallEng.gradVal = 1.0;
     log.info("overall eng from custom AD", overallEng, overallEng.val);
 
     return {
@@ -985,7 +984,7 @@ export const genOptProblem = (rng: seedrandom.prng, state: State): State => {
     xs,
     xsVars,
     res.energyGraph,
-    { tag: "Just", contents: weightInfo }
+    weightInfo
   );
 
   eig.GC.flush(); // Clear allocated matrix, vector objects in L-BFGS params
@@ -1056,7 +1055,7 @@ const genFn = (rng: seedrandom.prng, fn: Fn, s: State): FnCached => {
   const xsVars: VarAD[] = makeADInputVars(xs);
   const energyGraph: VarAD = overallObjective(...xsVars); // Note: `overallObjective` mutates `xsVars`
 
-  const weightInfo: MaybeVal<WeightInfo> = { tag: "Nothing" };
+  const weightInfo: WeightInfo | undefined = undefined;
 
   const { graphs, f, gradf } = energyAndGradCompiled(
     xs,

--- a/packages/core/src/parser/ParserUtil.ts
+++ b/packages/core/src/parser/ParserUtil.ts
@@ -130,11 +130,11 @@ export const rangeFrom = (children: SourceRange[]): SourceRange => {
 };
 
 export const rangeBetween = (
-  // alternatively, beginToken could be null if endToken isn't
+  // alternatively, beginToken could be undefined if endToken isn't
   beginToken: moo.Token | SourceRange,
-  endToken: moo.Token | SourceRange | null
+  endToken: moo.Token | SourceRange | undefined
 ): SourceRange => {
-  // handle null cases for easier use in postprocessors
+  // handle undefined cases for easier use in postprocessors
   if (!endToken) return rangeOf(beginToken);
   if (!beginToken) return rangeOf(endToken);
   const [beginRange, endRange] = [beginToken, endToken].map(rangeOf);

--- a/packages/core/src/renderer/Image.ts
+++ b/packages/core/src/renderer/Image.ts
@@ -20,7 +20,7 @@ const Image = async ({
   // Map/Fill the shape attributes while keeping track of input properties mapped
   const path = (shape.properties.href as IStrV).contents;
   let rawSVG = await pathResolver(path);
-  if (rawSVG === null) {
+  if (rawSVG === undefined) {
     console.error(`Could not resolve image path ${path}`);
     rawSVG = notFound["image"] as string;
   }

--- a/packages/core/src/renderer/Renderer.ts
+++ b/packages/core/src/renderer/Renderer.ts
@@ -14,9 +14,9 @@ import { shapedefs } from "shapes/Shapes";
 /**
  * Resolves path references into static strings. Implemented by client
  * since filesystem contexts vary (eg browser vs headless).
- * If path fails to resolve, return null
+ * If path fails to resolve, return undefined
  */
-export type PathResolver = (path: string) => Promise<string | null>;
+export type PathResolver = (path: string) => Promise<string | undefined>;
 
 export interface ShapeProps {
   shape: Shape;

--- a/packages/core/src/types/ad.ts
+++ b/packages/core/src/types/ad.ts
@@ -1,6 +1,5 @@
 //#region Types for reverse-mode autodiff
 
-import { MaybeVal } from "./common";
 import { LbfgsParams } from "./state";
 
 // ----- Core types
@@ -21,7 +20,7 @@ export interface IEdgeAD {
 
   // Function "flowing down" from parent z (output, which is the node stored here) to child v (input), dz/dv
   // Aka how sensitive the output is to this input -- a function encoded as a computational graph fragment
-  sensitivityNode: MaybeVal<VarAD>;
+  sensitivityNode: VarAD | undefined;
 }
 
 export type EdgeAD = IEdgeAD;
@@ -38,8 +37,8 @@ export interface IVarAD {
   childrenAD: EdgeAD[];
   parentsADGrad: EdgeAD[]; // The resulting values from an expression. e.g. in `z := x + y`, `z` is a parent of `x` and of `y`
   childrenADGrad: EdgeAD[];
-  gradVal: MaybeVal<number>;
-  gradNode: MaybeVal<VarAD>;
+  gradVal: number | undefined;
+  gradNode: VarAD | undefined;
   index: number; // -1 if not a leaf node, 0-n for leaf nodes (order in the leaf node list) so we know how to pass in the floats
 
   debug: boolean; // If true, this prints node debug info on evaluation
@@ -69,7 +68,7 @@ export interface IGradGraphs {
   energyOutput: VarAD;
   // The energy inputs may be different from the grad inputs bc the former may contain the EP weight (but for the latter, we do not want the derivative WRT the EP weight)
   gradOutputs: VarAD[];
-  weight: MaybeVal<VarAD>; // EP weight, a hyperparameter to both energy and gradient; TODO: generalize to multiple hyperparameters
+  weight: VarAD | undefined; // EP weight, a hyperparameter to both energy and gradient; TODO: generalize to multiple hyperparameters
 }
 
 export type OptInfo = IOptInfo;

--- a/packages/core/src/types/ast.ts
+++ b/packages/core/src/types/ast.ts
@@ -33,11 +33,11 @@ export type C = SourceRange;
 export type ConcreteNode = ASTNode<C>;
 
 // metaObj causes TypeScript to enforce that metaProps is correct
-const metaObj: { [k in keyof Omit<ConcreteNode, "tag">]: null } = {
-  nodeType: null,
-  children: null,
-  start: null,
-  end: null,
+const metaObj: { [k in keyof Omit<ConcreteNode, "tag">]: undefined } = {
+  nodeType: undefined,
+  children: undefined,
+  start: undefined,
+  end: undefined,
 };
 export const metaProps: string[] = Object.keys(metaObj);
 

--- a/packages/core/src/types/common.ts
+++ b/packages/core/src/types/common.ts
@@ -1,14 +1,3 @@
-export interface Nothing<T> {
-  tag: "Nothing";
-}
-
-export interface Just<T> {
-  tag: "Just";
-  contents: T;
-}
-
-export type MaybeVal<T> = Nothing<T> | Just<T>;
-
 export interface Left<A> {
   tag: "Left";
   contents: A;

--- a/packages/core/src/types/state.ts
+++ b/packages/core/src/types/state.ts
@@ -114,7 +114,6 @@ export interface ILbfgsParams {
   // TODO: Store as matrix types
   lastState: any | undefined; // nx1 (col vec)
   lastGrad: any | undefined; // nx1 (col vec)
-  // invH: Maybe<any>; // nxn matrix
   s_list: any[]; // list of nx1 col vecs
   y_list: any[]; // list of nx1 col vecs
   numUnconstrSteps: number;

--- a/packages/core/src/types/state.ts
+++ b/packages/core/src/types/state.ts
@@ -1,7 +1,6 @@
 import { Canvas } from "shapes/Samplers";
 import { VarAD, GradGraphs } from "./ad";
 import { A } from "./ast";
-import { MaybeVal } from "./common";
 import { Shape } from "./shape";
 import { Expr, Path } from "./style";
 import { ArgVal, IFloatV, Translation, Value } from "./value";
@@ -113,8 +112,8 @@ export type LbfgsParams = ILbfgsParams;
 // `n` is the size of the varying state
 export interface ILbfgsParams {
   // TODO: Store as matrix types
-  lastState: MaybeVal<any>; // nx1 (col vec)
-  lastGrad: MaybeVal<any>; // nx1 (col vec)
+  lastState: any | undefined; // nx1 (col vec)
+  lastGrad: any | undefined; // nx1 (col vec)
   // invH: Maybe<any>; // nxn matrix
   s_list: any[]; // list of nx1 col vecs
   y_list: any[]; // list of nx1 col vecs

--- a/packages/core/src/types/styleSemantics.ts
+++ b/packages/core/src/types/styleSemantics.ts
@@ -1,7 +1,6 @@
 //#region Style semantics
 
 import { A } from "./ast";
-import { MaybeVal } from "./common";
 import { StyleErrors } from "./errors";
 import { StyT, Header, BindingForm } from "./style";
 
@@ -33,7 +32,7 @@ export interface ISelEnv {
   varProgTypeMap: { [k: string]: [ProgType, BindingForm<A>] }; // Store aux info for debugging, COMBAK maybe combine it with sTypeVarMap
   // Variable => [Substance or Style variable, original data structure with program locs etc]
   skipBlock: boolean;
-  header: MaybeVal<Header<A>>; // Just for debugging
+  header: Header<A> | undefined; // Just for debugging
   warnings: StyleErrors;
   errors: StyleErrors;
 }

--- a/packages/core/src/utils/Error.ts
+++ b/packages/core/src/utils/Error.ts
@@ -1,6 +1,6 @@
 import { isConcrete } from "engine/EngineUtils";
 import { shapedefs } from "shapes/Shapes";
-import { Maybe, Result } from "true-myth";
+import { Result } from "true-myth";
 import { A, Identifier, SourceLoc, AbstractNode } from "types/ast";
 import { Arg, Prop, Type, TypeConstructor, TypeVar } from "types/domain";
 import {
@@ -625,7 +625,6 @@ export const all = <Ok, Error>(
 
 // NOTE: re-export all true-myth types to reduce boilerplate
 export {
-  Maybe,
   Result,
   and,
   or,

--- a/packages/core/src/utils/Util.ts
+++ b/packages/core/src/utils/Util.ts
@@ -20,10 +20,10 @@ import seedrandom from "seedrandom";
  * @param message Error message
  */
 export const safe = <T extends unknown>(
-  argument: T | undefined | null,
+  argument: T | undefined,
   message: string
 ): T => {
-  if (argument === undefined || argument === null) {
+  if (argument === undefined) {
     throw new TypeError(message);
   }
   return argument;
@@ -295,7 +295,6 @@ export const eqNum = (x: number, y: number): boolean => {
 };
 
 export const eqList = (xs: number[], ys: number[]): boolean => {
-  if (xs == null || ys == null) return false;
   if (xs.length !== ys.length) return false;
 
   //   _.every(_.zip(xs, ys), e => eqNum(e[0], e[1]));
@@ -400,7 +399,7 @@ export const dot = (xs: number[], ys: number[]): number => {
 
 class Node<T> {
   value: T;
-  next: Node<T> | null = null;
+  next: Node<T> | undefined = undefined;
 
   constructor(value: T) {
     this.value = value;
@@ -408,8 +407,8 @@ class Node<T> {
 }
 
 export class Queue<T> {
-  head: Node<T> | null = null;
-  tail: Node<T> | null = null;
+  head: Node<T> | undefined = undefined;
+  tail: Node<T> | undefined = undefined;
   queue_size = 0;
 
   constructor() {
@@ -419,7 +418,7 @@ export class Queue<T> {
   enqueue(value: T): void {
     const node = new Node(value);
 
-    if (this.head !== null && this.tail !== null) {
+    if (this.head !== undefined && this.tail !== undefined) {
       this.tail.next = node;
       this.tail = node;
     } else {
@@ -434,7 +433,7 @@ export class Queue<T> {
     const current = this.head;
     // need to check for nullness of this.head and this.current
     // to satisfy the type-checker
-    if (this.head === null || current === null) {
+    if (this.head === undefined || current === undefined) {
       throw new Error("Dequeue on empty queue");
     } else {
       if (this.head === this.tail) {
@@ -448,8 +447,8 @@ export class Queue<T> {
   }
 
   clear(): void {
-    this.head = null;
-    this.tail = null;
+    this.head = undefined;
+    this.tail = undefined;
     this.queue_size = 0;
   }
 

--- a/packages/core/src/utils/Util.ts
+++ b/packages/core/src/utils/Util.ts
@@ -4,7 +4,6 @@ import { zipWith, reduce, times } from "lodash";
 import { Properties } from "types/shape";
 import { Expr, Path } from "types/style";
 import { ArgVal, Color } from "types/value";
-import { Just, MaybeVal } from "types/common";
 import { VarAD } from "types/ad";
 import { Fn, Seeds, State } from "types/state";
 import { ILine } from "shapes/Line";
@@ -42,14 +41,6 @@ export const repeat = <T>(i: number, x: T): T[] => {
 
 export const all = (xs: boolean[]): boolean =>
   xs.reduce((prev, curr) => prev && curr, true);
-
-export const fromJust = <T>(n: MaybeVal<T>): T => {
-  if (n.tag === "Just") {
-    return n.contents;
-  }
-
-  throw Error("expected value in fromJust but got Nothing");
-};
 
 /**
  * Like _.zip but throws on different length instead of padding with undefined.

--- a/packages/panels/src/App.tsx
+++ b/packages/panels/src/App.tsx
@@ -108,8 +108,8 @@ function App({ location }: any) {
               authorship: {
                 name: sub,
                 madeBy: "github repo",
-                gistID: null,
-                avatar: null,
+                gistID: undefined,
+                avatar: undefined,
               },
             });
             tryDomainHighlight(dslContent, dispatch);
@@ -168,7 +168,7 @@ function App({ location }: any) {
       });
       tryDomainHighlight(dsl, dispatch);
       if (compileRes.isOk()) {
-        dispatch({ kind: "CHANGE_ERROR", content: null });
+        dispatch({ kind: "CHANGE_ERROR", content: undefined });
         (async () => {
           // resample because initial sampling did not use the special sampling seed
           const initState = resample(await prepareState(compileRes.value));

--- a/packages/panels/src/Util.ts
+++ b/packages/panels/src/Util.ts
@@ -116,12 +116,12 @@ export const retrieveGist = async (gistId: string, dispatch: Dispatcher) => {
 export const tryDomainHighlight = (
   dsl: string,
   dispatch?: Dispatcher
-): any | null => {
+): any | undefined => {
   const domainComp = compileDomain(dsl);
   if (domainComp.isOk()) {
     dispatch &&
       dispatch({ kind: "SET_DOMAIN_CACHE", domainCache: domainComp.value });
-    return domainComp.value || null;
+    return domainComp.value || undefined;
   }
 };
 

--- a/packages/panels/src/components/AuthorshipTitle.tsx
+++ b/packages/panels/src/components/AuthorshipTitle.tsx
@@ -11,7 +11,7 @@ const AuthorshipTitle = ({
 }: {
   authorship: AuthorshipInfo;
   onChangeTitle(name: string): void;
-  myUser: GithubUser | null;
+  myUser: GithubUser | undefined;
   onPublish(): void;
 }) => {
   const [editingTitle, setEditingTitle] = useState(false);
@@ -56,8 +56,8 @@ const AuthorshipTitle = ({
       {" - "}
       <span style={{ color: "#7d7d7d" }}>
         {authorship.madeBy ?? "anonymous"}
-        {authorship.gistID === null &&
-          (myUser === null ? (
+        {authorship.gistID === undefined &&
+          (myUser === undefined ? (
             <BlueButton onClick={onSignIn}>sign in</BlueButton>
           ) : (
             <BlueButton onClick={onPublish}>publish</BlueButton>

--- a/packages/panels/src/reducer.ts
+++ b/packages/panels/src/reducer.ts
@@ -12,9 +12,9 @@ export interface PaneState {
 
 export interface AuthorshipInfo {
   name: string;
-  madeBy: string | null;
-  gistID: string | null;
-  avatar: string | null;
+  madeBy: string | undefined;
+  gistID: string | undefined;
+  avatar: string | undefined;
 }
 
 export interface CurrentInstance {
@@ -22,10 +22,10 @@ export interface CurrentInstance {
   sub: string;
   sty: string;
   dsl: string;
-  state: PenroseState | null;
+  state: PenroseState | undefined;
   /* For syntax highlighting */
-  domainCache: any | null;
-  err: PenroseError | null;
+  domainCache: any | undefined;
+  err: PenroseError | undefined;
 }
 export interface GithubUser {
   username: string;
@@ -33,7 +33,7 @@ export interface GithubUser {
   avatar: string;
 }
 export interface ISettings {
-  githubUser: GithubUser | null;
+  githubUser: GithubUser | undefined;
   vimMode: boolean;
 }
 
@@ -59,29 +59,29 @@ export const initialState = (): State => {
       sub: "",
       sty: "",
       dsl: "",
-      state: null,
-      err: null,
-      domainCache: null,
+      state: undefined,
+      err: undefined,
+      domainCache: undefined,
       authorship: {
         name: "untitled",
-        madeBy: null,
-        avatar: null,
-        gistID: null,
+        madeBy: undefined,
+        avatar: undefined,
+        gistID: undefined,
       },
     },
-    settings: { githubUser: null, vimMode: false },
+    settings: { githubUser: undefined, vimMode: false },
   };
 };
 
 export const debouncedSave = debounce((state: State) => {
-  if (state.currentInstance.authorship.gistID !== null) {
+  if (state.currentInstance.authorship.gistID !== undefined) {
     // don't save if already gist
     return;
   }
   const modifiedState = cloneDeep(state);
-  modifiedState.currentInstance.state = null;
-  modifiedState.currentInstance.domainCache = null;
-  modifiedState.currentInstance.err = null;
+  modifiedState.currentInstance.state = undefined;
+  modifiedState.currentInstance.domainCache = undefined;
+  modifiedState.currentInstance.err = undefined;
 
   window.localStorage.setItem("state", JSON.stringify(modifiedState));
 }, 250);
@@ -93,10 +93,10 @@ export type Action =
   | { kind: "TOGGLE_PREVIEW_PANE" }
   | { kind: "CHANGE_CODE"; lang: "sub" | "sty" | "dsl"; content: string }
   | { kind: "SET_TRIO"; sub: string; sty: string; dsl: string }
-  | { kind: "SET_DOMAIN_CACHE"; domainCache: any | null }
+  | { kind: "SET_DOMAIN_CACHE"; domainCache: any | undefined }
   | { kind: "SET_AUTHORSHIP"; authorship: AuthorshipInfo }
-  | { kind: "CHANGE_CANVAS_STATE"; content: PenroseState | null }
-  | { kind: "CHANGE_ERROR"; content: PenroseError | null }
+  | { kind: "CHANGE_CANVAS_STATE"; content: PenroseState | undefined }
+  | { kind: "CHANGE_ERROR"; content: PenroseError | undefined }
   | { kind: "CHANGE_TITLE"; name: string }
   | { kind: "CHANGE_GH_USER"; user: GithubUser };
 
@@ -134,9 +134,8 @@ const reducer = (state: State, action: Action): State => {
             ...state.currentInstance.authorship,
             madeBy: state.settings.githubUser
               ? state.settings.githubUser.username
-              : null,
-            // null out so we can save another
-            gistID: null,
+              : undefined,
+            gistID: undefined, // so we can save another
           },
         },
       };

--- a/packages/roger/src/commands/watch.ts
+++ b/packages/roger/src/commands/watch.ts
@@ -44,7 +44,7 @@ export default class Watch extends Command {
     domain: "",
   };
 
-  wss: WebSocket.Server | null = null;
+  wss: WebSocket.Server | undefined = undefined;
 
   sendFiles = async () => {
     const {
@@ -95,13 +95,13 @@ export default class Watch extends Command {
     return ordered;
   };
 
-  readFile = async (fileName: string): Promise<string | null> => {
+  readFile = async (fileName: string): Promise<string | undefined> => {
     try {
       const read = await fsp.readFile(fileName, "utf8");
       return read;
     } catch (error) {
       console.error(`❌ Could not open ${fileName}: ${error}`);
-      return null;
+      return undefined;
     }
   };
 
@@ -119,7 +119,7 @@ export default class Watch extends Command {
     });
     watcher.on("change", async () => {
       const str = await this.readFile(fileName);
-      if (str === null) {
+      if (str === undefined) {
         this.exit(1);
       }
       this.current[type] = str;
@@ -132,7 +132,7 @@ export default class Watch extends Command {
       this.sendFiles();
     });
     const str = await this.readFile(fileName);
-    if (str === null) {
+    if (str === undefined) {
       this.exit(1);
     }
     this.current[type] = str;


### PR DESCRIPTION
# Description

Currently we have four different ways to represent "either something of type `T`, or nothing":

1. `T | undefined`
2. `T | null`
3. `Maybe<T>`, where `Maybe` is from [`true-myth`](https://www.npmjs.com/package/true-myth)
4. `MaybeVal<T>`, where `MaybeVal` is from `@penrose/core`

Options 1 and 2 are unavoidable due to signatures of functions built into JavaScript, the DOM, React, etc. There isn't really a reason to use 3 or 4. This PR replaces all of these with option 1 wherever possible, using option 2 where necessary.

# Checklist

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new ESLint warnings