### PR TITLE
chore: Add "look at diagrams/" to PR checklist

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -14,6 +14,7 @@ Include a high-level summary of the implementation strategy and list important d
 
 - [ ] I have commented my code, particularly in hard-to-understand areas
 - [ ] My changes generate no new ESLint warnings
+- [ ] I have reviewed any generated changes to the `diagrams/` folder
 
 # Open questions
 


### PR DESCRIPTION
# Description

As of #864, we now have a `diagrams/` folder to track changes to the generated diagrams for everything in the [registry](https://github.com/penrose/penrose/wiki/Registry). The workflow is to run `yarn test overall` in `packages/core/` (then commit and push the results) if a PR causes any of those to change. However, tracking these only has any real value if people actually review changes to that folder, so this PR adds an item to the checklist to encourage people to do that.

Our `.gitattributes` file includes this line:

https://github.com/penrose/penrose/blob/538661853dc231ca3379fb4c7748aea7575d23a0/.gitattributes#L1

This is because GitHub displays text diffs for SVG files by default, so it makes sense to hide those to avoid cluttering up the GitHub diff view. To view an actual image diff for one of the SVG files in `diagrams/` simply click the "Display the rich diff" button for that file. (To view the text diff, just click "Load diff"; same number of clicks either way.)

# Checklist

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new ESLint warnings
- [x] I have reviewed any generated changes to the `diagrams/` folder

# Open questions

- Should the item say "others have reviewed" instead of "I have reviewed"?