### PR TITLE
perf: Add a benchmark suite

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,6 +5,24 @@ on:
     branches:
       - main
 jobs:
+  bench:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Install packages
+        uses: ./.github/actions/packages
+      - name: Build @penrose/examples
+        run: yarn build
+        working-directory: packages/examples/
+      - name: Benchmark
+        run: yarn bench
+        working-directory: packages/core/
+      - uses: actions/upload-artifact@v2
+        with:
+          name: benchmarks
+          path: packages/core/benchmarks/
+
   build:
     runs-on: ubuntu-latest
     env:

--- a/packages/core/.eslintrc.js
+++ b/packages/core/.eslintrc.js
@@ -40,6 +40,7 @@ module.exports = {
   ignorePatterns: [
     "**/*.test.ts",
     "**/*.test.tsx",
+    "**/*.bench.ts",
     "src/__testfixtures__/transformtest.input.ts",
     "src/__testfixtures__/transformtest.output.ts",
     "src/parser/DomainParser.ts",

--- a/packages/core/.gitignore
+++ b/packages/core/.gitignore
@@ -1,4 +1,5 @@
 /coverage/
+/benchmarks/
 /docs/
 /reports/
 src/parser/DomainParser.ts

--- a/packages/core/jest-bench.config.ts
+++ b/packages/core/jest-bench.config.ts
@@ -1,0 +1,17 @@
+export default {
+  preset: "ts-jest",
+  testEnvironment: "jest-bench/environment",
+  reporters: ["default", "jest-bench/reporter"],
+  transform: {
+    "^.+\\.(ts|tsx)?$": "ts-jest",
+  },
+  testEnvironmentOptions: {
+    testEnvironment: "jest-environment-jsdom",
+  },
+  testRegex: "(/__benchmarks__/.*|(\\.|/)bench)\\.[jt]sx?$",
+  modulePaths: ["node_modules", "<rootDir>/src/"],
+  testPathIgnorePatterns: ["build/dist/"],
+  // coverageProvider: "v8",
+  // coveragePathIgnorePatterns: ["/node_modules/", "/test/"],
+  // collectCoverageFrom: ["src/**/*.ts"],
+};

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -78,7 +78,7 @@
     "eslint-plugin-react": "^7.28.0",
     "estrella": "^1.3.0",
     "jest": "^27.5.1",
-    "jest-bench": "^27.3.1",
+    "jest-bench": "^27.5.1",
     "jscodeshift": "^0.11.0",
     "rollup": "^2.40.0",
     "rollup-plugin-node-polyfills": "^0.2.1",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -76,6 +76,7 @@
     "eslint-plugin-react": "^7.28.0",
     "estrella": "^1.3.0",
     "jest": "^27.5.1",
+    "jest-bench": "^27.3.1",
     "jscodeshift": "^0.11.0",
     "rollup": "^2.40.0",
     "rollup-plugin-node-polyfills": "^0.2.1",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -12,6 +12,8 @@
   ],
   "scripts": {
     "clean": "rimraf build src/parser/SubstanceParser.ts src/parser/StyleParser.ts src/parser/DomainParser.ts",
+    "prebench": "yarn build",
+    "bench": "jest --projects jest-bench.config.ts",
     "build:parsers": "nearleyc src/parser/Domain.ne > src/parser/DomainParser.ts && nearleyc src/parser/Substance.ne > src/parser/SubstanceParser.ts && nearleyc src/parser/Style.ne > src/parser/StyleParser.ts",
     "prebuild": "yarn build:parsers",
     "build": "yarn build:esbuild",

--- a/packages/core/src/__benchmarks__/compilation.bench.ts
+++ b/packages/core/src/__benchmarks__/compilation.bench.ts
@@ -1,0 +1,46 @@
+import { examples, registry } from "@penrose/examples";
+import { benchmarkSuite } from "jest-bench";
+import { SuiteDescription } from "jest-bench/dist/suite";
+import { compileTrio, readRegistry, showError } from "../index";
+
+const exampleFromURI = (uri: string): string => {
+  let x = examples;
+  for (const part of uri.split("/")) {
+    x = x[part];
+  }
+  return (x as unknown) as string;
+};
+
+const compilationBenchmarks = (): SuiteDescription => {
+  const tests: SuiteDescription = {};
+  const trios = readRegistry(registry);
+  for (const trio of trios) {
+    const { name, substanceURI, domainURI, styleURI, variation } = trio;
+    const [sub, sty, dsl] = [substanceURI, styleURI, domainURI].map(
+      exampleFromURI
+    );
+    tests[`compile ${name}`] = () => {
+      const res = compileTrio({
+        substance: sub,
+        style: sty,
+        domain: dsl,
+        variation,
+      });
+
+      if (res.isErr()) {
+        fail(showError(res.error));
+      }
+    };
+  }
+  return tests;
+};
+
+benchmarkSuite("Energy graph compilation", {
+  // setup will not run just once, it will run for each loop
+  setup() {},
+
+  // same thing with teardown
+  teardown() {},
+
+  ...compilationBenchmarks(),
+});

--- a/packages/core/tsconfig.json
+++ b/packages/core/tsconfig.json
@@ -56,6 +56,7 @@
     "dist",
     "src/__tests__",
     "src/__testfixtures__",
+    "src/__benchmarks__",
     "scripts",
     "acceptance-tests",
     "webpack"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2183,7 +2183,7 @@
     jest-mock "^27.5.1"
     jest-util "^27.5.1"
 
-"@jest/globals@^27.3.1", "@jest/globals@^27.5.1":
+"@jest/globals@^27.5.1":
   version "27.5.1"
   resolved "https://registry.yarnpkg.com/@jest/globals/-/globals-27.5.1.tgz#7ac06ce57ab966566c7963431cef458434601b2b"
   integrity sha512-ZEJNB41OBQQgGzgyInAv0UUfDDj3upmHydjieSxFvTRuZElrx7tXg/uVQ5hYVEwiXs3+aMsAeEc9X7xiSKCm4Q==
@@ -2192,7 +2192,7 @@
     "@jest/types" "^27.5.1"
     expect "^27.5.1"
 
-"@jest/reporters@^27.3.1", "@jest/reporters@^27.5.1":
+"@jest/reporters@^27.5.1":
   version "27.5.1"
   resolved "https://registry.yarnpkg.com/@jest/reporters/-/reporters-27.5.1.tgz#ceda7be96170b03c923c37987b64015812ffec04"
   integrity sha512-cPXh9hWIlVJMQkVk84aIvXuBB4uQQmFqZiacloFuGiP3ah1sbCxCosidXFDfqG8+6fO1oR2dTJTlsOy4VFmUfw==
@@ -12916,13 +12916,13 @@ iterate-value@^1.0.2:
     es-get-iterator "^1.0.2"
     iterate-iterator "^1.0.1"
 
-jest-bench@^27.3.1:
-  version "27.3.1"
-  resolved "https://registry.yarnpkg.com/jest-bench/-/jest-bench-27.3.1.tgz#531628909a7e7f07e5849ef74539d7c1194d94c0"
-  integrity sha512-ucXb8AFYXDEqNPuqqkG61+zbM+XWnFYTNbetXBj2ftfH5zFSGCJXXPrN/mCEQ6xipTLHjQL3ROCx9D2zBTR+Tw==
+jest-bench@^27.5.1:
+  version "27.5.1"
+  resolved "https://registry.yarnpkg.com/jest-bench/-/jest-bench-27.5.1.tgz#407077e8d84883e6dffe7f449671be4639d0d255"
+  integrity sha512-mGdENN4ozZE5LMM8bZUfPFZUgCpb5UNIRgzOGGF1DtZ5iIVqpzR0nybdLfbGWSTZt42jZ+cam4Y0Ge//izJ33A==
   dependencies:
-    "@jest/globals" "^27.3.1"
-    "@jest/reporters" "^27.3.1"
+    "@jest/globals" "^27.5.1"
+    "@jest/reporters" "^27.5.1"
     benchmark "^2.1.4"
     chalk "^4.1.0"
     lodash "^4.17.20"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2183,7 +2183,7 @@
     jest-mock "^27.5.1"
     jest-util "^27.5.1"
 
-"@jest/globals@^27.5.1":
+"@jest/globals@^27.3.1", "@jest/globals@^27.5.1":
   version "27.5.1"
   resolved "https://registry.yarnpkg.com/@jest/globals/-/globals-27.5.1.tgz#7ac06ce57ab966566c7963431cef458434601b2b"
   integrity sha512-ZEJNB41OBQQgGzgyInAv0UUfDDj3upmHydjieSxFvTRuZElrx7tXg/uVQ5hYVEwiXs3+aMsAeEc9X7xiSKCm4Q==
@@ -2192,7 +2192,7 @@
     "@jest/types" "^27.5.1"
     expect "^27.5.1"
 
-"@jest/reporters@^27.5.1":
+"@jest/reporters@^27.3.1", "@jest/reporters@^27.5.1":
   version "27.5.1"
   resolved "https://registry.yarnpkg.com/@jest/reporters/-/reporters-27.5.1.tgz#ceda7be96170b03c923c37987b64015812ffec04"
   integrity sha512-cPXh9hWIlVJMQkVk84aIvXuBB4uQQmFqZiacloFuGiP3ah1sbCxCosidXFDfqG8+6fO1oR2dTJTlsOy4VFmUfw==
@@ -6801,6 +6801,14 @@ before-after-hook@^2.0.0, before-after-hook@^2.2.0:
   version "2.2.2"
   resolved "https://registry.yarnpkg.com/before-after-hook/-/before-after-hook-2.2.2.tgz#a6e8ca41028d90ee2c24222f201c90956091613e"
   integrity sha512-3pZEU3NT5BFUo/AD5ERPWOgQOCZITni6iavr5AUw5AUwQjMlI0kzu5btnyD39AF0gUEsDPwJT+oY1ORBJijPjQ==
+
+benchmark@^2.1.4:
+  version "2.1.4"
+  resolved "https://registry.yarnpkg.com/benchmark/-/benchmark-2.1.4.tgz#09f3de31c916425d498cc2ee565a0ebf3c2a5629"
+  integrity sha1-CfPeMckWQl1JjMLuVloOvzwqVik=
+  dependencies:
+    lodash "^4.17.4"
+    platform "^1.3.3"
 
 better-opn@^2.1.1:
   version "2.1.1"
@@ -12908,6 +12916,18 @@ iterate-value@^1.0.2:
     es-get-iterator "^1.0.2"
     iterate-iterator "^1.0.1"
 
+jest-bench@^27.3.1:
+  version "27.3.1"
+  resolved "https://registry.yarnpkg.com/jest-bench/-/jest-bench-27.3.1.tgz#531628909a7e7f07e5849ef74539d7c1194d94c0"
+  integrity sha512-ucXb8AFYXDEqNPuqqkG61+zbM+XWnFYTNbetXBj2ftfH5zFSGCJXXPrN/mCEQ6xipTLHjQL3ROCx9D2zBTR+Tw==
+  dependencies:
+    "@jest/globals" "^27.3.1"
+    "@jest/reporters" "^27.3.1"
+    benchmark "^2.1.4"
+    chalk "^4.1.0"
+    lodash "^4.17.20"
+    ndjson "^2.0.0"
+
 jest-changed-files@^27.5.1:
   version "27.5.1"
   resolved "https://registry.yarnpkg.com/jest-changed-files/-/jest-changed-files-27.5.1.tgz#a348aed00ec9bf671cc58a66fcbe7c3dfd6a68f5"
@@ -14215,7 +14235,7 @@ lodash.zip@^4.2.0:
   resolved "https://registry.yarnpkg.com/lodash.zip/-/lodash.zip-4.2.0.tgz#ec6662e4896408ed4ab6c542a3990b72cc080020"
   integrity sha1-7GZi5IlkCO1KtsVCo5kLcswIACA=
 
-lodash@^4.17.11, lodash@^4.17.12, lodash@^4.17.14, lodash@^4.17.15, lodash@^4.17.19, lodash@^4.17.20, lodash@^4.17.21, lodash@^4.2.1, lodash@^4.7.0:
+lodash@^4.17.11, lodash@^4.17.12, lodash@^4.17.14, lodash@^4.17.15, lodash@^4.17.19, lodash@^4.17.20, lodash@^4.17.21, lodash@^4.17.4, lodash@^4.2.1, lodash@^4.7.0:
   version "4.17.21"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.21.tgz#679591c564c3bffaae8454cf0b3df370c3d6911c"
   integrity sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==
@@ -15034,6 +15054,17 @@ natural-orderby@^2.0.1:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/natural-orderby/-/natural-orderby-2.0.3.tgz#8623bc518ba162f8ff1cdb8941d74deb0fdcc016"
   integrity sha512-p7KTHxU0CUrcOXe62Zfrb5Z13nLvPhSWR/so3kFulUQU0sgUll2Z0LwpsLN351eOOD+hRGu/F1g+6xDfPeD++Q==
+
+ndjson@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/ndjson/-/ndjson-2.0.0.tgz#320ac86f6fe53f5681897349b86ac6f43bfa3a19"
+  integrity sha512-nGl7LRGrzugTtaFcJMhLbpzJM6XdivmbkdlaGcrk/LXg2KL/YBC6z1g70xh0/al+oFuVFP8N8kiWRucmeEH/qQ==
+  dependencies:
+    json-stringify-safe "^5.0.1"
+    minimist "^1.2.5"
+    readable-stream "^3.6.0"
+    split2 "^3.0.0"
+    through2 "^4.0.0"
 
 nearley@^2.20.1, nearley@^2.7.10:
   version "2.20.1"
@@ -16157,6 +16188,11 @@ pkg-up@3.1.0, pkg-up@^3.1.0:
   integrity sha512-nDywThFk1i4BQK4twPQ6TA4RT8bDY96yeuCVBWL3ePARCiEKDRSrNGbFIgUJpLp+XeIR65v8ra7WuJOFUBtkMA==
   dependencies:
     find-up "^3.0.0"
+
+platform@^1.3.3:
+  version "1.3.6"
+  resolved "https://registry.yarnpkg.com/platform/-/platform-1.3.6.tgz#48b4ce983164b209c2d45a107adb31f473a6e7a7"
+  integrity sha512-fnWVljUchTro6RiCFvCXBbNhJc2NijN7oIQxbwsyL0buWJPG85v81ehlHI9fXrJsMNgTofEoWIQeClKpgxFLrg==
 
 pluralize@^8.0.0:
   version "8.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -20188,9 +20188,9 @@ ts-dedent@^2.0.0:
   integrity sha512-q5W7tVM71e2xjHZTlgfTDoPF/SmqKG5hddq9SzR49CH2hayqRKJtQ4mtRlSxKaJlR/+9rEM+mnBHf7I2/BQcpQ==
 
 ts-jest@^27.1.3:
-  version "27.1.3"
-  resolved "https://registry.yarnpkg.com/ts-jest/-/ts-jest-27.1.3.tgz#1f723e7e74027c4da92c0ffbd73287e8af2b2957"
-  integrity sha512-6Nlura7s6uM9BVUAoqLH7JHyMXjz8gluryjpPXxr3IxZdAXnU6FhjvVLHFtfd1vsE1p8zD1OJfskkc0jhTSnkA==
+  version "27.1.4"
+  resolved "https://registry.yarnpkg.com/ts-jest/-/ts-jest-27.1.4.tgz#84d42cf0f4e7157a52e7c64b1492c46330943e00"
+  integrity sha512-qjkZlVPWVctAezwsOD1OPzbZ+k7zA5z3oxII4dGdZo5ggX/PL7kvwTM0pXTr10fAtbiVpJaL3bWd502zAhpgSQ==
   dependencies:
     bs-logger "0.x"
     fast-json-stable-stringify "2.x"


### PR DESCRIPTION
# Description

Resolves #898.

# Implementation strategy and design decisions

We use [jest-bench](https://www.npmjs.com/package/jest-bench). Thanks @wodeni for figuring out how to get this to work with TypeScript!

Currently, the benchmarks get run in CI via a new `bench` job, which prints human-readable results in the log and also uploads machine-readable results as an artifact. Later we could add more sophisticated comparison/visualization if we want.

# Examples with steps to reproduce them

Run `yarn bench` from `packages/core/`.

# Checklist

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new ESLint warnings
- [x] I have reviewed any generated changes to the `diagrams/` folder

# Open questions

- Currently the only benchmark is for energy graph compilation. We'll want other benchmarks before, e.g., merging #907.