### PR TITLE
fix: Make autodiff deterministic in graph shape

### DIFF
--- a/packages/core/src/engine/Autodiff.test.ts
+++ b/packages/core/src/engine/Autodiff.test.ts
@@ -40,40 +40,7 @@ describe("makeGraph tests", () => {
     expect(gradient.length).toBe(2);
     expect(secondary.length).toBe(3);
 
-    // HACK: see comment on `count` in engine/AutodiffFunctions
-    const nodes: Omit<ad.Node, "i">[] = secondary.map((id) => {
-      const x = graph.node(id);
-      if (typeof x === "number") {
-        return x;
-      }
-      const { tag } = x;
-      switch (tag) {
-        case "Input": {
-          const { index } = x;
-          return { tag, index };
-        }
-        case "Unary": {
-          const { unop } = x;
-          return { tag, unop };
-        }
-        case "Binary": {
-          const { binop } = x;
-          return { tag, binop };
-        }
-        case "Ternary": {
-          return { tag };
-        }
-        case "Nary": {
-          const { op } = x;
-          return { tag, op };
-        }
-        case "Debug": {
-          const { info } = x;
-          return { tag, info };
-        }
-      }
-    });
-
+    const nodes: ad.Node[] = secondary.map((id) => graph.node(id));
     expect(nodes[0]).toEqual({ tag: "Binary", binop: "+" });
     expect(nodes[1]).toEqual({ tag: "Binary", binop: "*" });
     expect(nodes[2]).toEqual({ tag: "Binary", binop: "-" });

--- a/packages/core/src/types/ad.ts
+++ b/packages/core/src/types/ad.ts
@@ -117,7 +117,6 @@ export interface InputNode {
 
 export interface UnaryNode {
   tag: "Unary";
-  i: number; // HACK: see comment on `count` in engine/AutodiffFunctions
   unop:
     | "neg"
     | "squared"
@@ -152,7 +151,6 @@ export interface UnaryNode {
 
 export interface BinaryNode {
   tag: "Binary";
-  i: number; // HACK: see comment on `count` in engine/AutodiffFunctions
   binop:
     | "+"
     | "*"
@@ -171,18 +169,15 @@ export interface BinaryNode {
 
 export interface TernaryNode {
   tag: "Ternary";
-  i: number; // HACK: see comment on `count` in engine/AutodiffFunctions
 }
 
 export interface NaryNode {
   tag: "Nary";
-  i: number; // HACK: see comment on `count` in engine/AutodiffFunctions
   op: "addN" | "maxN" | "minN";
 }
 
 export interface DebugNode {
   tag: "Debug";
-  i: number; // HACK: see comment on `count` in engine/AutodiffFunctions
   info: string;
 }
 


### PR DESCRIPTION
# Description

This PR fixes the global `count` hack leftover by #907, replacing it with an ordering on nodes according to breadth-first search and the ordering on edge labels already given by the `children` function.

# Checklist

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new ESLint warnings
- [x] I have reviewed any generated changes to the `diagrams/` folder