### PR TITLE
ci: add semantic PR to GH Action

### DIFF
--- a/.github/workflows/lint-pr.yml
+++ b/.github/workflows/lint-pr.yml
@@ -1,0 +1,17 @@
+name: "Lint PR"
+
+on:
+  pull_request_target:
+    types:
+      - opened
+      - edited
+      - synchronize
+
+jobs:
+  main:
+    name: Validate PR title
+    runs-on: ubuntu-latest
+    steps:
+      - uses: amannn/action-semantic-pull-request@v4
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/lint-pr.yml
+++ b/.github/workflows/lint-pr.yml
@@ -1,6 +1,11 @@
 name: "Lint PR"
 
 on:
+  pull_request:
+    types:
+      - opened
+      - edited
+      - synchronize
   pull_request_target:
     types:
       - opened

--- a/.github/workflows/lint-pr.yml
+++ b/.github/workflows/lint-pr.yml
@@ -14,7 +14,7 @@ on:
 
 jobs:
   main:
-    name: Validate PR title
+    name: validate-pr-title
     runs-on: ubuntu-latest
     steps:
       - uses: amannn/action-semantic-pull-request@v4


### PR DESCRIPTION
# Description

[Semantic PR](https://github.com/zeke/semantic-pull-requests)'s service is unstable. This PR adds a GitHub Action that does the same thing, which should be much more reliable.
