### PR TITLE
style: Organize imports via Prettier

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "cross-env": "^7.0.3",
     "lerna": "^3.22.1",
     "prettier": "2.2.1",
+    "prettier-plugin-organize-imports": "^2.3.4",
     "pretty-quick": "^3.1.0",
     "rimraf": "^3.0.2",
     "typescript": "^4.1.3"

--- a/yarn.lock
+++ b/yarn.lock
@@ -16055,6 +16055,11 @@ prepend-http@^2.0.0:
   resolved "https://registry.yarnpkg.com/prepend-http/-/prepend-http-2.0.0.tgz#e92434bfa5ea8c19f41cdfd401d741a3c819d897"
   integrity sha1-6SQ0v6XqjBn0HN/UAddBo8gZ2Jc=
 
+prettier-plugin-organize-imports@^2.3.4:
+  version "2.3.4"
+  resolved "https://registry.yarnpkg.com/prettier-plugin-organize-imports/-/prettier-plugin-organize-imports-2.3.4.tgz#65473861ae5ab7960439fff270a2258558fbe9ba"
+  integrity sha512-R8o23sf5iVL/U71h9SFUdhdOEPsi3nm42FD/oDYIZ2PQa4TNWWuWecxln6jlIQzpZTDMUeO1NicJP6lLn2TtRw==
+
 prettier@2.2.1:
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.2.1.tgz#795a1a78dd52f073da0cd42b21f9c91381923ff5"


### PR DESCRIPTION
This PR adds https://github.com/simonhaenisch/prettier-plugin-organize-imports to the repo.