### PR TITLE
chore: evaluate binary addition on strings as concatenation

### DIFF
--- a/packages/core/src/engine/Evaluator.ts
+++ b/packages/core/src/engine/Evaluator.ts
@@ -955,6 +955,11 @@ export const evalBinOp = (
     }
 
     return { tag: "VectorV", contents: res as VarAD[] };
+  } else if (v1.tag === "StrV" && v2.tag === "StrV") {
+    switch (op) {
+      case "BPlus":
+        return { tag: "StrV", contents: v1.contents + v2.contents };
+    }
   } else {
     throw new Error(
       `the types of two operands to ${op} are not supported: ${v1.tag}, ${v2.tag}`


### PR DESCRIPTION
# Description

Fix: #922 

# Implementation strategy and design decisions

In `evalBinOp`, pattern match on string-type arguments to `+`, and perform plain string concatenation of them.

# Examples with steps to reproduce them

# Checklist

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new ESLint warnings
- [x] I have reviewed any generated changes to the `diagrams/` folder

# Open questions

This is only lightly tested, and we don't really have a suite for `Evaluator`. We should have one fairly soon though!
