### PR TITLE
build: use vite for live-reload mode in `@penrose/panels` and `@penrose/browser-ui`

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "clean": "lerna clean && lerna run clean --stream",
     "prestart": "lerna run build --scope=@penrose/examples --scope=@penrose/core",
     "start": "lerna run watch --stream --parallel --scope=@penrose/core --scope=@penrose/browser-ui",
+    "prestart:ide": "lerna run build --scope=@penrose/examples --scope=@penrose/core",
     "start:ide": "lerna run watch --stream --parallel --scope=@penrose/core --scope=@penrose/panels",
     "build:ide": "lerna run build --stream --scope=@penrose/core --scope=@penrose/panels  --include-dependencies",
     "build:docs-site": "lerna run build --stream --scope=@penrose/core --scope=@penrose/components --scope=@penrose/docs-site",

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
   "scripts": {
     "build": "lerna run build --stream --concurrency 1",
     "clean": "lerna clean && lerna run clean --stream",
+    "prestart": "lerna run build --scope=@penrose/core",
     "start": "lerna run watch --stream --parallel --scope=@penrose/core --scope=@penrose/browser-ui",
     "start:ide": "lerna run watch --stream --parallel --scope=@penrose/core --scope=@penrose/panels",
     "build:ide": "lerna run build --stream --scope=@penrose/core --scope=@penrose/panels  --include-dependencies",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "scripts": {
     "build": "lerna run build --stream --concurrency 1",
     "clean": "lerna clean && lerna run clean --stream",
-    "prestart": "lerna run build --scope=@penrose/core",
+    "prestart": "lerna run build --scope=@penrose/examples --scope=@penrose/core",
     "start": "lerna run watch --stream --parallel --scope=@penrose/core --scope=@penrose/browser-ui",
     "start:ide": "lerna run watch --stream --parallel --scope=@penrose/core --scope=@penrose/panels",
     "build:ide": "lerna run build --stream --scope=@penrose/core --scope=@penrose/panels  --include-dependencies",

--- a/packages/browser-ui/index.html
+++ b/packages/browser-ui/index.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <link rel="icon" type="image/svg+xml" href="/src/favicon.svg" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Penrose</title>
+    <link
+      href="https://fonts.googleapis.com/css?family=Open+Sans:300,400,600,700"
+      rel="stylesheet"
+    />
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/index.tsx"></script>
+  </body>
+</html>

--- a/packages/browser-ui/index.html
+++ b/packages/browser-ui/index.html
@@ -12,6 +12,10 @@
   </head>
   <body>
     <div id="root"></div>
+    <script type="text/javascript">
+      // HACK for eigen dep which uses `global`
+      window.global = window;
+    </script>
     <script type="module" src="/src/index.tsx"></script>
   </body>
 </html>

--- a/packages/browser-ui/package.json
+++ b/packages/browser-ui/package.json
@@ -37,8 +37,9 @@
     "/build"
   ],
   "scripts": {
-    "watch": "node build.js -w",
-    "start": "yarn watch",
+    "dev": "vite",
+    "watch": "vite",
+    "start": "vite",
     "build": "node build.js",
     "test": "echo NO TESTS",
     "lint": "eslint --ext js,ts,tsx src",
@@ -72,7 +73,9 @@
     "ttypescript": "^1.5.12",
     "typescript": "^4.1.3",
     "typescript-transform-paths": "^2.0.1",
-    "webpack-cli": "^4.2.0"
+    "webpack-cli": "^4.2.0",
+    "vite": "^2.8.0",
+    "@vitejs/plugin-react": "^1.0.7"
   },
   "browserslist": [
     ">0.2%",

--- a/packages/browser-ui/package.json
+++ b/packages/browser-ui/package.json
@@ -64,7 +64,7 @@
     "eslint-config-prettier": "^6.13.0",
     "eslint-plugin-jsdoc": "^30.7.3",
     "eslint-plugin-prefer-arrow": "^1.2.2",
-    "estrella": "^1.3.0",
+    "estrella": "^1.4.1",
     "jest-junit": "^12.0.0",
     "serve-http": "^1.0.6",
     "terser": "^5.5.1",

--- a/packages/browser-ui/src/App.tsx
+++ b/packages/browser-ui/src/App.tsx
@@ -15,12 +15,12 @@ import {
 } from "@penrose/core";
 import animalNameList from "animals";
 import colorNameList from "color-name-list";
-import Inspector from "inspector/Inspector";
 import { isEqual } from "lodash";
 import * as React from "react";
 import SplitPane from "react-split-pane";
-import ButtonBar from "ui/ButtonBar";
-import { FileSocket, FileSocketResult } from "ui/FileSocket";
+import Inspector from "./inspector/Inspector";
+import ButtonBar from "./ui/ButtonBar";
+import { FileSocket, FileSocketResult } from "./ui/FileSocket";
 
 //#region variation generation
 

--- a/packages/browser-ui/src/inspector/views/ShapeView.tsx
+++ b/packages/browser-ui/src/inspector/views/ShapeView.tsx
@@ -1,6 +1,6 @@
-import makeViewBoxes from "inspector/makeViewBoxes";
 import * as React from "react";
 import { ObjectInspector } from "react-inspector";
+import makeViewBoxes from "../../inspector/makeViewBoxes";
 import IViewProps from "./IViewProps";
 
 interface IState {

--- a/packages/browser-ui/src/inspector/views/viewMap.tsx
+++ b/packages/browser-ui/src/inspector/views/viewMap.tsx
@@ -1,5 +1,5 @@
-import Errors from "inspector/views/Errors";
 //import Opt from "./Opt";
+import Errors from "../../inspector/views/Errors";
 import CompGraph from "./CompGraph";
 import Frames from "./Frames";
 import Settings from "./Settings";

--- a/packages/browser-ui/src/vite-env.d.ts
+++ b/packages/browser-ui/src/vite-env.d.ts
@@ -1,0 +1,1 @@
+/// <reference types="vite/client" />

--- a/packages/browser-ui/vite.config.js
+++ b/packages/browser-ui/vite.config.js
@@ -4,9 +4,6 @@ import { defineConfig } from "vite";
 // https://vitejs.dev/config/
 export default defineConfig({
   plugins: [react()],
-  define: {
-    global: "window",
-  },
   json: {
     stringify: true,
   },

--- a/packages/browser-ui/vite.config.js
+++ b/packages/browser-ui/vite.config.js
@@ -1,0 +1,24 @@
+import react from "@vitejs/plugin-react";
+import { defineConfig } from "vite";
+
+// https://vitejs.dev/config/
+export default defineConfig({
+  plugins: [react()],
+  define: {
+    global: "window",
+  },
+  json: {
+    stringify: true,
+  },
+  build: {
+    sourcemap: true,
+    rollupOptions: {
+      external: ["react", "react-dom"],
+      output: {
+        globals: {
+          react: "React",
+        },
+      },
+    },
+  },
+});

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -77,7 +77,7 @@
     "eslint-plugin-import": "^2.22.1",
     "eslint-plugin-jsdoc": "^30.7.3",
     "eslint-plugin-react": "^7.28.0",
-    "estrella": "^1.3.0",
+    "estrella": "^1.4.1",
     "jest": "^27.5.1",
     "jest-bench": "^27.5.1",
     "jscodeshift": "^0.11.0",

--- a/packages/panels/index.html
+++ b/packages/panels/index.html
@@ -16,7 +16,7 @@
       href="https://fonts.googleapis.com/css?family=Open+Sans:300,400,600,700"
       rel="stylesheet"
     />
-    <link href="./app.css" rel="stylesheet" />
+    <link href="/src/App.css" rel="stylesheet" />
 
     <!--
       Notice the use of %PUBLIC_URL% in the tags above.
@@ -33,7 +33,7 @@
   <body>
     <noscript> You need to enable JavaScript to run this app. </noscript>
     <div id="root"></div>
-    <script type="text/javascript" src="./app.js"></script>
+    <script type="module" src="/src/App.tsx"></script>
     <!--
       This HTML file is a template.
       If you open it directly in the browser, you will see an empty page.

--- a/packages/panels/index.html
+++ b/packages/panels/index.html
@@ -33,7 +33,11 @@
   <body>
     <noscript> You need to enable JavaScript to run this app. </noscript>
     <div id="root"></div>
-    <script type="module" src="/src/App.tsx"></script>
+    <script type="text/javascript">
+      // HACK for eigen dep which uses `global`
+      window.global = window;
+    </script>
+    <script type="module" src="/src/index.tsx"></script>
     <!--
       This HTML file is a template.
       If you open it directly in the browser, you will see an empty page.

--- a/packages/panels/package.json
+++ b/packages/panels/package.json
@@ -54,7 +54,7 @@
     "@types/react-panelgroup": "^1.0.1",
     "@types/react-router-dom": "^5.1.7",
     "@types/styled-components": "^5.1.7",
-    "estrella": "^1.3.0",
+    "estrella": "^1.4.1",
     "typescript": "^4.1.3",
     "web-vitals": "^0.2.4"
   }

--- a/packages/panels/package.json
+++ b/packages/panels/package.json
@@ -5,10 +5,10 @@
   "license": "MIT",
   "dependencies": {
     "@monaco-editor/react": "^4.0.11",
-    "monaco-editor": "^0.22.3",
     "@octokit/rest": "^18.3.2",
     "@penrose/core": "^1.3.0",
     "lodash": "^4.17.21",
+    "monaco-editor": "^0.22.3",
     "react": "^17.0.1",
     "react-dom": "^17.0.1",
     "react-router-dom": "^5.2.0",
@@ -17,8 +17,9 @@
     "styled-components": "4.4.1"
   },
   "scripts": {
-    "watch": "node build.js -w",
-    "start": "node build.js -w",
+    "dev": "vite",
+    "watch": "vite",
+    "start": "vite",
     "build": "node build.js",
     "test": "echo NO TESTS",
     "prepack": "yarn build",
@@ -43,6 +44,7 @@
     ]
   },
   "devDependencies": {
+    "@esbuild-plugins/node-modules-polyfill": "^0.1.4",
     "@testing-library/jest-dom": "^5.11.6",
     "@testing-library/react": "^11.2.2",
     "@testing-library/user-event": "^12.6.0",

--- a/packages/panels/package.json
+++ b/packages/panels/package.json
@@ -17,9 +17,8 @@
     "styled-components": "4.4.1"
   },
   "scripts": {
-    "dev": "vite",
-    "watch": "vite",
-    "start": "vite",
+    "watch": "node build.js -w",
+    "start": "node build.js -w",
     "build": "node build.js",
     "test": "echo NO TESTS",
     "prepack": "yarn build",

--- a/packages/panels/package.json
+++ b/packages/panels/package.json
@@ -17,8 +17,9 @@
     "styled-components": "4.4.1"
   },
   "scripts": {
-    "start": "yarn watch",
-    "watch": "node build.js -w",
+    "dev": "vite",
+    "watch": "vite",
+    "start": "vite",
     "build": "node build.js",
     "test": "echo NO TESTS",
     "prepack": "yarn build",

--- a/packages/panels/vite.config.js
+++ b/packages/panels/vite.config.js
@@ -1,14 +1,20 @@
+import { NodeModulesPolyfillPlugin } from "@esbuild-plugins/node-modules-polyfill";
 import react from "@vitejs/plugin-react";
 import { defineConfig } from "vite";
 
 // https://vitejs.dev/config/
 export default defineConfig({
   plugins: [react()],
-  define: {
-    global: "window",
+  resolve: {
+    alias: {
+      stream: "rollup-plugin-node-polyfills/polyfills/stream",
+    },
   },
-  json: {
-    stringify: true,
+  optimizeDeps: {
+    esbuildOptions: {
+      // Enable esbuild polyfill plugins
+      plugins: [NodeModulesPolyfillPlugin()],
+    },
   },
   build: {
     sourcemap: true,

--- a/packages/panels/vite.config.js
+++ b/packages/panels/vite.config.js
@@ -1,0 +1,24 @@
+import react from "@vitejs/plugin-react";
+import { defineConfig } from "vite";
+
+// https://vitejs.dev/config/
+export default defineConfig({
+  plugins: [react()],
+  define: {
+    global: "window",
+  },
+  json: {
+    stringify: true,
+  },
+  build: {
+    sourcemap: true,
+    rollupOptions: {
+      external: ["react", "react-dom"],
+      output: {
+        globals: {
+          react: "React",
+        },
+      },
+    },
+  },
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -10218,7 +10218,7 @@ estree-walker@^2.0.1:
   resolved "https://registry.yarnpkg.com/estree-walker/-/estree-walker-2.0.2.tgz#52f010178c2a4c117a7757cfe942adb7d2da4cac"
   integrity sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==
 
-estrella@^1.3.0, estrella@^1.4.1:
+estrella@^1.4.1:
   version "1.4.1"
   resolved "https://registry.yarnpkg.com/estrella/-/estrella-1.4.1.tgz#6971a710a91d38abe3ced6f6ffa68c0c6e08d369"
   integrity sha512-h8vlec27CFxw+8uYFtgbvLvohx0v+IssCwb/haTQnI+kO2WaL0ApSTWxg49LneAtqrZkrnYVwXQB2ZgyIIAImw==

--- a/yarn.lock
+++ b/yarn.lock
@@ -10218,7 +10218,7 @@ estree-walker@^2.0.1:
   resolved "https://registry.yarnpkg.com/estree-walker/-/estree-walker-2.0.2.tgz#52f010178c2a4c117a7757cfe942adb7d2da4cac"
   integrity sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==
 
-estrella@^1.3.0:
+estrella@^1.3.0, estrella@^1.4.1:
   version "1.4.1"
   resolved "https://registry.yarnpkg.com/estrella/-/estrella-1.4.1.tgz#6971a710a91d38abe3ced6f6ffa68c0c6e08d369"
   integrity sha512-h8vlec27CFxw+8uYFtgbvLvohx0v+IssCwb/haTQnI+kO2WaL0ApSTWxg49LneAtqrZkrnYVwXQB2ZgyIIAImw==

--- a/yarn.lock
+++ b/yarn.lock
@@ -2008,6 +2008,14 @@
   resolved "https://registry.yarnpkg.com/@emotion/weak-memoize/-/weak-memoize-0.2.5.tgz#8eed982e2ee6f7f4e44c253e12962980791efd46"
   integrity sha512-6U71C2Wp7r5XtFtQzYrW5iKFT67OixrSxjI4MptCHzdSVlgabczzqLe0ZSgnub/5Kp4hSbpDB1tMytZY9pwxxA==
 
+"@esbuild-plugins/node-modules-polyfill@^0.1.4":
+  version "0.1.4"
+  resolved "https://registry.yarnpkg.com/@esbuild-plugins/node-modules-polyfill/-/node-modules-polyfill-0.1.4.tgz#eb2f55da11967b2986c913f1a7957d1c868849c0"
+  integrity sha512-uZbcXi0zbmKC/050p3gJnne5Qdzw8vkXIv+c2BW0Lsc1ji1SkrxbKPUy5Efr0blbTu1SL8w4eyfpnSdPg3G0Qg==
+  dependencies:
+    escape-string-regexp "^4.0.0"
+    rollup-plugin-node-polyfills "^0.2.1"
+
 "@evocateur/libnpmaccess@^3.1.2":
   version "3.1.2"
   resolved "https://registry.yarnpkg.com/@evocateur/libnpmaccess/-/libnpmaccess-3.1.2.tgz#ecf7f6ce6b004e9f942b098d92200be4a4b1c845"


### PR DESCRIPTION
# Description

Resolves #913; see also #552 

As reported in #913, `serve-http` causes errors on Linux because it uses Node's `watch` function. We use `serve-http` for the estrella live-watch mode and unfortunately it's not actively maintained. Since we've already transitioned `synthesizer-ui` to vite, it makes more sense for us to use it for `panels` and `browser-ui`. 

# Implementation strategy and design decisions

* Add vite configuration to both packages
* Tested live-watch mode on OSX


# Examples with steps to reproduce them

* `yarn start` for `browser-ui`
* `yarn start:ide` for `panels`

# Checklist

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new ESLint warnings
- [x] I have reviewed any generated changes to the `diagrams/` folder

# Open questions

* Still need to test on linux. @samestep can you try whenever you have a chance?
* I'm keeping estrella for building both packages, because I couldn't get `vite build` to work :(.
