### PR TITLE
chore: Add MDX extension to penrose.code-workspace

### DIFF
--- a/penrose.code-workspace
+++ b/penrose.code-workspace
@@ -5,7 +5,8 @@
       "esbenp.prettier-vscode",
       "folke.vscode-monorepo-workspace",
       "karyfoundation.nearley",
-      "penrose.penrose-vs"
+      "penrose.penrose-vs",
+      "silvenon.mdx"
     ]
   },
   "folders": [


### PR DESCRIPTION
While reviewing #897, I realized that VS Code doesn't have built-in support for [MDX](https://mdxjs.com/). Via a quick search, I found three extensions for the language:

- [MDX](https://marketplace.visualstudio.com/items?itemName=silvenon.mdx)
- [MDX Preview](https://marketplace.visualstudio.com/items?itemName=xyc.vscode-mdx-preview)
- [VSCode MDX](https://marketplace.visualstudio.com/items?itemName=JounQin.vscode-mdx)

This PR adds the most popular of those three as a recommended extension for working on Penrose.

(aside: [Prettier](https://prettier.io/) says it works on MDX, but it seems to completely ignore the `*.mdx` files in the Penrose repo... anyone know why?)