### PR TITLE
chore: Explicitly use Prettier in VS Code for MDX

### DIFF
--- a/penrose.code-workspace
+++ b/penrose.code-workspace
@@ -80,6 +80,9 @@
     "[markdown]": {
       "editor.defaultFormatter": "esbenp.prettier-vscode"
     },
+    "[mdx]": {
+      "editor.defaultFormatter": "esbenp.prettier-vscode"
+    },
     "[scss]": {
       "editor.defaultFormatter": "esbenp.prettier-vscode"
     },


### PR DESCRIPTION
I haven't yet noticed any discrepancies between Prettier and what VS Code is currently doing, but this can't hurt.

This is a followup to #899: https://github.com/silvenon/vscode-mdx/blob/v0.1.0/package.json#L26