### PR TITLE
test: Extend from eslint:recommended in core

### DIFF
--- a/packages/core/.eslintrc.js
+++ b/packages/core/.eslintrc.js
@@ -17,6 +17,7 @@ module.exports = {
     node: true,
   },
   extends: [
+    "eslint:recommended",
     "plugin:@typescript-eslint/recommended",
     "plugin:react/recommended",
     "prettier",

--- a/packages/core/src/compiler/Style.ts
+++ b/packages/core/src/compiler/Style.ts
@@ -1576,7 +1576,7 @@ const nameAnonStatement = (i: number, s: Stmt<A>): [number, Stmt<A>] => {
       }, // TODO: Why is it parsed like this?
       path: {
         tag: "InternalLocalVar",
-        contents: `\$${ANON_KEYWORD}_${i}`,
+        contents: `$${ANON_KEYWORD}_${i}`,
         nodeType: "SyntheticStyle",
       },
       value: s.contents,

--- a/packages/core/src/compiler/Substance.ts
+++ b/packages/core/src/compiler/Substance.ts
@@ -329,9 +329,10 @@ const checkStmt = (stmt: SubStmt<A>, env: Env): CheckerResult<SubStmt<A>> => {
         ({ env }) => ok({ env, contents: stmt }),
         checkVar(stmt.variable, env)
       );
-    case "NoLabel":
+    case "NoLabel": {
       const argsOk = every(...stmt.args.map((a) => checkVar(a, env)));
       return andThen(({ env }) => ok({ env, contents: stmt }), argsOk);
+    }
   }
 };
 
@@ -733,7 +734,7 @@ export const prettyStmt = (stmt: SubStmt<A>): string => {
     case "NoLabel":
       return `NoLabel ${stmt.args.map((a) => prettyVar(a)).join(", ")}`;
     case "LabelDecl":
-      return `Label ${prettyVar(stmt.variable)} \$${stmt.label.contents}\$`;
+      return `Label ${prettyVar(stmt.variable)} $${stmt.label.contents}$`;
     case "ApplyPredicate":
       return prettyPredicate(stmt);
     case "EqualExprs":

--- a/packages/core/src/engine/EngineUtils.ts
+++ b/packages/core/src/engine/EngineUtils.ts
@@ -586,7 +586,10 @@ export const insertExpr = (
       if (
         compiling &&
         !override &&
-        Object.hasOwn(trans.trMap[name.contents.value], field.value)
+        Object.prototype.hasOwnProperty.call(
+          trans.trMap[name.contents.value],
+          field.value
+        )
       ) {
         trans = addWarn(trans, {
           tag: "InsertedPathWithoutOverrideError",
@@ -671,7 +674,11 @@ export const insertExpr = (
 
         // TODO(error): check for field/property overrides of paths that don't already exist
         // TODO(error): if there are multiple matches, override errors behave oddly...
-        if (compiling && !override && Object.hasOwn(properties, prop.value)) {
+        if (
+          compiling &&
+          !override &&
+          Object.prototype.hasOwnProperty.call(properties, prop.value)
+        ) {
           trans = addWarn(trans, {
             tag: "InsertedPathWithoutOverrideError",
             path,

--- a/packages/core/src/engine/EngineUtils.ts
+++ b/packages/core/src/engine/EngineUtils.ts
@@ -586,7 +586,10 @@ export const insertExpr = (
       if (
         compiling &&
         !override &&
-        trans.trMap[name.contents.value].hasOwnProperty(field.value)
+        Object.prototype.hasOwnProperty.call(
+          trans.trMap[name.contents.value],
+          field.value
+        )
       ) {
         trans = addWarn(trans, {
           tag: "InsertedPathWithoutOverrideError",
@@ -671,7 +674,11 @@ export const insertExpr = (
 
         // TODO(error): check for field/property overrides of paths that don't already exist
         // TODO(error): if there are multiple matches, override errors behave oddly...
-        if (compiling && !override && properties.hasOwnProperty(prop.value)) {
+        if (
+          compiling &&
+          !override &&
+          Object.prototype.hasOwnProperty.call(properties, prop.value)
+        ) {
           trans = addWarn(trans, {
             tag: "InsertedPathWithoutOverrideError",
             path,

--- a/packages/core/src/engine/EngineUtils.ts
+++ b/packages/core/src/engine/EngineUtils.ts
@@ -586,10 +586,7 @@ export const insertExpr = (
       if (
         compiling &&
         !override &&
-        Object.prototype.hasOwnProperty.call(
-          trans.trMap[name.contents.value],
-          field.value
-        )
+        Object.hasOwn(trans.trMap[name.contents.value], field.value)
       ) {
         trans = addWarn(trans, {
           tag: "InsertedPathWithoutOverrideError",
@@ -674,11 +671,7 @@ export const insertExpr = (
 
         // TODO(error): check for field/property overrides of paths that don't already exist
         // TODO(error): if there are multiple matches, override errors behave oddly...
-        if (
-          compiling &&
-          !override &&
-          Object.prototype.hasOwnProperty.call(properties, prop.value)
-        ) {
+        if (compiling && !override && Object.hasOwn(properties, prop.value)) {
           trans = addWarn(trans, {
             tag: "InsertedPathWithoutOverrideError",
             path,

--- a/packages/core/src/engine/Optimizer.ts
+++ b/packages/core/src/engine/Optimizer.ts
@@ -193,48 +193,24 @@ export const step = (
 
       // if (!state.params.functionsCompiled) {
       // TODO: Doesn't reuse compiled function for now (since caching function in App currently does not work)
-      if (true) {
-        const { objectiveAndGradient } = state.params;
-        if (!objectiveAndGradient) {
-          return genOptProblem(rng, state);
-        } else {
-          return {
-            ...state,
-            params: {
-              ...state.params,
-              currObjectiveAndGradient: objectiveAndGradient(
-                initConstraintWeight
-              ),
-              weight: initConstraintWeight,
-              UOround: 0,
-              EPround: 0,
-              optStatus: "UnconstrainedRunning" as const,
-              lbfgsInfo: defaultLbfgsParams,
-            },
-          };
-        }
+      const { objectiveAndGradient } = state.params;
+      if (!objectiveAndGradient) {
+        return genOptProblem(rng, state);
       } else {
-        // Reuse compiled functions for resample; set other initialization params accordingly
-        // The computational graph gets destroyed in resample (just for now, because it can't get serialized)
-        // But it's not needed for the optimization
-        log.info("Reusing compiled objective and gradients");
-        const params = state.params;
-
-        const newParams: Params = {
-          ...params,
-          lastGradient: repeat(xs.length, 0),
-          lastGradientPreconditioned: repeat(xs.length, 0),
-          currObjectiveAndGradient: params.objectiveAndGradient(
-            initConstraintWeight
-          ),
-          weight: initConstraintWeight,
-          UOround: 0,
-          EPround: 0,
-          optStatus: "UnconstrainedRunning",
-          lbfgsInfo: defaultLbfgsParams,
+        return {
+          ...state,
+          params: {
+            ...state.params,
+            currObjectiveAndGradient: objectiveAndGradient(
+              initConstraintWeight
+            ),
+            weight: initConstraintWeight,
+            UOround: 0,
+            EPround: 0,
+            optStatus: "UnconstrainedRunning" as const,
+            lbfgsInfo: defaultLbfgsParams,
+          },
         };
-
-        return { ...state, params: newParams };
       }
     }
 
@@ -451,7 +427,12 @@ const awLineSearch2 = (
   const wolfe = weakWolfe; // Set this if using strongWolfe instead
 
   // Interval check
-  const shouldStop = (numUpdates: number, ai: number, bi: number) => {
+  const shouldStop = (
+    numUpdates: number,
+    ai: number,
+    bi: number,
+    t: number
+  ) => {
     const intervalTooSmall = Math.abs(bi - ai) < minInterval;
     const tooManySteps = numUpdates > maxSteps;
 
@@ -462,7 +443,12 @@ const awLineSearch2 = (
       log.info("line search stopping: step count exceeded");
     }
 
-    return intervalTooSmall || tooManySteps;
+    const needToStop = intervalTooSmall || tooManySteps;
+
+    if (needToStop && DEBUG_LINE_SEARCH) {
+      log.info("stopping early: (i, a, b, t) = ", numUpdates, ai, bi, t);
+    }
+    return needToStop;
   };
 
   // Consts / initial values
@@ -482,16 +468,7 @@ const awLineSearch2 = (
   }
 
   // Main loop + update check
-  while (true) {
-    const needToStop = shouldStop(i, a, b);
-
-    if (needToStop) {
-      if (DEBUG_LINE_SEARCH) {
-        log.info("stopping early: (i, a, b, t) = ", i, a, b, t);
-      }
-      break;
-    }
-
+  while (!shouldStop(i, a, b, t)) {
     const { f: obj, gradf: grad } = f(addv(xs0, scalev(t, descentDir)));
     const isArmijo = armijo(t, obj);
     const isWolfe = wolfe(t, grad);

--- a/packages/core/src/synthesis/Synthesizer.ts
+++ b/packages/core/src/synthesis/Synthesizer.ts
@@ -928,7 +928,7 @@ const generateArg = (
           };
         }
       }
-      case "generated":
+      case "generated": {
         const argTypeDecl = ctx.env.types.get(argType.name.value);
         if (argTypeDecl) {
           const { res: decl, ctx: newCtx } = generateDecl(argTypeDecl, ctx);
@@ -943,6 +943,7 @@ const generateArg = (
             `${argType.name.value} not found in the candidate list`
           );
         }
+      }
       case "mixed":
         return generateArg(
           arg,

--- a/packages/core/src/utils/CollectLabels.ts
+++ b/packages/core/src/utils/CollectLabels.ts
@@ -72,7 +72,7 @@ const tex2svg = async (
   new Promise((resolve) => {
     const output = convert(contents, fontSize);
     if (output.isErr()) {
-      resolve(err(`MathJax could not render \$${contents}\$: ${output.error}`));
+      resolve(err(`MathJax could not render $${contents}$: ${output.error}`));
       return;
     }
     const body = output.value;


### PR DESCRIPTION
# Description

The [typescript-eslint docs](https://typescript-eslint.io/docs/linting/) recommend extending from both `plugin:@typescript-eslint/recommended` and `eslint:recommended`. Previously we were only using the former, so this PR adds the latter and fixes the resulting lint errors:

- [no-case-declarations](https://eslint.org/docs/rules/no-case-declarations)
- [no-constant-condition](https://eslint.org/docs/rules/no-constant-condition)
- [no-prototype-builtins](https://eslint.org/docs/rules/no-prototype-builtins)
- [no-useless-escape](https://eslint.org/docs/rules/no-useless-escape)

# Checklist

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new ESLint warnings
- [x] I have reviewed any generated changes to the `diagrams/` folder