### PR TITLE
chore: Prefix synthesizer-ui name with @penrose

### DIFF
--- a/packages/synthesizer-ui/package.json
+++ b/packages/synthesizer-ui/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "synthesizer-ui",
+  "name": "@penrose/synthesizer-ui",
   "private": true,
   "version": "0.0.0",
   "scripts": {


### PR DESCRIPTION
I'm guessing this is just an oversight?