### PR TITLE
ci: Make @penrose/examples private

### DIFF
--- a/packages/examples/package.json
+++ b/packages/examples/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@penrose/examples",
-  "version": "0.0.0",
+  "version": "1.3.0",
   "private": true,
   "scripts": {
     "build": "node build.js"

--- a/packages/examples/package.json
+++ b/packages/examples/package.json
@@ -1,8 +1,7 @@
 {
   "name": "@penrose/examples",
-  "version": "1.3.0",
-  "author": "Penrose Team (https://penrose.ink)",
-  "license": "MIT",
+  "version": "0.0.0",
+  "private": true,
   "scripts": {
     "build": "node build.js"
   }


### PR DESCRIPTION
Hopefully this fixes the canary release: https://github.com/penrose/penrose/runs/5431152530?check_suite_focus=true#step:6:78

> ```
> lerna http fetch PUT 402 https://registry.npmjs.org/@penrose%2fexamples 498ms
> lerna ERR! E402 You must sign up for private packages
> ```