### PR TITLE
docs: Bring back the demo

### DIFF
--- a/packages/components/src/Demo.tsx
+++ b/packages/components/src/Demo.tsx
@@ -11,6 +11,7 @@ const Demo = (props: {
   }[];
   width: string; // the width of each half; total width is twice this
   // height must be equal to width (including in the passed Style canvas!)
+  darkMode: boolean;
 }) => {
   const [index, setIndex] = useState(0);
 
@@ -38,6 +39,7 @@ const Demo = (props: {
         substance={example.sub}
         width={props.width}
         height={props.width}
+        monacoOptions={{ theme: props.darkMode ? "vs-dark" : "vs" }}
       />
       <div style={{ width: props.width, height: props.width }}>
         <Simple

--- a/packages/components/src/Listing.tsx
+++ b/packages/components/src/Listing.tsx
@@ -8,7 +8,7 @@ import {
   SubstanceLanguageTokens,
 } from "./editing/languages/SubstanceConfig";
 
-export const monacoOptions: editor.IStandaloneEditorConstructionOptions = {
+export const defaultMonacoOptions: editor.IStandaloneEditorConstructionOptions = {
   automaticLayout: true,
   readOnly: true,
   minimap: { enabled: false },
@@ -27,11 +27,13 @@ const Listing = ({
   substance,
   width,
   height,
+  monacoOptions,
 }: {
   domain: string;
   substance: string;
   width: string;
   height: string;
+  monacoOptions?: editor.IStandaloneEditorConstructionOptions;
 }) => {
   const env = compileDomain(domain).unsafelyUnwrap();
   const monaco = useMonaco();
@@ -77,7 +79,11 @@ const Listing = ({
       width={width}
       height={height}
       defaultLanguage="substance"
-      options={monacoOptions}
+      options={
+        monacoOptions
+          ? { ...monacoOptions, ...defaultMonacoOptions }
+          : defaultMonacoOptions
+      }
     />
   );
 };

--- a/packages/components/src/editing/languages/SubstanceConfig.ts
+++ b/packages/components/src/editing/languages/SubstanceConfig.ts
@@ -68,7 +68,7 @@ export const SubstanceCompletions = (
   range: IRange,
   domainCache: any
 ): languages.CompletionItem[] => {
-  const types = [...domainCache.types.keys()].map((type) => ({
+  const types = Array.from(domainCache.types.keys()).map((type: any) => ({
     label: type,
     insertText: type + " $0",
     insertTextRules: languages.CompletionItemInsertTextRule.InsertAsSnippet,
@@ -76,7 +76,7 @@ export const SubstanceCompletions = (
     detail: "type",
     range,
   }));
-  const predicates = [...domainCache.predicates.keys()].map((type) => ({
+  const predicates = Array.from(domainCache.predicates.keys()).map((type) => ({
     label: type,
     insertText: type + "($0)",
     insertTextRules: languages.CompletionItemInsertTextRule.InsertAsSnippet,
@@ -84,14 +84,16 @@ export const SubstanceCompletions = (
     detail: "predicate",
     range,
   }));
-  const constructors = [...domainCache.constructors.keys()].map((type) => ({
-    label: type,
-    insertText: type + "($0)",
-    insertTextRules: languages.CompletionItemInsertTextRule.InsertAsSnippet,
-    kind: languages.CompletionItemKind.Constructor,
-    detail: "constructor",
-    range,
-  }));
+  const constructors = Array.from(domainCache.constructors.keys()).map(
+    (type) => ({
+      label: type,
+      insertText: type + "($0)",
+      insertTextRules: languages.CompletionItemInsertTextRule.InsertAsSnippet,
+      kind: languages.CompletionItemKind.Constructor,
+      detail: "constructor",
+      range,
+    })
+  );
   const labeling = ["AutoLabel", "Label", "NoLabel", "All"].map((type) => ({
     label: type,
     insertText: type,
@@ -100,21 +102,23 @@ export const SubstanceCompletions = (
     range,
   }));
 
-  const fns = [...domainCache.functions.entries()].map(([name, fn]) => ({
-    label: name,
-    insertText: `${name}($0)`,
-    insertTextRules: languages.CompletionItemInsertTextRule.InsertAsSnippet,
-    kind: languages.CompletionItemKind.Function,
-    detail: `function -> ${fn.output.type.name.value}`,
-    documentation: {
-      value: `${fn.args
-        .map((arg: any) => {
-          return arg.type.name.value + " " + arg.variable.value;
-        })
-        .join(" * ")} -> ${fn.output.type.name.value}`,
-    },
-    range,
-  }));
+  const fns = Array.from(domainCache.functions.entries()).map(
+    ([name, fn]: any) => ({
+      label: name,
+      insertText: `${name}($0)`,
+      insertTextRules: languages.CompletionItemInsertTextRule.InsertAsSnippet,
+      kind: languages.CompletionItemKind.Function,
+      detail: `function -> ${fn.output.type.name.value}`,
+      documentation: {
+        value: `${fn.args
+          .map((arg: any) => {
+            return arg.type.name.value + " " + arg.variable.value;
+          })
+          .join(" * ")} -> ${fn.output.type.name.value}`,
+      },
+      range,
+    })
+  );
 
   return [...types, ...fns, ...predicates, ...constructors, ...labeling];
 };

--- a/packages/components/src/editing/languages/SubstanceConfig.ts
+++ b/packages/components/src/editing/languages/SubstanceConfig.ts
@@ -31,11 +31,11 @@ export const SubstanceLanguageTokens = (
   domainCache: Env
 ): languages.IMonarchLanguage => {
   const refs = {
-    types: [...domainCache.types.keys()],
+    types: Array.from(domainCache.types.keys()),
     functionLikes: [
-      ...domainCache.constructors.keys(),
-      ...domainCache.functions.keys(),
-      ...domainCache.predicates.keys(),
+      ...Array.from(domainCache.constructors.keys()),
+      ...Array.from(domainCache.functions.keys()),
+      ...Array.from(domainCache.predicates.keys()),
     ],
     control: ["AutoLabel", "Label", "NoLabel", "All"],
   };

--- a/packages/components/src/stories/Listing.stories.tsx
+++ b/packages/components/src/stories/Listing.stories.tsx
@@ -29,6 +29,17 @@ ContinuousMap.args = {
   height: "300px",
 };
 
+export const ContinuousMapDark = Template.bind({});
+ContinuousMapDark.args = {
+  domain: continuousMap.domain,
+  substance: continuousMap.substance,
+  width: "400px",
+  height: "300px",
+  monacoOptions: {
+    theme: "vs-dark",
+  },
+};
+
 export const OneSet = Template.bind({});
 OneSet.args = {
   domain: continuousMap.domain,

--- a/packages/core/src/analysis/SubstanceAnalysis.ts
+++ b/packages/core/src/analysis/SubstanceAnalysis.ts
@@ -153,7 +153,7 @@ export const matchDecls = <T>(
 ): ArgStmtDecl<T>[] => {
   //generate signature for the original statement
   const origSignature = getSignature(stmt);
-  const decls: ArgStmtDecl<T>[] = [...opts.values()];
+  const decls: ArgStmtDecl<T>[] = Array.from(opts.values());
   return decls.filter((d) => {
     // does not add original statement to list of matches
     return stmt !== d && matchFunc(origSignature, getSignature(d));
@@ -273,13 +273,13 @@ export const identicalTypeDecls = (
 
     // a match is any var of the same type as the current identifier
     // which is not already being used in the statement
-    const matchedObjs = [
-      ...env.vars
+    const matchedObjs = Array.from(
+      env.vars
         .filter(
           (t, id) => !idSet.includes(id) && typeStr && t.name.value === typeStr
         )
-        .keys(),
-    ];
+        .keys()
+    );
 
     const matches = matchedObjs.flatMap((id) =>
       env.varIDs.filter((v) => v.value === id)
@@ -336,7 +336,7 @@ export const cascadingDelete = <T>(
       removedStmts.add(stmt);
     });
   }
-  return [...removedStmts.values()];
+  return Array.from(removedStmts.values());
 };
 
 export const printStmts = (

--- a/packages/core/src/compiler/Domain.ts
+++ b/packages/core/src/compiler/Domain.ts
@@ -282,7 +282,7 @@ export const checkTypeConstructor = (
   const { name, args } = type;
   // check if name of the type exists
   if (!env.types.has(name.value)) {
-    const [...suggestions] = env.types.values();
+    const suggestions = [...env.types.values()];
     return err(
       typeNotFound(
         name,
@@ -316,7 +316,7 @@ const addSubtype = (
 
 const computeTypeGraph = (env: Env): CheckerResult => {
   const { subTypes, types, typeGraph } = env;
-  const [...typeNames] = types.keys();
+  const typeNames = [...types.keys()];
   typeNames.map((t: string) => typeGraph.setNode(t, t));
   // NOTE: since we search for super types upstream, subtyping arrow points to supertype
   subTypes.map(

--- a/packages/core/src/compiler/Domain.ts
+++ b/packages/core/src/compiler/Domain.ts
@@ -282,7 +282,7 @@ export const checkTypeConstructor = (
   const { name, args } = type;
   // check if name of the type exists
   if (!env.types.has(name.value)) {
-    const suggestions = [...env.types.values()];
+    const suggestions = Array.from(env.types.values());
     return err(
       typeNotFound(
         name,
@@ -316,7 +316,7 @@ const addSubtype = (
 
 const computeTypeGraph = (env: Env): CheckerResult => {
   const { subTypes, types, typeGraph } = env;
-  const typeNames = [...types.keys()];
+  const typeNames = Array.from(types.keys());
   typeNames.map((t: string) => typeGraph.setNode(t, t));
   // NOTE: since we search for super types upstream, subtyping arrow points to supertype
   subTypes.map(

--- a/packages/core/src/compiler/Substance.ts
+++ b/packages/core/src/compiler/Substance.ts
@@ -111,7 +111,7 @@ const initEnv = (ast: SubProg<A>, env: Env): SubstanceEnv => ({
   predEqualities: [],
   bindings: Map<string, SubExpr<C>>(),
   labels: Map<string, LabelValue>(
-    [...env.vars.keys()].map((id: string) => [id, EMPTY_LABEL])
+    Array.from(env.vars.keys()).map((id: string) => [id, EMPTY_LABEL])
   ),
   predicates: [],
   ast,
@@ -152,7 +152,7 @@ const processLabelStmt = (
   switch (stmt.tag) {
     case "AutoLabel": {
       if (stmt.option.tag === "DefaultLabels") {
-        const ids = [...env.vars.keys()];
+        const ids = Array.from(env.vars.keys());
         const newLabels: LabelMap = Map(
           ids.map((id) => [id, { value: id, type: "MathLabel" }])
         );
@@ -609,8 +609,8 @@ const checkFunc = (
   } else {
     return err(
       typeNotFound(func.name, [
-        ...[...env.constructors.values()].map((c) => c.name),
-        ...[...env.functions.values()].map((c) => c.name),
+        ...Array.from(env.constructors.values()).map((c) => c.name),
+        ...Array.from(env.functions.values()).map((c) => c.name),
       ])
     );
   }

--- a/packages/core/src/compiler/Substance.ts
+++ b/packages/core/src/compiler/Substance.ts
@@ -152,7 +152,7 @@ const processLabelStmt = (
   switch (stmt.tag) {
     case "AutoLabel": {
       if (stmt.option.tag === "DefaultLabels") {
-        const [...ids] = env.vars.keys();
+        const ids = [...env.vars.keys()];
         const newLabels: LabelMap = Map(
           ids.map((id) => [id, { value: id, type: "MathLabel" }])
         );

--- a/packages/core/src/contrib/Minkowski.ts
+++ b/packages/core/src/contrib/Minkowski.ts
@@ -176,7 +176,7 @@ export const convexPartitions = (p: VarAD[][]): VarAD[][][] => {
     })
   );
 
-  const contour = [...pointMap.keys()];
+  const contour = Array.from(pointMap.keys());
   if (isClockwise(contour)) {
     contour.reverse();
   }

--- a/packages/core/src/synthesis/Synthesizer.ts
+++ b/packages/core/src/synthesis/Synthesizer.ts
@@ -162,10 +162,10 @@ export const filterContext = (
 
 export const showEnv = (env: Env): string =>
   [
-    `types: ${[...env.types.keys()]}`,
-    `predicates: ${[...env.predicates.keys()]}`,
-    `functions: ${[...env.functions.keys()]}`,
-    `constructors: ${[...env.constructors.keys()]}`,
+    `types: ${Array.from(env.types.keys())}`,
+    `predicates: ${Array.from(env.predicates.keys())}`,
+    `functions: ${Array.from(env.functions.keys())}`,
+    `constructors: ${Array.from(env.constructors.keys())}`,
   ].join("\n");
 
 const getDecls = (
@@ -484,7 +484,7 @@ export class Synthesizer {
         (
           options: Immutable.Map<string, Identifier<A>[]>
         ): Identifier<A> | undefined => {
-          const varId = this.choice([...options.keys()]);
+          const varId = this.choice(Array.from(options.keys()));
           const swapOptions = options.get(varId);
           return swapOptions ? this.choice(swapOptions) : undefined;
         },
@@ -499,7 +499,7 @@ export class Synthesizer {
         (
           options: Immutable.Map<string, Identifier<A>[]>
         ): Identifier<A> | undefined => {
-          const varId = this.choice([...options.keys()]);
+          const varId = this.choice(Array.from(options.keys()));
           const swapOptions = options.get(varId);
           return swapOptions ? this.choice(swapOptions) : undefined;
         },
@@ -580,7 +580,7 @@ export class Synthesizer {
     // pick a kind of statement to edit
     const chosenType = this.choice(nonEmptyDecls(ctx));
     // get all possible types within this kind
-    const candidates = [...getDecls(ctx, chosenType).keys()];
+    const candidates = Array.from(getDecls(ctx, chosenType).keys());
     // choose a name
     const chosenName = this.choice(candidates);
     log.debug(
@@ -678,7 +678,7 @@ export class Synthesizer {
   enumerateDelete = (ctx: SynthesisContext): MutationGroup => {
     log.debug("Deleting statement");
     const chosenType = this.choice(nonEmptyDecls(ctx));
-    const candidates = [...getDecls(ctx, chosenType).keys()];
+    const candidates = Array.from(getDecls(ctx, chosenType).keys());
     const chosenName = this.choice(candidates);
     const stmt = this.findStmt(chosenType, chosenName);
     let possibleOps: Mutation[] = [];

--- a/packages/docs-site/package.json
+++ b/packages/docs-site/package.json
@@ -21,6 +21,7 @@
     "@mdx-js/react": "^1.6.21",
     "@penrose/components": "^1.3.0",
     "@penrose/core": "^1.3.0",
+    "@penrose/examples": "^1.3.0",
     "clsx": "^1.1.1",
     "hast-util-is-element": "1.1.0",
     "prism-react-renderer": "^1.2.1",

--- a/packages/docs-site/src/components/DemoWrapper.js
+++ b/packages/docs-site/src/components/DemoWrapper.js
@@ -1,5 +1,6 @@
 import BrowserOnly from "@docusaurus/BrowserOnly";
 import ExecutionEnvironment from "@docusaurus/ExecutionEnvironment";
+import { useColorMode } from "@docusaurus/theme-common";
 import React from "react";
 
 // Hack bc penrose doesn't work in SSR??
@@ -9,9 +10,10 @@ if (ExecutionEnvironment.canUseDOM) {
 }
 
 export default function DemoWrapper(props) {
+  const { isDarkTheme } = useColorMode();
   return (
     <BrowserOnly fallback={<div>Loading...</div>}>
-      {() => <Demo {...props} />}
+      {() => <Demo {...props} darkMode={isDarkTheme} />}
     </BrowserOnly>
   );
 }

--- a/packages/docs-site/src/pages/index.js
+++ b/packages/docs-site/src/pages/index.js
@@ -1,9 +1,10 @@
 import Link from "@docusaurus/Link";
 import useDocusaurusContext from "@docusaurus/useDocusaurusContext";
+import { examples } from "@penrose/examples";
 import Layout from "@theme/Layout";
 import clsx from "clsx";
 import * as React from "react";
-//import DemoWrapper from "../components/DemoWrapper";
+import DemoWrapper from "../components/DemoWrapper";
 import styles from "./index.module.css";
 
 function HomepageHeader() {
@@ -36,21 +37,11 @@ export default function Home() {
   const { siteConfig } = useDocusaurusContext();
 
   const trio = {
-    dsl: "type Set",
-    sub: "Set A\nAutoLabel All",
-    sty: `canvas {
-  width = 500
-  height = 500
-}
-  Set X {
-  X.shape = Circle { strokeWidth : 0 }
-  X.text  = Equation { string: X.label }
-  ensure contains(X.shape, X.text)
-  ensure maxSize(X.shape, canvas.width / 2)
-}
-`,
+    dsl: examples["set-theory-domain"]["setTheory.dsl"],
+    sub: examples["set-theory-domain"]["tree.sub"],
+    sty: examples["set-theory-domain"]["venn.sty"],
   };
-  const examples = [
+  const demo = [
     { variation: "foo", ...trio },
     { variation: "bar", ...trio },
     { variation: "baz", ...trio },
@@ -87,15 +78,9 @@ export default function Home() {
           Feel free to <a href="mailto:team@penrose.ink">get in touch</a>.
         </p>
 
-        {/* Temporarily commented out & will re-visit
         <h1>Example</h1>
         <p>Here's Penrose running in your browser:</p>
-        <DemoWrapper
-          style={{ margin: "auto" }}
-          examples={examples}
-          width="400px"
-        />
-        */}
+        <DemoWrapper style={{ margin: "auto" }} examples={demo} width="400px" />
       </main>
     </Layout>
   );

--- a/packages/panels/src/languages/SubstanceConfig.ts
+++ b/packages/panels/src/languages/SubstanceConfig.ts
@@ -30,11 +30,11 @@ export const SubstanceLanguageTokens = (
   domainCache: Env
 ): languages.IMonarchLanguage => {
   const refs = {
-    types: [...domainCache.types.keys()],
+    types: Array.from(domainCache.types.keys()),
     functionLikes: [
-      ...domainCache.constructors.keys(),
-      ...domainCache.functions.keys(),
-      ...domainCache.predicates.keys(),
+      ...Array.from(domainCache.constructors.keys()),
+      ...Array.from(domainCache.functions.keys()),
+      ...Array.from(domainCache.predicates.keys()),
     ],
     control: ["AutoLabel", "Label", "NoLabel", "All"],
   };
@@ -67,7 +67,7 @@ export const SubstanceCompletions = (
   range: IRange,
   domainCache: any
 ): languages.CompletionItem[] => {
-  const types = [...domainCache.types.keys()].map((type) => ({
+  const types = Array.from(domainCache.types.keys()).map((type) => ({
     label: type,
     insertText: type + " $0",
     insertTextRules: languages.CompletionItemInsertTextRule.InsertAsSnippet,
@@ -75,7 +75,7 @@ export const SubstanceCompletions = (
     detail: "type",
     range,
   }));
-  const predicates = [...domainCache.predicates.keys()].map((type) => ({
+  const predicates = Array.from(domainCache.predicates.keys()).map((type) => ({
     label: type,
     insertText: type + "($0)",
     insertTextRules: languages.CompletionItemInsertTextRule.InsertAsSnippet,
@@ -83,37 +83,43 @@ export const SubstanceCompletions = (
     detail: "predicate",
     range,
   }));
-  const constructors = [...domainCache.constructors.keys()].map((type) => ({
-    label: type,
-    insertText: type + "($0)",
-    insertTextRules: languages.CompletionItemInsertTextRule.InsertAsSnippet,
-    kind: languages.CompletionItemKind.Constructor,
-    detail: "constructor",
-    range,
-  }));
-  const labeling = ["AutoLabel", "Label", "NoLabel", "All"].map((type) => ({
-    label: type,
-    insertText: type,
-    kind: languages.CompletionItemKind.Color,
-    detail: "labeling",
-    range,
-  }));
+  const constructors = Array.from(domainCache.constructors.keys()).map(
+    (type) => ({
+      label: type,
+      insertText: type + "($0)",
+      insertTextRules: languages.CompletionItemInsertTextRule.InsertAsSnippet,
+      kind: languages.CompletionItemKind.Constructor,
+      detail: "constructor",
+      range,
+    })
+  );
+  const labeling = ["AutoLabel", "Label", "NoLabel", "All"].map(
+    (type: any) => ({
+      label: type,
+      insertText: type,
+      kind: languages.CompletionItemKind.Color,
+      detail: "labeling",
+      range,
+    })
+  );
 
-  const fns = [...domainCache.functions.entries()].map(([name, fn]) => ({
-    label: name,
-    insertText: `${name}($0)`,
-    insertTextRules: languages.CompletionItemInsertTextRule.InsertAsSnippet,
-    kind: languages.CompletionItemKind.Function,
-    detail: `function -> ${fn.output.type.name.value}`,
-    documentation: {
-      value: `${fn.args
-        .map((arg: any) => {
-          return arg.type.name.value + " " + arg.variable.value;
-        })
-        .join(" * ")} -> ${fn.output.type.name.value}`,
-    },
-    range,
-  }));
+  const fns = Array.from(domainCache.functions.entries()).map(
+    ([name, fn]: any) => ({
+      label: name,
+      insertText: `${name}($0)`,
+      insertTextRules: languages.CompletionItemInsertTextRule.InsertAsSnippet,
+      kind: languages.CompletionItemKind.Function,
+      detail: `function -> ${fn.output.type.name.value}`,
+      documentation: {
+        value: `${fn.args
+          .map((arg: any) => {
+            return arg.type.name.value + " " + arg.variable.value;
+          })
+          .join(" * ")} -> ${fn.output.type.name.value}`,
+      },
+      range,
+    })
+  );
 
   return [...types, ...fns, ...predicates, ...constructors, ...labeling];
 };


### PR DESCRIPTION
# Description

This PR reenables the homepage demo which was added in #882 and then removed in #916. I don't remember the exact reasoning for removing the demo before; @cmumatt could you comment on this? If the problem is simply that the text should be tweaked, I can do that in this PR, I just wasn't sure exactly what needed to change.

In any case, now that #904 has made a `@penrose/examples` package available to `@penrose/docs-site`, we can simply use the more sophisticated trio we show in the README as of #955. The animation is pretty fun to watch, in my opinion.

Finally, thanks to @wodeni, this PR also adds dark mode support to the demo.

# Implementation strategy and design decisions

Webpack (which we use for Docusaurus) doesn't seem to correctly handle the spread operator for ES6 iterators. Specifically, given this:
```typescript
const [...foo] = arr.keys();
```
it assigns this to `foo`:
```javascript
arr.keys().slice(0)
```
And it translates this:
```typescript
[...arr.keys()]
```
into this:
```javascript
[].concat(arr.keys()
```
These are very wrong, and they cause things to break when we use `@penrose/core` or `@penrose/components` in `@penrose/docs-site`. To fix this, I replaced this pattern with [`Array.from`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/from) throughout our entire codebase.

# Checklist

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new ESLint warnings
- [x] I have reviewed any generated changes to the `diagrams/` folder