### PR TITLE
test: Warn about type assertions in @penrose/core

### DIFF
--- a/packages/core/.eslintrc.js
+++ b/packages/core/.eslintrc.js
@@ -34,6 +34,10 @@ module.exports = {
     "eslint-plugin-import",
   ],
   rules: {
+    "@typescript-eslint/consistent-type-assertions": [
+      1,
+      { assertionStyle: "never" },
+    ],
     "import/no-cycle": 2,
     "no-fallthrough": 2,
   },

--- a/packages/core/.eslintrc.js
+++ b/packages/core/.eslintrc.js
@@ -38,6 +38,7 @@ module.exports = {
       1,
       { assertionStyle: "never" },
     ],
+    "@typescript-eslint/non-nullable-type-assertion-style": 2,
     "import/no-cycle": 2,
     "no-fallthrough": 2,
   },

--- a/packages/core/src/analysis/SubstanceAnalysis.ts
+++ b/packages/core/src/analysis/SubstanceAnalysis.ts
@@ -216,9 +216,8 @@ export const getSignature = (decl: ArgStmtDecl<A>): Signature => {
     });
   }
   // see if there is an output field:
-  const d = decl as ConstructorDecl<A>;
-  if (d.output && d.output.type.tag === "TypeConstructor") {
-    outType = d.output.type.name.value;
+  if ("output" in decl && decl.output.type.tag === "TypeConstructor") {
+    outType = decl.output.type.name.value;
   }
   return {
     args: argTypes,
@@ -343,8 +342,7 @@ export const printStmts = (
   stmts: PredicateDecl<A>[] | ConstructorDecl<A>[] | FunctionDecl<A>[]
 ): void => {
   let outStr = "";
-  const s = stmts as PredicateDecl<A>[];
-  s.forEach((stmt) => {
+  stmts.forEach((stmt) => {
     outStr += stmt.name.value + " ";
   });
   console.log(`[${outStr}]`);

--- a/packages/core/src/compiler/Domain.ts
+++ b/packages/core/src/compiler/Domain.ts
@@ -49,7 +49,7 @@ export const parseDomain = (
   try {
     const { results } = parser.feed(prog).feed("\n"); // NOTE: extra newline to avoid trailing comments
     if (results.length > 0) {
-      const ast: DomainProg<C> = results[0] as DomainProg<C>;
+      const ast: DomainProg<C> = results[0];
       return ok(ast);
     } else {
       return err(parseError(`Unexpected end of input`, lastLocation(parser)));

--- a/packages/core/src/compiler/Style.ts
+++ b/packages/core/src/compiler/Style.ts
@@ -170,12 +170,12 @@ export function numbered<A>(xs: A[]): [A, number][] {
 // TODO move to util
 
 export function isLeft<A, B>(val: Either<A, B>): val is Left<A> {
-  if ((val as Left<A>).tag === "Left") return true;
+  if (val.tag === "Left") return true;
   return false;
 }
 
 export function isRight<A, B>(val: Either<A, B>): val is Right<B> {
-  if ((val as Right<B>).tag === "Right") return true;
+  if (val.tag === "Right") return true;
   return false;
 }
 
@@ -1679,7 +1679,12 @@ const deleteProperty = (
             // TODO(error)
             return addWarn(trans, {
               tag: "CircularPathAlias",
-              path: { tag: "FieldPath", name, field } as Path<A>,
+              path: {
+                tag: "FieldPath",
+                nodeType: "SyntheticStyle",
+                name,
+                field,
+              },
             });
           }
           return deleteProperty(trans, p, p.name, p.field, property);
@@ -2472,7 +2477,8 @@ const findGPIName = (
 ): [string, Field][] => {
   switch (fexpr.tag) {
     case "FGPI": {
-      return ([[name, field]] as [string, Field][]).concat(acc);
+      const head: [string, Field] = [name, field];
+      return [head].concat(acc);
     }
     case "FExpr": {
       return acc;
@@ -2495,9 +2501,11 @@ const findShapeProperties = (
   switch (fexpr.tag) {
     case "FGPI": {
       const properties = fexpr.contents[1];
-      const paths = Object.keys(properties).map(
-        (property) => [name, field, property] as [string, Field, Property]
-      );
+      const paths = Object.keys(properties).map((property): [
+        string,
+        Field,
+        Property
+      ] => [name, field, property]);
       return paths.concat(acc);
     }
     case "FExpr": {
@@ -2602,10 +2610,16 @@ const toFns = ([objfns, constrfns]: [StyleOptFn[], StyleOptFn[]]): [
 
 // COMBAK: Move this to utils
 function partitionEithers<A, B>(es: Either<A, B>[]): [A[], B[]] {
-  return [
-    es.filter((e) => e.tag === "Left").map((e) => e.contents as A),
-    es.filter((e) => e.tag === "Right").map((e) => e.contents as B),
-  ];
+  const a: A[] = [];
+  const b: B[] = [];
+  for (const e of es) {
+    if (e.tag === "Left") {
+      a.push(e.contents);
+    } else {
+      b.push(e.contents);
+    }
+  }
+  return [a, b];
 }
 
 const convertFns = (fns: Either<StyleOptFn, StyleOptFn>[]): [Fn[], Fn[]] => {
@@ -3112,7 +3126,7 @@ export const parseStyle = (p: string): Result<StyProg<C>, ParseError> => {
   try {
     const { results } = parser.feed(p).feed("\n");
     if (results.length > 0) {
-      const ast: StyProg<C> = results[0] as StyProg<C>;
+      const ast: StyProg<C> = results[0];
       return ok(ast);
     } else {
       return err(parseError(`Unexpected end of input`, lastLocation(parser)));

--- a/packages/core/src/compiler/Substance.ts
+++ b/packages/core/src/compiler/Substance.ts
@@ -63,7 +63,7 @@ export const parseSubstance = (
   try {
     const { results } = parser.feed(prog).feed("\n"); // NOTE: extra newline to avoid trailing comments
     if (results.length > 0) {
-      const ast: SubProg<C> = results[0] as SubProg<C>;
+      const ast: SubProg<C> = results[0];
       return ok(ast);
     } else {
       return err(parseError(`Unexpected end of input`, lastLocation(parser)));
@@ -231,6 +231,7 @@ export const checkSubstance = (
 ): CheckerResult<SubProg<A>> => {
   const { statements } = prog;
   // check all statements
+  const contents: SubStmt<A>[] = [];
   const stmtsOk: CheckerResult<SubStmt<A>[]> = safeChain(
     statements,
     (stmt, { env, contents: stmts }) =>
@@ -239,7 +240,7 @@ export const checkSubstance = (
           ok({ env, contents: [...stmts, checkedStmt] }),
         checkStmt(stmt, env)
       ),
-    ok({ env, contents: [] as SubStmt<A>[] })
+    ok({ env, contents })
   );
   return andThen(
     ({ env, contents }) =>
@@ -346,6 +347,7 @@ export const checkPredicate = (
     // initialize substitution environment
     const substEnv: SubstitutionEnv = Map<string, TypeConsApp<C>>();
     const argPairs = zip2(args, predDecl.args);
+    const contents: SubPredArg<A>[] = [];
     const argsOk: SubstitutionResult<SubPredArg<A>[]> = safeChain(
       argPairs,
       ([expr, arg], { substEnv: cxt, env: e, contents: args }) =>
@@ -353,7 +355,7 @@ export const checkPredicate = (
           (res) => ok({ ...res, contents: [...args, res.contents] }),
           checkPredArg(expr, arg, cxt, e)
         ),
-      ok({ substEnv, env, contents: [] as SubPredArg<A>[] })
+      ok({ substEnv, env, contents })
     );
     // NOTE: throw away the substitution because this layer above doesn't need to typecheck
     return andThen(

--- a/packages/core/src/contrib/Functions.ts
+++ b/packages/core/src/contrib/Functions.ts
@@ -130,7 +130,7 @@ export const compDict = {
       return {
         tag: "FloatV",
         // TODO: Improve error if varName is not in map
-        contents: optDebugInfo.gradient.get(varName) as number,
+        contents: optDebugInfo.gradient.get(varName)!,
       };
     }
 
@@ -169,7 +169,7 @@ export const compDict = {
       return {
         tag: "FloatV",
         // TODO: Improve error if varName is not in map
-        contents: optDebugInfo.gradientPreconditioned.get(varName) as number,
+        contents: optDebugInfo.gradientPreconditioned.get(varName)!,
       };
     }
 

--- a/packages/core/src/engine/BBox.ts
+++ b/packages/core/src/engine/BBox.ts
@@ -153,10 +153,10 @@ export const yRange = (b: BBox): [VarAD, VarAD] => {
  */
 export const edges = (b: BBox): Edges => {
   return {
-    top: <[Pt2, Pt2]>[corners(b).topLeft, corners(b).topRight],
-    bot: <[Pt2, Pt2]>[corners(b).bottomLeft, corners(b).bottomRight],
-    left: <[Pt2, Pt2]>[corners(b).bottomLeft, corners(b).topLeft],
-    right: <[Pt2, Pt2]>[corners(b).bottomRight, corners(b).topRight],
+    top: [corners(b).topLeft, corners(b).topRight],
+    bot: [corners(b).bottomLeft, corners(b).bottomRight],
+    left: [corners(b).bottomLeft, corners(b).topLeft],
+    right: [corners(b).bottomRight, corners(b).topRight],
   };
 };
 

--- a/packages/core/src/engine/EngineUtils.ts
+++ b/packages/core/src/engine/EngineUtils.ts
@@ -7,7 +7,6 @@ import { VarAD } from "types/ad";
 import {
   A,
   ASTNode,
-  C,
   ConcreteNode,
   Identifier,
   NodeType,
@@ -17,14 +16,7 @@ import {
 import { StyleError, Warning } from "types/errors";
 import { Shape, ShapeAD } from "types/shape";
 import { LbfgsParams } from "types/state";
-import {
-  AnnoFloat,
-  Expr,
-  IPropertyPath,
-  IVector,
-  Path,
-  PropertyDecl,
-} from "types/style";
+import { AnnoFloat, Expr, IVector, Path, PropertyDecl } from "types/style";
 import {
   Color,
   FieldExpr,
@@ -188,9 +180,9 @@ function mapPathData<T, S>(f: (arg: T) => S, v: IPathDataV<T>): IPathDataV<S> {
 function mapColorInner<T, S>(f: (arg: T) => S, v: Color<T>): Color<S> {
   switch (v.tag) {
     case "RGBA":
-      return { tag: v.tag, contents: mapTuple(f, (v as any).contents) };
+      return { tag: v.tag, contents: mapTuple(f, v.contents) };
     case "HSVA":
-      return { tag: v.tag, contents: mapTuple(f, (v as any).contents) };
+      return { tag: v.tag, contents: mapTuple(f, v.contents) };
     case "NONE":
       return { tag: v.tag };
   }
@@ -246,7 +238,7 @@ export function mapValueNumeric<T, S>(f: (arg: T) => S, v: Value<T>): Value<S> {
     case "FileV":
     case "StyleV":
     case "IntV":
-      return v as Value<S>;
+      return v;
   }
 }
 
@@ -780,7 +772,7 @@ export const insertExpr = (
         }
 
         case "PropertyPath": {
-          const ip = innerPath as IPropertyPath<C>;
+          const ip = innerPath;
           // a.x.y[0] = e
           [name, field, prop] = [ip.name, ip.field, ip.property];
           const gpi = trans.trMap[name.contents.value][

--- a/packages/core/src/engine/Evaluator.ts
+++ b/packages/core/src/engine/Evaluator.ts
@@ -22,7 +22,6 @@ import {
   IFGPI,
   IFloatV,
   IIntV,
-  ILListV,
   IVal,
   IVectorV,
   TagExpr,
@@ -411,7 +410,7 @@ export const evalExpr = (
           tag: "Val",
           contents: {
             tag: "ListV",
-            contents: [] as VarAD[],
+            contents: [],
           },
         };
       }
@@ -433,7 +432,7 @@ export const evalExpr = (
             contents: {
               tag: "LListV", // NOTE: The type has changed from ListV to LListV! That's because ListV's `T` is "not parametric enough" to represent a list of elements
               contents: argVals.map(toVecVal),
-            } as ILListV<VarAD>,
+            },
           };
         } else {
           throw Error("unknown tag");
@@ -634,7 +633,7 @@ export const evalExpr = (
           tag: "Val",
           contents: compDict[fnName](
             { rng },
-            optDebugInfo as OptDebugInfo,
+            optDebugInfo!,
             prettyPrintPath(p) // COMBAK: Test that derivatives still work
           ),
         };
@@ -743,10 +742,9 @@ export const resolvePath = (
             // Evaluate each property path and cache the results (so, e.g. the next lookup just returns a Value)
             // `resolve path A.val.x = f(z, y)` ===> `f(z, y) evaluates to c` ===>
             // `set A.val.x = r` ===> `next lookup of A.val.x yields c instead of computing f(z, y)`
-            const propertyPathExpr = propertyPath as Path<A>;
             const val: Value<VarAD> = (evalExpr(
               rng,
-              propertyPathExpr,
+              propertyPath,
               trans,
               varyingMap,
               optDebugInfo
@@ -915,7 +913,7 @@ export const evalBinOp = (
 
     return { tag: "IntV", contents: res };
   } else if (v1.tag === "VectorV" && v2.tag === "VectorV") {
-    let res;
+    let res: VarAD[] | undefined;
 
     switch (op) {
       case "BPlus": {
@@ -929,9 +927,9 @@ export const evalBinOp = (
       }
     }
 
-    return { tag: "VectorV", contents: res as VarAD[] };
+    return { tag: "VectorV", contents: res! };
   } else if (v1.tag === "FloatV" && v2.tag === "VectorV") {
-    let res;
+    let res: VarAD[] | undefined;
 
     switch (op) {
       case "Multiply": {
@@ -939,9 +937,9 @@ export const evalBinOp = (
         break;
       }
     }
-    return { tag: "VectorV", contents: res as VarAD[] };
+    return { tag: "VectorV", contents: res! };
   } else if (v1.tag === "VectorV" && v2.tag === "FloatV") {
-    let res;
+    let res: VarAD[] | undefined;
 
     switch (op) {
       case "Divide": {
@@ -955,7 +953,7 @@ export const evalBinOp = (
       }
     }
 
-    return { tag: "VectorV", contents: res as VarAD[] };
+    return { tag: "VectorV", contents: res! };
   } else if (v1.tag === "StrV" && v2.tag === "StrV") {
     switch (op) {
       case "BPlus":

--- a/packages/core/src/engine/Optimizer.ts
+++ b/packages/core/src/engine/Optimizer.ts
@@ -872,7 +872,7 @@ export const evalEnergyOnCustom = (rng: seedrandom.prng, state: State) => {
     const translation = insertVaryings(translationInit, varyingMapList);
 
     // construct a new varying map
-    const varyingMap = genPathMap(varyingPaths, xsVars) as VaryMap<VarAD>;
+    const varyingMap: VaryMap<VarAD> = genPathMap(varyingPaths, xsVars);
 
     // NOTE: This will mutate the var inputs
     const objEvaled = evalFns(rng, objFns, translation, varyingMap);
@@ -990,7 +990,7 @@ const evalFnOn = (rng: seedrandom.prng, fn: Fn, s: State) => {
     const translationInit = clone(makeTranslationNumeric(s.translation));
     const varyingMapList = zip2(varyingPaths, xsVars);
     const translation = insertVaryings(translationInit, varyingMapList);
-    const varyingMap = genPathMap(varyingPaths, xsVars) as VaryMap<VarAD>;
+    const varyingMap: VaryMap<VarAD> = genPathMap(varyingPaths, xsVars);
 
     // NOTE: This will mutate the var inputs
     const fnArgsEvaled: FnDone<VarAD> = evalFn(

--- a/packages/core/src/engine/PropagateUpdate.ts
+++ b/packages/core/src/engine/PropagateUpdate.ts
@@ -2,7 +2,7 @@ import { exprToNumber, insertExpr } from "engine/EngineUtils";
 import { A } from "types/ast";
 import { Shape } from "types/shape";
 import { LabelCache, State } from "types/state";
-import { IAccessPath, IPropertyPath, Path } from "types/style";
+import { IPropertyPath, Path } from "types/style";
 import { Translation, Value } from "types/value";
 import { retrieveLabel } from "utils/CollectLabels";
 
@@ -16,7 +16,7 @@ import { retrieveLabel } from "utils/CollectLabels";
 const findShapeProperty = (shapes: any, path: Path<A>): Value<number> | any => {
   const getProperty = (path: IPropertyPath<A>) => {
     const [subName, field, prop]: [string, string, string] = [
-      (path as IPropertyPath<A>).name.contents.value,
+      path.name.contents.value,
       path.field.value,
       path.property.value,
     ];
@@ -46,10 +46,7 @@ const findShapeProperty = (shapes: any, path: Path<A>): Value<number> | any => {
       return getProperty(path);
     }
     case "AccessPath": {
-      const [propertyPath, indices] = [
-        (path as IAccessPath<A>).path,
-        path.indices,
-      ];
+      const { path: propertyPath, indices } = path;
       if (propertyPath.tag === "PropertyPath") {
         const property = getProperty(propertyPath);
         // walk the structure to access all indices

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -150,7 +150,7 @@ export const interactiveDiagram = async (
       updateData,
       pathResolver
     );
-    node.replaceChild(rendering, node.firstChild as Node);
+    node.replaceChild(rendering, node.firstChild!);
   };
   const res = compileTrio(prog);
   if (res.isOk()) {

--- a/packages/core/src/renderer/Image.ts
+++ b/packages/core/src/renderer/Image.ts
@@ -27,7 +27,7 @@ const Image = async ({
   attrToNotAutoMap.push("href");
   elem.innerHTML = rawSVG;
   // We assume the first svg element in the file is the one to display
-  const svg = elem.querySelector("svg") as SVGSVGElement;
+  const svg = elem.querySelector("svg")!;
   const defs = svg.getElementsByTagName("defs");
   /**
    * HACK:

--- a/packages/core/src/synthesis/Mutation.ts
+++ b/packages/core/src/synthesis/Mutation.ts
@@ -21,8 +21,6 @@ import {
   ApplyPredicate,
   Bind,
   Func,
-  SubExpr,
-  SubPredArg,
   SubProg,
   SubStmt,
 } from "types/substance";
@@ -331,7 +329,7 @@ export const checkSwapExprArgs = (
             expr: {
               ...expr,
               args: swap(expr.args, elem1, elem2),
-            } as SubExpr<A>, // TODO: fix types to avoid casting
+            },
           };
           return withCtx(replaceStmt(prog, stmt, newStmt), ctx);
         },
@@ -372,7 +370,7 @@ export const checkSwapInStmtArgs = (
           const newStmt: SubStmt<A> = {
             ...stmt,
             args: stmt.args.map((arg, idx) => {
-              return (idx === elem ? swap : arg) as SubPredArg<A>;
+              return idx === elem ? swap : arg;
             }),
           };
           return withCtx(replaceStmt(prog, stmt, newStmt), ctx);
@@ -426,7 +424,7 @@ export const checkSwapInExprArgs = (
               expr: {
                 ...expr,
                 args: expr.args.map((arg, idx) => {
-                  return (idx === elem ? swap : arg) as SubExpr<A>;
+                  return idx === elem ? swap : arg;
                 }),
               },
             };
@@ -642,7 +640,7 @@ export const enumSwapExprArgs = (stmt: SubStmt<A>): SwapExprArgs[] => {
             expr: {
               ...expr,
               args: swap(expr.args, elem1, elem2),
-            } as SubExpr<A>, // TODO: fix types to avoid casting
+            },
           };
           return withCtx(replaceStmt(prog, stmt, newStmt), ctx);
         },

--- a/packages/core/src/synthesis/Synthesizer.ts
+++ b/packages/core/src/synthesis/Synthesizer.ts
@@ -743,7 +743,7 @@ export const generateArgStmt = (
   // NOTE: if arguments are supplied explicitly, the caller must have the right types for the arguments.
   switch (decl.tag) {
     case "PredicateDecl":
-      return generatePredicate(decl, ctx, args as SubPredArg<A>[]);
+      return generatePredicate(decl, ctx, args);
     case "FunctionDecl":
       return generateFunction(decl, ctx, args as SubExpr<A>[]);
     case "ConstructorDecl":

--- a/packages/core/src/utils/CollectLabels.ts
+++ b/packages/core/src/utils/CollectLabels.ts
@@ -13,7 +13,7 @@ import { err, ok, Result } from "./Error";
 // https://github.com/mathjax/MathJax-demos-node/blob/master/direct/tex2svg
 // const adaptor = chooseAdaptor();
 const adaptor = browserAdaptor();
-RegisterHTMLHandler(adaptor as any);
+RegisterHTMLHandler(adaptor);
 const tex = new TeX({
   packages: AllPackages,
   macros: {
@@ -49,7 +49,7 @@ const convert = (
     // Not sure if this call does anything:
     // https://github.com/mathjax/MathJax-src/blob/master/ts/adaptors/liteAdaptor.ts#L523
     adaptor.setStyle(node, "font-size", fontSize);
-    return ok(node.firstChild as HTMLElement);
+    return ok(node.firstChild);
   } catch (error: any) {
     return err(error.message);
   }

--- a/packages/core/src/utils/toCustomAD.ts
+++ b/packages/core/src/utils/toCustomAD.ts
@@ -103,7 +103,7 @@ export default function (fileInfo: FileInfo, api: API) {
   };
   // ternary to call expression
   const TERN2CE = (target: string, node: any): CallExpression => {
-    const ternNode = node as ConditionalExpression;
+    const ternNode: ConditionalExpression = node;
     const test = ternNode.test;
     const consequent = ternNode.consequent;
     const alternate = ternNode.alternate;
@@ -377,7 +377,7 @@ export default function (fileInfo: FileInfo, api: API) {
     // todo the next line excludes qualified types e.g. Foo.Bar as a type. fix this
     else if (node.type === "TSTypeReference") {
       // transform custom types
-      const matchKey = hasMatch(node as TSTypeReference, TYPS);
+      const matchKey = hasMatch(node, TYPS);
       return matchKey ? TYPS[matchKey] : false;
     } else if (node.type in TYPS) return TYPS[node.type];
     // keyword types //todo doublecheck


### PR DESCRIPTION
# Description

This PR enables [`@typescript-eslint/consistent-type-assertions`](https://github.com/typescript-eslint/typescript-eslint/blob/v4.5.0/packages/eslint-plugin/docs/rules/consistent-type-assertions.md) with `{ assertionStyle: "never" }` in `@penrose/core`, at the `"warning"` level because we currently have a bunch of them. I got rid of as many as I could without making nontrivial code changes:

- many were completely unnecessary and could be removed without any further changes
- many could be directly replaced with type annotations, which are safe and should always be preferred
- some could be replaced with non-null assertions, which are still unsafe but are less general and thus preferable
  - we already have [`@typescript-eslint/no-non-null-assertion`](https://github.com/typescript-eslint/typescript-eslint/blob/v4.5.0/packages/eslint-plugin/docs/rules/no-non-null-assertion.md) enabled at the `"warning"` level, so previously our ESLint config was encouraging people to prefer type assertions over non-null assertions, which is the opposite of what we want
  - to remedy that issue, this PR also enables [`@typescript-eslint/non-nullable-type-assertion-style`](https://github.com/typescript-eslint/typescript-eslint/blob/v4.33.0/packages/eslint-plugin/docs/rules/non-nullable-type-assertion-style.md) at the `"error"` level
- some could be eliminated via very minor code changes

I left the rest as-is. We now have more ESLint warnings, but the goal is that this discourages us from adding more unsafe type assertions in the future.

# Checklist

- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new ESLint warnings
- [x] I have reviewed any generated changes to the `diagrams/` folder