### PR TITLE
test: Enable a few good typescript-eslint rules

### DIFF
--- a/packages/core/.eslintrc.js
+++ b/packages/core/.eslintrc.js
@@ -34,6 +34,11 @@ module.exports = {
     "eslint-plugin-import",
   ],
   rules: {
+    "@typescript-eslint/no-base-to-string": 1,
+    "@typescript-eslint/no-confusing-void-expression": 2,
+    "@typescript-eslint/no-unnecessary-boolean-literal-compare": 2,
+    "@typescript-eslint/no-unnecessary-condition": 1,
+    "@typescript-eslint/prefer-ts-expect-error": 2,
     "import/no-cycle": 2,
     "no-fallthrough": 2,
   },

--- a/packages/core/src/compiler/Style.ts
+++ b/packages/core/src/compiler/Style.ts
@@ -163,7 +163,6 @@ const numbers = (r: number): number[] => {
 };
 
 export function numbered<A>(xs: A[]): [A, number][] {
-  if (!xs) throw Error("fail");
   return zip2(xs, numbers(xs.length));
 }
 
@@ -1426,10 +1425,7 @@ const typesMatched = (
   substanceType: TypeConsApp<A>,
   styleType: StyT<A>
 ): boolean => {
-  if (
-    substanceType.tag === "TypeConstructor" &&
-    substanceType.args.length === 0
-  ) {
+  if (substanceType.args.length === 0) {
     // Style type needs to be more generic than Style type
     return isDeclaredSubtype(substanceType, toSubstanceType(styleType), varEnv);
   }
@@ -2566,7 +2562,7 @@ const findFieldDefaultFns = (
     if (
       onCanvasProp &&
       onCanvasProp.contents.tag === "BoolV" &&
-      onCanvasProp.contents.contents === true
+      onCanvasProp.contents.contents
     ) {
       const onCanvasFn: StyleOptFn = [
         "onCanvas",

--- a/packages/core/src/contrib/Utils.ts
+++ b/packages/core/src/contrib/Utils.ts
@@ -150,16 +150,12 @@ export const centerArrow2 = (
   const vec = ops.vsub(center2, center1); // direction the arrow should point to
   const dir = ops.vnormalize(vec);
 
-  let start = center1;
-  let end = center2;
+  // TODO: add abs; also, unless `gt(ops.vnorm(vec), add(o1, absVal(o2)))`,
+  // should just set `start` to `center1` and `end` to `center2`
+  const start = ops.vadd(center1, ops.vmul(o1, dir));
+  const end = ops.vadd(center2, ops.vmul(o2, dir));
 
   // TODO: take in spacing, use the right text dimension/distance?, note on arrow directionality
-
-  // TODO: add abs
-  if (gt(ops.vnorm(vec), add(o1, absVal(o2)))) {
-    start = ops.vadd(center1, ops.vmul(o1, dir));
-    end = ops.vadd(center2, ops.vmul(o2, dir));
-  }
 
   const fromPt = arr.start.contents;
   const toPt = arr.end.contents;

--- a/packages/core/src/engine/Autodiff.ts
+++ b/packages/core/src/engine/Autodiff.ts
@@ -468,7 +468,9 @@ export const makeGraph = (
 
   for (const matrix of sensitivities.values()) {
     // `forEach` ignores holes
-    matrix.forEach((row) => row.forEach(addNode));
+    matrix.forEach((row) => {
+      row.forEach(addNode);
+    });
   }
   while (!queue.isEmpty()) {
     addNode(queue.dequeue());
@@ -510,7 +512,7 @@ export const makeGraph = (
       const matrix = sensitivities.get(`${name}${id}${w}`);
       if (matrix !== undefined) {
         // `forEach` ignores holes
-        matrix.forEach((row, i) =>
+        matrix.forEach((row, i) => {
           row.forEach((x, j) => {
             const sensitivityID = safe(nodes.get(x), "missing sensitivity");
             const parentGradIDs = safe(gradNodes.get(w), "missing parent grad");
@@ -525,8 +527,8 @@ export const makeGraph = (
               }
               grad[j].push(addendID);
             }
-          })
-        );
+          });
+        });
       }
     }
 

--- a/packages/core/src/engine/EngineUtils.ts
+++ b/packages/core/src/engine/EngineUtils.ts
@@ -560,7 +560,7 @@ export const insertExpr = (
       [name, field] = [path.name, path.field];
 
       // Initialize the field dict if it hasn't been initialized
-      if (!trans.trMap[name.contents.value]) {
+      if (!(name.contents.value in trans.trMap)) {
         trans.trMap[name.contents.value] = {};
       }
 
@@ -603,7 +603,7 @@ export const insertExpr = (
     case "PropertyPath": {
       [name, field, prop] = [path.name, path.field, path.property];
 
-      if (!trans.trMap[name.contents.value]) {
+      if (!(name.contents.value in trans.trMap)) {
         trans.trMap[name.contents.value] = {};
       }
 

--- a/packages/core/src/engine/Evaluator.ts
+++ b/packages/core/src/engine/Evaluator.ts
@@ -199,24 +199,26 @@ export const evalShape = (
     propExprs,
     (prop: TagExpr<VarAD>): Value<VarAD> => {
       // TODO: Refactor these cases to be more concise
-      if (prop.tag === "OptEval") {
-        // For display, evaluate expressions with autodiff types (incl. varying vars as AD types), then convert to numbers
-        // (The tradeoff for using autodiff types is that evaluating the display step will be a little slower, but then we won't have to write two versions of all computations)
-        const res: Value<VarAD> = (evalExpr(
-          rng,
-          prop.contents,
-          trans,
-          varyingVars,
-          optDebugInfo
-        ) as IVal<VarAD>).contents;
-        return res;
-      } else if (prop.tag === "Done") {
-        return prop.contents;
-      } else if (prop.tag === "Pending") {
-        // Pending expressions are just converted because they get converted back to numbers later
-        return prop.contents;
-      } else {
-        throw Error("unknown tag");
+      switch (prop.tag) {
+        case "OptEval": {
+          // For display, evaluate expressions with autodiff types (incl. varying vars as AD types), then convert to numbers
+          // (The tradeoff for using autodiff types is that evaluating the display step will be a little slower, but then we won't have to write two versions of all computations)
+          const res: Value<VarAD> = (evalExpr(
+            rng,
+            prop.contents,
+            trans,
+            varyingVars,
+            optDebugInfo
+          ) as IVal<VarAD>).contents;
+          return res;
+        }
+        case "Done": {
+          return prop.contents;
+        }
+        case "Pending": {
+          // Pending expressions are just converted because they get converted back to numbers later
+          return prop.contents;
+        }
       }
     }
   );

--- a/packages/core/src/renderer/Path.ts
+++ b/packages/core/src/renderer/Path.ts
@@ -18,12 +18,13 @@ const toPathString = (
       }
       const pathStr = flatten(
         contents.map((c: ISubPath<number>) => {
-          if (c.tag === "CoordV")
-            return toScreen(c.contents as [number, number], canvasSize);
-          else if (c.tag === "ValueV") return c.contents;
-          else {
-            console.error("WARNING: improperly formed pathData");
-            return;
+          switch (c.tag) {
+            case "CoordV": {
+              return toScreen(c.contents as [number, number], canvasSize);
+            }
+            case "ValueV": {
+              return c.contents;
+            }
           }
         })
       ).join(" ");

--- a/packages/core/src/renderer/Path.ts
+++ b/packages/core/src/renderer/Path.ts
@@ -17,7 +17,9 @@ const toPathString = (
         return "";
       }
       const pathStr = flatten(
-        contents.map((c: ISubPath<number>) => {
+        // the `number[]` type annotation is necessary to ensure that a compile
+        // error occurs here if more `ISubPath` subtypes are added in the future
+        contents.map((c: ISubPath<number>): number[] => {
           switch (c.tag) {
             case "CoordV": {
               return toScreen(c.contents as [number, number], canvasSize);

--- a/packages/core/src/synthesis/Search.ts
+++ b/packages/core/src/synthesis/Search.ts
@@ -262,8 +262,10 @@ export const updateDiffs = (mappings: SimilarMapping[]): UpdateDiff[] => {
   const diffs = [];
   for (const m of mappings) {
     const diff = toUpdateDiff(picked, m);
-    diffs.push(diff);
-    picked.push(diff.result);
+    if (diff) {
+      diffs.push(diff);
+      picked.push(diff.result);
+    }
   }
   return diffs;
 };
@@ -271,8 +273,9 @@ export const updateDiffs = (mappings: SimilarMapping[]): UpdateDiff[] => {
 const toUpdateDiff = (
   picked: SubStmt<A>[],
   { similarStmts, source }: SimilarMapping
-): UpdateDiff => {
+): UpdateDiff | undefined => {
   const result = difference(similarStmts, picked)[0]; // TODO: insert ranking algorithm here
+  if (result === undefined) return undefined;
   const rawDiffs = getDiff(cleanNode(source), cleanNode(result));
   return {
     diffType: "Update",

--- a/packages/core/src/synthesis/Search.ts
+++ b/packages/core/src/synthesis/Search.ts
@@ -262,10 +262,8 @@ export const updateDiffs = (mappings: SimilarMapping[]): UpdateDiff[] => {
   const diffs = [];
   for (const m of mappings) {
     const diff = toUpdateDiff(picked, m);
-    if (diff) {
-      diffs.push(diff);
-      picked.push(diff.result);
-    }
+    diffs.push(diff);
+    picked.push(diff.result);
   }
   return diffs;
 };
@@ -273,9 +271,8 @@ export const updateDiffs = (mappings: SimilarMapping[]): UpdateDiff[] => {
 const toUpdateDiff = (
   picked: SubStmt<A>[],
   { similarStmts, source }: SimilarMapping
-): UpdateDiff | undefined => {
+): UpdateDiff => {
   const result = difference(similarStmts, picked)[0]; // TODO: insert ranking algorithm here
-  if (result === undefined) return undefined;
   const rawDiffs = getDiff(cleanNode(source), cleanNode(result));
   return {
     diffType: "Update",

--- a/packages/core/src/synthesis/Synthesizer.ts
+++ b/packages/core/src/synthesis/Synthesizer.ts
@@ -695,7 +695,9 @@ export class Synthesizer {
         possibleOps = del ? [del] : [];
       }
     }
-    log.debug(`Found mutations for delete:\n${showMutations(possibleOps)}`);
+    if (possibleOps.length > 0) {
+      log.debug(`Found mutations for delete:\n${showMutations(possibleOps)}`);
+    }
     return possibleOps;
   };
 

--- a/packages/core/src/synthesis/Synthesizer.ts
+++ b/packages/core/src/synthesis/Synthesizer.ts
@@ -695,10 +695,8 @@ export class Synthesizer {
         possibleOps = del ? [del] : [];
       }
     }
-    if (possibleOps) {
-      log.debug(`Found mutations for delete:\n${showMutations(possibleOps)}`);
-      return possibleOps;
-    } else return [];
+    log.debug(`Found mutations for delete:\n${showMutations(possibleOps)}`);
+    return possibleOps;
   };
 
   // TODO: add an option to distinguish between edited vs original statements?

--- a/packages/core/src/utils/CollectLabels.ts
+++ b/packages/core/src/utils/CollectLabels.ts
@@ -94,14 +94,12 @@ export const retrieveLabel = (
   shapeName: string,
   labels: LabelCache
 ): LabelData | undefined => {
-  if (labels) {
-    const res = labels.find(([name]) => name === shapeName);
-    if (res) {
-      return res[1];
-    } else {
-      return undefined;
-    }
-  } else return undefined;
+  const res = labels.find(([name]) => name === shapeName);
+  if (res) {
+    return res[1];
+  } else {
+    return undefined;
+  }
 };
 
 const floatV = (contents: number): IFloatV<number> => ({

--- a/packages/core/src/utils/Util.ts
+++ b/packages/core/src/utils/Util.ts
@@ -256,10 +256,6 @@ export const round2 = (n: number): number => roundTo(n, 2);
 export const roundTo = (n: number, digits: number): number => {
   let negative = false;
 
-  if (digits === undefined) {
-    digits = 0;
-  }
-
   if (n < 0) {
     negative = true;
     n = n * -1;
@@ -336,7 +332,7 @@ export const bBoxDims = (
     [w, h] = [20, 20]; // TODO: find a better measure for this... check with max?
   } else if (shapeType === "Polyline") {
     [w, h] = [20, 20]; // TODO: find a better measure for this... check with max?
-  } else if (properties.width && properties.height) {
+  } else if ("width" in properties && "height" in properties) {
     [w, h] = [
       properties.width.contents as number,
       properties.height.contents as number,


### PR DESCRIPTION
# Description

This PR enables a few good typescript-eslint rules:

- [`@typescript-eslint/no-base-to-string`](https://github.com/typescript-eslint/typescript-eslint/blob/v4.33.0/packages/eslint-plugin/docs/rules/no-base-to-string.md) catches a bunch of places where we try to stringify things that would just show up as `"[object Object]"`; I didn't have the bandwidth in this PR to fix these so I just set this rule to `"warning"`, but they are all genuine bugs as far as I can tell
- [`@typescript-eslint/no-confusing-void-expression`](https://github.com/typescript-eslint/typescript-eslint/blob/v4.33.0/packages/eslint-plugin/docs/rules/no-confusing-void-expression.md) might be a bit more of a stylistic thing, but I think it's pretty good for clarity
- [`@typescript-eslint/no-unnecessary-boolean-literal-compare`](https://github.com/typescript-eslint/typescript-eslint/blob/v4.33.0/packages/eslint-plugin/docs/rules/no-unnecessary-boolean-literal-compare.md) didn't surface much, but it seems like a good thing to have enabled
- [`@typescript-eslint/no-unnecessary-condition`](https://github.com/typescript-eslint/typescript-eslint/blob/v4.33.0/packages/eslint-plugin/docs/rules/no-unnecessary-condition.md) surfaced a bunch of bugs and also a bunch of things that are due to us using the type system poorly; again I didn't have the bandwidth here to fix all these so I just made it a `"warning"`, but this is very good to have enabled
- [`@typescript-eslint/prefer-ts-expect-error`](https://github.com/typescript-eslint/typescript-eslint/blob/v4.33.0/packages/eslint-plugin/docs/rules/prefer-ts-expect-error.md) doesn't actually affect anything currently, but it is quite good so I'm enabling it proactively

# Checklist

- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new ESLint warnings
- [x] I have reviewed any generated changes to the `diagrams/` folder