### PR TITLE
style: Run Prettier on docs/ folders

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,12 +1,12 @@
 **/build/
 **/coverage/
 **/dist/
-**/docs/
 **/public/app.css
 **/public/app.js
 **/tsconfig.tsbuildinfo
 packages/browser-ui/tsconfig.json
 packages/components/storybook-static/
+packages/core/docs/
 packages/core/src/__testfixtures__/
 packages/core/src/parser/DomainParser.ts
 packages/core/src/parser/StyleParser.ts

--- a/docs/graphical-api.md
+++ b/docs/graphical-api.md
@@ -1,43 +1,46 @@
 - Go through the algo for `contains`
-    - Original pseudocode:
-    ```
-    -- Top-level function on two generic objects
-    contains A B =
-        let d = contains (bbox A) (bbox B)
-        if d != 0 then d
-        else
-            contains (levelSet A) (levelSet B)
 
-    contains (BBox a) (BBox b) =
-        if ! ( a.L > b. L .... )
-            return dist( a.center, b.center) - Epsilon
-        else 0
+  - Original pseudocode:
 
-    contains (LevelSet a) (LevelSet b) =
-        -- Assuming we have globally uniform grid resolution
+  ```
+  -- Top-level function on two generic objects
+  contains A B =
+      let d = contains (bbox A) (bbox B)
+      if d != 0 then d
+      else
+          contains (levelSet A) (levelSet B)
 
-        for x in width that they overlap
-           for y in height that they overlap
-               if ( b.grid[ x,y ] <= 0 )
-                   if ( a.grid[ x,y ] > 0 )
-                   -- return farthest “worst” pixel distance function   
-                   -- average or handle points          
-               return 0
-    ```
+  contains (BBox a) (BBox b) =
+      if ! ( a.L > b. L .... )
+          return dist( a.center, b.center) - Epsilon
+      else 0
+
+  contains (LevelSet a) (LevelSet b) =
+      -- Assuming we have globally uniform grid resolution
+
+      for x in width that they overlap
+         for y in height that they overlap
+             if ( b.grid[ x,y ] <= 0 )
+                 if ( a.grid[ x,y ] > 0 )
+                 -- return farthest “worst” pixel distance function
+                 -- average or handle points
+             return 0
+  ```
+
 - Alignment
-    - Idea 1: recompute the overlapped region with pixel resolution and forget about alignment (most likely we need the entire initial SDF)
-        - Potential performance cost
-        - Force users to input initial SDF in pixel resolution?
-        - Overall, maybe run into problems with up/downsampling and interpolation
+  - Idea 1: recompute the overlapped region with pixel resolution and forget about alignment (most likely we need the entire initial SDF)
+    - Potential performance cost
+    - Force users to input initial SDF in pixel resolution?
+    - Overall, maybe run into problems with up/downsampling and interpolation
 - Recomputation of levelset and BVH - solving slow runtime
-    - Idea 1: compute finer levelset on demand -> if only BVH needed to finish the spatial query, compute levelSet at a coarser level. Once the BVH test is not deterministic, then compute finer levelset
+  - Idea 1: compute finer levelset on demand -> if only BVH needed to finish the spatial query, compute levelSet at a coarser level. Once the BVH test is not deterministic, then compute finer levelset
 - Coordinate systems and transformations among them
-    - the grid coordinates (levelset)
-    - the math coordinates (default in the system)
-    - the screen coordinates (frontend)
-    - Transformations
-        - math <-> screen: translation (CANVAS dimensions)
-        - grid <-> math: translation and scaling (resolution of LevelSet, __top-left corner of the grid in math coords__)
+  - the grid coordinates (levelset)
+  - the math coordinates (default in the system)
+  - the screen coordinates (frontend)
+  - Transformations
+    - math <-> screen: translation (CANVAS dimensions)
+    - grid <-> math: translation and scaling (resolution of LevelSet, **top-left corner of the grid in math coords**)
 - Other objectives
-    - `intersects`
-    - `overlap`
+  - `intersects`
+  - `overlap`

--- a/docs/mathtransformer.md
+++ b/docs/mathtransformer.md
@@ -1,6 +1,7 @@
 # Math Transformer
 
 ## Prerequisities
+
 You must install [jscodeshift](https://www.npmjs.com/package/jscodeshift) by running `npm i jscodeshift`. If you want to run the JSCodeshift tests, run it in the `__tests__` directory. You may also want to install the corresponding types module: `npm i @types/jscodeshift`.
 
 ## Code Breakdown
@@ -17,7 +18,7 @@ This section contains all the use-case-specific code. In most cases, this is the
 
 #### Subsection 1: Transformation Methods
 
-This section contains instructions on how to transform one type of node to another node. For example, the function `BO2CE` takes in a binary expression and transforms it into a call expression. You shouldn't need to modify any of the existing code, but if you want to transform a node in a way that's not already defined, you may need to define new functions here. You can also place custom transforms here. For example, the function `squaredTransform` is custom written to transform the expression `Math.pow(x, 2)` into `squared(x)`. The dropping of an argument necessitates a custom transform, since in most cases you want to preserve all arguments when condensing a call expression. 
+This section contains instructions on how to transform one type of node to another node. For example, the function `BO2CE` takes in a binary expression and transforms it into a call expression. You shouldn't need to modify any of the existing code, but if you want to transform a node in a way that's not already defined, you may need to define new functions here. You can also place custom transforms here. For example, the function `squaredTransform` is custom written to transform the expression `Math.pow(x, 2)` into `squared(x)`. The dropping of an argument necessitates a custom transform, since in most cases you want to preserve all arguments when condensing a call expression.
 
 #### Subsection 2: Match Target Functions
 
@@ -41,24 +42,21 @@ This section contains everything specific to JSCodeshift and is the only section
 
 ## Current Functionality
 
-Currently the following transforms will occur (you can see this in more detail in Section 1.3 of the code): 
+Currently the following transforms will occur (you can see this in more detail in Section 1.3 of the code):
 
-|Original   | AD |
-|-----------|----|
-| x + y     | add(x, y)|
-| x - y     | sub(x, y)|
-| x * y     | mul(x, y)|
-| x / y     | div(x, y)|
-| -x        | neg(x)|
-| x: number | x: VarAD|
-| Math.pow(x, y) | pow(x, y)|
-| Math.pow(x, 2) | squared(x)|
-| x ? y : z | ifCond(x, y, z) |
-
-
+| Original       | AD              |
+| -------------- | --------------- |
+| x + y          | add(x, y)       |
+| x - y          | sub(x, y)       |
+| x \* y         | mul(x, y)       |
+| x / y          | div(x, y)       |
+| -x             | neg(x)          |
+| x: number      | x: VarAD        |
+| Math.pow(x, y) | pow(x, y)       |
+| Math.pow(x, 2) | squared(x)      |
+| x ? y : z      | ifCond(x, y, z) |
 
 NB - Due to a bug in jscodeshift, the program currently does not transform type names when they appear in an array pattern (i.e. types declared like this: `([t1, s1]: [string, any], [t2, s2]: [string, any])`). You must manually translate these names yourself (though the program will translate the same type name for you in all other contexts)
-
 
 ## Marking nodes to transform
 
@@ -71,8 +69,6 @@ CLI usage for jscodeshift can be found [here](https://github.com/facebook/jscode
 You can run the default JSCodeshift tests by running `npm test` from the `__tests__` directory. If you're getting errors, make sure you've installed JSCodeshift in the `__tests__` directory.
 
 Template: `jscodeshift YOURFILE.ts -t toCustomAD.ts -p -d`
-
-
 
 ### IMPORTANT NOTE - JSCODESHIFT MODIFIES THE INPUT FILE!
 
@@ -91,6 +87,7 @@ JSCodeshift will modify your input file in place. If this is undesirable behavio
     }
 
 ## Sample Output
+
     export const objDict = {
         // autodiff
         equal: (x: VarAD, y: VarAD) => squared(sub(x, y)),

--- a/packages/core/.gitignore
+++ b/packages/core/.gitignore
@@ -1,4 +1,5 @@
 /coverage/
+/docs/
 /reports/
 src/parser/DomainParser.ts
 src/parser/StyleParser.ts


### PR DESCRIPTION
As I mentioned in https://github.com/penrose/penrose/pull/899#issuecomment-1055733958, we haven't been running Prettier on any folders named `docs/` due to a bug in our `.prettierignore`. This PR fixes that, and also adds `packages/core/docs/` to `.gitignore`.