### PR TITLE
fix: Automator NPE in staged mode. Resolves #887

### DIFF
--- a/packages/automator/index.tsx
+++ b/packages/automator/index.tsx
@@ -119,7 +119,8 @@ const singleProcess = async (
   const reactRenderStart = process.hrtime();
 
   // make a list of canvas data if staged (prepare to generate multiple SVGs)
-  let listOfCanvasData, canvas;
+  const listOfCanvasData: string[] = [];
+  let canvas;
   const resolvePath = async (filePath: string) => {
     const parentDir = parse(join(prefix, sty)).dir;
     const joined = resolve(parentDir, filePath);


### PR DESCRIPTION
# Description

Resolves #887

This PR corrects an NPE in Automator's staged mode.  Starting with PR #825, `listOfCanvasData` was never initialized and executing in staged mode would always fail.  This bug was discovered via static analysis.

# Implementation strategy and design decisions

Initialized the variable `listOfCanvasData` prior to its use.

# Examples with steps to reproduce them

```
cd ./packages/automator
yarn start draw tree.sub venn.sty setTheory.dsl ./out/ --src-prefix=../examples/src/set-theory-domain --folders --staged
```

# Checklist

- [X] I have commented my code, particularly in hard-to-understand areas
- [X] My changes generate no new ESLint warnings
- [X] I have reviewed any generated changes to the `diagrams/` folder

# Open questions

No open questions.
