### PR TITLE
refactor: Replace map with forEach when possible

### DIFF
--- a/packages/automator/index.tsx
+++ b/packages/automator/index.tsx
@@ -216,7 +216,7 @@ const singleProcess = async (
         fs.writeFileSync(filename, canvasData);
         console.log(chalk.green(`The diagram has been saved as ${filename}`));
       };
-      listOfCanvasData.map(writeFileOut);
+      listOfCanvasData.forEach(writeFileOut);
     } else {
       // not staged --> just need one diagram
       fs.writeFileSync(
@@ -247,7 +247,7 @@ const singleProcess = async (
         fs.writeFileSync(newStr, canvasData);
         console.log(chalk.green(`The diagram has been saved as ${newStr}`));
       };
-      listOfCanvasData.map(writeFileOut);
+      listOfCanvasData.forEach(writeFileOut);
     } else {
       // just the final diagram
       fs.writeFileSync(out, prettier.format(canvas, { parser: "html" }));

--- a/packages/core/src/compiler/Domain.test.ts
+++ b/packages/core/src/compiler/Domain.test.ts
@@ -27,10 +27,10 @@ const contextHas = (
   if (res.isOk()) {
     const { types, typeVars, constructors, functions, predicates } = res.value;
     expect(typeVars.size).toBe(0);
-    expectedTypes.map((t) => expect(types.has(t)).toBe(true));
-    expectedConstructors.map((c) => expect(constructors.has(c)).toBe(true));
-    expectedFunctions.map((f) => expect(functions.has(f)).toBe(true));
-    expectedPredicates.map((p) => expect(predicates.has(p)).toBe(true));
+    expectedTypes.forEach((t) => expect(types.has(t)).toBe(true));
+    expectedConstructors.forEach((c) => expect(constructors.has(c)).toBe(true));
+    expectedFunctions.forEach((f) => expect(functions.has(f)).toBe(true));
+    expectedPredicates.forEach((p) => expect(predicates.has(p)).toBe(true));
   } else {
     fail(showError(res.error));
   }

--- a/packages/core/src/compiler/Domain.ts
+++ b/packages/core/src/compiler/Domain.ts
@@ -315,9 +315,9 @@ const addSubtype = (
 const computeTypeGraph = (env: Env): CheckerResult => {
   const { subTypes, types, typeGraph } = env;
   const [...typeNames] = types.keys();
-  typeNames.map((t: string) => typeGraph.setNode(t, t));
+  typeNames.forEach((t: string) => typeGraph.setNode(t, t));
   // NOTE: since we search for super types upstream, subtyping arrow points to supertype
-  subTypes.map(
+  subTypes.forEach(
     ([subType, superType]: [TypeConstructor<C>, TypeConstructor<C>]) =>
       typeGraph.setEdge(subType.name.value, superType.name.value)
   );

--- a/packages/core/src/compiler/Style.ts
+++ b/packages/core/src/compiler/Style.ts
@@ -2910,9 +2910,9 @@ export const topSortLayering = (
   partialOrderings: [string, string][]
 ): string[] => {
   const layerGraph: Graph = new Graph();
-  allGPINames.map((name: string) => layerGraph.setNode(name));
+  allGPINames.forEach((name: string) => layerGraph.setNode(name));
   // topsort will return the most upstream node first. Since `shapeOrdering` is consistent with the SVG drawing order, we assign edges as "below => above".
-  partialOrderings.map(([below, above]: [string, string]) =>
+  partialOrderings.forEach(([below, above]: [string, string]) =>
     layerGraph.setEdge(below, above)
   );
 
@@ -2945,7 +2945,7 @@ const pseudoTopsort = (graph: Graph): string[] => {
     else return aIn.length - bIn.length;
   });
   const res: string[] = [];
-  graph.nodes().map((n: string) => toVisit.insert(n));
+  graph.nodes().forEach((n: string) => toVisit.insert(n));
   while (toVisit.size() > 0) {
     // remove element with fewest incoming edges and append to result
     const node: string = toVisit.extractRoot() as string;

--- a/packages/core/src/compiler/Substance.test.ts
+++ b/packages/core/src/compiler/Substance.test.ts
@@ -28,7 +28,7 @@ const subPaths = [
 ];
 
 const hasVars = (env: Env, vars: [string, string][]) => {
-  vars.map(([name, type]: [string, string]) => {
+  vars.forEach(([name, type]: [string, string]) => {
     expect(env.vars.has(name)).toBe(true);
     expect(showType(env.vars.get(name)!)).toEqual(type);
   });
@@ -156,7 +156,7 @@ NoLabel D, E
         ["E", "", "NoLabel"],
       ];
       const labelMap = res.value[0].labels;
-      expected.map(([id, value, type]) => {
+      expected.forEach(([id, value, type]) => {
         const label = labelMap.get(id)!;
         expect(label.value).toEqual(value);
         expect(label.type).toEqual(type);
@@ -535,7 +535,7 @@ describe("Real Programs", () => {
     fs.mkdirSync(outputDir);
   }
 
-  subPaths.map(([domainPath, examplePath]) => {
+  subPaths.forEach(([domainPath, examplePath]) => {
     // a bit hacky, only works with 2-part paths
     const [domPart0, domPart1] = domainPath.split("/");
     const [subPart0, subPart1] = examplePath.split("/");

--- a/packages/core/src/contrib/Functions.ts
+++ b/packages/core/src/contrib/Functions.ts
@@ -595,7 +595,7 @@ export const compDict = {
     const path = new PathBuilder();
     const [start, ...tailpts] = pts;
     path.moveTo(start);
-    tailpts.map((pt: Pt2) => path.lineTo(pt));
+    tailpts.forEach((pt: Pt2) => path.lineTo(pt));
     if (pathType === "closed") path.closePath();
     return path.getPath();
   },
@@ -612,7 +612,7 @@ export const compDict = {
     const [start, cp, second, ...tailpts] = pts;
     path.moveTo(start);
     path.quadraticCurveTo(cp, second);
-    tailpts.map((pt: Pt2) => path.quadraticCurveJoin(pt));
+    tailpts.forEach((pt: Pt2) => path.quadraticCurveJoin(pt));
     if (pathType === "closed") path.closePath();
     return path.getPath();
   },
@@ -629,7 +629,7 @@ export const compDict = {
     const [start, cp1, cp2, second, ...tailpts] = pts;
     path.moveTo(start);
     path.bezierCurveTo(cp1, cp2, second);
-    _.chunk(tailpts, 2).map(([cp, pt]) => path.cubicCurveJoin(cp, pt));
+    _.chunk(tailpts, 2).forEach(([cp, pt]) => path.cubicCurveJoin(cp, pt));
     if (pathType === "closed") path.closePath();
     return path.getPath();
   },
@@ -958,7 +958,7 @@ export const compDict = {
     const [x1p, y1p] = ops.vmove(mid, tickLength, normalDir);
     const [x2p, y2p] = ops.vmove(mid, tickLength, ops.vneg(normalDir));
 
-    multipliers.map((multiplier) => {
+    multipliers.forEach((multiplier) => {
       const [sx, sy] = ops.vmove([x1p, y1p], multiplier, unit);
       const [ex, ey] = ops.vmove([x2p, y2p], multiplier, unit);
       path.moveTo([sx, sy]).lineTo([ex, ey]);

--- a/packages/core/src/parser/DomainParser.test.ts
+++ b/packages/core/src/parser/DomainParser.test.ts
@@ -208,7 +208,7 @@ describe("Real Programs", () => {
     fs.mkdirSync(outputDir);
   }
 
-  domainPaths.map((examplePath) => {
+  domainPaths.forEach((examplePath) => {
     // a bit hacky, only works with 2-part paths
     const [part0, part1] = examplePath.split("/");
     const prog = examples[part0][part1];

--- a/packages/core/src/parser/StyleParser.test.ts
+++ b/packages/core/src/parser/StyleParser.test.ts
@@ -448,7 +448,7 @@ describe("Real Programs", () => {
     fs.mkdirSync(outputDir);
   }
 
-  styPaths.map((examplePath) => {
+  styPaths.forEach((examplePath) => {
     // a bit hacky, only works with 2-part paths
     const [part0, part1] = examplePath.split("/");
     const prog = examples[part0][part1];

--- a/packages/core/src/parser/SubstanceParser.test.ts
+++ b/packages/core/src/parser/SubstanceParser.test.ts
@@ -183,7 +183,7 @@ describe("Real Programs", () => {
     fs.mkdirSync(outputDir);
   }
 
-  subPaths.map((examplePath) => {
+  subPaths.forEach((examplePath) => {
     // a bit hacky, only works with 2-part paths
     const [part0, part1] = examplePath.split("/");
     const prog = examples[part0][part1];

--- a/packages/synthesizer/index.ts
+++ b/packages/synthesizer/index.ts
@@ -190,7 +190,7 @@ const writePrograms = (
       }
     }
 
-    // progs.map((prog) => console.log(prettySubstance(prog) + "\n-------"));
+    // progs.forEach((prog) => console.log(prettySubstance(prog) + "\n-------"));
   } else {
     console.log(
       `Error when compiling the domain program:\n${showError(envOrError.error)}`


### PR DESCRIPTION
# Description

This PR replaces [`map`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/map) with [`forEach`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/forEach) whenever the returned array is ignored. See also: https://dev.to/smeijer/stop-mutating-in-map-reduce-and-foreach-58bf

# Checklist

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new ESLint warnings
- [x] I have reviewed any generated changes to the `diagrams/` folder

# Open questions

- Is there a way to lint this automatically for the future?