### PR TITLE
test: Disallow eslint-disable comments in core

### DIFF
--- a/packages/core/.eslintrc.js
+++ b/packages/core/.eslintrc.js
@@ -28,12 +28,14 @@ module.exports = {
     sourceType: "module",
   },
   plugins: [
+    "eslint-comments",
     "eslint-plugin-import",
     "eslint-plugin-jsdoc",
     "eslint-plugin-react",
     "eslint-plugin-import",
   ],
   rules: {
+    "eslint-comments/no-use": 2,
     "import/no-cycle": 2,
     "no-fallthrough": 2,
   },

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -71,6 +71,7 @@
     "@typescript-eslint/parser": "^4.5.0",
     "eslint": "^6.6.0",
     "eslint-config-prettier": "^6.13.0",
+    "eslint-plugin-eslint-comments": "^3.2.0",
     "eslint-plugin-import": "^2.22.1",
     "eslint-plugin-jsdoc": "^30.7.3",
     "eslint-plugin-react": "^7.28.0",

--- a/packages/core/src/compiler/Style.ts
+++ b/packages/core/src/compiler/Style.ts
@@ -636,11 +636,8 @@ export const uniqueKeysAndVals = (subst: Subst): boolean => {
 
 // Optimization to filter out Substance statements that have no hope of matching any of the substituted relation patterns, so we don't do redundant work for every substitution (of which there could be millions). This function is only called once per selector.
 const couldMatchRels = (
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   typeEnv: Env,
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   rels: RelationPattern<A>[],
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   stmt: SubStmt<A>
 ): boolean => {
   // TODO < (this is an optimization; will only implement if needed)
@@ -1974,7 +1971,6 @@ const checkBlockExpr = (selEnv: SelEnv, expr: Expr<A>): StyleResults => {
   }
 };
 
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
 const checkBlockPath = (selEnv: SelEnv, path: Path<A>): StyleResults => {
   // TODO(errors) / Block statics
   // Currently there is nothing to check for paths
@@ -2168,7 +2164,6 @@ const translateStyProg = (
   subProg: SubProg<A>,
   styProg: StyProg<A>,
   labelMap: LabelMap,
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   styVals: number[]
 ): Either<StyleErrors, Translation> => {
   // COMBAK: Deal with styVals
@@ -2550,13 +2545,9 @@ const findUserAppliedFns = (tr: Translation): [Fn[], Fn[]] => {
 };
 
 const findFieldDefaultFns = (
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   name: string,
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   field: Field,
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   fexpr: FieldExpr<VarAD>,
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   acc: Either<StyleOptFn, StyleOptFn>[]
 ): Either<StyleOptFn, StyleOptFn>[] => {
   if (fexpr.tag === "FGPI") {
@@ -2890,7 +2881,6 @@ const findLayeringExprs = (tr: Translation): ILayering<A>[] => {
   return foldSubObjs(findLayeringExpr, tr);
 };
 
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
 const lookupGPIName = (p: Path<A>, tr: Translation): string => {
   if (p.tag === "FieldPath") {
     // COMBAK: Deal with path synonyms / aliases by looking them up?

--- a/packages/core/src/contrib/Functions.ts
+++ b/packages/core/src/contrib/Functions.ts
@@ -1469,7 +1469,6 @@ export const compDict = {
 // _compDictVals causes TypeScript to enforce that every function in compDict
 // takes a Context as its first parameter
 
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
 const _compDictVals: ((
   context: Context,
   ...rest: never[]

--- a/packages/core/src/parser/ParserUtil.ts
+++ b/packages/core/src/parser/ParserUtil.ts
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/naming-convention */
 import { compact, flatten } from "lodash";
 import * as moo from "moo";
 import { C, Identifier, NodeType, SourceLoc, SourceRange } from "types/ast";

--- a/packages/core/src/utils/CollectLabels.ts
+++ b/packages/core/src/utils/CollectLabels.ts
@@ -233,6 +233,9 @@ export type TextMeasurement = {
   actualAscent: number;
 };
 
+const measureTextElement = document.createElement("canvas");
+const measureTextContext = measureTextElement.getContext("2d")!;
+
 /**
  *
  * @param text the content of the text
@@ -242,9 +245,9 @@ export type TextMeasurement = {
  * @returns `TextMeasurement` object and includes data such as `width` and `height` of the text.
  */
 export function measureText(text: string, font: string): TextMeasurement {
-  measureText.context.textBaseline = "alphabetic";
-  measureText.context.font = font;
-  const measurements = measureText.context.measureText(text);
+  measureTextContext.textBaseline = "alphabetic";
+  measureTextContext.font = font;
+  const measurements = measureTextContext.measureText(text);
   return {
     width:
       Math.abs(measurements.actualBoundingBoxLeft) +
@@ -255,13 +258,6 @@ export function measureText(text: string, font: string): TextMeasurement {
     actualDescent: Math.abs(measurements.actualBoundingBoxDescent),
     actualAscent: Math.abs(measurements.actualBoundingBoxAscent),
   };
-}
-// static variable
-// eslint-disable-next-line @typescript-eslint/no-namespace
-export namespace measureText {
-  export const element = document.createElement("canvas");
-  // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-  export const context = element.getContext("2d")!;
 }
 
 //#endregion

--- a/yarn.lock
+++ b/yarn.lock
@@ -9709,6 +9709,14 @@ eslint-plugin-es@^3.0.0:
     eslint-utils "^2.0.0"
     regexpp "^3.0.0"
 
+eslint-plugin-eslint-comments@^3.2.0:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-eslint-comments/-/eslint-plugin-eslint-comments-3.2.0.tgz#9e1cd7b4413526abb313933071d7aba05ca12ffa"
+  integrity sha512-0jkOl0hfojIHHmEHgmNdqv4fmh7300NdpA9FFpF7zaoLvB/QeXOGNLIo86oAveJFrfB1p05kC8hpEMHM8DwWVQ==
+  dependencies:
+    escape-string-regexp "^1.0.5"
+    ignore "^5.0.5"
+
 eslint-plugin-import@^2.22.1:
   version "2.25.4"
   resolved "https://registry.yarnpkg.com/eslint-plugin-import/-/eslint-plugin-import-2.25.4.tgz#322f3f916a4e9e991ac7af32032c25ce313209f1"
@@ -11860,7 +11868,7 @@ ignore@^4.0.2, ignore@^4.0.3, ignore@^4.0.6:
   resolved "https://registry.yarnpkg.com/ignore/-/ignore-4.0.6.tgz#750e3db5862087b4737ebac8207ffd1ef27b25fc"
   integrity sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg==
 
-ignore@^5.1.1, ignore@^5.1.4, ignore@^5.1.8, ignore@^5.1.9, ignore@^5.2.0:
+ignore@^5.0.5, ignore@^5.1.1, ignore@^5.1.4, ignore@^5.1.8, ignore@^5.1.9, ignore@^5.2.0:
   version "5.2.0"
   resolved "https://registry.yarnpkg.com/ignore/-/ignore-5.2.0.tgz#6d3bac8fa7fe0d45d9f9be7bac2fc279577e345a"
   integrity sha512-CmxgYGiEPCLhfLnpPp1MoRmifwEIOgjcHXxOBjv7mY96c+eWScsOP9c112ZyLdWHi0FxHjI+4uVhKYp/gcdRmQ==


### PR DESCRIPTION
# Description

This PR uses [`eslint-plugin-eslint-comments`](https://mysticatea.github.io/eslint-plugin-eslint-comments/) to disallow `eslint-disable` comments in `@penrose/core`. Many of the ones we already had were added by me in #817, and a couple by @wodeni in #829, but some of them were simply outdated.

# Checklist

- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new ESLint warnings
- [x] I have reviewed any generated changes to the `diagrams/` folder