### PR TITLE
feat: Make NotTypeConsIn... into ParseError

### DIFF
--- a/packages/core/src/compiler/Domain.test.ts
+++ b/packages/core/src/compiler/Domain.test.ts
@@ -183,13 +183,13 @@ constructor Cons ['X] ('X head, List('X) tail) -> List('X)
   type Set
   Prop <: Set
     `;
-    expectErrorOf(prog, "NotTypeConsInSubtype");
+    expectErrorOf(prog, "ParseError");
   });
   test("type var in subtyping relation", () => {
     const prog = `
   'T <: 'V
     `;
-    expectErrorOf(prog, "NotTypeConsInSubtype");
+    expectErrorOf(prog, "ParseError");
   });
   test("subtype cycle", () => {
     const prog = `

--- a/packages/core/src/compiler/Domain.ts
+++ b/packages/core/src/compiler/Domain.ts
@@ -34,7 +34,6 @@ import {
   err,
   every as everyResult,
   notTypeConsInPrelude,
-  notTypeConsInSubtype,
   ok,
   parseError,
   Result,
@@ -236,9 +235,6 @@ const checkStmt = (stmt: DomainStmt<C>, env: Env): CheckerResult => {
     }
     case "SubTypeDecl": {
       const { subType, superType } = stmt;
-      // make sure only type cons are involved in the subtyping relation
-      if (subType.tag !== "TypeConstructor")
-        return err(notTypeConsInSubtype(subType));
       const subOk = checkType(subType, env);
       const updatedEnv = addSubtype(subType, superType, env);
       return everyResult(subOk, updatedEnv);
@@ -298,12 +294,9 @@ const checkArg = (arg: Arg<C>, env: Env): CheckerResult =>
 
 const addSubtype = (
   subType: TypeConstructor<C>, // assume already checked
-  superType: Type<C>,
+  superType: TypeConstructor<C>,
   env: Env
 ): CheckerResult => {
-  // make sure only type cons are involved in the subtyping relation
-  if (superType.tag !== "TypeConstructor")
-    return err(notTypeConsInSubtype(superType));
   const superOk = checkType(superType, env);
   const updatedEnv: CheckerResult = ok({
     ...env,

--- a/packages/core/src/compiler/Domain.ts
+++ b/packages/core/src/compiler/Domain.ts
@@ -33,7 +33,6 @@ import {
   duplicateName,
   err,
   every as everyResult,
-  notTypeConsInPrelude,
   ok,
   parseError,
   Result,
@@ -224,9 +223,6 @@ const checkStmt = (stmt: DomainStmt<C>, env: Env): CheckerResult => {
     case "PreludeDecl": {
       const { name, type } = stmt;
       const typeOk = checkType(type, env);
-      // make sure only type cons are involved in the prelude decl
-      if (type.tag !== "TypeConstructor")
-        return err(notTypeConsInPrelude(type));
       const updatedEnv: CheckerResult = ok({
         ...env,
         preludeValues: env.preludeValues.set(name.value, type),

--- a/packages/core/src/parser/Domain.ne
+++ b/packages/core/src/parser/Domain.ne
@@ -70,7 +70,7 @@ statement
   |  subtype     {% id %}
 
 # not to be confused with `type`, defined below
-type_decl -> "type" __ identifier (_ "(" _ type_params _ ")"):? (_ "<:" _ sepBy1[type, ","]):? {%
+type_decl -> "type" __ identifier (_ "(" _ type_params _ ")"):? (_ "<:" _ sepBy1[type_constructor, ","]):? {%
   ([typ, , name, ps, sub]): TypeDecl<C> => {
     const params = ps ? ps[3] : [];
     const superTypes = sub ? sub[3] : [];
@@ -135,7 +135,7 @@ notation -> "notation" _  string_lit  _ "~" _ string_lit {%
   })
 %} 
 
-subtype -> type _ "<:" _ type {%
+subtype -> type_constructor _ "<:" _ type_constructor {%
   ([subType, , , , superType]): SubTypeDecl<C> => ({
     ...nodeData,
     ...rangeBetween(subType, superType),

--- a/packages/core/src/parser/Domain.ne
+++ b/packages/core/src/parser/Domain.ne
@@ -119,7 +119,7 @@ constructor_decl
     }
   %}
 
-prelude -> "value" __ var _ ":" _ type {%
+prelude -> "value" __ var _ ":" _ type_constructor {%
   ([kw, , name, , , , type]): PreludeDecl<C> => ({
     ...nodeData,
     ...rangeBetween(rangeOf(kw), type),

--- a/packages/core/src/types/domain.ts
+++ b/packages/core/src/types/domain.ts
@@ -74,7 +74,7 @@ export type ConstructorDecl<T> = ASTNode<T> & {
 export type PreludeDecl<T> = ASTNode<T> & {
   tag: "PreludeDecl";
   name: Var<T>;
-  type: Type<T>;
+  type: TypeConstructor<T>;
 };
 // TODO: check if string type is enough
 export type NotationDecl<T> = ASTNode<T> & {

--- a/packages/core/src/types/domain.ts
+++ b/packages/core/src/types/domain.ts
@@ -47,7 +47,7 @@ export type TypeDecl<T> = ASTNode<T> & {
   tag: "TypeDecl";
   name: Identifier<T>;
   params: TypeVar<T>[];
-  superTypes: Type<T>[];
+  superTypes: TypeConstructor<T>[];
 };
 
 export type PredicateDecl<T> = ASTNode<T> & {
@@ -84,8 +84,8 @@ export type NotationDecl<T> = ASTNode<T> & {
 };
 export type SubTypeDecl<T> = ASTNode<T> & {
   tag: "SubTypeDecl";
-  subType: Type<T>;
-  superType: Type<T>;
+  subType: TypeConstructor<T>;
+  superType: TypeConstructor<T>;
 };
 
 //#endregion

--- a/packages/core/src/types/errors.ts
+++ b/packages/core/src/types/errors.ts
@@ -1,6 +1,6 @@
 //#region ErrorTypes
 import { A, AbstractNode, Identifier, SourceLoc } from "./ast";
-import { Arg, Prop, TypeConstructor, TypeVar } from "./domain";
+import { Arg, TypeConstructor, TypeVar } from "./domain";
 import { State } from "./state";
 import { BindingForm, Path } from "./style";
 import { Deconstructor, SubExpr, TypeConsApp } from "./substance";
@@ -50,8 +50,7 @@ export type DomainError =
   | TypeVarNotFound
   | TypeNotFound
   | DuplicateName
-  | CyclicSubtypes
-  | NotTypeConsInPrelude;
+  | CyclicSubtypes;
 
 export interface UnexpectedExprForNestedPred {
   tag: "UnexpectedExprForNestedPred";
@@ -63,10 +62,6 @@ export interface UnexpectedExprForNestedPred {
 export interface CyclicSubtypes {
   tag: "CyclicSubtypes";
   cycles: string[][];
-}
-export interface NotTypeConsInPrelude {
-  tag: "NotTypeConsInPrelude";
-  type: Prop<A> | TypeVar<A>;
 }
 
 export interface TypeDeclared {

--- a/packages/core/src/types/errors.ts
+++ b/packages/core/src/types/errors.ts
@@ -51,7 +51,6 @@ export type DomainError =
   | TypeNotFound
   | DuplicateName
   | CyclicSubtypes
-  | NotTypeConsInSubtype
   | NotTypeConsInPrelude;
 
 export interface UnexpectedExprForNestedPred {
@@ -70,10 +69,6 @@ export interface NotTypeConsInPrelude {
   type: Prop<A> | TypeVar<A>;
 }
 
-export interface NotTypeConsInSubtype {
-  tag: "NotTypeConsInSubtype";
-  type: Prop<A> | TypeVar<A>;
-}
 export interface TypeDeclared {
   tag: "TypeDeclared";
   typeName: Identifier<A>;

--- a/packages/core/src/utils/Error.ts
+++ b/packages/core/src/utils/Error.ts
@@ -12,7 +12,6 @@ import {
   FatalError,
   NaNError,
   NotTypeConsInPrelude,
-  NotTypeConsInSubtype,
   ParseError,
   PenroseError,
   RuntimeError,
@@ -118,17 +117,6 @@ export const showError = (
       return `Name ${name.value} (at ${loc(
         location
       )}) already exists, first declared at ${loc(firstDefined)}.`;
-    }
-    case "NotTypeConsInSubtype": {
-      if (error.type.tag === "Prop") {
-        return `Prop (at ${loc(
-          error.type
-        )}) is not a type constructor. Only type constructors are allowed in subtyping relations.`;
-      } else {
-        return `${error.type.name.value} (at ${loc(
-          error.type
-        )}) is not a type constructor. Only type constructors are allowed in subtyping relations.`;
-      }
     }
     case "CyclicSubtypes": {
       return `Subtyping relations in this program form a cycle. Cycles of types are:\n${showCycles(
@@ -417,13 +405,6 @@ export const notTypeConsInPrelude = (
   type: Prop<A> | TypeVar<A>
 ): NotTypeConsInPrelude => ({
   tag: "NotTypeConsInPrelude",
-  type,
-});
-
-export const notTypeConsInSubtype = (
-  type: Prop<A> | TypeVar<A>
-): NotTypeConsInSubtype => ({
-  tag: "NotTypeConsInSubtype",
   type,
 });
 

--- a/packages/core/src/utils/Error.ts
+++ b/packages/core/src/utils/Error.ts
@@ -2,7 +2,7 @@ import { isConcrete } from "engine/EngineUtils";
 import { shapedefs } from "shapes/Shapes";
 import { Result } from "true-myth";
 import { A, AbstractNode, Identifier, SourceLoc } from "types/ast";
-import { Arg, Prop, Type, TypeConstructor, TypeVar } from "types/domain";
+import { Arg, Type, TypeConstructor } from "types/domain";
 import {
   ArgLengthMismatch,
   CyclicSubtypes,
@@ -11,7 +11,6 @@ import {
   DuplicateName,
   FatalError,
   NaNError,
-  NotTypeConsInPrelude,
   ParseError,
   PenroseError,
   RuntimeError,
@@ -122,17 +121,6 @@ export const showError = (
       return `Subtyping relations in this program form a cycle. Cycles of types are:\n${showCycles(
         error.cycles
       )}`;
-    }
-    case "NotTypeConsInPrelude": {
-      if (error.type.tag === "Prop") {
-        return `Prop (at ${loc(
-          error.type
-        )}) is not a type constructor. Only type constructors are allowed for prelude values.`;
-      } else {
-        return `${error.type.name.value} (at ${loc(
-          error.type
-        )}) is not a type constructor. Only type constructors are allowed in prelude values.`;
-      }
     }
     case "TypeMismatch": {
       const { sourceExpr, sourceType, expectedExpr, expectedType } = error;
@@ -399,13 +387,6 @@ const showCycles = (cycles: string[][]) => {
 export const cyclicSubtypes = (cycles: string[][]): CyclicSubtypes => ({
   tag: "CyclicSubtypes",
   cycles,
-});
-
-export const notTypeConsInPrelude = (
-  type: Prop<A> | TypeVar<A>
-): NotTypeConsInPrelude => ({
-  tag: "NotTypeConsInPrelude",
-  type,
 });
 
 // action constructors for error


### PR DESCRIPTION
# Description

Previously `TypeDecl`'s `superTypes` field, `SubTypeDecl`'s `subType` and `superType` fields, and `PreludeDecl`'s `type` field were `Type`, but `compiler/Domain` checked that they were actually `TypeConstructor` and errored otherwise. This PR puts `TypeConstructor` into our grammar and gets rid of the `NotTypeConsInSubtype` and `NotTypeConsInPrelude` error types.

# Checklist

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new ESLint warnings
- [x] I have reviewed any generated changes to the `diagrams/` folder