### PR TITLE
fix: Resample button in panes

### DIFF
--- a/packages/panels/src/App.tsx
+++ b/packages/panels/src/App.tsx
@@ -15,6 +15,7 @@ import {
   resample,
   showError,
   stepUntilConvergence,
+  variationSeeds,
 } from "@penrose/core";
 import {
   DownloadSVG,
@@ -30,6 +31,11 @@ import StylePane from "./StylePane";
 import SubstancePane from "./SubstancePane";
 import DomainPane from "./DomainPane";
 import seedrandom from "seedrandom";
+
+// currently there's no way to view or set the variation in panes, so we just
+// generate an ugly variation instead of the pretty ones we use in browser-ui;
+// TODO: use the same generateVariation everywhere
+const generateVariation = () => Math.random().toString();
 
 const TabButton = styled.a<{ open: boolean }>`
   outline: none;
@@ -164,7 +170,7 @@ function App({ location }: any) {
         substance: sub,
         style: sty,
         domain: dsl,
-        variation: Math.random().toString(), // TODO: make this seed configurable in the UI
+        variation: generateVariation(),
       });
       tryDomainHighlight(dsl, dispatch);
       if (compileRes.isOk()) {
@@ -186,8 +192,10 @@ function App({ location }: any) {
   }, [state, convergeRenderState]);
 
   const onResample = useCallback(() => {
-    if (state.currentInstance.state) {
-      const resampled = resample(state.currentInstance.state);
+    const oldState = state.currentInstance.state;
+    if (oldState) {
+      oldState.seeds = variationSeeds(generateVariation()).seeds;
+      const resampled = resample(oldState);
       convergeRenderState(resampled);
     }
   }, [state, convergeRenderState]);


### PR DESCRIPTION
# Description

#864 changed the semantics of `resample` so now it only resets the diagram using its current seeds instead of resampling with new seeds. The same PR updated `browser-ui` so that the "resample" button in the UI also generates new seeds before calling `resample`, but did not update `panes` to do the same. This PR fixes that bug.

# Examples with steps to reproduce them

Open any diagram in panes, click the resample button and see whether it changes.

# Checklist

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new ESLint warnings