### PR TITLE
 refactor: produce semantically checked AST from the Substance checker

### DIFF
--- a/packages/core/src/compiler/Style.test.ts
+++ b/packages/core/src/compiler/Style.test.ts
@@ -2,11 +2,7 @@
 
 import { examples } from "@penrose/examples";
 import * as S from "compiler/Style";
-import {
-  compileSubstance,
-  disambiguateFunctions,
-  parseSubstance,
-} from "compiler/Substance";
+import { compileSubstance, parseSubstance } from "compiler/Substance";
 import _ from "lodash";
 import { A, C } from "types/ast";
 import { Either } from "types/common";
@@ -33,7 +29,6 @@ const loadFiles = (paths: string[]): string[] => {
 
 // Run the Domain + Substance parsers and checkers to yield the Style compiler's input
 // files must follow schema: { domain, substance, style }
-// Disambiguates functions as well
 export const loadProgs = ([domainStr, subStr, styStr]: [
   string,
   string,
@@ -59,7 +54,6 @@ export const loadProgs = ([domainStr, subStr, styStr]: [
     styProg,
   ];
 
-  disambiguateFunctions(varEnv, subProg);
   return res;
 };
 

--- a/packages/core/src/compiler/Style.ts
+++ b/packages/core/src/compiler/Style.ts
@@ -108,11 +108,17 @@ import {
   selectorFieldNotSupported,
   toStyleErrors,
 } from "utils/Error";
-import { prettyPrintPath, randFloat, variationSeeds, zip2 } from "utils/Util";
+import {
+  prettyPrintFn,
+  prettyPrintPath,
+  randFloat,
+  variationSeeds,
+  zip2,
+} from "utils/Util";
 import { checkTypeConstructor, isDeclaredSubtype } from "./Domain";
 
 const log = consola
-  .create({ level: LogLevel.Warn })
+  .create({ level: LogLevel.Info })
   .withScope("Style Compiler");
 const clone = rfdc({ proto: false, circles: false });
 
@@ -1435,7 +1441,6 @@ const typesMatched = (
   }
 
   // TODO(errors)
-  console.log(substanceType, styleType);
   throw Error(
     "internal error: expected two nullary types (parametrized types to be implemented)"
   );
@@ -2092,6 +2097,7 @@ const translatePair = (
         hb.header,
         selEnv,
       ]);
+      log.debug("Translating block", hb, "with substitutions", substs);
       return translateSubstsBlock(trans, numbered(substs), [
         hb.block,
         blockNum,
@@ -3057,6 +3063,8 @@ const genState = (
     objfnsDecl.concat(objfnsDefault),
     constrfnsDecl.concat(constrfnsDefault),
   ];
+  log.debug("Objectives", objFns.map(prettyPrintFn));
+  log.debug("Constraints", constrFns.map(prettyPrintFn));
 
   const [initialGPIs, transEvaled] = [[], transInitAll];
   const initVaryingState: number[] = lookupNumericPaths(

--- a/packages/core/src/compiler/Substance.test.ts
+++ b/packages/core/src/compiler/Substance.test.ts
@@ -322,13 +322,23 @@ AutoLabel All
     const res = compileSubstance(prog, env);
     expectErrorOf(res, "DuplicateName");
   });
-  test("type not found", () => {
+  test("decl type not found", () => {
     const env = envOrError(domainProg);
     const prog = `
 Set A, B, C
 List(Set) l
 Alien a
 NotExistentType b
+    `;
+    const res = compileSubstance(prog, env);
+    expectErrorOf(res, "TypeNotFound");
+  });
+  test("func type not found", () => {
+    const env = envOrError(domainProg);
+    const prog = `
+Set A, B, C
+List(Set) l
+C := NotExistentFunc(A, B)
     `;
     const res = compileSubstance(prog, env);
     expectErrorOf(res, "TypeNotFound");
@@ -546,6 +556,8 @@ l := Cons(Z, nil)
 Empty(C)
 IsSubset(D, E)
 IsSubset(D, A)
+Not(IsSubset(D, A))
+Not(Intersecting(B, C))
 IsSubset(A, B) <-> IsSubset(B, C)
 Subset(A, B) = Subset(B, C)
 AutoLabel All

--- a/packages/core/src/compiler/Substance.ts
+++ b/packages/core/src/compiler/Substance.ts
@@ -358,7 +358,10 @@ export const checkPredicate = (
       ok({ substEnv, env, contents: [] as SubPredArg<A>[] })
     );
     // NOTE: throw away the substitution because this layer above doesn't need to typecheck
-    return andThen(({ env }) => ok({ env, contents: stmt }), argsOk);
+    return andThen(
+      ({ env, contents: args }) => ok({ env, contents: { ...stmt, args } }),
+      argsOk
+    );
   } else {
     return err(
       typeNotFound(
@@ -384,7 +387,8 @@ const checkPredArg = (
     const predOk = checkPredicate(arg, env);
     // NOTE: throw out the env from the check because it's not updating anything
     return andThen(
-      ({ env }) => ok({ substEnv: subst, env, contents: arg }),
+      ({ env, contents: predArg }) =>
+        ok({ substEnv: subst, env, contents: predArg }),
       predOk
     );
   } else {
@@ -756,7 +760,7 @@ export const prettySubNode = (
   }
 };
 
-const prettyPredicate = (pred: ApplyPredicate<A>): string => {
+export const prettyPredicate = (pred: ApplyPredicate<A>): string => {
   const { name, args } = pred;
   const argStr = args.map((a) => prettyPredArg(a)).join(", ");
   return `${prettyVar(name)}(${argStr})`;

--- a/packages/core/src/compiler/Substance.ts
+++ b/packages/core/src/compiler/Substance.ts
@@ -379,8 +379,15 @@ const checkPredArg = (
   env: Env
 ): SubstitutionResult<SubPredArg<A>> => {
   // HACK: predicate-typed args are parsed into `Func` type first, explicitly check and change it to predicate if the func is actually a predicate in the context
-  if (arg.tag === "Func" && env.predicates.get(arg.name.value)) {
-    arg = { ...arg, tag: "ApplyPredicate" };
+  if (arg.tag === "Func") {
+    const name = arg.name.value;
+    if (env.predicates.get(name)) {
+      arg = { ...arg, tag: "ApplyPredicate" };
+    } else if (env.constructors.has(name)) {
+      arg = { ...arg, tag: "ApplyConstructor" };
+    } else if (env.functions.has(name)) {
+      arg = { ...arg, tag: "ApplyFunction" };
+    }
   }
   if (arg.tag === "ApplyPredicate") {
     // if the argument is a nested predicate, call checkPredicate again


### PR DESCRIPTION
# Description

Related issue/PR: #638, #446  

(@samestep commented on the `disambiguateFunctions` function in #638, which reminded me of this issue)

There are two ambiguous parts of the Substance (and also Style selector) spec:

1. The right hand side of `Bind` could either be a constructor or function: `C := SubSet(A, B)`. It's syntactically impossible to see if `SubSet` is a function or constructor.
2. Nested predicate vs. anonymous function/constructor: In `Not(Intersecting(A, B))`, `Interesecting(A, B)`'s type cannot be determined by the parser.

To resolve 1 and 2, the current system parse both cases into a generic `Func` type and implements `disambiguateFunctions`, which mutates an AST, to resolve these issues. However, the Substance semantic checker is already doing similar work in functions like `checkFunc`. In this PR, I update the semantic checker so it returns a new, disambiguated AST along with the Substance environment.

# Implementation strategy and design decisions

* Parametrize `CheckerResult` by the type of the AST node returned
* Thread the return values in the checker and eventually return the new AST in `SubstanceEnv.ast`

# Examples with steps to reproduce them

* In `Substance.test.ts`, I added a test case for disambiguating cases 1 and 2 above.

# Checklist

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new ESLint warnings
- [x] I have reviewed any generated changes to the `diagrams/` folder

# Open questions

* There's no test for the same thing in Style selectors. Add them?
