### PR TITLE
fix: Delete packages/browser-ui/src/contexts.tsx

### DIFF
--- a/packages/browser-ui/src/contexts.tsx
+++ b/packages/browser-ui/src/contexts.tsx
@@ -1,1 +1,0 @@
-// export const LockContext = React.createContext(false);


### PR DESCRIPTION
@jiriminarcik discovered today that `yarn start` currently gives this error:
```
@penrose/core: yarn run build-decls exited (0)
@penrose/browser-ui: src/contexts.tsx(1,1): error TS1208: 'contexts.tsx' cannot be compiled under '--isolatedModules' because it is considered a global script file. Add an import, export, or an empty 'export {}' statement to make it a module.
```
It seems to have been caused by the deletion of this line by #883:

https://github.com/penrose/penrose/blob/c1626cfdc7936fe7d4c0e6d7fcba9688f346313a/packages/browser-ui/src/contexts.tsx#L1

I'm very confused how none of us discovered this error earlier since that PR was merged a month ago, but in any case, this fixes it.