### PR TITLE
refactor: allow resample on runtime errors in `browser-ui`

### DIFF
--- a/packages/browser-ui/src/App.tsx
+++ b/packages/browser-ui/src/App.tsx
@@ -218,7 +218,7 @@ class App extends React.Component<unknown, ICanvasState> {
           message: `Runtime error encountered: '${e}' Check console for more information.`,
         };
 
-        const errorWrapper = { error, currentState: undefined };
+        const errorWrapper = { error };
         this.setState(errorWrapper);
         throw e;
       }
@@ -234,7 +234,7 @@ class App extends React.Component<unknown, ICanvasState> {
         this.state.settings.autoStepSize
       );
       if (stepped.isErr()) {
-        this.setState({ error: stepped.error, currentState: undefined });
+        this.setState({ error: stepped.error });
       } else {
         void this.onCanvasState(stepped.value);
       }
@@ -405,6 +405,7 @@ class App extends React.Component<unknown, ICanvasState> {
             autoStepToggle={this.autoStepToggle}
             reset={this.reset}
             resample={this.resample}
+            error={error !== undefined}
             converged={data ? stateConverged(data) : false}
             initial={data ? stateInitial(data) : false}
             toggleInspector={this.toggleInspector}
@@ -424,7 +425,7 @@ class App extends React.Component<unknown, ICanvasState> {
             pane2Style={{ overflow: "hidden" }}
           >
             <div style={{ width: "100%", height: "100%" }}>
-              {data && (
+              {data && !error && (
                 <div
                   style={{ width: "100%", height: "100%" }}
                   ref={this.canvasRef}

--- a/packages/browser-ui/src/ui/ButtonBar.tsx
+++ b/packages/browser-ui/src/ui/ButtonBar.tsx
@@ -5,6 +5,7 @@ interface IProps {
   converged: boolean;
   autostep: boolean;
   initial: boolean;
+  error: boolean;
   showInspector: boolean;
   files: FileSocketResult | undefined;
   connected: boolean;
@@ -40,6 +41,7 @@ class ButtonBar extends React.Component<IProps> {
       files,
       connected,
       reconnect,
+      error,
     } = this.props;
     return (
       <div style={{ display: "flex", justifyContent: "middle" }}>
@@ -50,12 +52,15 @@ class ButtonBar extends React.Component<IProps> {
         )}
         <button onClick={() => step(1)}>x1 optimization step</button>
         <button onClick={stepUntilConvergence}>step until convergence</button>
-        <button onClick={reset} disabled={!converged && !initial && autostep}>
+        <button
+          onClick={reset}
+          disabled={!converged && !initial && !error && autostep}
+        >
           reset
         </button>
         <button
           onClick={resample}
-          disabled={!converged && !initial && autostep}
+          disabled={!converged && !initial && !error && autostep}
         >
           resample
         </button>


### PR DESCRIPTION
# Description

Fixes: #878 

`@penrose/browser-ui` currently disables the "resample" button and throw away the current `State` object when there's an error. This PR retains the error `State` and allow users to press "resample" to recover from the error.

# Implementation strategy and design decisions

* Do not set `currentState: undefined` in error wrappers
* To avoid rendering the error message and error state at the same time, add a conditional check to see if there's an error before rendering the canvas.
* Pass error state to `ButtonBar` and don't disable "reset" and "resample" if there's an error.

# Examples with steps to reproduce them

* Run in repo root: `git checkout origin/arc-mesh -- examples/arc-mesh/`
* With seed `TrimMallard5012`, run in `examples/arc-mesh`: `npx roger watch example.sub arc-mesh.sty arc-mesh.dsl`

![error-resample](https://user-images.githubusercontent.com/11740102/152816867-02c8f856-9c58-476c-9d8e-02ffa2638233.gif)

# Checklist

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new ESLint warnings
