### PR TITLE
test: Use eqeqeq and no-template-curly-in-string

### DIFF
--- a/packages/core/.eslintrc.js
+++ b/packages/core/.eslintrc.js
@@ -34,8 +34,10 @@ module.exports = {
     "eslint-plugin-import",
   ],
   rules: {
+    eqeqeq: 2,
     "import/no-cycle": 2,
     "no-fallthrough": 2,
+    "no-template-curly-in-string": 2,
   },
   ignorePatterns: [
     "**/*.test.ts",

--- a/packages/core/src/contrib/Functions.ts
+++ b/packages/core/src/contrib/Functions.ts
@@ -991,7 +991,7 @@ export const compDict = {
         .closePath()
         .getPath();
     } else {
-      throw Error("orientedSquare undefined for types ${t1}, ${t2}");
+      throw Error(`orientedSquare undefined for types ${t1}, ${t2}`);
     }
   },
 
@@ -1543,7 +1543,7 @@ const tickPlacement = (
   for (let i = 1; i < numPts; i++) {
     if (even && i === 1) multiplier = neg(multiplier);
     const shift =
-      i % 2 == 0
+      i % 2 === 0
         ? mul(padding, mul(neg(i), multiplier))
         : mul(padding, mul(i, multiplier));
     pts.push(add(pts[i - 1], shift));

--- a/packages/core/src/contrib/Queries.ts
+++ b/packages/core/src/contrib/Queries.ts
@@ -30,7 +30,7 @@ export const shapeCenter = ([t, s]: [string, any]): Pt2 => {
  * - `sqrt( w * h )`, where `w` and `h` are the width and height of the bounding box, for all other shapes.
  */
 export const shapeSize = ([t, s]: [string, any]): VarAD => {
-  if (t == "Circle") {
+  if (t === "Circle") {
     return mul(2, s.r.contents);
   } else {
     const bbox = bboxFromShape([t, s]);
@@ -42,7 +42,7 @@ export const shapeSize = ([t, s]: [string, any]): VarAD => {
  * Return vertices of polygon-like shapes.
  */
 export const polygonLikePoints = ([t, s]: [string, any]): Pt2[] => {
-  if (t == "Polygon") return s.points.contents;
+  if (t === "Polygon") return s.points.contents;
   else if (shapedefs[t].isLinelike) return [s.start.contents, s.end.contents];
   else if (shapedefs[t].isRectlike) {
     // TODO: add support for rotated rectangles

--- a/packages/core/src/engine/Evaluator.ts
+++ b/packages/core/src/engine/Evaluator.ts
@@ -15,7 +15,7 @@ import { OptDebugInfo, VarAD } from "types/ad";
 import { A, SourceLoc } from "types/ast";
 import { ShapeAD } from "types/shape";
 import { Fn, FnDone, State, VaryMap } from "types/state";
-import { BinaryOp, Expr, IPropertyPath, Path, UnaryOp } from "types/style";
+import { BinaryOp, Expr, IPropertyPath, Path } from "types/style";
 import {
   ArgVal,
   GPI,
@@ -977,26 +977,19 @@ export const evalBinOp = (
  * @param arg the argument, must be float or int
  */
 export const evalUOp = (
-  op: UnaryOp,
+  op: "UMinus", // this line will cause a type error if the UnaryOp type changes
   arg: IFloatV<VarAD> | IIntV | IVectorV<VarAD>
 ): Value<VarAD> => {
-  if (arg.tag === "FloatV") {
-    switch (op) {
-      case "UMinus":
-        return { ...arg, contents: neg(arg.contents) };
+  switch (arg.tag) {
+    case "FloatV": {
+      return { ...arg, contents: neg(arg.contents) };
     }
-  } else if (arg.tag === "IntV") {
-    switch (op) {
-      case "UMinus":
-        return { ...arg, contents: -arg.contents };
+    case "IntV": {
+      return { ...arg, contents: -arg.contents };
     }
-  } else if (arg.tag === "VectorV") {
-    switch (op) {
-      case "UMinus":
-        return { ...arg, contents: ops.vneg(arg.contents) };
+    case "VectorV": {
+      return { ...arg, contents: ops.vneg(arg.contents) };
     }
-  } else {
-    throw Error("unary op undefined on type ${arg.tag}, op ${op}");
   }
 };
 

--- a/packages/core/src/renderer/AttrHelper.ts
+++ b/packages/core/src/renderer/AttrHelper.ts
@@ -110,7 +110,7 @@ export const attrScale = (
   scale = scale || 1;
   let transform = elem.getAttribute("transform");
   transform =
-    transform == null ? `scale(${scale})` : transform + `scale{${scale}}`;
+    transform === null ? `scale(${scale})` : transform + `scale{${scale}}`;
   elem.setAttribute("transform", transform);
 
   return ["scale"]; // Return array of input properties programatically mapped
@@ -130,7 +130,7 @@ export const attrTransformCoords = (
   const h = properties.height as IFloatV<number>;
   let transform = elem.getAttribute("transform");
   transform =
-    transform == null
+    transform === null
       ? `translate(${x - w.contents / 2}, ${y - h.contents / 2})`
       : transform + `translate(${x - w.contents / 2}, ${y - h.contents / 2})`;
   elem.setAttribute("transform", transform);
@@ -176,7 +176,7 @@ export const attrRotation = (
   const [x, y] = toScreen(center.contents as [number, number], canvasSize);
   let transform = elem.getAttribute("transform");
   transform =
-    transform == null
+    transform === null
       ? `rotate(${rotation}, ${x - w.contents / 2}, ${y - h.contents / 2})`
       : transform +
         `rotate(${rotation}, ${x - w.contents / 2}, ${y - h.contents / 2})`;


### PR DESCRIPTION
# Description

This PR enables the ESLint rules [`eqeqeq`](https://eslint.org/docs/rules/eqeqeq) and [`no-template-curly-in-string`](https://eslint.org/docs/rules/no-template-curly-in-string) at the `"error"` level in `@penrose/core`. I chose these specific ones because they both revealed some code that actually should be changed, rather than just being stylistic or not surfacing any issues in our codebase at all.

# Checklist

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new ESLint warnings
- [x] I have reviewed any generated changes to the `diagrams/` folder