### PR TITLE
feat: display errors in the `Simple` component

### DIFF
--- a/packages/components/src/Simple.tsx
+++ b/packages/components/src/Simple.tsx
@@ -83,21 +83,23 @@ class Simple extends React.Component<ISimpleProps, ISimpleState> {
   };
 
   componentDidUpdate = async (prevProps: ISimpleProps) => {
+    // re-compile if the programs change
+    if (
+      this.props.domain !== prevProps.domain ||
+      this.props.substance !== prevProps.substance ||
+      this.props.style !== prevProps.style
+    ) {
+      await this.compile();
+      if (!this.props.animate) {
+        await this.converge();
+      }
+      this.renderCanvas();
+    }
+
     // update the component only if there's no error
     // in the case of an error, they component should not attempt to re-render
-    if (!this.state.error) {
+    if (this.penroseState && !this.state.error) {
       if (
-        this.props.domain !== prevProps.domain ||
-        this.props.substance !== prevProps.substance ||
-        this.props.style !== prevProps.style ||
-        !this.penroseState
-      ) {
-        await this.compile();
-        if (!this.props.animate) {
-          await this.converge();
-        }
-        this.renderCanvas();
-      } else if (
         this.props.variation !== prevProps.variation ||
         this.props.animate !== prevProps.animate
       ) {

--- a/packages/components/src/Simple.tsx
+++ b/packages/components/src/Simple.tsx
@@ -1,5 +1,6 @@
 import {
   compileTrio,
+  PenroseError,
   PenroseState,
   prepareState,
   RenderInteractive,
@@ -23,10 +24,21 @@ export interface ISimpleProps {
   animate?: boolean; // considered false by default
 }
 
-class Simple extends React.Component<ISimpleProps> {
+export interface ISimpleState {
+  error?: PenroseError;
+}
+
+class Simple extends React.Component<ISimpleProps, ISimpleState> {
   readonly canvasRef = React.createRef<HTMLDivElement>();
   penroseState: PenroseState | undefined = undefined;
   timerID: number | undefined = undefined; // for animation
+
+  constructor(props: ISimpleProps) {
+    super(props);
+    this.state = {
+      error: undefined,
+    };
+  }
 
   compile = async (): Promise<void> => {
     this.penroseState = undefined;
@@ -35,7 +47,7 @@ class Simple extends React.Component<ISimpleProps> {
       // resample because initial sampling did not use the special sampling seed
       this.penroseState = resample(await prepareState(compilerResult.value));
     } else {
-      console.log(showError(compilerResult.error));
+      this.setState({ error: compilerResult.error });
     }
   };
 
@@ -45,7 +57,7 @@ class Simple extends React.Component<ISimpleProps> {
       if (stepped.isOk()) {
         this.penroseState = stepped.value;
       } else {
-        console.log(showError(stepped.error));
+        this.setState({ error: stepped.error });
       }
     }
   };
@@ -133,8 +145,28 @@ class Simple extends React.Component<ISimpleProps> {
   };
 
   render = () => {
+    const { error } = this.state;
     return (
-      <div style={{ width: "100%", height: "100%" }} ref={this.canvasRef} />
+      <div style={{ width: "100%", height: "100%" }}>
+        {!error && (
+          <div style={{ width: "100%", height: "100%" }} ref={this.canvasRef} />
+        )}
+        {error && (
+          <div style={{ padding: "1em" }}>
+            <div style={{ fontWeight: 700 }}>1 error:</div>
+            <div style={{ fontFamily: "monospace" }}>
+              {showError(error)
+                .toString()
+                .split("\n")
+                .map((line: string, key: number) => (
+                  <p key={`err-ln-${key}`} style={{ margin: 0 }}>
+                    {line}
+                  </p>
+                ))}
+            </div>
+          </div>
+        )}
+      </div>
     );
   };
 }

--- a/packages/components/src/Simple.tsx
+++ b/packages/components/src/Simple.tsx
@@ -83,29 +83,33 @@ class Simple extends React.Component<ISimpleProps, ISimpleState> {
   };
 
   componentDidUpdate = async (prevProps: ISimpleProps) => {
-    if (
-      this.props.domain !== prevProps.domain ||
-      this.props.substance !== prevProps.substance ||
-      this.props.style !== prevProps.style ||
-      !this.penroseState
-    ) {
-      await this.compile();
-      if (!this.props.animate) {
-        await this.converge();
+    // update the component only if there's no error
+    // in the case of an error, they component should not attempt to re-render
+    if (!this.state.error) {
+      if (
+        this.props.domain !== prevProps.domain ||
+        this.props.substance !== prevProps.substance ||
+        this.props.style !== prevProps.style ||
+        !this.penroseState
+      ) {
+        await this.compile();
+        if (!this.props.animate) {
+          await this.converge();
+        }
+        this.renderCanvas();
+      } else if (
+        this.props.variation !== prevProps.variation ||
+        this.props.animate !== prevProps.animate
+      ) {
+        this.penroseState.seeds = variationSeeds(this.props.variation).seeds;
+        this.penroseState = resample(this.penroseState);
+        if (!this.props.animate) {
+          await this.converge();
+        }
+        this.renderCanvas();
+      } else if (this.props.interactive !== prevProps.interactive) {
+        this.renderCanvas();
       }
-      this.renderCanvas();
-    } else if (
-      this.props.variation !== prevProps.variation ||
-      this.props.animate !== prevProps.animate
-    ) {
-      this.penroseState.seeds = variationSeeds(this.props.variation).seeds;
-      this.penroseState = resample(this.penroseState);
-      if (!this.props.animate) {
-        await this.converge();
-      }
-      this.renderCanvas();
-    } else if (this.props.interactive !== prevProps.interactive) {
-      this.renderCanvas();
     }
   };
 
@@ -152,7 +156,7 @@ class Simple extends React.Component<ISimpleProps, ISimpleState> {
           <div style={{ width: "100%", height: "100%" }} ref={this.canvasRef} />
         )}
         {error && (
-          <div style={{ padding: "1em" }}>
+          <div style={{ padding: "1em", height: "100%" }}>
             <div style={{ fontWeight: 700 }}>1 error:</div>
             <div style={{ fontFamily: "monospace" }}>
               {showError(error)

--- a/packages/components/src/stories/Embed.stories.tsx
+++ b/packages/components/src/stories/Embed.stories.tsx
@@ -1,6 +1,6 @@
 import { ComponentMeta, ComponentStory } from "@storybook/react";
 import { Embed } from "../Embed";
-import { continuousMap, oneSet } from "./PenrosePrograms";
+import { continuousMap, error, oneSet } from "./PenrosePrograms";
 
 // const diagram = await getDiagram();
 
@@ -26,3 +26,6 @@ ContinuousMap.args = continuousMap;
 
 export const OneSet = Template.bind({});
 OneSet.args = oneSet;
+
+export const Error = Template.bind({});
+Error.args = error;

--- a/packages/components/src/stories/PenrosePrograms.tsx
+++ b/packages/components/src/stories/PenrosePrograms.tsx
@@ -1,3 +1,12 @@
+export const error = {
+  domain: `typeppp Set`,
+  substancce: `Set A + B`,
+  style: `
+  Set a {
+
+  }
+  `,
+};
 export const oneSet = {
   domain: `
 type Set

--- a/packages/components/src/stories/Simple.stories.tsx
+++ b/packages/components/src/stories/Simple.stories.tsx
@@ -1,6 +1,6 @@
 import { ComponentMeta, ComponentStory } from "@storybook/react";
 import { Simple } from "../Simple";
-import { continuousMap, oneSet } from "./PenrosePrograms";
+import { continuousMap, error, oneSet } from "./PenrosePrograms";
 
 // const diagram = await getDiagram();
 
@@ -26,3 +26,6 @@ ContinuousMap.args = continuousMap;
 
 export const OneSet = Template.bind({});
 OneSet.args = oneSet;
+
+export const Error = Template.bind({});
+Error.args = error;

--- a/packages/core/src/compiler/Style.ts
+++ b/packages/core/src/compiler/Style.ts
@@ -117,7 +117,7 @@ import {
 import { checkTypeConstructor, isDeclaredSubtype } from "./Domain";
 
 const log = consola
-  .create({ level: LogLevel.Info })
+  .create({ level: LogLevel.Warn })
   .withScope("Style Compiler");
 const clone = rfdc({ proto: false, circles: false });
 

--- a/packages/synthesizer-ui/src/components/Content.tsx
+++ b/packages/synthesizer-ui/src/components/Content.tsx
@@ -137,7 +137,7 @@ export class Content extends React.Component<ContentProps, ContentState> {
       const synth = new Synthesizer(
         env,
         setting,
-        subResult
+        subResult,
         Math.random().toString()
       );
       let progs = synth.generateSubstances(numPrograms);

--- a/packages/synthesizer-ui/src/components/Content.tsx
+++ b/packages/synthesizer-ui/src/components/Content.tsx
@@ -137,7 +137,7 @@ export class Content extends React.Component<ContentProps, ContentState> {
       const synth = new Synthesizer(
         env,
         setting,
-        subResult,
+        subResult
         Math.random().toString()
       );
       let progs = synth.generateSubstances(numPrograms);

--- a/packages/synthesizer-ui/src/components/Gridbox.tsx
+++ b/packages/synthesizer-ui/src/components/Gridbox.tsx
@@ -97,7 +97,7 @@ const ResampleBtn = styled(Button)({
 });
 
 interface GridboxState {
-  showDiagram: boolean;
+  showDiagramInfo: boolean;
   isSelected: boolean;
   diagramSVG: string;
   energy: number;
@@ -108,7 +108,7 @@ export class Gridbox extends React.Component<GridboxProps, GridboxState> {
   constructor(props: GridboxProps) {
     super(props);
     this.state = {
-      showDiagram: true,
+      showDiagramInfo: false,
       isSelected: false,
       diagramSVG: "",
       energy: 0,
@@ -140,7 +140,7 @@ export class Gridbox extends React.Component<GridboxProps, GridboxState> {
   };
 
   toggleView = () => {
-    this.setState({ showDiagram: !this.state.showDiagram });
+    this.setState({ showDiagramInfo: !this.state.showDiagramInfo });
   };
 
   checkboxClick = () => {
@@ -195,15 +195,7 @@ export class Gridbox extends React.Component<GridboxProps, GridboxState> {
         </Header>
 
         <div onClick={this.toggleView}>
-          {this.state.showDiagram ? (
-            <Simple
-              domain={this.props.domain}
-              substance={prettySubstance(this.props.substance.prog)}
-              style={this.props.style}
-              variation={this.state.variation}
-              interactive={false}
-            />
-          ) : (
+          {this.state.showDiagramInfo && (
             <Body>
               <H2>Mutations</H2>
               {this.props.progNumber === 0
@@ -213,6 +205,13 @@ export class Gridbox extends React.Component<GridboxProps, GridboxState> {
               {`${stmts}`}
             </Body>
           )}
+          <Simple
+            domain={this.props.domain}
+            substance={prettySubstance(this.props.substance.prog)}
+            style={this.props.style}
+            variation={this.state.variation}
+            interactive={false}
+          />
         </div>
       </Section>
     );

--- a/packages/synthesizer-ui/src/components/Gridbox.tsx
+++ b/packages/synthesizer-ui/src/components/Gridbox.tsx
@@ -38,6 +38,8 @@ const Section = styled(Card)(({ theme }) => ({
   borderStyle: "outset",
   color: theme.palette.primary.main,
   borderRadius: "5px",
+  display: "flex",
+  flexDirection: "column",
 }));
 
 const LowEnergy = styled(Chip)(({ theme }) => ({
@@ -194,7 +196,7 @@ export class Gridbox extends React.Component<GridboxProps, GridboxState> {
           </Box>
         </Header>
 
-        <div onClick={this.toggleView}>
+        <div onClick={this.toggleView} style={{ height: "100%" }}>
           {this.state.showDiagramInfo && (
             <Body>
               <H2>Mutations</H2>

--- a/packages/synthesizer-ui/src/components/Gridbox.tsx
+++ b/packages/synthesizer-ui/src/components/Gridbox.tsx
@@ -7,18 +7,13 @@ import {
   styled,
   Typography,
 } from "@material-ui/core";
-import { fetchResolver } from "@penrose/components";
+import { Simple } from "@penrose/components";
 import {
-  compileTrio,
   evalEnergy,
   PenroseState,
   prepareState,
   prettySubstance,
-  RenderStatic,
-  resample,
-  showError,
   showMutations,
-  stepUntilConvergence,
   SynthesizedSubstance,
 } from "@penrose/core";
 import React from "react";
@@ -106,6 +101,7 @@ interface GridboxState {
   isSelected: boolean;
   diagramSVG: string;
   energy: number;
+  variation: string;
 }
 
 export class Gridbox extends React.Component<GridboxProps, GridboxState> {
@@ -116,6 +112,7 @@ export class Gridbox extends React.Component<GridboxProps, GridboxState> {
       isSelected: false,
       diagramSVG: "",
       energy: 0,
+      variation: props.variation,
     };
   }
 
@@ -142,56 +139,6 @@ export class Gridbox extends React.Component<GridboxProps, GridboxState> {
     }
   };
 
-  // TODO: this should really be put in a web worker, it blocks browser interaction
-  async update() {
-    const res = compileTrio({
-      substance: prettySubstance(this.props.substance.prog),
-      style: this.props.style,
-      domain: this.props.domain,
-      variation: this.props.variation,
-    });
-    if (res.isOk()) {
-      try {
-        // https://stackoverflow.com/a/19626821
-        // setTimeout causes this function to be pushed to bottom of call stack. Since Gridbox
-        // component is rendered in an array, we want to delay ALL componentDidMount calls until
-        // after ALL gridboxes have been initially rendered.
-        await new Promise((r) => setTimeout(r, 1));
-        // resample because initial sampling did not use the special sampling seed
-        let state = resample(await prepareState(res.value));
-        state = resample(state);
-        const opt = stepUntilConvergence(state);
-        if (opt.isErr()) {
-          console.log(showError(opt.error));
-          throw Error("optimization failed");
-        }
-        const optimized = opt.value;
-        const rendered = await RenderStatic(optimized, fetchResolver);
-        this.setState({ diagramSVG: rendered.outerHTML });
-        if (this.props.progNumber === 0) {
-          // original program is cached by parent component to be used for CIEE with mutated progs
-          this.props.updateSrcProg(optimized);
-        } else {
-          this.computeEnergy(optimized);
-        }
-      } catch (e) {
-        console.log(e);
-      }
-    } else {
-      throw res.error;
-    }
-  }
-
-  async componentDidMount() {
-    await this.update();
-  }
-
-  async componentDidUpdate(prevProps: GridboxProps) {
-    if (this.props.substance.prog !== prevProps.substance.prog) {
-      await this.update();
-    }
-  }
-
   toggleView = () => {
     this.setState({ showDiagram: !this.state.showDiagram });
   };
@@ -199,10 +146,6 @@ export class Gridbox extends React.Component<GridboxProps, GridboxState> {
   checkboxClick = () => {
     this.setState({ isSelected: !this.state.isSelected });
     this.props.onStaged(this.props.progNumber, this.state.diagramSVG);
-  };
-
-  resample = () => {
-    this.update();
   };
 
   // NOTE: not rendered by default, uncomment in render function to see
@@ -217,6 +160,10 @@ export class Gridbox extends React.Component<GridboxProps, GridboxState> {
     ) : (
       <LowEnergy label={`energy: ${this.state.energy}`} size="small" />
     );
+  };
+
+  resample = () => {
+    this.setState({ variation: Math.random().toString() });
   };
 
   render() {
@@ -249,11 +196,12 @@ export class Gridbox extends React.Component<GridboxProps, GridboxState> {
 
         <div onClick={this.toggleView}>
           {this.state.showDiagram ? (
-            <div
-              style={{ width: "100%", height: "100%" }}
-              dangerouslySetInnerHTML={{
-                __html: this.state.diagramSVG,
-              }}
+            <Simple
+              domain={this.props.domain}
+              substance={prettySubstance(this.props.substance.prog)}
+              style={this.props.style}
+              variation={this.state.variation}
+              interactive={false}
             />
           ) : (
             <Body>


### PR DESCRIPTION
# Description

Related issue/PR: #535, #671

`Simple` is a raw canvas for Penrose-generated diagrams. In the past iterations, the component didn't handle errors and rendered a blank canvas. In this PR, whenever `Simple` encounters an error, it renders the pretty-printed error message directly on canvas.

# Implementation strategy and design decisions

* Remove `memoize` from `CollectLabels`
* Keep `error` in the state of `Simple`. This is mostly to let React handle re-rendering, which is a different case from `penroseState` (?)
* Used error rendering code from `browser-ui`
* Added errors to the storybook example
* Change Edgeworth to use `Simple` (see below)

# Examples with steps to reproduce them

In `synthesizer-ui`, I changed `Gridbox` so it's just a wrapper around `Simple`, a few minor notes:
* `Gridbox` has an overlay for mutation info and used to conditionally render the Penrose diagram whenever the user toggles the overlay. When using `<Simple>`, this can be very slow because re-rendering will also run the Penrose optimizer. Instead, I always keep `<Simple>` in the parent `div`, and only stack the info `div` on top of it once toggled.
*  In terms of the behavior of Edgeworth, the system seems to render all diagrams at once after loading on a blank screen for a while, not sure if this is new.
* See below: "mutated program 3" show an error

![image](https://user-images.githubusercontent.com/11740102/167496619-31420618-bddc-4065-ad81-428c65610321.png)


# Checklist

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new ESLint warnings
- [x] I have reviewed any generated changes to the `diagrams/` folder

# Open questions

Questions that require more discussion or to be addressed in future development:
