### PR TITLE
chore: Enable more typescript checks for Automator

### DIFF
--- a/packages/automator/artifacts.ts
+++ b/packages/automator/artifacts.ts
@@ -62,7 +62,7 @@ export const renderArtifacts = (artifactsDir: string, outDir: string) => {
       right = current + delta + 1,
       range: number[] = [],
       rangeWithDots: (number | string)[] = [],
-      l: number = -1;
+      l: number | undefined = undefined;
 
     for (let i = 1; i <= last; i++) {
       if (i == 1 || i == last || (i >= left && i < right)) {
@@ -71,7 +71,7 @@ export const renderArtifacts = (artifactsDir: string, outDir: string) => {
     }
 
     for (let i of range) {
-      if (l >= 0) {
+      if (l !== undefined && l) {
         if (i - l === 2) {
           rangeWithDots.push(l + 1);
         } else if (i - l !== 1) {

--- a/packages/automator/artifacts.ts
+++ b/packages/automator/artifacts.ts
@@ -60,9 +60,9 @@ export const renderArtifacts = (artifactsDir: string, outDir: string) => {
       delta = 2,
       left = current - delta,
       right = current + delta + 1,
-      range:number[] = [],
+      range: number[] = [],
       rangeWithDots: any[] = [],
-      l:number = -1;
+      l: number = -1;
 
     for (let i = 1; i <= last; i++) {
       if (i == 1 || i == last || (i >= left && i < right)) {

--- a/packages/automator/artifacts.ts
+++ b/packages/automator/artifacts.ts
@@ -60,9 +60,9 @@ export const renderArtifacts = (artifactsDir: string, outDir: string) => {
       delta = 2,
       left = current - delta,
       right = current + delta + 1,
-      range = [],
-      rangeWithDots = [],
-      l;
+      range:number[] = [],
+      rangeWithDots: any[] = [],
+      l:number = -1;
 
     for (let i = 1; i <= last; i++) {
       if (i == 1 || i == last || (i >= left && i < right)) {
@@ -71,7 +71,7 @@ export const renderArtifacts = (artifactsDir: string, outDir: string) => {
     }
 
     for (let i of range) {
-      if (l) {
+      if (l >= 0) {
         if (i - l === 2) {
           rangeWithDots.push(l + 1);
         } else if (i - l !== 1) {

--- a/packages/automator/artifacts.ts
+++ b/packages/automator/artifacts.ts
@@ -61,7 +61,7 @@ export const renderArtifacts = (artifactsDir: string, outDir: string) => {
       left = current - delta,
       right = current + delta + 1,
       range: number[] = [],
-      rangeWithDots: any[] = [],
+      rangeWithDots: (number | string)[] = [],
       l: number = -1;
 
     for (let i = 1; i <= last; i++) {

--- a/packages/automator/index.tsx
+++ b/packages/automator/index.tsx
@@ -151,7 +151,7 @@ const singleProcess = async (
     //   console.log("This instance has non-zero constraints: ");
     //   // return;
     // }
-    let crossEnergy = undefined;
+    let crossEnergy: number = Infinity;
     if (ciee) {
       console.log(chalk.yellow(`Computing cross energy...`));
       if (referenceState) {
@@ -319,7 +319,7 @@ const batchProcess = async (
         referenceState,
         meta
       );
-      if (folders) {
+      if (folders && res !== undefined) {
         const { metadata, state } = res;
         if (referenceFlag) {
           referenceState = state;

--- a/packages/automator/tsconfig.json
+++ b/packages/automator/tsconfig.json
@@ -8,7 +8,25 @@
     "sourceMap": true,
     "outDir": "dist",
     "jsx": "react",
-    "typeRoots": ["./node_modules/@types"]
+    "typeRoots": ["./node_modules/@types"],
+    "lib": ["es5", "es6", "es7", "esnext", "dom"],
+    "forceConsistentCasingInFileNames": true,
+    "importHelpers": true,
+    "suppressImplicitAnyIndexErrors": true,
+    "allowSyntheticDefaultImports": true,
+    "resolveJsonModule": true,
+    "noUnusedLocals": false,
+    "skipLibCheck": true,
+    "downlevelIteration": true,
+    "types": ["jest", "node", "tslib"],
+    "isolatedModules": true,
+    "declaration": true,
+    "declarationMap": true,
+    "noImplicitThis": true,
+    "strictNullChecks": true,
   },
-  "lib": ["es2015", "es7"]
+  "COMBAK-leftOffForNowDueToErrors": {
+    "noImplicitAny": true,
+    "strict": true,
+  },
 }

--- a/packages/automator/tsconfig.json
+++ b/packages/automator/tsconfig.json
@@ -23,10 +23,10 @@
     "declaration": true,
     "declarationMap": true,
     "noImplicitThis": true,
-    "strictNullChecks": true,
+    "strictNullChecks": true
   },
   "COMBAK-leftOffForNowDueToErrors": {
     "noImplicitAny": true,
-    "strict": true,
-  },
+    "strict": true
+  }
 }


### PR DESCRIPTION
# Description

Recently we discovered some bugs in Automator.  These bugs would probably have been more obvious and had a briefer existence if more TypeScript checks were enabled in Automator.  This PR turns on most of the checks already enabled in core for Automator.  This required some code changes to correct uninitialized variables, etc. identified by these checks.

# Implementation strategy and design decisions

This PR enables the TypeScript checks currently present in core, with the exception of `noImplicitAny` and `strict`, which currently generate a fair number of errors if enabled.  The remaining work to resolve this is tracked in Issue #948 

# Checklist

- [X] I have commented my code, particularly in hard-to-understand areas
- [X] My changes generate no new ESLint warnings
- [X] I have reviewed any generated changes to the `diagrams/` folder

# Open questions

Opened issue #948 to address the remaining two TypeScript checks.
