### PR TITLE
fix: Fix #935 Automator fails in draw mode

### DIFF
--- a/packages/automator/README.md
+++ b/packages/automator/README.md
@@ -16,7 +16,7 @@ Options:
   -o, --outFile PATH Path to either an SVG file or a folder, depending on the value of --folders. [default: output.svg]
   --folders Include metadata about each output diagram. If enabled, outFile has to be a path to a folder.
   --src-prefix PREFIX the prefix to SUBSTANCE, STYLE, and DOMAIN, or the library equivalent in batch mode. No trailing "/" required. [default: .]
-  --repeat TIMES the number of instances 
+  --repeat TIMES the number of instances
   --staged Generate staged SVGs of the final diagram
   --cross-energy Compute the cross-instance energy
   --variation The variation to use

--- a/packages/automator/README.md
+++ b/packages/automator/README.md
@@ -8,22 +8,24 @@ Usage:
 Penrose Automator.
 
 Usage:
-  automator batch LIB OUTFOLDER [--folders]  [--src-prefix=PREFIX] [--repeat=TIMES] [--render=OUTFOLDER]
+  automator batch LIB OUTFOLDER [--folders] [--src-prefix=PREFIX] [--repeat=TIMES] [--render=OUTFOLDER] [--staged] [--cross-energy]
   automator render ARTIFACTSFOLDER OUTFOLDER
-  automator draw SUBSTANCE STYLE DOMAIN OUTFOLDER [--folders] [--src-prefix=PREFIX] [--staged]
+  automator draw SUBSTANCE STYLE DOMAIN OUTFOLDER [--src-prefix=PREFIX] [--staged] [--variation=VARIATION] [--folders] [--cross-energy]
 
 Options:
   -o, --outFile PATH Path to either an SVG file or a folder, depending on the value of --folders. [default: output.svg]
   --folders Include metadata about each output diagram. If enabled, outFile has to be a path to a folder.
   --src-prefix PREFIX the prefix to SUBSTANCE, STYLE, and DOMAIN, or the library equivalent in batch mode. No trailing "/" required. [default: .]
-  --repeat TIMES the number of instances
+  --repeat TIMES the number of instances 
   --staged Generate staged SVGs of the final diagram
+  --cross-energy Compute the cross-instance energy
+  --variation The variation to use
 ```
 
 ## Getting started
 
 - Follow the instruction in the [wiki page](https://github.com/penrose/penrose/wiki/Building-and-running) to install Penrose.
-- Run `yarn start batch registry.json out/ --src-prefix=../../examples` in this directory. The output SVGs will appear in `out`.
+- Run `yarn start batch registry.json out/ --src-prefix=../examples/src/` in this directory. The output SVGs will appear in `out`.
 
 ## Using `automator` for local development
 
@@ -35,7 +37,7 @@ Options:
 
 In addition to batch-processing Penrose programs, you can also use `automator` to generate a static site for viewing the diagrams and metadata (e.g. performance statistics). Here's an example:
 
-- Run `yarn start batch registry.json out --src-prefix=../../examples --folders` in this directory.
+- Run `yarn start batch registry.json out --src-prefix=../examples/src/ --folders` in this directory.
   - Different from the example above, the `--folders` option asks `automator` to output metadata along with SVGs. `automator render` requires the output to have associated metadata.
 - Run `yarn start render out browser` to generate a static site.
 - Open `browser/index.html` to view the result.
@@ -44,5 +46,5 @@ In addition to batch-processing Penrose programs, you can also use `automator` t
 
 ## Staged Diagram Generation
 
-- Run `yarn start draw tree.sub venn.sty setTheory.dsl out --src-prefix=../../examples/set-theory-domain` in this directory to generate an output SVG.
+- Run `yarn start draw tree.sub venn.sty setTheory.dsl out --src-prefix=/../examples/src/set-theory-domain` in this directory to generate an output SVG.
 - Add the `--staged` flag to the command to generate multiple staged SVGs for the sub/sty/dsl trio.

--- a/packages/automator/index.tsx
+++ b/packages/automator/index.tsx
@@ -367,7 +367,7 @@ const batchProcess = async (
       args.STYLE,
       args.DOMAIN,
       folders,
-      (folders ? args.OUTFOLDER : outFile),
+      folders ? args.OUTFOLDER : outFile,
       prefix,
       staged,
       {

--- a/packages/automator/index.tsx
+++ b/packages/automator/index.tsx
@@ -22,9 +22,9 @@ const USAGE = `
 Penrose Automator.
 
 Usage:
-  automator batch LIB OUTFOLDER [--folders]  [--src-prefix=PREFIX] [--repeat=TIMES] [--render=OUTFOLDER] [--staged] [--cross-energy]
+  automator batch LIB OUTFOLDER [--folders] [--src-prefix=PREFIX] [--repeat=TIMES] [--render=OUTFOLDER] [--staged] [--cross-energy]
   automator render ARTIFACTSFOLDER OUTFOLDER
-  automator draw SUBSTANCE STYLE DOMAIN OUTFOLDER [--src-prefix=PREFIX] [--staged]
+  automator draw SUBSTANCE STYLE DOMAIN OUTFOLDER [--src-prefix=PREFIX] [--staged] [--variation=VARIATION] [--folders] [--cross-energy]
 
 Options:
   -o, --outFile PATH Path to either an SVG file or a folder, depending on the value of --folders. [default: output.svg]
@@ -32,7 +32,8 @@ Options:
   --src-prefix PREFIX the prefix to SUBSTANCE, STYLE, and DOMAIN, or the library equivalent in batch mode. No trailing "/" required. [default: .]
   --repeat TIMES the number of instances 
   --staged Generate staged SVGs of the final diagram
-  --cross-energy compute the cross-instance energy
+  --cross-energy Compute the cross-instance energy
+  --variation The variation to use
 `;
 
 const nonZeroConstraints = (
@@ -56,8 +57,8 @@ const toMs = (hr: any) => hr[1] / 1000000;
 // In an async context, communicate with the backend to compile and optimize the diagram
 const singleProcess = async (
   variation: string,
-  sub: any,
-  sty: any,
+  sub: string,
+  sty: string,
   dsl: string,
   folders: boolean,
   out: string,
@@ -346,6 +347,7 @@ const batchProcess = async (
   const outFile = args["--outFile"] || join(args.OUTFOLDER, "output.svg");
   const times = args["--repeat"] || 1;
   const prefix = args["--src-prefix"];
+  const variation = args["--variation"] || "";
 
   const staged = args["--staged"] || false;
 
@@ -360,13 +362,23 @@ const batchProcess = async (
     renderArtifacts(args.ARTIFACTSFOLDER, args.OUTFOLDER);
   } else if (args.draw) {
     await singleProcess(
+      variation,
       args.SUBSTANCE,
       args.STYLE,
       args.DOMAIN,
       folders,
-      outFile,
+      (folders ? args.OUTFOLDER : outFile),
       prefix,
       staged,
+      {
+        substanceName: args.SUBSTANCE,
+        styleName: args.STYLE,
+        domainName: args.DOMAIN,
+        id: uniqid("instance-"),
+      },
+      undefined, // reference
+      undefined, // referenceState
+      undefined, // extraMetadata
       ciee
     );
   } else {


### PR DESCRIPTION
# Description

This PR expands on PR #937 's fix (developed in parallel) to issue #935.  This PR additionally updates documentation and allows folder and cross-energy output in draw mode, similar to batch mode. 

# Checklist

- [X] I have commented my code, particularly in hard-to-understand areas
- [X] My changes generate no new ESLint warnings
- [X] I have reviewed any generated changes to the `diagrams/` folder
