### PR TITLE
chore: Use Automator renderer in .github/bench.sh

### DIFF
--- a/.github/bench.sh
+++ b/.github/bench.sh
@@ -2,74 +2,91 @@
 set -eo pipefail
 
 function get_run() {
-  gh run list --branch="$1" --jq='.[]' --limit=1 --workflow=Build \
+  local branch="$1"
+
+  gh run list --branch="$branch" --jq='.[]' --limit=1 --workflow=Build \
     --json=conclusion,databaseId,event,headSha,status
 }
 
 function check_run() {
+  local branch="$1"
+  local trigger="$2"
+  local run="$3"
+
   # https://github.com/koalaman/shellcheck/wiki/SC2155
 
   local sha_local
-  sha_local=$(git rev-parse "$1")
+  sha_local=$(git rev-parse "$branch")
   local sha_remote
-  sha_remote=$(jq --raw-output '.headSha' <<< "$3")
+  sha_remote=$(jq --raw-output '.headSha' <<< "$run")
 
   if [[ "$sha_remote" != "$sha_local" ]]; then
-    echo "commit for latest \`$1\` run does not match local branch:"
+    echo "latest \`$branch\` run commit does not match local branch:"
     echo "  $sha_local (local)"
     echo "  $sha_remote (remote)"
     false
   fi
 
   local event
-  event=$(jq --raw-output '.event' <<< "$3")
+  event=$(jq --raw-output '.event' <<< "$run")
 
-  if [[ "$event" != "$2" ]]; then
-    echo "event for latest \`$1\` run is \`$event\`, not \`$2\` as expected"
+  if [[ "$event" != "$trigger" ]]; then
+    echo "latest \`$branch\` run event is \`$event\`, not \`$trigger\`"
     false
   fi
 
   local status
-  status=$(jq --raw-output '.status' <<< "$3")
-  local completed
-  completed=completed
+  status=$(jq --raw-output '.status' <<< "$run")
+  local completed=completed
 
   if [[ "$status" != "$completed" ]]; then
-    echo "latest \`$1\` run status is \`$status\`, not \`$completed\`"
+    echo "latest \`$branch\` run status is \`$status\`, not \`$completed\`"
     false
   fi
 
   local conclusion
-  conclusion=$(jq --raw-output '.conclusion' <<< "$3")
-  local success
-  success=success
+  conclusion=$(jq --raw-output '.conclusion' <<< "$run")
+  local succ=success
 
-  if [[ "$conclusion" != "$success" ]]; then
-    echo "latest \`$1\` run conclusion is \`$conclusion\`, not \`$success\`"
+  if [[ "$conclusion" != "$succ" ]]; then
+    echo "latest \`$branch\` run conclusion is \`$conclusion\`, not \`$succ\`"
     false
   fi
 }
 
 artifact=diagrams
-dir=.github/artifacts/"$artifact"
+dir=.github/artifacts/"$artifact"/
 
-function download_diagrams() {
-  local dir_branch="$dir/$1"
+function visualize() {
+  local branch="$1"
+  local event="$2"
 
-  if [[ -e "$dir_branch" ]]; then
-    echo "\`$dir_branch\` already exists, skipping download"
+  local commit
+  commit=$(git rev-parse "$branch")
+  local dir_commit="$dir$commit"/
+
+  if [[ -e "$dir_commit" ]]; then
+    echo "\`$dir_commit\` already exists, skipping download"
   else
     local run
-    run=$(get_run "$1")
-    check_run "$1" "$2" "$run"
+    run=$(get_run "$branch")
+    check_run "$branch" "$event" "$run"
+
     local id
     id=$(jq '.databaseId' <<< "$run")
-    gh run download "$id" --dir="$dir_branch" --name="$artifact"
+    gh run download "$id" --dir="$dir_commit" --name="$artifact"
   fi
+
+  pushd packages/automator/
+  local out=out/
+  mkdir -p "$out"
+
+  local out_branch="$out$branch"/
+  yarn start render ../../"$dir_commit" "$out_branch"
+  open "$out_branch"vis.html
+  popd
 }
 
-download_diagrams main push
+visualize main push
 branch_name=$(git symbolic-ref --short HEAD)
-download_diagrams "$branch_name" pull_request
-
-icdiff "$dir/main/aggregateData.json" "$dir/$branch_name/aggregateData.json"
+visualize "$branch_name" pull_request


### PR DESCRIPTION
# Description

This PR modifies `.github/bench.sh` (originally added in #907 to diff the timings generated by the `bench` CI job for a branch with those from `main`) to use `@penrose/automator`'s [static-site-generation](https://github.com/penrose/penrose/tree/bfdbe4303cc9732e4e7a258830c2d9c5d50383ba/packages/automator#static-site-generation) to generate visual performance charts instead of just running [`icdiff`](https://www.jefftk.com/icdiff) on the raw numbers.

# Implementation strategy and design decisions

I realized that the previous strategy to cache the downloaded artifacts under `.github/artifacts/diagrams/$branch/` was foolish, because that makes it very easy to see incorrect diffs if one doesn't habitually delete `.github/artifacts/diagrams/`. Thus, I changed it to store them under `.github/artifacts/diagrams/$commit/` instead. However, for the generated HTML files, I use `packages/automator/out/$branch/`, because those always get regenerated instead of being cached, and it is important for the URL of the opened HTML file to include the branch name so that the user can easily tell which one they are looking at.

I also made a couple minor style improvements to `.github/bench.sh`:

- name all `function` arguments at the top
- don't split `local` declaration/assignment across multiple lines unless necessary

# Examples with steps to reproduce them

```
git switch github-bench-visualize
.github/bench.sh
```

# Checklist

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new ESLint warnings
- [x] I have reviewed any generated changes to the `diagrams/` folder

# Open questions

- This currently just opens up the two webpages separately in the browser. It would be nice to instead actually show some visual diff of the performance.