### PR TITLE
build: Run tsc --noEmit as prebuild for vite build

### DIFF
--- a/packages/browser-ui/package.json
+++ b/packages/browser-ui/package.json
@@ -24,6 +24,7 @@
     "dev": "vite",
     "watch": "vite",
     "start": "vite",
+    "prebuild": "tsc --noEmit",
     "build": "vite build",
     "test": "echo NO TESTS",
     "lint": "eslint --ext js,ts,tsx src",

--- a/packages/browser-ui/src/inspector/views/GraphUtils.ts
+++ b/packages/browser-ui/src/inspector/views/GraphUtils.ts
@@ -33,12 +33,14 @@ const labelNode = (node: Node): string => {
   }
   switch (node.tag) {
     case "Input": {
-      return `x${node.index}`;
+      return `x${node.key}`;
     }
     case "Unary": {
       return node.unop;
     }
-    case "Binary": {
+    case "Binary":
+    case "Comp":
+    case "Logic": {
       return node.binop;
     }
     case "Ternary": {
@@ -46,6 +48,12 @@ const labelNode = (node: Node): string => {
     }
     case "Nary": {
       return node.op;
+    }
+    case "PolyRoots": {
+      return "polyRoots";
+    }
+    case "Index": {
+      return `[${node.index}]`;
     }
     case "Debug": {
       return JSON.stringify(node.info);

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -8,7 +8,8 @@
   "scripts": {
     "dev": "vite",
     "watch": "vite build --watch",
-    "build": "cross-env vite build && tsc",
+    "prebuild": "tsc --noEmit",
+    "build": "cross-env vite build",
     "preview": "vite preview",
     "storybook": "start-storybook -p 6006",
     "build-storybook": "build-storybook",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -8,8 +8,7 @@
   "scripts": {
     "dev": "vite",
     "watch": "vite build --watch",
-    "prebuild": "tsc --noEmit",
-    "build": "cross-env vite build",
+    "build": "cross-env vite build && tsc",
     "preview": "vite preview",
     "storybook": "start-storybook -p 6006",
     "build-storybook": "build-storybook",

--- a/packages/panels/package.json
+++ b/packages/panels/package.json
@@ -19,6 +19,7 @@
     "dev": "vite",
     "watch": "vite",
     "start": "vite",
+    "prebuild": "tsc --noEmit",
     "build": "vite build",
     "test": "echo NO TESTS",
     "prepack": "yarn build",

--- a/packages/synthesizer-ui/package.json
+++ b/packages/synthesizer-ui/package.json
@@ -6,7 +6,8 @@
     "dev": "vite",
     "watch": "vite",
     "start": "vite",
-    "build": "tsc && NODE_OPTIONS='--max-old-space-size=8192' vite build",
+    "prebuild": "tsc --noEmit",
+    "build": "NODE_OPTIONS='--max-old-space-size=8192' vite build",
     "preview": "vite preview"
   },
   "dependencies": {


### PR DESCRIPTION
# Description

Fixes #866. @wodeni and I made some progress toward this in #941 and #942, but #943 seems to have caused some regression, because [Vite doesn't typecheck code](https://vitejs.dev/guide/features.html#typescript):

> Vite only performs transpilation on `.ts` files and does **NOT** perform type checking. It assumes type checking is taken care of by your IDE and build process (you can run `tsc --noEmit` in the build script or install `vue-tsc` and run `vue-tsc --noEmit` to also type check your `*.vue` files).

Thus, this PR adds `tsc --noEmit` as a [`prebuild`](https://docs.npmjs.com/cli/v8/using-npm/scripts#pre--post-scripts) script before every `vite build` script (except for `@penrose/components`, which seems to do something special and for which `tsc --noEmit` fails). This exposes a couple type errors caused by #906, which this PR also fixes.

# Checklist

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new ESLint warnings
- [x] I have reviewed any generated changes to the `diagrams/` folder