### PR TITLE
fix: Remove duplicate 'pow' conditional

### DIFF
--- a/packages/core/src/engine/Autodiff.ts
+++ b/packages/core/src/engine/Autodiff.ts
@@ -1033,8 +1033,7 @@ const traverseGraph = (i: number, z: IVarAD, setting: string): any => {
       stmt = `const ${parName} = ${childName0} / (${childName1} + ${EPS_DENOM});`;
     } else if (z.op === "atan2") {
       stmt = `const ${parName} = Math.atan2(${childName0}, ${childName1});`;
-    } else if (z.op === "pow") {
-      stmt = `const ${parName} = Math.pow(${childName0}, ${childName1});`;
+
     } else {
       stmt = `const ${parName} = ${childName0} ${op} ${childName1};`;
     }

--- a/packages/core/src/engine/Autodiff.ts
+++ b/packages/core/src/engine/Autodiff.ts
@@ -1033,7 +1033,6 @@ const traverseGraph = (i: number, z: IVarAD, setting: string): any => {
       stmt = `const ${parName} = ${childName0} / (${childName1} + ${EPS_DENOM});`;
     } else if (z.op === "atan2") {
       stmt = `const ${parName} = Math.atan2(${childName0}, ${childName1});`;
-
     } else {
       stmt = `const ${parName} = ${childName0} ${op} ${childName1};`;
     }


### PR DESCRIPTION
# Description

Closes #869 

This is a non-functional change to remove a duplicate 'pow' conditional that could be confusing to future developers.  

# Checklist

- [X] I have commented my code, particularly in hard-to-understand areas
- [X] My changes generate no new ESLint warnings