### PR TITLE
refactor: Fix some lint warnings in @penrose/core

### DIFF
--- a/packages/core/src/analysis/SubstanceAnalysis.ts
+++ b/packages/core/src/analysis/SubstanceAnalysis.ts
@@ -80,8 +80,8 @@ export const argMatches = (
     | Bind<A>,
   env: Env
 ): ArgStmtDecl<C>[] => {
-  const options = (s: any) => {
-    const [st] = findDecl(s.name.value, env);
+  const options = (s: SubExpr<A> | ApplyPredicate<A>) => {
+    const [st] = "name" in s ? findDecl(s.name.value, env) : [undefined];
     return st
       ? [
           matchDecls(st, env.constructors, signatureArgsEqual),
@@ -521,7 +521,7 @@ export const cleanNode = (prog: AbstractNode): AbstractNode =>
  * @returns
  */
 export const typeOf = (id: string, env: Env): string | undefined =>
-  env.vars.get(id)!.name.value;
+  env.vars.get(id)?.name.value;
 
 // helper function for omitting properties in an object
 const omitDeep = (originalCollection: any, excludeKeys: string[]): any => {

--- a/packages/core/src/compiler/Domain.ts
+++ b/packages/core/src/compiler/Domain.ts
@@ -131,8 +131,9 @@ const checkStmt = (stmt: DomainStmt<C>, env: Env): CheckerResult => {
       // NOTE: params are not reused, so no need to check
       const { name, superTypes } = stmt;
       // check name duplicate
-      if (env.types.has(name.value))
-        return err(duplicateName(name, stmt, env.types.get(name.value)!));
+      const existing = env.types.get(name.value);
+      if (existing !== undefined)
+        return err(duplicateName(name, stmt, existing));
       // insert type into env
       const updatedEnv: CheckerResult = ok({
         ...env,
@@ -161,10 +162,9 @@ const checkStmt = (stmt: DomainStmt<C>, env: Env): CheckerResult => {
         typeVars: Map(keyBy(params, "name.value")),
       };
       // check name duplicate
-      if (env.constructors.has(name.value))
-        return err(
-          duplicateName(name, stmt, env.constructors.get(name.value)!)
-        );
+      const existing = env.constructors.get(name.value);
+      if (existing !== undefined)
+        return err(duplicateName(name, stmt, existing));
       // check arguments
       const argsOk = safeChain(args, checkArg, ok(localEnv));
       // check output
@@ -184,8 +184,9 @@ const checkStmt = (stmt: DomainStmt<C>, env: Env): CheckerResult => {
         typeVars: Map(keyBy(params, "name.value")),
       };
       // check name duplicate
-      if (env.functions.has(name.value))
-        return err(duplicateName(name, stmt, env.functions.get(name.value)!));
+      const existing = env.functions.get(name.value);
+      if (existing !== undefined)
+        return err(duplicateName(name, stmt, existing));
       // check arguments
       const argsOk = safeChain(args, checkArg, ok(localEnv));
       // check output
@@ -205,8 +206,8 @@ const checkStmt = (stmt: DomainStmt<C>, env: Env): CheckerResult => {
         typeVars: Map(keyBy(params, "name.value")),
       };
       // check name duplicate
-      if (env.predicates.has(name.value))
-        return err(duplicateName(name, stmt, env.predicates.get(name.value)!));
+      const existing = env.predicates.get(name.value);
+      if (existing) return err(duplicateName(name, stmt, existing));
       // check arguments
       const argsOk = safeChain(args, checkArg, ok(localEnv));
       // insert predicate into env

--- a/packages/core/src/contrib/Constraints.ts
+++ b/packages/core/src/contrib/Constraints.ts
@@ -94,7 +94,7 @@ const constrDictSimple = {
   /**
    * Make scalar `c` disjoint from a range `left, right`.
    */
-  disjointScalar: (c: any, left: any, right: any) => {
+  disjointScalar: (c: VarAD, left: VarAD, right: VarAD) => {
     const d = (x: VarAD, y: VarAD) => absVal(sub(x, y));
 
     // if (x \in [l, r]) then min(d(x,l), d(x,r)) else 0

--- a/packages/core/src/contrib/ConstraintsUtils.ts
+++ b/packages/core/src/contrib/ConstraintsUtils.ts
@@ -102,8 +102,8 @@ export const overlappingRectlikeCircle = (
  * Require that circle `s1` overlaps line `s2` with some padding `padding`.
  */
 export const overlappingCircleLine = (
-  [t1, s1]: [string, Circle],
-  [t2, s2]: [string, Line],
+  [, s1]: [string, Circle],
+  [, s2]: [string, Line],
   padding: VarAD = 0
 ): VarAD => {
   // collect constants

--- a/packages/core/src/contrib/Functions.ts
+++ b/packages/core/src/contrib/Functions.ts
@@ -112,7 +112,7 @@ export const compDict = {
     _context: Context,
     optDebugInfo: OptDebugInfo,
     varName: string
-  ): IFloatV<any> => {
+  ): IFloatV<VarAD> => {
     if (
       !optDebugInfo ||
       !("gradient" in optDebugInfo) ||
@@ -151,7 +151,7 @@ export const compDict = {
     _context: Context,
     optDebugInfo: OptDebugInfo,
     varName: string
-  ): IFloatV<any> => {
+  ): IFloatV<VarAD> => {
     if (
       !optDebugInfo ||
       !("gradientPreconditioned" in optDebugInfo) ||
@@ -185,7 +185,7 @@ export const compDict = {
   /**
    * Return `i`th element of list `xs, assuming lists only hold floats.
    */
-  get: (_context: Context, xs: VarAD[], i: number): IFloatV<any> => {
+  get: (_context: Context, xs: VarAD[], i: number): IFloatV<VarAD> => {
     const res = xs[i];
     return {
       tag: "FloatV",
@@ -260,7 +260,7 @@ export const compDict = {
   /**
    * Return a paint of none (no paint)
    */
-  none: (_context: Context): IColorV<any> => {
+  none: (_context: Context): IColorV<VarAD> => {
     return {
       tag: "ColorV",
       contents: {
@@ -542,10 +542,7 @@ export const compDict = {
   /**
    * Return the length of the line or arrow shape `[type, props]`.
    */
-  lineLength: (
-    _context: Context,
-    [type, props]: [string, any]
-  ): IFloatV<VarAD> => {
+  lineLength: (_context: Context, [, props]: [string, any]): IFloatV<VarAD> => {
     const [p1, p2] = linePts(props);
     return {
       tag: "FloatV",
@@ -556,7 +553,7 @@ export const compDict = {
   /**
    * Return the length of the line or arrow shape `[type, props]`.
    */
-  len: (_context: Context, [type, props]: [string, any]): IFloatV<VarAD> => {
+  len: (_context: Context, [, props]: [string, any]): IFloatV<VarAD> => {
     const [p1, p2] = linePts(props);
     return {
       tag: "FloatV",
@@ -639,8 +636,8 @@ export const compDict = {
    */
   unitMark: (
     _context: Context,
-    [t1, s1]: [string, any],
-    [t2, s2]: [string, any],
+    [, s1]: [string, any],
+    [, s2]: [string, any],
     t: string,
     padding: VarAD,
     barSize: VarAD
@@ -941,7 +938,7 @@ export const compDict = {
     spacing: VarAD,
     numTicks: VarAD,
     tickLength: VarAD
-  ) => {
+  ): IPathDataV<VarAD> => {
     if (typeof numTicks !== "number") {
       throw Error("numTicks must be a constant");
     }
@@ -980,7 +977,7 @@ export const compDict = {
       (t1 === "Arrow" || t1 === "Line") &&
       (t2 === "Arrow" || t2 === "Line")
     ) {
-      const [seg1, seg2]: any = [linePts(s1), linePts(s2)];
+      const [seg1, seg2] = [linePts(s1), linePts(s2)];
       const [ptL, ptLR, ptR] = perpPathFlat(len, seg1, seg2);
       const path = new PathBuilder();
       return path
@@ -1097,10 +1094,8 @@ export const compDict = {
     alpha: VarAD,
     colorType: string
   ): IColorV<VarAD> => {
-    checkFloat(alpha);
-
     if (colorType === "rgb") {
-      const rgb = range(3).map((_) => randFloat(context.rng, 0.1, 0.9));
+      const rgb = range(3).map(() => randFloat(context.rng, 0.1, 0.9));
 
       return {
         tag: "ColorV",
@@ -1444,7 +1439,7 @@ export const compDict = {
   /**
    * Rotate a 2D vector `v` by 90 degrees counterclockwise.
    */
-  rot90: (_context: Context, v: VarAD[]) => {
+  rot90: (_context: Context, v: VarAD[]): IVectorV<VarAD> => {
     if (v.length !== 2) {
       throw Error("expected 2D vector in `rot90`");
     }
@@ -1455,7 +1450,7 @@ export const compDict = {
   /**
    * Rotate a 2D vector `v` by theta degrees counterclockwise.
    */
-  rotateBy: (_context: Context, v: VarAD[], theta: VarAD) => {
+  rotateBy: (_context: Context, v: VarAD[], theta: VarAD): IVectorV<VarAD> => {
     if (v.length !== 2) {
       throw Error("expected 2D vector in `rotateBy`");
     }
@@ -1476,15 +1471,8 @@ const _compDictVals: ((
 ) => unknown)[] = Object.values(compDict);
 
 // Ignore this
-export const checkComp = (fn: string, args: ArgVal<VarAD>[]) => {
+export const checkComp = (fn: string, args: ArgVal<VarAD>[]): void => {
   if (!compDict[fn]) throw new Error(`Computation function "${fn}" not found`);
-};
-
-// Make sure all arguments are not numbers (they should be VarADs if floats)
-const checkFloat = (x: any) => {
-  if (typeof x === "number") {
-    throw Error("expected float converted to VarAD; got number (int?)");
-  }
 };
 
 const toPt = (v: VecAD): Pt2 => {

--- a/packages/core/src/contrib/Objectives.ts
+++ b/packages/core/src/contrib/Objectives.ts
@@ -31,38 +31,38 @@ export const objDictSimple = {
   /**
    * Encourage the input value to be close to negative infinity
    */
-  minimal: (x: VarAD) => x,
+  minimal: (x: VarAD): VarAD => x,
 
   /**
    * Encourage the input value to be close to infinity
    */
-  maximal: (x: VarAD) => neg(x),
+  maximal: (x: VarAD): VarAD => neg(x),
 
   /**
    * Encourage the inputs to have the same value: `(x - y)^2`
    */
-  equal: (x: VarAD, y: VarAD) => squared(sub(x, y)),
+  equal: (x: VarAD, y: VarAD): VarAD => squared(sub(x, y)),
 
   /**
    * Encourage x to be greater than or equal to y: `max(0,y - x)^2`
    */
-  greaterThan: (x: VarAD, y: VarAD) => squared(max(0, sub(y, x))),
+  greaterThan: (x: VarAD, y: VarAD): VarAD => squared(max(0, sub(y, x))),
 
   /**
    * Encourage x to be less than or equal to y: `max(0,x - y)^2`
    */
-  lessThan: (x: VarAD, y: VarAD) => squared(max(0, sub(x, y))),
+  lessThan: (x: VarAD, y: VarAD): VarAD => squared(max(0, sub(x, y))),
 
   /**
    * Repel point `a` from another scalar `b` with weight `weight`.
    */
-  repelPt: (weight: VarAD, a: VarAD[], b: VarAD[]) =>
+  repelPt: (weight: VarAD, a: VarAD[], b: VarAD[]): VarAD =>
     mul(weight, inverse(ops.vdistsq(a, b))),
 
   /**
    * Repel scalar `c` from another scalar `d`.
    */
-  repelScalar: (c: VarAD, d: VarAD) => {
+  repelScalar: (c: VarAD, d: VarAD): VarAD => {
     // 1/(c-d)^2
     return inverse(squared(sub(c, d)));
   },
@@ -79,7 +79,7 @@ export const objDictGeneral = {
     [tBottom, sBottom]: [string, any],
     [tTop, sTop]: [string, any],
     offset = 100
-  ) => {
+  ): VarAD => {
     return inDirection([tBottom, sBottom], [tTop, sTop], [0, 1], offset);
   },
 
@@ -90,7 +90,7 @@ export const objDictGeneral = {
     [tTop, sTop]: [string, any],
     [tBottom, sBottom]: [string, any],
     offset = 100
-  ) => {
+  ): VarAD => {
     return inDirection([tTop, sTop], [tBottom, sBottom], [0, 1], offset);
   },
 
@@ -101,7 +101,7 @@ export const objDictGeneral = {
     [tLeft, sLeft]: [string, any],
     [tRight, sRight]: [string, any],
     offset = 100
-  ) => {
+  ): VarAD => {
     return inDirection([tLeft, sLeft], [tRight, sRight], [1, 0], offset);
   },
 
@@ -112,14 +112,14 @@ export const objDictGeneral = {
     [tRight, sRight]: [string, any],
     [tLeft, sLeft]: [string, any],
     offset = 100
-  ) => {
+  ): VarAD => {
     return inDirection([tRight, sRight], [tLeft, sLeft], [1, 0], offset);
   },
 
   /**
    * Encourage shape `s1` to have the same center position as shape `s2`.
    */
-  sameCenter: ([t1, s1]: [string, any], [t2, s2]: [string, any]) => {
+  sameCenter: ([t1, s1]: [string, any], [t2, s2]: [string, any]): VarAD => {
     const center1 = shapeCenter([t1, s1]);
     const center2 = shapeCenter([t2, s2]);
     return ops.vdistsq(center1, center2);
@@ -128,7 +128,11 @@ export const objDictGeneral = {
   /**
    * Try to repel shapes `s1` and `s2` with some weight.
    */
-  repel: ([t1, s1]: [string, any], [t2, s2]: [string, any], weight = 10.0) => {
+  repel: (
+    [t1, s1]: [string, any],
+    [t2, s2]: [string, any],
+    weight = 10.0
+  ): VarAD => {
     // HACK: `repel` typically needs to have a weight multiplied since its magnitude is small
     // TODO: find this out programmatically
     const repelWeight = 10e6;
@@ -156,7 +160,11 @@ export const objDictGeneral = {
   /**
    * Try to place shape `s1` near shape `s2` (putting their centers at the same place).
    */
-  near: ([t1, s1]: [string, any], [t2, s2]: [string, any], offset = 10.0) => {
+  near: (
+    [t1, s1]: [string, any],
+    [t2, s2]: [string, any],
+    offset = 10.0
+  ): VarAD => {
     const res = absVal(
       ops.vdistsq(shapeCenter([t1, s1]), shapeCenter([t2, s2]))
     );
@@ -166,7 +174,7 @@ export const objDictGeneral = {
   /**
    * Try to place shape `s1` near a location `(x, y)`.
    */
-  nearPt: ([t1, s1]: [string, any], x: any, y: any) => {
+  nearPt: ([t1, s1]: [string, any], x: any, y: any): VarAD => {
     return ops.vdistsq(shapeCenter([t1, s1]), [x, y]);
   },
 
@@ -180,7 +188,7 @@ export const objDictGeneral = {
     [t2, p2]: [string, any],
     strength = 20,
     range = 10
-  ) => {
+  ): VarAD => {
     const c0 = shapeCenter([t0, p0]);
     const c1 = shapeCenter([t1, p1]);
     const c2 = shapeCenter([t2, p2]);
@@ -275,7 +283,11 @@ export const objDictSpecific = {
   /**
    * try to make distance between a point and a segment `s1` = padding.
    */
-  pointLineDist: (point: VarAD[], [t1, s1]: [string, any], padding: VarAD) => {
+  pointLineDist: (
+    point: VarAD[],
+    [t1, s1]: [string, any],
+    padding: VarAD
+  ): VarAD => {
     if (!shapedefs[t1].isLinelike) {
       throw new Error(`pointLineDist: expected a point and a line, got ${t1}`);
     }

--- a/packages/core/src/contrib/Utils.ts
+++ b/packages/core/src/contrib/Utils.ts
@@ -120,7 +120,7 @@ const lerp2 = (l: VarAD[], r: VarAD[], k: VarAD): [VarAD, VarAD] => {
 /**
  * Sample a line `line` at `NUM_SAMPLES` points uniformly.
  */
-export const sampleSeg = (line: VarAD[][]) => {
+export const sampleSeg = (line: VarAD[][]): Pt2[] => {
   const NUM_SAMPLES = 15;
   const NUM_SAMPLES2 = 1 + NUM_SAMPLES;
   // TODO: Check that this covers the whole line, i.e. no off-by-one error
@@ -135,7 +135,7 @@ export const sampleSeg = (line: VarAD[][]) => {
 /**
  * Repel a vector `a` from a vector `b` with weight `c`.
  */
-export const repelPoint = (c: VarAD, a: VarAD[], b: VarAD[]) =>
+export const repelPoint = (c: VarAD, a: VarAD[], b: VarAD[]): VarAD =>
   div(c, add(ops.vdistsq(a, b), EPS_DENOM));
 
 /**

--- a/packages/core/src/engine/EngineUtils.ts
+++ b/packages/core/src/engine/EngineUtils.ts
@@ -188,9 +188,9 @@ function mapPathData<T, S>(f: (arg: T) => S, v: IPathDataV<T>): IPathDataV<S> {
 function mapColorInner<T, S>(f: (arg: T) => S, v: Color<T>): Color<S> {
   switch (v.tag) {
     case "RGBA":
-      return { tag: v.tag, contents: mapTuple(f, (v as any).contents) };
+      return { tag: v.tag, contents: mapTuple(f, v.contents) };
     case "HSVA":
-      return { tag: v.tag, contents: mapTuple(f, (v as any).contents) };
+      return { tag: v.tag, contents: mapTuple(f, v.contents) };
     case "NONE":
       return { tag: v.tag };
   }
@@ -908,7 +908,9 @@ export const insertExprs = (
   return tr2;
 };
 
-export const isTagExpr = (e: any): e is TagExpr<VarAD> => {
+export const isTagExpr = (
+  e: TagExpr<VarAD> | StyleError
+): e is TagExpr<VarAD> => {
   return e.tag === "OptEval" || e.tag === "Done" || e.tag === "Pending";
 };
 

--- a/packages/core/src/engine/Evaluator.ts
+++ b/packages/core/src/engine/Evaluator.ts
@@ -12,7 +12,7 @@ import { mapValues } from "lodash";
 import rfdc from "rfdc";
 import seedrandom from "seedrandom";
 import { OptDebugInfo, VarAD } from "types/ad";
-import { A, SourceLoc } from "types/ast";
+import { A } from "types/ast";
 import { ShapeAD } from "types/shape";
 import { Fn, FnDone, State, VaryMap } from "types/state";
 import { BinaryOp, Expr, IPropertyPath, Path, UnaryOp } from "types/style";
@@ -43,11 +43,6 @@ const log = consola.create({ level: LogLevel.Warn }).withScope("Evaluator");
  * NOTE: possible eval optimization:
  * - Analyze the comp graph first and mark all non-varying props or fields (including those that don't depend on varying vals) permanantly "Done".
  */
-
-// COMBAK: Import the dummy functions from Style -> EngineUtils
-const dummySourceLoc = (): SourceLoc => {
-  return { line: -1, col: -1 };
-};
 
 /**
  * Evaluate all shapes in the `State` by walking the `Translation` data structure, finding out all shape expressions (`FGPI` expressions computed by the Style compiler), and evaluating every property in each shape.
@@ -87,10 +82,7 @@ export const evalShapes = (rng: seedrandom.prng, s: State): ShapeAD[] => {
   log.info("shapePaths", s.shapePaths.map(prettyPrintPath));
 
   // Evaluate each of the shapes (note: the translation is mutated, not returned)
-  const [shapesEvaled, transEvaled]: [
-    ShapeAD[],
-    Translation
-  ] = shapeExprs.reduce(
+  const [shapesEvaled]: [ShapeAD[], Translation] = shapeExprs.reduce(
     ([currShapes, tr]: [ShapeAD[], Translation], e: IFGPI<VarAD>) =>
       evalShape(rng, e, tr, s.varyingMap, currShapes, optDebugInfo),
     [[], trans]
@@ -751,11 +743,7 @@ export const resolvePath = (
               varyingMap,
               optDebugInfo
             ) as IVal<VarAD>).contents;
-            const transNew = insertExpr(
-              propertyPath,
-              { tag: "Done", contents: val },
-              trans
-            );
+            insertExpr(propertyPath, { tag: "Done", contents: val }, trans);
             return val;
           } else {
             // Look up in varyingMap to see if there is a fresh value
@@ -793,11 +781,7 @@ export const resolvePath = (
           );
 
           if (res.tag === "Val") {
-            const transNew = insertExpr(
-              path,
-              { tag: "Done", contents: res.contents },
-              trans
-            );
+            insertExpr(path, { tag: "Done", contents: res.contents }, trans);
             return res;
           } else if (res.tag === "GPI") {
             throw Error(
@@ -883,7 +867,6 @@ export const evalBinOp = (
 
     return { tag: "FloatV", contents: res };
   } else if (v1.tag === "IntV" && v2.tag === "IntV") {
-    const returnType = "IntV";
     let res;
 
     switch (op) {

--- a/packages/core/src/engine/Optimizer.ts
+++ b/packages/core/src/engine/Optimizer.ts
@@ -97,8 +97,6 @@ const USE_LINE_SEARCH = true;
 const BREAK_EARLY = true;
 const DEBUG_LBFGS = false;
 
-const EPS = uoStop;
-
 ////////////////////////////////////////////////////////////////////////////////
 
 const unconstrainedConverged2 = (normGrad: number): boolean => {
@@ -533,11 +531,6 @@ const awLineSearch2 = (
   }
 
   return t;
-};
-
-const printVec = (xs: Matrix) => {
-  // Prints a col vector (nx1)
-  log.info("xs (matrix)", xs.to1DArray());
 };
 
 // Precondition the gradient:

--- a/packages/core/src/engine/PropagateUpdate.ts
+++ b/packages/core/src/engine/PropagateUpdate.ts
@@ -116,9 +116,12 @@ export const insertPending = (state: State): State => {
     pendingPaths: [],
     // for each of the pending paths, update the translation using the updated shapes with new label dimensions etc.
     translation: state.pendingPaths
-      .map((p: Path<A>) => [p, findLabelValue(p, state.labelCache)])
+      .map((p: Path<A>): [Path<A>, Value<number>] => [
+        p,
+        findLabelValue(p, state.labelCache),
+      ])
       .reduce(
-        (trans: Translation, [path, v]: any) =>
+        (trans: Translation, [path, v]) =>
           insertExpr(path, { tag: "Done", contents: v }, trans),
         state.translation
       ),

--- a/packages/core/src/renderer/Image.ts
+++ b/packages/core/src/renderer/Image.ts
@@ -35,13 +35,13 @@ const Image = async ({
    * are integrated in one diagram.
    */
   if (defs.length > 0) {
-    defs[0].querySelectorAll("*").forEach((node: any) => {
+    defs[0].querySelectorAll("*").forEach((node) => {
       if (node.id !== "") {
         // BUG: not matching on fill="url(#...)", only hrefs
         const users = svg.querySelectorAll(
           `[*|href="#${node.id}"]:not([href])`
         );
-        users.forEach((user: any) => {
+        users.forEach((user) => {
           const unique = `${(shape.properties.name as IStrV).contents}-ns-${
             node.id
           }`;

--- a/packages/core/src/synthesis/Mutation.ts
+++ b/packages/core/src/synthesis/Mutation.ts
@@ -11,7 +11,6 @@ import {
   stmtExists,
 } from "analysis/SubstanceAnalysis";
 import { prettyStmt, prettySubNode } from "compiler/Substance";
-import consola, { LogLevel } from "consola";
 import { dummyIdentifier } from "engine/EngineUtils";
 import { range, without } from "lodash";
 import { A, Identifier } from "types/ast";
@@ -33,10 +32,6 @@ import {
   SynthesisContext,
   WithContext,
 } from "./Synthesizer";
-
-const log = consola
-  .create({ level: LogLevel.Info })
-  .withScope("Substance mutation");
 
 //#region Mutation types
 
@@ -511,7 +506,7 @@ export const checkDeleteStmt = (
 };
 
 const changeType = (
-  { stmt, newStmt, additionalMutations }: ChangeStmtType | ChangeExprType,
+  { newStmt, additionalMutations }: ChangeStmtType | ChangeExprType,
   prog: SubProg<A>,
   ctx: SynthesisContext
 ) => {

--- a/packages/core/src/utils/CollectLabels.ts
+++ b/packages/core/src/utils/CollectLabels.ts
@@ -13,7 +13,7 @@ import { err, ok, Result } from "./Error";
 // https://github.com/mathjax/MathJax-demos-node/blob/master/direct/tex2svg
 // const adaptor = chooseAdaptor();
 const adaptor = browserAdaptor();
-RegisterHTMLHandler(adaptor as any);
+RegisterHTMLHandler(adaptor);
 const tex = new TeX({
   packages: AllPackages,
   macros: {

--- a/packages/core/src/utils/toCustomAD.ts
+++ b/packages/core/src/utils/toCustomAD.ts
@@ -33,7 +33,7 @@ interface Transform {
 
 // jscodeshift tests.ts -t toCustomAD.ts -p -d
 
-export default function (fileInfo: FileInfo, api: API) {
+export default function (fileInfo: FileInfo, api: API): string {
   const j = api.jscodeshift; // DO NOT REMOVE
 
   const KWTYPS: string[] = [
@@ -93,11 +93,6 @@ export default function (fileInfo: FileInfo, api: API) {
   // member expression to id
   const ME2ID = (target: string, node: any): Identifier => {
     node.type = "Identifier";
-    node.name = target;
-    return node;
-  };
-  // identifier to identifier
-  const ID2ID = (target: string, node: any): Identifier => {
     node.name = target;
     return node;
   };


### PR DESCRIPTION
# Description

This PR eliminates 32% of the 215 ESLint warnings currently in `@penrose/core`. All the changes are fairly trivial; I didn't do any significant refactoring.

# Checklist

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new ESLint warnings
- [x] I have reviewed any generated changes to the `diagrams/` folder