### PR TITLE
build: Disable Babel's iterableIsArray assumption

### DIFF
--- a/packages/components/src/editing/languages/SubstanceConfig.ts
+++ b/packages/components/src/editing/languages/SubstanceConfig.ts
@@ -31,11 +31,11 @@ export const SubstanceLanguageTokens = (
   domainCache: Env
 ): languages.IMonarchLanguage => {
   const refs = {
-    types: Array.from(domainCache.types.keys()),
+    types: [...domainCache.types.keys()],
     functionLikes: [
-      ...Array.from(domainCache.constructors.keys()),
-      ...Array.from(domainCache.functions.keys()),
-      ...Array.from(domainCache.predicates.keys()),
+      ...domainCache.constructors.keys(),
+      ...domainCache.functions.keys(),
+      ...domainCache.predicates.keys(),
     ],
     control: ["AutoLabel", "Label", "NoLabel", "All"],
   };
@@ -68,7 +68,7 @@ export const SubstanceCompletions = (
   range: IRange,
   domainCache: any
 ): languages.CompletionItem[] => {
-  const types = Array.from(domainCache.types.keys()).map((type: any) => ({
+  const types = [...domainCache.types.keys()].map((type) => ({
     label: type,
     insertText: type + " $0",
     insertTextRules: languages.CompletionItemInsertTextRule.InsertAsSnippet,
@@ -76,7 +76,7 @@ export const SubstanceCompletions = (
     detail: "type",
     range,
   }));
-  const predicates = Array.from(domainCache.predicates.keys()).map((type) => ({
+  const predicates = [...domainCache.predicates.keys()].map((type) => ({
     label: type,
     insertText: type + "($0)",
     insertTextRules: languages.CompletionItemInsertTextRule.InsertAsSnippet,
@@ -84,16 +84,14 @@ export const SubstanceCompletions = (
     detail: "predicate",
     range,
   }));
-  const constructors = Array.from(domainCache.constructors.keys()).map(
-    (type) => ({
-      label: type,
-      insertText: type + "($0)",
-      insertTextRules: languages.CompletionItemInsertTextRule.InsertAsSnippet,
-      kind: languages.CompletionItemKind.Constructor,
-      detail: "constructor",
-      range,
-    })
-  );
+  const constructors = [...domainCache.constructors.keys()].map((type) => ({
+    label: type,
+    insertText: type + "($0)",
+    insertTextRules: languages.CompletionItemInsertTextRule.InsertAsSnippet,
+    kind: languages.CompletionItemKind.Constructor,
+    detail: "constructor",
+    range,
+  }));
   const labeling = ["AutoLabel", "Label", "NoLabel", "All"].map((type) => ({
     label: type,
     insertText: type,
@@ -102,23 +100,21 @@ export const SubstanceCompletions = (
     range,
   }));
 
-  const fns = Array.from(domainCache.functions.entries()).map(
-    ([name, fn]: any) => ({
-      label: name,
-      insertText: `${name}($0)`,
-      insertTextRules: languages.CompletionItemInsertTextRule.InsertAsSnippet,
-      kind: languages.CompletionItemKind.Function,
-      detail: `function -> ${fn.output.type.name.value}`,
-      documentation: {
-        value: `${fn.args
-          .map((arg: any) => {
-            return arg.type.name.value + " " + arg.variable.value;
-          })
-          .join(" * ")} -> ${fn.output.type.name.value}`,
-      },
-      range,
-    })
-  );
+  const fns = [...domainCache.functions.entries()].map(([name, fn]) => ({
+    label: name,
+    insertText: `${name}($0)`,
+    insertTextRules: languages.CompletionItemInsertTextRule.InsertAsSnippet,
+    kind: languages.CompletionItemKind.Function,
+    detail: `function -> ${fn.output.type.name.value}`,
+    documentation: {
+      value: `${fn.args
+        .map((arg: any) => {
+          return arg.type.name.value + " " + arg.variable.value;
+        })
+        .join(" * ")} -> ${fn.output.type.name.value}`,
+    },
+    range,
+  }));
 
   return [...types, ...fns, ...predicates, ...constructors, ...labeling];
 };

--- a/packages/core/src/analysis/SubstanceAnalysis.ts
+++ b/packages/core/src/analysis/SubstanceAnalysis.ts
@@ -153,7 +153,7 @@ export const matchDecls = <T>(
 ): ArgStmtDecl<T>[] => {
   //generate signature for the original statement
   const origSignature = getSignature(stmt);
-  const decls: ArgStmtDecl<T>[] = Array.from(opts.values());
+  const decls: ArgStmtDecl<T>[] = [...opts.values()];
   return decls.filter((d) => {
     // does not add original statement to list of matches
     return stmt !== d && matchFunc(origSignature, getSignature(d));
@@ -273,13 +273,13 @@ export const identicalTypeDecls = (
 
     // a match is any var of the same type as the current identifier
     // which is not already being used in the statement
-    const matchedObjs = Array.from(
-      env.vars
+    const matchedObjs = [
+      ...env.vars
         .filter(
           (t, id) => !idSet.includes(id) && typeStr && t.name.value === typeStr
         )
-        .keys()
-    );
+        .keys(),
+    ];
 
     const matches = matchedObjs.flatMap((id) =>
       env.varIDs.filter((v) => v.value === id)
@@ -336,7 +336,7 @@ export const cascadingDelete = <T>(
       removedStmts.add(stmt);
     });
   }
-  return Array.from(removedStmts.values());
+  return [...removedStmts.values()];
 };
 
 export const printStmts = (

--- a/packages/core/src/compiler/Domain.ts
+++ b/packages/core/src/compiler/Domain.ts
@@ -280,7 +280,7 @@ export const checkTypeConstructor = (
   const { name, args } = type;
   // check if name of the type exists
   if (!env.types.has(name.value)) {
-    const suggestions = Array.from(env.types.values());
+    const [...suggestions] = env.types.values();
     return err(
       typeNotFound(
         name,
@@ -314,7 +314,7 @@ const addSubtype = (
 
 const computeTypeGraph = (env: Env): CheckerResult => {
   const { subTypes, types, typeGraph } = env;
-  const typeNames = Array.from(types.keys());
+  const [...typeNames] = types.keys();
   typeNames.map((t: string) => typeGraph.setNode(t, t));
   // NOTE: since we search for super types upstream, subtyping arrow points to supertype
   subTypes.map(

--- a/packages/core/src/compiler/Substance.ts
+++ b/packages/core/src/compiler/Substance.ts
@@ -111,7 +111,7 @@ const initEnv = (ast: SubProg<A>, env: Env): SubstanceEnv => ({
   predEqualities: [],
   bindings: Map<string, SubExpr<C>>(),
   labels: Map<string, LabelValue>(
-    Array.from(env.vars.keys()).map((id: string) => [id, EMPTY_LABEL])
+    [...env.vars.keys()].map((id: string) => [id, EMPTY_LABEL])
   ),
   predicates: [],
   ast,
@@ -151,7 +151,7 @@ const processLabelStmt = (
   switch (stmt.tag) {
     case "AutoLabel": {
       if (stmt.option.tag === "DefaultLabels") {
-        const ids = Array.from(env.vars.keys());
+        const [...ids] = env.vars.keys();
         const newLabels: LabelMap = Map(
           ids.map((id) => [id, { value: id, type: "MathLabel" }])
         );
@@ -607,8 +607,8 @@ const checkFunc = (
   } else {
     return err(
       typeNotFound(func.name, [
-        ...Array.from(env.constructors.values()).map((c) => c.name),
-        ...Array.from(env.functions.values()).map((c) => c.name),
+        ...[...env.constructors.values()].map((c) => c.name),
+        ...[...env.functions.values()].map((c) => c.name),
       ])
     );
   }

--- a/packages/core/src/contrib/Minkowski.ts
+++ b/packages/core/src/contrib/Minkowski.ts
@@ -176,7 +176,7 @@ export const convexPartitions = (p: VarAD[][]): VarAD[][][] => {
     })
   );
 
-  const contour = Array.from(pointMap.keys());
+  const contour = [...pointMap.keys()];
   if (isClockwise(contour)) {
     contour.reverse();
   }

--- a/packages/core/src/synthesis/Synthesizer.ts
+++ b/packages/core/src/synthesis/Synthesizer.ts
@@ -162,10 +162,10 @@ export const filterContext = (
 
 export const showEnv = (env: Env): string =>
   [
-    `types: ${Array.from(env.types.keys())}`,
-    `predicates: ${Array.from(env.predicates.keys())}`,
-    `functions: ${Array.from(env.functions.keys())}`,
-    `constructors: ${Array.from(env.constructors.keys())}`,
+    `types: ${[...env.types.keys()]}`,
+    `predicates: ${[...env.predicates.keys()]}`,
+    `functions: ${[...env.functions.keys()]}`,
+    `constructors: ${[...env.constructors.keys()]}`,
   ].join("\n");
 
 const getDecls = (
@@ -483,7 +483,7 @@ export class Synthesizer {
         (
           options: Immutable.Map<string, Identifier<A>[]>
         ): Identifier<A> | undefined => {
-          const varId = this.choice(Array.from(options.keys()));
+          const varId = this.choice([...options.keys()]);
           const swapOptions = options.get(varId);
           return swapOptions ? this.choice(swapOptions) : undefined;
         },
@@ -498,7 +498,7 @@ export class Synthesizer {
         (
           options: Immutable.Map<string, Identifier<A>[]>
         ): Identifier<A> | undefined => {
-          const varId = this.choice(Array.from(options.keys()));
+          const varId = this.choice([...options.keys()]);
           const swapOptions = options.get(varId);
           return swapOptions ? this.choice(swapOptions) : undefined;
         },
@@ -579,7 +579,7 @@ export class Synthesizer {
     // pick a kind of statement to edit
     const chosenType = this.choice(nonEmptyDecls(ctx));
     // get all possible types within this kind
-    const candidates = Array.from(getDecls(ctx, chosenType).keys());
+    const candidates = [...getDecls(ctx, chosenType).keys()];
     // choose a name
     const chosenName = this.choice(candidates);
     log.debug(
@@ -677,7 +677,7 @@ export class Synthesizer {
   enumerateDelete = (ctx: SynthesisContext): MutationGroup => {
     log.debug("Deleting statement");
     const chosenType = this.choice(nonEmptyDecls(ctx));
-    const candidates = Array.from(getDecls(ctx, chosenType).keys());
+    const candidates = [...getDecls(ctx, chosenType).keys()];
     const chosenName = this.choice(candidates);
     const stmt = this.findStmt(chosenType, chosenName);
     let possibleOps: Mutation[] = [];

--- a/packages/docs-site/babel.config.js
+++ b/packages/docs-site/babel.config.js
@@ -1,3 +1,5 @@
 module.exports = {
+  assumptions: { iterableIsArray: false },
   presets: [require.resolve("@docusaurus/core/lib/babel/preset")],
+  sourceType: "unambiguous",
 };

--- a/packages/panels/src/languages/SubstanceConfig.ts
+++ b/packages/panels/src/languages/SubstanceConfig.ts
@@ -30,11 +30,11 @@ export const SubstanceLanguageTokens = (
   domainCache: Env
 ): languages.IMonarchLanguage => {
   const refs = {
-    types: Array.from(domainCache.types.keys()),
+    types: [...domainCache.types.keys()],
     functionLikes: [
-      ...Array.from(domainCache.constructors.keys()),
-      ...Array.from(domainCache.functions.keys()),
-      ...Array.from(domainCache.predicates.keys()),
+      ...domainCache.constructors.keys(),
+      ...domainCache.functions.keys(),
+      ...domainCache.predicates.keys(),
     ],
     control: ["AutoLabel", "Label", "NoLabel", "All"],
   };
@@ -67,7 +67,7 @@ export const SubstanceCompletions = (
   range: IRange,
   domainCache: any
 ): languages.CompletionItem[] => {
-  const types = Array.from(domainCache.types.keys()).map((type) => ({
+  const types = [...domainCache.types.keys()].map((type) => ({
     label: type,
     insertText: type + " $0",
     insertTextRules: languages.CompletionItemInsertTextRule.InsertAsSnippet,
@@ -75,7 +75,7 @@ export const SubstanceCompletions = (
     detail: "type",
     range,
   }));
-  const predicates = Array.from(domainCache.predicates.keys()).map((type) => ({
+  const predicates = [...domainCache.predicates.keys()].map((type) => ({
     label: type,
     insertText: type + "($0)",
     insertTextRules: languages.CompletionItemInsertTextRule.InsertAsSnippet,
@@ -83,43 +83,37 @@ export const SubstanceCompletions = (
     detail: "predicate",
     range,
   }));
-  const constructors = Array.from(domainCache.constructors.keys()).map(
-    (type) => ({
-      label: type,
-      insertText: type + "($0)",
-      insertTextRules: languages.CompletionItemInsertTextRule.InsertAsSnippet,
-      kind: languages.CompletionItemKind.Constructor,
-      detail: "constructor",
-      range,
-    })
-  );
-  const labeling = ["AutoLabel", "Label", "NoLabel", "All"].map(
-    (type: any) => ({
-      label: type,
-      insertText: type,
-      kind: languages.CompletionItemKind.Color,
-      detail: "labeling",
-      range,
-    })
-  );
+  const constructors = [...domainCache.constructors.keys()].map((type) => ({
+    label: type,
+    insertText: type + "($0)",
+    insertTextRules: languages.CompletionItemInsertTextRule.InsertAsSnippet,
+    kind: languages.CompletionItemKind.Constructor,
+    detail: "constructor",
+    range,
+  }));
+  const labeling = ["AutoLabel", "Label", "NoLabel", "All"].map((type) => ({
+    label: type,
+    insertText: type,
+    kind: languages.CompletionItemKind.Color,
+    detail: "labeling",
+    range,
+  }));
 
-  const fns = Array.from(domainCache.functions.entries()).map(
-    ([name, fn]: any) => ({
-      label: name,
-      insertText: `${name}($0)`,
-      insertTextRules: languages.CompletionItemInsertTextRule.InsertAsSnippet,
-      kind: languages.CompletionItemKind.Function,
-      detail: `function -> ${fn.output.type.name.value}`,
-      documentation: {
-        value: `${fn.args
-          .map((arg: any) => {
-            return arg.type.name.value + " " + arg.variable.value;
-          })
-          .join(" * ")} -> ${fn.output.type.name.value}`,
-      },
-      range,
-    })
-  );
+  const fns = [...domainCache.functions.entries()].map(([name, fn]) => ({
+    label: name,
+    insertText: `${name}($0)`,
+    insertTextRules: languages.CompletionItemInsertTextRule.InsertAsSnippet,
+    kind: languages.CompletionItemKind.Function,
+    detail: `function -> ${fn.output.type.name.value}`,
+    documentation: {
+      value: `${fn.args
+        .map((arg: any) => {
+          return arg.type.name.value + " " + arg.variable.value;
+        })
+        .join(" * ")} -> ${fn.output.type.name.value}`,
+    },
+    range,
+  }));
 
   return [...types, ...fns, ...predicates, ...constructors, ...labeling];
 };


### PR DESCRIPTION
# Description

This PR reverts all the iterator spread removal from #958, instead fixing the Docusaurus issue by disabling Babel's [`iterableIsArray`](https://babeljs.io/docs/en/assumptions#iterableisarray) assumption. This by itself doesn't quite work, as it introduces another error, but that can be resolved by setting `sourceType` to `"unambiguous"`: https://github.com/babel/babel/issues/9187#issuecomment-447704595

The relevant plugin for the original issue seen in #958 is `@babel/plugin-transform-spread`, which [uses `options.loose` as a fallback for the `iterableIsArray` assumption](https://github.com/babel/babel/blob/6dc633e71ef65943554e4087c39a4b939b0eadd0/packages/babel-plugin-transform-spread/src/index.ts#L16). Thus, my guess is that the problem was caused by Docusaurus's Babel preset [enabling the `loose` option](https://github.com/facebook/docusaurus/blob/32ec84ef3c0a238436e913b2026ab809e5750fa8/packages/docusaurus/src/babel/preset.ts#L32).

# Checklist

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new ESLint warnings
- [x] I have reviewed any generated changes to the `diagrams/` folder