### PR TITLE
fix: Make TypeDecl subType range more precise

### DIFF
--- a/packages/core/src/compiler/Domain.ts
+++ b/packages/core/src/compiler/Domain.ts
@@ -144,8 +144,8 @@ const checkStmt = (stmt: DomainStmt<C>, env: Env): CheckerResult => {
       const subType: TypeConstructor<C> = {
         tag: "TypeConstructor",
         nodeType: "Substance",
-        start: stmt.start,
-        end: stmt.end,
+        start: name.start,
+        end: name.end,
         name,
         args: [],
       };


### PR DESCRIPTION
# Description

When compiling a `TypeDecl`, the Domain compiler needs to wrap the `name` (an `Identifier`) into a `TypeConstructor`. Previously it was using the range of the whole `TypeDecl` statement as the range of this `TypeConstructor`, when it really should have just been using the range of the `Identifier`.

# Checklist

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new ESLint warnings
- [x] I have reviewed any generated changes to the `diagrams/` folder