### PR TITLE
refactor: Rename VarAD to ad.Num and delete VecAD

### DIFF
--- a/docs/mathtransformer.md
+++ b/docs/mathtransformer.md
@@ -51,7 +51,7 @@ Currently the following transforms will occur (you can see this in more detail i
 | x \* y         | mul(x, y)       |
 | x / y          | div(x, y)       |
 | -x             | neg(x)          |
-| x: number      | x: VarAD        |
+| x: number      | x: ad.Num       |
 | Math.pow(x, y) | pow(x, y)       |
 | Math.pow(x, 2) | squared(x)      |
 | x ? y : z      | ifCond(x, y, z) |
@@ -90,7 +90,7 @@ JSCodeshift will modify your input file in place. If this is undesirable behavio
 
     export const objDict = {
         // autodiff
-        equal: (x: VarAD, y: VarAD) => squared(sub(x, y)),
+        equal: (x: ad.Num, y: ad.Num) => squared(sub(x, y)),
 
         // autodiff
         above: ([t1, top]: [string, any], [t2, bottom]: [string, any], offset = 100) =>

--- a/packages/browser-ui/src/inspector/views/GraphUtils.ts
+++ b/packages/browser-ui/src/inspector/views/GraphUtils.ts
@@ -5,7 +5,7 @@ import {
   prettyPrintPath,
   secondaryGraph,
 } from "@penrose/core";
-import { Node, VarAD } from "@penrose/core/build/dist/types/ad";
+import * as ad from "@penrose/core/build/dist/types/ad";
 import { A } from "@penrose/core/build/dist/types/ast";
 import { Fn } from "@penrose/core/build/dist/types/state";
 import { Path } from "@penrose/core/build/dist/types/style";
@@ -27,7 +27,7 @@ export type PGraph = ElementsDefinition;
  */
 const merge = <T>(arr: T[][]): T[] => ([] as T[]).concat(...arr);
 
-const labelNode = (node: Node): string => {
+const labelNode = (node: ad.Node): string => {
   if (typeof node === "number") {
     return `${node}`;
   }
@@ -65,9 +65,9 @@ const labelNode = (node: Node): string => {
  * For building atomic op graph.
  * Given a parent node, returns the graph corresponding to nodes and edges of children
  * Returns unique nodes after all nodes are merged
- * TODO: Add type for graph and VarAD
+ * TODO: Add type for graph and ad.Num
  */
-export const traverseUnique = (par: VarAD): PGraph => {
+export const traverseUnique = (par: ad.Num): PGraph => {
   // TODO: do not navigate graph outside core
   const { graph } = secondaryGraph([par]);
   return {

--- a/packages/core/src/__testfixtures__/transformtest.output.ts
+++ b/packages/core/src/__testfixtures__/transformtest.output.ts
@@ -23,10 +23,10 @@ export const objDict = {
     testbops1: ([t1, s1]: [string, any]) => add(x, 3),
 
     //autodiff
-    testbops2: (x: VarAD) => sub(add(sub(add(x, 2), 3), div(mul(5, 7), 2)), (add(3, 4))),
+    testbops2: (x: ad.Num) => sub(add(sub(add(x, 2), 3), div(mul(5, 7), 2)), (add(3, 4))),
 
     //autodiff
-    testbops3: (x: VarAD) => add(add(x, 3), (add(2, (add(1, 4))))),
+    testbops3: (x: ad.Num) => add(add(x, 3), (add(2, (add(1, 4))))),
 
     // autodiff
     testsq1: ([t1, s1]: [string, any], [t2, s2]: [string, any]) =>
@@ -49,19 +49,19 @@ export const objDict = {
     ops.vdistsq(add(2, (ifCond(x, 3, bob(squared(4)))))),
 
     //autodiff
-    testtyps1: (x : VarAD, y: VarAD) : VarAD => 3,
+    testtyps1: (x : ad.Num, y: ad.Num) : ad.Num => 3,
 
     //autodiff
-    testuops1: (x: VarAD) => neg(x),
+    testuops1: (x: ad.Num) => neg(x),
 
     //autodiff
-    testuops2: (x: VarAD) => neg(ops.vdistsq(3, 2)),
+    testuops2: (x: ad.Num) => neg(ops.vdistsq(3, 2)),
 
     //autodiff
-    testuops3: (x: VarAD) => -7,
+    testuops3: (x: ad.Num) => -7,
 
     //autodiff
-    testuops4: (x: VarAD) => neg((add(3, mul(-5, (ifCond(2, x, y)))))),
+    testuops4: (x: ad.Num) => neg((add(3, mul(-5, (ifCond(2, x, y)))))),
 
     //autodiff
     testtern1: (x: any) => ifCond(x, 3, sub(4, 2)),

--- a/packages/core/src/compiler/Style.ts
+++ b/packages/core/src/compiler/Style.ts
@@ -30,7 +30,7 @@ import rfdc from "rfdc";
 import seedrandom from "seedrandom";
 import { Canvas } from "shapes/Samplers";
 import { ShapeDef, shapedefs } from "shapes/Shapes";
-import { VarAD } from "types/ad";
+import * as ad from "types/ad";
 import { A, C, Identifier } from "types/ast";
 import { Either, Left, Right } from "types/common";
 import { ConstructorDecl, Env, TypeConstructor } from "types/domain";
@@ -1644,7 +1644,7 @@ const deleteProperty = (
     });
   }
 
-  const prop: FieldExpr<VarAD> = fieldDict[fld];
+  const prop: FieldExpr<ad.Num> = fieldDict[fld];
 
   if (!prop) {
     // TODO(errors / warnings): Should this be fatal?
@@ -1779,7 +1779,7 @@ const addPath = (
   override: boolean,
   trans: Translation,
   path: Path<A>,
-  expr: TagExpr<VarAD>
+  expr: TagExpr<ad.Num>
 ): Either<StyleErrors, Translation> => {
   // Extended `insertExpr` with an optional flag to deal with errors and warnings
   // `insertExpr` replaces the old .hs functions `addField` and `addProperty`
@@ -2137,14 +2137,14 @@ const insertNames = (trans: Translation): Translation => {
 const insertLabels = (trans: Translation, labels: LabelMap): void => {
   for (const labelData of labels) {
     const [name, label] = labelData;
-    const labelValue: TagExpr<VarAD> = {
+    const labelValue: TagExpr<ad.Num> = {
       tag: "Done",
       contents: {
         tag: "StrV",
         contents: label.value,
       },
     };
-    const labelExpr: FieldExpr<VarAD> = {
+    const labelExpr: FieldExpr<ad.Num> = {
       tag: "FExpr",
       contents: labelValue,
     };
@@ -2197,8 +2197,8 @@ const translateStyProg = (
 //#region Translation utilities -- TODO move to EngineUtils
 
 function foldFields<T>(
-  f: (s: string, field: Field, fexpr: FieldExpr<VarAD>, acc: T[]) => T[],
-  [name, fieldDict]: [string, { [k: string]: FieldExpr<VarAD> }],
+  f: (s: string, field: Field, fexpr: FieldExpr<ad.Num>, acc: T[]) => T[],
+  [name, fieldDict]: [string, { [k: string]: FieldExpr<ad.Num> }],
   acc: T[]
 ): T[] {
   const res: T[] = Object.entries(fieldDict).reduce(
@@ -2209,7 +2209,7 @@ function foldFields<T>(
 }
 
 function foldSubObjs<T>(
-  f: (s: string, f: Field, fexpr: FieldExpr<VarAD>, acc: T[]) => T[],
+  f: (s: string, f: Field, fexpr: FieldExpr<ad.Num>, acc: T[]) => T[],
   tr: Translation
 ): T[] {
   return Object.entries(tr.trMap).reduce(
@@ -2240,7 +2240,7 @@ const unoptimizedFloatProperties: string[] = [
 
 const optimizedVectorProperties: string[] = ["start", "end", "center"];
 
-const declaredVarying = (t: TagExpr<VarAD>): boolean => {
+const declaredVarying = (t: TagExpr<ad.Num>): boolean => {
   if (t.tag === "OptEval") {
     return isVarying(t.contents);
   }
@@ -2300,7 +2300,7 @@ const isPending = (s: ShapeTypeStr, p: PropID): boolean => {
 const findPropertyVarying = (
   name: string,
   field: Field,
-  properties: { [k: string]: TagExpr<VarAD> },
+  properties: { [k: string]: TagExpr<ad.Num> },
   floatProperty: string,
   acc: Path<A>[]
 ): Path<A>[] => {
@@ -2313,7 +2313,7 @@ const findPropertyVarying = (
     }
 
     if (optimizedVectorProperties.includes(floatProperty)) {
-      const defaultVec2: TagExpr<VarAD> = {
+      const defaultVec2: TagExpr<ad.Num> = {
         tag: "OptEval",
         contents: {
           nodeType: "SyntheticStyle",
@@ -2341,7 +2341,7 @@ const findPropertyVarying = (
 };
 
 // Look for nested varying variables, given the path to its parent var (e.g. `x.r` => (-1.2, ?)) => `x.r`[1] is varying
-const findNestedVarying = (e: TagExpr<VarAD>, p: Path<A>): Path<A>[] => {
+const findNestedVarying = (e: TagExpr<ad.Num>, p: Path<A>): Path<A>[] => {
   if (e.tag === "OptEval") {
     const res = e.contents;
     if (res.tag === "Vector") {
@@ -2376,7 +2376,7 @@ const findNestedVarying = (e: TagExpr<VarAD>, p: Path<A>): Path<A>[] => {
 const findFieldVarying = (
   name: string,
   field: Field,
-  fexpr: FieldExpr<VarAD>,
+  fexpr: FieldExpr<ad.Num>,
   acc: Path<A>[]
 ): Path<A>[] => {
   switch (fexpr.tag) {
@@ -2430,7 +2430,7 @@ const findPropertyUninitialized = (
 const findFieldUninitialized = (
   name: string,
   field: Field,
-  fexpr: FieldExpr<VarAD>,
+  fexpr: FieldExpr<ad.Num>,
   acc: Path<A>[]
 ): Path<A>[] => {
   // NOTE: we don't find uninitialized field because you can't leave them uninitialized. Plus, we don't know what types they are
@@ -2463,7 +2463,7 @@ const findUninitialized = (tr: Translation): Path<A>[] => {
 const findGPIName = (
   name: string,
   field: Field,
-  fexpr: FieldExpr<VarAD>,
+  fexpr: FieldExpr<ad.Num>,
   acc: [string, Field][]
 ): [string, Field][] => {
   switch (fexpr.tag) {
@@ -2486,7 +2486,7 @@ const findShapeNames = (tr: Translation): [string, string][] => {
 const findShapeProperties = (
   name: string,
   field: Field,
-  fexpr: FieldExpr<VarAD>,
+  fexpr: FieldExpr<ad.Num>,
   acc: [string, Field, Property][]
 ): [string, Field, Property][] => {
   switch (fexpr.tag) {
@@ -2514,7 +2514,7 @@ const findShapesProperties = (tr: Translation): [string, string, string][] => {
 const findFieldFns = (
   name: string,
   field: Field,
-  fexpr: FieldExpr<VarAD>,
+  fexpr: FieldExpr<ad.Num>,
   acc: Either<StyleOptFn, StyleOptFn>[]
 ): Either<StyleOptFn, StyleOptFn>[] => {
   if (fexpr.tag === "FExpr") {
@@ -2551,7 +2551,7 @@ const findUserAppliedFns = (tr: Translation): [Fn[], Fn[]] => {
 const findFieldDefaultFns = (
   name: string,
   field: Field,
-  fexpr: FieldExpr<VarAD>,
+  fexpr: FieldExpr<ad.Num>,
   acc: Either<StyleOptFn, StyleOptFn>[]
 ): Either<StyleOptFn, StyleOptFn>[] => {
   if (fexpr.tag === "FGPI") {
@@ -2615,7 +2615,7 @@ const convertFns = (fns: Either<StyleOptFn, StyleOptFn>[]): [Fn[], Fn[]] => {
 
 // Extract number from a more complicated type
 // also ported from `lookupPaths`
-const getNum = (e: TagExpr<VarAD> | IFGPI<VarAD>): number => {
+const getNum = (e: TagExpr<ad.Num> | IFGPI<ad.Num>): number => {
   switch (e.tag) {
     case "OptEval": {
       if (e.contents.tag === "Fix") {
@@ -2661,7 +2661,7 @@ export const lookupNumericPaths = (
 const findFieldPending = (
   name: string,
   field: Field,
-  fexpr: FieldExpr<VarAD>,
+  fexpr: FieldExpr<ad.Num>,
   acc: Path<A>[]
 ): Path<A>[] => {
   switch (fexpr.tag) {
@@ -2672,7 +2672,7 @@ const findFieldPending = (
       const properties = fexpr.contents[1];
       const pendingProps = Object.entries(properties)
         .filter(([, v]) => v.tag === "Pending")
-        .map((e: [string, TagExpr<VarAD>]) => e[0]);
+        .map((e: [string, TagExpr<ad.Num>]) => e[0]);
 
       // TODO: Pending properties currently don't support AccessPaths
       return pendingProps
@@ -2717,7 +2717,7 @@ const initFieldsAndAccessPaths = (
   const canvas = getCanvas(tr);
 
   const initVals = varyingFieldsAndAccessPaths.map(
-    (p: Path<A>): TagExpr<VarAD> => {
+    (p: Path<A>): TagExpr<ad.Num> => {
       // by default, sample randomly in canvas X range
       let initVal = randFloat(rng, ...canvas.xRange);
 
@@ -2760,8 +2760,8 @@ const initFieldsAndAccessPaths = (
 const initProperty = (
   shapeType: ShapeTypeStr,
   propName: string,
-  styleSetting: TagExpr<VarAD>
-): TagExpr<VarAD> | undefined => {
+  styleSetting: TagExpr<ad.Num>
+): TagExpr<ad.Num> | undefined => {
   // Property set in Style
   switch (styleSetting.tag) {
     case "OptEval": {
@@ -2818,7 +2818,7 @@ const initShape = (
   if (res.tag === "FGPI") {
     const [stype, props] = res.contents;
     const shapedef: ShapeDef = shapedefs[stype];
-    const instantiatedGPIProps: GPIProps<VarAD> = {
+    const instantiatedGPIProps: GPIProps<ad.Num> = {
       // start by sampling all properties for the shape according to its shapedef
       ...Object.fromEntries(
         Object.entries(
@@ -2852,7 +2852,7 @@ const initShape = (
         contents: shapeName,
       },
     };
-    const gpi: IFGPI<VarAD> = {
+    const gpi: IFGPI<ad.Num> = {
       tag: "FGPI",
       contents: [stype, instantiatedGPIProps],
     };
@@ -2873,7 +2873,7 @@ const initShapes = (
 const findLayeringExpr = (
   name: string,
   field: Field,
-  fexpr: FieldExpr<VarAD>,
+  fexpr: FieldExpr<ad.Num>,
   acc: ILayering<A>[]
 ): ILayering<A>[] => {
   if (fexpr.tag === "FExpr") {
@@ -3124,7 +3124,7 @@ export const parseStyle = (p: string): Result<StyProg<C>, ParseError> => {
 
 //#region Checking translation
 
-const isStyErr = (res: TagExpr<VarAD> | IFGPI<VarAD> | StyleError): boolean =>
+const isStyErr = (res: TagExpr<ad.Num> | IFGPI<ad.Num> | StyleError): boolean =>
   res.tag !== "FGPI" && !isTagExpr(res);
 
 const findPathsExpr = <T>(expr: Expr<T>): Path<T>[] => {
@@ -3192,7 +3192,7 @@ const findPathsExpr = <T>(expr: Expr<T>): Path<T>[] => {
 const findPathsField = (
   name: string,
   field: Field,
-  fexpr: FieldExpr<VarAD>,
+  fexpr: FieldExpr<ad.Num>,
   acc: Path<A>[]
 ): Path<A>[] => {
   switch (fexpr.tag) {
@@ -3209,9 +3209,9 @@ const findPathsField = (
       // Get any exprs that the properties are set to
       const propExprs: Expr<A>[] = Object.entries(fexpr.contents[1])
         .map((e) => e[1])
-        .filter((e: TagExpr<VarAD>): boolean => e.tag === "OptEval")
-        .map((e) => e as IOptEval<VarAD>) // Have to cast because TypeScript doesn't know the type changed from the filter above
-        .map((e: IOptEval<VarAD>): Expr<A> => e.contents);
+        .filter((e: TagExpr<ad.Num>): boolean => e.tag === "OptEval")
+        .map((e) => e as IOptEval<ad.Num>) // Have to cast because TypeScript doesn't know the type changed from the filter above
+        .map((e: IOptEval<ad.Num>): Expr<A> => e.contents);
       const res: Path<A>[] = _.flatMap(propExprs, findPathsExpr);
       return acc.concat(res);
     }
@@ -3324,10 +3324,10 @@ const canvasHeightPath: Path<A> = mkPath(["canvas", "height"]);
 
 /* Precondition: checkCanvas returns without error */
 export const getCanvas = (tr: Translation): Canvas => {
-  const width = ((tr.trMap.canvas.width.contents as TagExpr<VarAD>)
-    .contents as Value<VarAD>).contents as number;
-  const height = ((tr.trMap.canvas.height.contents as TagExpr<VarAD>)
-    .contents as Value<VarAD>).contents as number;
+  const width = ((tr.trMap.canvas.width.contents as TagExpr<ad.Num>)
+    .contents as Value<ad.Num>).contents as number;
+  const height = ((tr.trMap.canvas.height.contents as TagExpr<ad.Num>)
+    .contents as Value<ad.Num>).contents as number;
   return {
     width,
     height,

--- a/packages/core/src/contrib/Constraints.ts
+++ b/packages/core/src/contrib/Constraints.ts
@@ -32,36 +32,36 @@ import {
 } from "engine/AutodiffFunctions";
 import * as BBox from "engine/BBox";
 import { shapedefs } from "shapes/Shapes";
-import { VarAD } from "types/ad";
+import * as ad from "types/ad";
 
 // -------- Simple constraints
-// Do not require shape quaries, operate directly with `VarAD` parameters.
+// Do not require shape quaries, operate directly with `ad.Num` parameters.
 const constrDictSimple = {
   /**
    * Require that the value `x` is equal to the value `y`
    */
-  equal: (x: VarAD, y: VarAD) => {
+  equal: (x: ad.Num, y: ad.Num) => {
     return absVal(sub(x, y));
   },
 
   /**
    * Require that the value `x` is less than the value `y` with optional padding `padding`
    */
-  lessThan: (x: VarAD, y: VarAD, padding = 0) => {
+  lessThan: (x: ad.Num, y: ad.Num, padding = 0) => {
     return add(sub(x, y), padding);
   },
 
   /**
    * Require that the value `x` is greater than the value `y` with optional padding `padding`
    */
-  greaterThan: (x: VarAD, y: VarAD, padding = 0) => {
+  greaterThan: (x: ad.Num, y: ad.Num, padding = 0) => {
     return add(sub(y, x), padding);
   },
 
   /**
    * Require that the value `x` is less than the value `y`, with steeper penalty
    */
-  lessThanSq: (x: VarAD, y: VarAD) => {
+  lessThanSq: (x: ad.Num, y: ad.Num) => {
     // if x < y then 0 else (x - y)^2
     return ifCond(lt(x, y), 0, squared(sub(x, y)));
   },
@@ -69,21 +69,24 @@ const constrDictSimple = {
   /**
    * Require that the value `x` is greater than the value `y`, with steeper penalty
    */
-  greaterThanSq: (x: VarAD, y: VarAD) => {
+  greaterThanSq: (x: ad.Num, y: ad.Num) => {
     return ifCond(lt(y, x), 0, squared(sub(y, x)));
   },
 
   /**
    * Require that the value `x` is in the range defined by `[x0, x1]`.
    */
-  inRange: (x: VarAD, x0: VarAD, x1: VarAD) => {
+  inRange: (x: ad.Num, x0: ad.Num, x1: ad.Num) => {
     return mul(sub(x, x0), sub(x, x1));
   },
 
   /**
    * Require that an interval `[l1, r1]` contains another interval `[l2, r2]`. If not possible, returns 0.
    */
-  contains1D: ([l1, r1]: [VarAD, VarAD], [l2, r2]: [VarAD, VarAD]): VarAD => {
+  contains1D: (
+    [l1, r1]: [ad.Num, ad.Num],
+    [l2, r2]: [ad.Num, ad.Num]
+  ): ad.Num => {
     // [if len2 <= len1,] require that (l2 > l1) & (r2 < r1)
     return add(
       constrDictSimple.lessThanSq(l1, l2),
@@ -94,8 +97,8 @@ const constrDictSimple = {
   /**
    * Make scalar `c` disjoint from a range `left, right`.
    */
-  disjointScalar: (c: VarAD, left: VarAD, right: VarAD) => {
-    const d = (x: VarAD, y: VarAD) => absVal(sub(x, y));
+  disjointScalar: (c: ad.Num, left: ad.Num, right: ad.Num) => {
+    const d = (x: ad.Num, y: ad.Num) => absVal(sub(x, y));
 
     // if (x \in [l, r]) then min(d(x,l), d(x,r)) else 0
     return ifCond(inRange(c, left, right), min(d(c, left), d(c, right)), 0);
@@ -104,7 +107,7 @@ const constrDictSimple = {
   /**
    * Require that the vector defined by `(q, p)` is perpendicular from the vector defined by `(r, p)`.
    */
-  perpendicular: (q: VarAD[], p: VarAD[], r: VarAD[]): VarAD => {
+  perpendicular: (q: ad.Num[], p: ad.Num[], r: ad.Num[]): ad.Num => {
     const v1 = ops.vsub(q, p);
     const v2 = ops.vsub(r, p);
     const dotProd = ops.vdot(v1, v2);
@@ -115,7 +118,7 @@ const constrDictSimple = {
    * Require that three points be collinear.
    * Depends on the specific ordering of points.
    */
-  collinear: (c1: VarAD[], c2: VarAD[], c3: VarAD[]) => {
+  collinear: (c1: ad.Num[], c2: ad.Num[], c3: ad.Num[]) => {
     const v1 = ops.vsub(c1, c2);
     const v2 = ops.vsub(c2, c3);
     const v3 = ops.vsub(c1, c3);
@@ -128,7 +131,7 @@ const constrDictSimple = {
    * Require that three points be collinear.
    * Does not enforce a specific ordering of points, instead it takes the arrangement of points that is most easily satisfiable.
    */
-  collinearUnordered: (c1: VarAD[], c2: VarAD[], c3: VarAD[]) => {
+  collinearUnordered: (c1: ad.Num[], c2: ad.Num[], c3: ad.Num[]) => {
     const v1 = ops.vnorm(ops.vsub(c1, c2));
     const v2 = ops.vnorm(ops.vsub(c2, c3));
     const v3 = ops.vnorm(ops.vsub(c1, c3));
@@ -147,15 +150,15 @@ const constrDictGeneral = {
   /** Require that `shape` is on the canvas */
   onCanvas: (
     [shapeType, props]: any,
-    canvasWidth: VarAD,
-    canvasHeight: VarAD
+    canvasWidth: ad.Num,
+    canvasHeight: ad.Num
   ) => {
     const box = bboxFromShape([shapeType, props]);
-    const canvasXRange: [VarAD, VarAD] = [
+    const canvasXRange: [ad.Num, ad.Num] = [
       mul(canvasWidth, -0.5),
       div(canvasWidth, 2),
     ];
-    const canvasYRange: [VarAD, VarAD] = [
+    const canvasYRange: [ad.Num, ad.Num] = [
       mul(canvasHeight, -0.5),
       div(canvasHeight, 2),
     ];
@@ -174,7 +177,7 @@ const constrDictGeneral = {
   /**
    * Require that a shape have a size less than some constant maximum, based on the type of the shape.
    */
-  maxSize: ([shapeType, props]: [string, any], limit: VarAD) => {
+  maxSize: ([shapeType, props]: [string, any], limit: ad.Num) => {
     return sub(shapeSize([shapeType, props]), limit);
   },
 
@@ -292,7 +295,7 @@ const constrDictGeneral = {
 // -------- Specific constraints
 // Defined only for specific use-case or specific shapes.
 const constrDictSpecific = {
-  ptCircleIntersect: (p: VarAD[], [t, s]: [string, any]) => {
+  ptCircleIntersect: (p: ad.Num[], [t, s]: [string, any]) => {
     if (t === "Circle") {
       const r = s.r.contents;
       const c = shapeCenter([t, s]);
@@ -315,7 +318,7 @@ const constrDictSpecific = {
 };
 
 export const constrDict = {
-  ...constrDictSimple, // Do not require shape quaries, operate directly with `VarAD` parameters.
+  ...constrDictSimple, // Do not require shape quaries, operate directly with `ad.Num` parameters.
   ...constrDictGeneral, // Defined for all shapes, generally require shape queries or call multiple specific constrains.
   ...constrDictSpecific, // Defined only for specific use-case or specific shapes.
 };

--- a/packages/core/src/contrib/ConstraintsUtils.ts
+++ b/packages/core/src/contrib/ConstraintsUtils.ts
@@ -30,7 +30,7 @@ import { Polygon } from "shapes/Polygon";
 import { Rectangle } from "shapes/Rectangle";
 import { shapedefs } from "shapes/Shapes";
 import { Text } from "shapes/Text";
-import { VarAD } from "types/ad";
+import * as ad from "types/ad";
 
 // -------- Ovelapping helpers
 
@@ -40,8 +40,8 @@ import { VarAD } from "types/ad";
 export const overlappingCircles = (
   [t1, s1]: [string, Circle],
   [t2, s2]: [string, Circle],
-  padding: VarAD = 0
-): VarAD => {
+  padding: ad.Num = 0
+): ad.Num => {
   const d = ops.vdist(shapeCenter([t1, s1]), shapeCenter([t2, s2]));
   const o = [s1.r.contents, s2.r.contents, padding];
   return sub(d, addN(o));
@@ -53,8 +53,8 @@ export const overlappingCircles = (
 export const overlappingPolygons = (
   [t1, s1]: [string, Polygon | Rectangle | Text | Equation | Image | Line],
   [t2, s2]: [string, Polygon | Rectangle | Text | Equation | Image | Line],
-  padding: VarAD = 0
-): VarAD => {
+  padding: ad.Num = 0
+): ad.Num => {
   return overlappingPolygonPoints(
     polygonLikePoints([t1, s1]),
     polygonLikePoints([t2, s2]),
@@ -68,8 +68,8 @@ export const overlappingPolygons = (
 export const overlappingAABBs = (
   [t1, s1]: [string, any],
   [t2, s2]: [string, any],
-  padding: VarAD = 0
-): VarAD => {
+  padding: ad.Num = 0
+): ad.Num => {
   // Prepare axis-aligned bounding boxes
   const box1 = bboxFromShape([t1, s1]);
   const box2 = bboxFromShape([t2, s2]);
@@ -85,8 +85,8 @@ export const overlappingAABBs = (
 export const overlappingRectlikeCircle = (
   [t1, s1]: [string, Rectangle | Text | Equation | Image],
   [t2, s2]: [string, Circle],
-  padding: VarAD = 0
-): VarAD => {
+  padding: ad.Num = 0
+): ad.Num => {
   // Prepare axis-aligned bounding boxes
   const box1 = bboxFromShape([t1, s1]);
   const box2 = bboxFromShape([t2, s2]);
@@ -104,8 +104,8 @@ export const overlappingRectlikeCircle = (
 export const overlappingCircleLine = (
   [, s1]: [string, Circle],
   [, s2]: [string, Line],
-  padding: VarAD = 0
-): VarAD => {
+  padding: ad.Num = 0
+): ad.Num => {
   // collect constants
   const c = s1.center.contents;
   const r = s1.r.contents;
@@ -136,8 +136,8 @@ export const overlappingCircleLine = (
 export const atDistLabel = (
   [t1, s1]: [string, any],
   [t2, s2]: [string, any],
-  distance: VarAD
-): VarAD => {
+  distance: ad.Num
+): ad.Num => {
   let pt;
   if (shapedefs[t1].isLinelike) {
     // Position label close to the arrow's end
@@ -167,8 +167,8 @@ export const atDistLabel = (
 export const containsCircles = (
   [t1, s1]: [string, Circle],
   [t2, s2]: [string, Circle],
-  padding: VarAD = 0
-): VarAD => {
+  padding: ad.Num = 0
+): ad.Num => {
   const d = ops.vdist(shapeCenter([t1, s1]), shapeCenter([t2, s2]));
   const o = padding
     ? sub(sub(s1.r.contents, s2.r.contents), padding)
@@ -183,8 +183,8 @@ export const containsCircles = (
 export const containsCircleRectlike = (
   [t1, s1]: [string, Circle],
   [t2, s2]: [string, Rectangle | Text | Equation | Image],
-  padding: VarAD = 0
-): VarAD => {
+  padding: ad.Num = 0
+): ad.Num => {
   // TODO: Remake using Minkowski penalties
   const s2BBox = bboxFromShape([t2, s2]);
   const d = ops.vdist(shapeCenter([t1, s1]), s2BBox.center);
@@ -198,8 +198,8 @@ export const containsCircleRectlike = (
 export const containsRectlikeCircle = (
   [, s1]: [string, Rectangle | Text | Equation | Image],
   [, s2]: [string, Circle],
-  padding: VarAD = 0
-): VarAD => {
+  padding: ad.Num = 0
+): ad.Num => {
   // TODO: Remake using Minkowski penalties
 
   // collect constants
@@ -228,8 +228,8 @@ export const containsRectlikeCircle = (
 export const containsAABBs = (
   [t1, s1]: [string, any],
   [t2, s2]: [string, any],
-  padding: VarAD = 0
-): VarAD => {
+  padding: ad.Num = 0
+): ad.Num => {
   // TODO: Remake using Minkowski penalties
   const box1 = bboxFromShape([t1, s1]);
   const box2 = bboxFromShape([t2, s2]);
@@ -249,8 +249,8 @@ export const containsAABBs = (
 export const containsPolygonPolygon = (
   [, s1]: [string, Polygon],
   [, s2]: [string, Polygon],
-  padding: VarAD = 0
-): VarAD => {
+  padding: ad.Num = 0
+): ad.Num => {
   return maxN(
     s2.points.contents.map((x) =>
       containsPolygonPoints(s1.points.contents, x, padding)
@@ -264,8 +264,8 @@ export const containsPolygonPolygon = (
 export const containsPolygonCircle = (
   [, s1]: [string, Polygon],
   [, s2]: [string, Circle],
-  padding: VarAD = 0
-): VarAD => {
+  padding: ad.Num = 0
+): ad.Num => {
   return containsPolygonPoints(
     s1.points.contents,
     s2.center.contents,
@@ -279,8 +279,8 @@ export const containsPolygonCircle = (
 export const containsCirclePolygon = (
   [, s1]: [string, Circle],
   [, s2]: [string, Polygon],
-  padding: VarAD = 0
-): VarAD => {
+  padding: ad.Num = 0
+): ad.Num => {
   return maxN(
     s2.points.contents.map((x) =>
       sub(add(ops.vdist(x, s1.center.contents), padding), s1.r.contents)

--- a/packages/core/src/contrib/Objectives.ts
+++ b/packages/core/src/contrib/Objectives.ts
@@ -22,47 +22,47 @@ import {
   sub,
 } from "engine/AutodiffFunctions";
 import { shapedefs } from "shapes/Shapes";
-import { VarAD } from "types/ad";
+import * as ad from "types/ad";
 import { linePts } from "utils/Util";
 
 // -------- Simple objective functions
-// Do not require shape quaries, operate directly with `VarAD` parameters.
+// Do not require shape quaries, operate directly with `ad.Num` parameters.
 export const objDictSimple = {
   /**
    * Encourage the input value to be close to negative infinity
    */
-  minimal: (x: VarAD): VarAD => x,
+  minimal: (x: ad.Num): ad.Num => x,
 
   /**
    * Encourage the input value to be close to infinity
    */
-  maximal: (x: VarAD): VarAD => neg(x),
+  maximal: (x: ad.Num): ad.Num => neg(x),
 
   /**
    * Encourage the inputs to have the same value: `(x - y)^2`
    */
-  equal: (x: VarAD, y: VarAD): VarAD => squared(sub(x, y)),
+  equal: (x: ad.Num, y: ad.Num): ad.Num => squared(sub(x, y)),
 
   /**
    * Encourage x to be greater than or equal to y: `max(0,y - x)^2`
    */
-  greaterThan: (x: VarAD, y: VarAD): VarAD => squared(max(0, sub(y, x))),
+  greaterThan: (x: ad.Num, y: ad.Num): ad.Num => squared(max(0, sub(y, x))),
 
   /**
    * Encourage x to be less than or equal to y: `max(0,x - y)^2`
    */
-  lessThan: (x: VarAD, y: VarAD): VarAD => squared(max(0, sub(x, y))),
+  lessThan: (x: ad.Num, y: ad.Num): ad.Num => squared(max(0, sub(x, y))),
 
   /**
    * Repel point `a` from another scalar `b` with weight `weight`.
    */
-  repelPt: (weight: VarAD, a: VarAD[], b: VarAD[]): VarAD =>
+  repelPt: (weight: ad.Num, a: ad.Num[], b: ad.Num[]): ad.Num =>
     mul(weight, inverse(ops.vdistsq(a, b))),
 
   /**
    * Repel scalar `c` from another scalar `d`.
    */
-  repelScalar: (c: VarAD, d: VarAD): VarAD => {
+  repelScalar: (c: ad.Num, d: ad.Num): ad.Num => {
     // 1/(c-d)^2
     return inverse(squared(sub(c, d)));
   },
@@ -79,7 +79,7 @@ export const objDictGeneral = {
     [tBottom, sBottom]: [string, any],
     [tTop, sTop]: [string, any],
     offset = 100
-  ): VarAD => {
+  ): ad.Num => {
     return inDirection([tBottom, sBottom], [tTop, sTop], [0, 1], offset);
   },
 
@@ -90,7 +90,7 @@ export const objDictGeneral = {
     [tTop, sTop]: [string, any],
     [tBottom, sBottom]: [string, any],
     offset = 100
-  ): VarAD => {
+  ): ad.Num => {
     return inDirection([tTop, sTop], [tBottom, sBottom], [0, 1], offset);
   },
 
@@ -101,7 +101,7 @@ export const objDictGeneral = {
     [tLeft, sLeft]: [string, any],
     [tRight, sRight]: [string, any],
     offset = 100
-  ): VarAD => {
+  ): ad.Num => {
     return inDirection([tLeft, sLeft], [tRight, sRight], [1, 0], offset);
   },
 
@@ -112,14 +112,14 @@ export const objDictGeneral = {
     [tRight, sRight]: [string, any],
     [tLeft, sLeft]: [string, any],
     offset = 100
-  ): VarAD => {
+  ): ad.Num => {
     return inDirection([tRight, sRight], [tLeft, sLeft], [1, 0], offset);
   },
 
   /**
    * Encourage shape `s1` to have the same center position as shape `s2`.
    */
-  sameCenter: ([t1, s1]: [string, any], [t2, s2]: [string, any]): VarAD => {
+  sameCenter: ([t1, s1]: [string, any], [t2, s2]: [string, any]): ad.Num => {
     const center1 = shapeCenter([t1, s1]);
     const center2 = shapeCenter([t2, s2]);
     return ops.vdistsq(center1, center2);
@@ -132,7 +132,7 @@ export const objDictGeneral = {
     [t1, s1]: [string, any],
     [t2, s2]: [string, any],
     weight = 10.0
-  ): VarAD => {
+  ): ad.Num => {
     // HACK: `repel` typically needs to have a weight multiplied since its magnitude is small
     // TODO: find this out programmatically
     const repelWeight = 10e6;
@@ -164,7 +164,7 @@ export const objDictGeneral = {
     [t1, s1]: [string, any],
     [t2, s2]: [string, any],
     offset = 10.0
-  ): VarAD => {
+  ): ad.Num => {
     const res = absVal(
       ops.vdistsq(shapeCenter([t1, s1]), shapeCenter([t2, s2]))
     );
@@ -174,7 +174,7 @@ export const objDictGeneral = {
   /**
    * Try to place shape `s1` near a location `(x, y)`.
    */
-  nearPt: ([t1, s1]: [string, any], x: any, y: any): VarAD => {
+  nearPt: ([t1, s1]: [string, any], x: any, y: any): ad.Num => {
     return ops.vdistsq(shapeCenter([t1, s1]), [x, y]);
   },
 
@@ -188,7 +188,7 @@ export const objDictGeneral = {
     [t2, p2]: [string, any],
     strength = 20,
     range = 10
-  ): VarAD => {
+  ): ad.Num => {
     const c0 = shapeCenter([t0, p0]);
     const c1 = shapeCenter([t1, p1]);
     const c2 = shapeCenter([t2, p2]);
@@ -215,7 +215,7 @@ export const objDictSpecific = {
     [t1, arr]: [string, any],
     [t2, s2]: [string, any],
     [t3, s3]: [string, any]
-  ): VarAD => {
+  ): ad.Num => {
     const spacing = 1.1; // arbitrary
 
     if (
@@ -238,7 +238,7 @@ export const objDictSpecific = {
     [t1, s1]: [string, any],
     [t2, s2]: [string, any],
     w: number
-  ): VarAD => {
+  ): ad.Num => {
     if (shapedefs[t1].isLinelike && shapedefs[t2].isRectlike) {
       const [arr, text] = [s1, s2];
       const mx = div(add(arr.start.contents[0], arr.end.contents[0]), 2);
@@ -262,7 +262,7 @@ export const objDictSpecific = {
     [t2, s2]: [string, any],
     w: number,
     padding = 10
-  ): VarAD => {
+  ): ad.Num => {
     if (shapedefs[t1].isLinelike && shapedefs[t2].isRectlike) {
       // The distance between the midpoint of the arrow and the center of the text should be approx. the label's "radius" plus some padding
       const [arr, text] = [s1, s2];
@@ -284,10 +284,10 @@ export const objDictSpecific = {
    * try to make distance between a point and a segment `s1` = padding.
    */
   pointLineDist: (
-    point: VarAD[],
+    point: ad.Num[],
     [t1, s1]: [string, any],
-    padding: VarAD
-  ): VarAD => {
+    padding: ad.Num
+  ): ad.Num => {
     if (!shapedefs[t1].isLinelike) {
       throw new Error(`pointLineDist: expected a point and a line, got ${t1}`);
     }
@@ -304,7 +304,7 @@ export const objDictSpecific = {
 };
 
 export const objDict = {
-  ...objDictSimple, // Do not require shape quaries, operate directly with `VarAD` parameters.
+  ...objDictSimple, // Do not require shape quaries, operate directly with `ad.Num` parameters.
   ...objDictGeneral, // Defined for all shapes, generally require shape queries or call multiple specific objective functions.
   ...objDictSpecific, // Defined only for specific use-case or specific shapes.
 };

--- a/packages/core/src/contrib/ObjectivesUtils.ts
+++ b/packages/core/src/contrib/ObjectivesUtils.ts
@@ -1,7 +1,7 @@
 import { shapeCenter } from "contrib/Queries";
 import { ops } from "engine/Autodiff";
 import { squared, sub } from "engine/AutodiffFunctions";
-import { Pt2, VarAD } from "types/ad";
+import * as ad from "types/ad";
 
 /**
  * Encourage the center of the shape `shape` to be in the direction `direction` with respect to shape `shapeRef`.
@@ -10,9 +10,9 @@ import { Pt2, VarAD } from "types/ad";
 export const inDirection = (
   [t, shape]: [string, any],
   [tRef, shapeRef]: [string, any],
-  unitDirectionVector: Pt2,
-  offset: VarAD
-): VarAD => {
+  unitDirectionVector: ad.Pt2,
+  offset: ad.Num
+): ad.Num => {
   const center = shapeCenter([t, shape]);
   const centerRef = shapeCenter([tRef, shapeRef]);
   const dotProduct = ops.vdot(ops.vsub(center, centerRef), unitDirectionVector);

--- a/packages/core/src/contrib/Queries.ts
+++ b/packages/core/src/contrib/Queries.ts
@@ -1,7 +1,7 @@
 import { mul, sqrt } from "engine/AutodiffFunctions";
 import * as BBox from "engine/BBox";
 import { shapedefs } from "shapes/Shapes";
-import { Pt2, VarAD } from "types/ad";
+import * as ad from "types/ad";
 
 /**
  * Return bounding box from any provided shape.
@@ -14,7 +14,7 @@ export const bboxFromShape = ([t, s]: [string, any]): BBox.BBox => {
  * Return center of the shape `shape`.
  * For shapes without the property `center`, the center of their bounding box is returned.
  */
-export const shapeCenter = ([t, s]: [string, any]): Pt2 => {
+export const shapeCenter = ([t, s]: [string, any]): ad.Pt2 => {
   if ("center" in s) {
     return s.center.contents;
   } else {
@@ -29,7 +29,7 @@ export const shapeCenter = ([t, s]: [string, any]): Pt2 => {
  * - `radius` for circles.
  * - `sqrt( w * h )`, where `w` and `h` are the width and height of the bounding box, for all other shapes.
  */
-export const shapeSize = ([t, s]: [string, any]): VarAD => {
+export const shapeSize = ([t, s]: [string, any]): ad.Num => {
   if (t === "Circle") {
     return mul(2, s.r.contents);
   } else {
@@ -41,7 +41,7 @@ export const shapeSize = ([t, s]: [string, any]): VarAD => {
 /**
  * Return vertices of polygon-like shapes.
  */
-export const polygonLikePoints = ([t, s]: [string, any]): Pt2[] => {
+export const polygonLikePoints = ([t, s]: [string, any]): ad.Pt2[] => {
   if (t === "Polygon") return s.points.contents;
   else if (shapedefs[t].isLinelike) return [s.start.contents, s.end.contents];
   else if (shapedefs[t].isRectlike) {

--- a/packages/core/src/contrib/Utils.ts
+++ b/packages/core/src/contrib/Utils.ts
@@ -17,18 +17,17 @@ import {
 import * as BBox from "engine/BBox";
 import * as _ from "lodash";
 import * as ad from "types/ad";
-import { Pt2, VarAD } from "types/ad";
 
 /**
  * Require that a shape at `center1` with radius `r1` not intersect a shape at `center2` with radius `r2` with optional padding `padding`. (For a non-circle shape, its radius should be half of the shape's general "width")
  */
 export const noIntersectCircles = (
-  center1: VarAD[],
-  r1: VarAD,
-  center2: VarAD[],
-  r2: VarAD,
+  center1: ad.Num[],
+  r1: ad.Num,
+  center2: ad.Num[],
+  r2: ad.Num,
   padding = 10
-): VarAD => {
+): ad.Num => {
   // noIntersect [[x1, y1, s1], [x2, y2, s2]] = - dist (x1, y1) (x2, y2) + (s1 + s2 + 10)
   const res = add(add(r1, r2), padding);
   return sub(res, ops.vdist(center1, center2));
@@ -39,7 +38,7 @@ export const noIntersectCircles = (
 /**
  * Return true iff `p` is in rect `b`.
  */
-export const pointInBox = (p: Pt2, rect: BBox.BBox): ad.Bool => {
+export const pointInBox = (p: ad.Pt2, rect: BBox.BBox): ad.Bool => {
   return and(
     and(lt(BBox.minX(rect), p[0]), lt(p[0], BBox.maxX(rect))),
     and(lt(BBox.minY(rect), p[1]), lt(p[1], BBox.maxY(rect)))
@@ -51,10 +50,10 @@ export const pointInBox = (p: Pt2, rect: BBox.BBox): ad.Bool => {
  * If the point is outside the box, try to get the distance from the point to equal the desired distance.
  */
 export const atDistOutside = (
-  pt: Pt2,
+  pt: ad.Pt2,
   rect: BBox.BBox,
-  offset: VarAD
-): VarAD => {
+  offset: ad.Num
+): ad.Num => {
   const dsqRes = dsqBP(pt, rect);
   const WEIGHT = 1;
   return mul(WEIGHT, absVal(sub(dsqRes, squared(offset))));
@@ -65,7 +64,7 @@ export const atDistOutside = (
  * compute the positive distance squared from point `p` to box `rect` (not the signed distance).
  * https://stackoverflow.com/questions/5254838/calculating-distance-between-a-point-and-a-rectangular-box-nearest-point
  */
-const dsqBP = (p: Pt2, rect: BBox.BBox): VarAD => {
+const dsqBP = (p: ad.Pt2, rect: BBox.BBox): ad.Num => {
   const dx = max(
     max(sub(BBox.minX(rect), p[0]), 0),
     sub(p[0], BBox.maxX(rect))
@@ -83,11 +82,11 @@ const dsqBP = (p: Pt2, rect: BBox.BBox): VarAD => {
  * Return the amount of overlap between two intervals in R. (0 if none)
  */
 export const overlap1D = (
-  [l1, r1]: [VarAD, VarAD],
-  [l2, r2]: [VarAD, VarAD]
-): VarAD => {
-  const d = (x: VarAD, y: VarAD) => absVal(sub(x, y)); // Distance between two reals
-  // const d = (x: VarAD, y: VarAD) => squared(sub(x, y)); // Distance squared, if just the asymptotic behavior matters
+  [l1, r1]: [ad.Num, ad.Num],
+  [l2, r2]: [ad.Num, ad.Num]
+): ad.Num => {
+  const d = (x: ad.Num, y: ad.Num) => absVal(sub(x, y)); // Distance between two reals
+  // const d = (x: ad.Num, y: ad.Num) => squared(sub(x, y)); // Distance squared, if just the asymptotic behavior matters
   return ifCond(
     or(lt(r1, l2), lt(r2, l1)), // disjoint intervals => overlap is 0
     0,
@@ -98,14 +97,14 @@ export const overlap1D = (
 /**
  * Return numerically-encoded boolean indicating whether `x \in [l, r]`.
  */
-export const inRange = (x: VarAD, l: VarAD, r: VarAD): ad.Bool => {
+export const inRange = (x: ad.Num, l: ad.Num, r: ad.Num): ad.Bool => {
   return and(gt(x, l), lt(x, r));
 };
 
 /**
  * Linearly interpolate between left `l` and right `r` endpoints, at fraction `k` of interpolation.
  */
-const lerp = (l: VarAD, r: VarAD, k: VarAD): VarAD => {
+const lerp = (l: ad.Num, r: ad.Num, k: ad.Num): ad.Num => {
   // TODO: Rewrite the lerp code to be more concise
   return add(mul(l, sub(1, k)), mul(r, k));
 };
@@ -113,14 +112,14 @@ const lerp = (l: VarAD, r: VarAD, k: VarAD): VarAD => {
 /**
  * Linearly interpolate between vector `l` and vector `r` endpoints, at fraction `k` of interpolation.
  */
-const lerp2 = (l: VarAD[], r: VarAD[], k: VarAD): [VarAD, VarAD] => {
+const lerp2 = (l: ad.Num[], r: ad.Num[], k: ad.Num): [ad.Num, ad.Num] => {
   return [lerp(l[0], r[0], k), lerp(l[1], r[1], k)];
 };
 
 /**
  * Sample a line `line` at `NUM_SAMPLES` points uniformly.
  */
-export const sampleSeg = (line: VarAD[][]): Pt2[] => {
+export const sampleSeg = (line: ad.Num[][]): ad.Pt2[] => {
   const NUM_SAMPLES = 15;
   const NUM_SAMPLES2 = 1 + NUM_SAMPLES;
   // TODO: Check that this covers the whole line, i.e. no off-by-one error
@@ -135,7 +134,7 @@ export const sampleSeg = (line: VarAD[][]): Pt2[] => {
 /**
  * Repel a vector `a` from a vector `b` with weight `c`.
  */
-export const repelPoint = (c: VarAD, a: VarAD[], b: VarAD[]): VarAD =>
+export const repelPoint = (c: ad.Num, a: ad.Num[], b: ad.Num[]): ad.Num =>
   div(c, add(ops.vdistsq(a, b), EPS_DENOM));
 
 /**
@@ -143,10 +142,10 @@ export const repelPoint = (c: VarAD, a: VarAD[], b: VarAD[]): VarAD =>
  */
 export const centerArrow2 = (
   arr: any,
-  center1: VarAD[],
-  center2: VarAD[],
-  [o1, o2]: VarAD[]
-): VarAD => {
+  center1: ad.Num[],
+  center2: ad.Num[],
+  [o1, o2]: ad.Num[]
+): ad.Num => {
   const vec = ops.vsub(center2, center1); // direction the arrow should point to
   const dir = ops.vnormalize(vec);
 
@@ -166,7 +165,7 @@ export const centerArrow2 = (
 /**
  * Clamp `x` in range `[l, r]`.
  */
-const clamp = ([l, r]: number[], x: VarAD): VarAD => {
+const clamp = ([l, r]: number[], x: ad.Num): ad.Num => {
   return max(l, min(r, x));
 };
 
@@ -174,9 +173,9 @@ const clamp = ([l, r]: number[], x: VarAD): VarAD => {
  * Return the closest point on segment `[start, end]` to point `pt`.
  */
 export const closestPt_PtSeg = (
-  pt: VarAD[],
-  [start, end]: VarAD[][]
-): VarAD[] => {
+  pt: ad.Num[],
+  [start, end]: ad.Num[][]
+): ad.Num[] => {
   const EPS0 = 10e-3;
   const lensq = max(ops.vdistsq(start, end), EPS0); // Avoid a divide-by-0 if the line is too small
 

--- a/packages/core/src/contrib/__tests__/Constraints.test.ts
+++ b/packages/core/src/contrib/__tests__/Constraints.test.ts
@@ -6,9 +6,9 @@ import {
   _rectangles,
 } from "contrib/__testfixtures__/TestShapes.input";
 import { genCode, secondaryGraph } from "engine/Autodiff";
-import { VarAD } from "types/ad";
+import * as ad from "types/ad";
 
-const numOf = (x: VarAD) => {
+const numOf = (x: ad.Num) => {
   const g = secondaryGraph([x]);
   const f = genCode(g);
   const [y] = f([]).secondary; // no inputs, so, empty array
@@ -175,13 +175,13 @@ describe("simple constraint", () => {
 });
 
 describe("general constraints", () => {
-  const expectSatified = (x: VarAD) => {
+  const expectSatified = (x: ad.Num) => {
     expect(numOf(x)).toBeLessThanOrEqual(1e-5);
   };
-  const expectJustSatified = (x: VarAD) => {
+  const expectJustSatified = (x: ad.Num) => {
     expect(numOf(x)).toBeCloseTo(0, 5);
   };
-  const expectNotSatisfied = (x: VarAD) => {
+  const expectNotSatisfied = (x: ad.Num) => {
     expect(numOf(x)).toBeGreaterThan(5);
   };
 

--- a/packages/core/src/contrib/__tests__/Minkowski.test.ts
+++ b/packages/core/src/contrib/__tests__/Minkowski.test.ts
@@ -7,13 +7,13 @@ import {
 import { genCode, ops, secondaryGraph } from "engine/Autodiff";
 import { sub } from "engine/AutodiffFunctions";
 import * as BBox from "engine/BBox";
-import { Pt2, VarAD } from "types/ad";
+import * as ad from "types/ad";
 
 const digitPrecision = 4;
 
 describe("rectangleDifference", () => {
   const expectRectDiff = (
-    result: [Pt2, Pt2],
+    result: [ad.Pt2, ad.Pt2],
     expected: [[number, number], [number, number]]
   ) => {
     const g = secondaryGraph([
@@ -114,7 +114,7 @@ describe("outwardUnitNormal", () => {
 });
 
 describe("halfPlaneSDF", () => {
-  const numOf = (x: VarAD) => {
+  const numOf = (x: ad.Num) => {
     const g = secondaryGraph([x]);
     const f = genCode(g);
     const [y] = f([]).secondary; // no inputs, so, empty array
@@ -139,8 +139,8 @@ describe("halfPlaneSDF", () => {
 
 describe("convexPartitions", () => {
   // note: in each of these examples, we don't need to do anything special to
-  // convert VarADs to numbers because all the VarADs we're using happen to
-  // already be constants
+  // convert `ad.Num`s to numbers because all the `ad.Num`s we're using happen
+  // to already be constants
 
   // https://link.springer.com/content/pdf/10.1007/3-540-12689-9_105.pdf
   // point locations approximated by tracing in Inkscape; also note, this

--- a/packages/core/src/contrib/__tests__/Objectives.test.ts
+++ b/packages/core/src/contrib/__tests__/Objectives.test.ts
@@ -1,8 +1,8 @@
 import { objDict } from "contrib/Objectives";
 import { genCode, secondaryGraph } from "engine/Autodiff";
-import { VarAD } from "types/ad";
+import * as ad from "types/ad";
 
-const numOf = (x: VarAD) => {
+const numOf = (x: ad.Num) => {
   const g = secondaryGraph([x]);
   const f = genCode(g);
   const [y] = f([]).secondary; // no inputs, so, empty array

--- a/packages/core/src/contrib/__tests__/ObjectivesUtils.test.ts
+++ b/packages/core/src/contrib/__tests__/ObjectivesUtils.test.ts
@@ -1,11 +1,11 @@
 import { inDirection } from "contrib/ObjectivesUtils";
 import { genCode, secondaryGraph } from "engine/Autodiff";
-import { VarAD } from "types/ad";
+import * as ad from "types/ad";
 
 const testShape = { center: { contents: [0, 2] } };
 const testRefShape = { center: { contents: [1, 1] } };
 
-const numOf = (x: VarAD) => {
+const numOf = (x: ad.Num) => {
   const g = secondaryGraph([x]);
   const f = genCode(g);
   const [y] = f([]).secondary; // no inputs, so, empty array

--- a/packages/core/src/engine/Autodiff.test.ts
+++ b/packages/core/src/engine/Autodiff.test.ts
@@ -10,7 +10,6 @@ import {
 import * as _ from "lodash";
 import seedrandom from "seedrandom";
 import * as ad from "types/ad";
-import { VarAD } from "types/ad";
 import { eqList, randList } from "utils/Util";
 import {
   add,
@@ -308,7 +307,7 @@ describe("polyRoots tests", () => {
     expect(f([x])).toEqual({ gradient: [-1], primary: -x, secondary: [] });
   });
 
-  type F = (v: VarAD, w: VarAD) => VarAD;
+  type F = (v: ad.Num, w: ad.Num) => ad.Num;
 
   // check that `polyRoots` gives the same answer as just doing symbolic
   // differentiation on the quadratic formula

--- a/packages/core/src/engine/Autodiff.ts
+++ b/packages/core/src/engine/Autodiff.ts
@@ -3,7 +3,6 @@ import consola, { LogLevel } from "consola";
 import * as _ from "lodash";
 import { EigenvalueDecomposition, Matrix } from "ml-matrix";
 import * as ad from "types/ad";
-import { GradGraphs, VarAD } from "types/ad";
 import { WeightInfo } from "types/state";
 import { Multidigraph } from "utils/Graph";
 import { safe, zip2 } from "utils/Util";
@@ -50,7 +49,7 @@ export const input = ({ key, val }: Omit<ad.Input, "tag">): ad.Input => ({
 export const makeADInputVars = (xs: number[], start = 0): ad.Input[] =>
   xs.map((val, i) => input({ key: start + i, val }));
 
-// every VarAD is already an ad.Node, but this function returns a new object
+// every ad.Num is already an ad.Node, but this function returns a new object
 // with all the children removed
 const makeNode = (x: ad.Expr): ad.Node => {
   if (typeof x === "number") {
@@ -100,7 +99,7 @@ const makeNode = (x: ad.Expr): ad.Node => {
   }
 };
 
-const unarySensitivity = (z: ad.Unary): VarAD => {
+const unarySensitivity = (z: ad.Unary): ad.Num => {
   const { unop, param: v } = z;
   switch (unop) {
     case "neg": {
@@ -187,7 +186,7 @@ const unarySensitivity = (z: ad.Unary): VarAD => {
   }
 };
 
-const binarySensitivities = (z: ad.Binary): { left: VarAD; right: VarAD } => {
+const binarySensitivities = (z: ad.Binary): { left: ad.Num; right: ad.Num } => {
   const { binop, left: v, right: w } = z;
   switch (binop) {
     case "+": {
@@ -250,7 +249,7 @@ const rankEdge = (edge: ad.Edge): number => {
 interface Child {
   child: ad.Expr;
   name: ad.Edge;
-  sensitivity: VarAD[][]; // rows for parent, columns for child
+  sensitivity: ad.Num[][]; // rows for parent, columns for child
 }
 
 // note that this function constructs the sensitivities even when we don't need
@@ -313,17 +312,17 @@ const children = (x: ad.Expr): Child[] => {
       // https://www.skewray.com/articles/how-do-the-roots-of-a-polynomial-depend-on-the-coefficients
 
       const n = x.coeffs.length;
-      const derivCoeffs: VarAD[] = x.coeffs.map((c, i) => mul(i, c));
+      const derivCoeffs: ad.Num[] = x.coeffs.map((c, i) => mul(i, c));
       derivCoeffs.shift();
       // the polynomial is assumed monic, so `x.coeffs` doesn't include the
       // coefficient 1 on the highest-degree term
       derivCoeffs.push(n);
 
-      const sensitivities: VarAD[][] = x.coeffs.map((_, index) => {
-        const t: VarAD = { tag: "Index", index, vec: x }; // a root
+      const sensitivities: ad.Num[][] = x.coeffs.map((_, index) => {
+        const t: ad.Num = { tag: "Index", index, vec: x }; // a root
 
-        let power: VarAD = 1;
-        const powers: VarAD[] = [power];
+        let power: ad.Num = 1;
+        const powers: ad.Num[] = [power];
         for (let i = 1; i < n; i++) {
           power = mul(power, t);
           powers.push(power);
@@ -385,7 +384,7 @@ const getInputs = (
  * to any given gradient node are added up according to that total order.
  */
 export const makeGraph = (
-  outputs: Omit<ad.Outputs<VarAD>, "gradient">
+  outputs: Omit<ad.Outputs<ad.Num>, "gradient">
 ): ad.Graph => {
   const graph = new Multidigraph<ad.Id, ad.Node, ad.Edge>();
   const nodes = new Map<ad.Expr, ad.Id>();
@@ -452,7 +451,7 @@ export const makeGraph = (
   // concatenation doesn't cause any problems, because no stringified Edge
   // contains an underscore, and every Id starts with an underscore, so it's
   // essentially just three components separated by underscores
-  const sensitivities = new Map<`${ad.Edge}${ad.Id}${ad.Id}`, VarAD[][]>();
+  const sensitivities = new Map<`${ad.Edge}${ad.Id}${ad.Id}`, ad.Num[][]>();
   while (!edges.isEmpty()) {
     const [{ child, name, sensitivity }, parent] = edges.dequeue();
     const [v, w] = addEdge(child, parent, name);
@@ -585,14 +584,14 @@ export const makeGraph = (
 /**
  * Construct a graph with a primary output but no secondary outputs.
  */
-export const primaryGraph = (output: VarAD): ad.Graph =>
+export const primaryGraph = (output: ad.Num): ad.Graph =>
   makeGraph({ primary: output, secondary: [] });
 
 /**
  * Construct a graph from an array of only secondary outputs, for which we don't
  * care about the gradient. The primary output is just the constant 1.
  */
-export const secondaryGraph = (outputs: VarAD[]): ad.Graph =>
+export const secondaryGraph = (outputs: ad.Num[]): ad.Graph =>
   // use 1 because makeGraph always constructs a constant gradient node 1 for
   // the primary output, and so if that's already present in the graph then we
   // have one fewer node total
@@ -604,7 +603,7 @@ export const secondaryGraph = (outputs: VarAD[]): ad.Graph =>
  * Creates a wrapper node around a node `v` to store log info. Dumps node value (during evaluation) to the console. You must use the node that `debug` returns, otherwise the debug information will not appear.
  * For more documentation on how to use this function, see the Penrose wiki page.
  */
-export const debug = (v: VarAD, info = "no additional info"): ad.Debug => ({
+export const debug = (v: ad.Num, info = "no additional info"): ad.Debug => ({
   tag: "Debug",
   node: v,
   info,
@@ -613,7 +612,7 @@ export const debug = (v: VarAD, info = "no additional info"): ad.Debug => ({
 // ----------------- Other ops
 
 /**
- * Some vector operations that can be used on `VarAD`.
+ * Some vector operations that can be used on `ad.Num`.
  */
 export const ops = {
   // Note that these ops MUST use the custom var ops for grads
@@ -622,17 +621,17 @@ export const ops = {
   /**
    * Return the norm of the 2-vector `[c1, c2]`.
    */
-  norm: (c1: VarAD, c2: VarAD): VarAD => ops.vnorm([c1, c2]),
+  norm: (c1: ad.Num, c2: ad.Num): ad.Num => ops.vnorm([c1, c2]),
 
   /**
    * Return the Euclidean distance between scalars `c1, c2`.
    */
-  dist: (c1: VarAD, c2: VarAD): VarAD => ops.vnorm([c1, c2]),
+  dist: (c1: ad.Num, c2: ad.Num): ad.Num => ops.vnorm([c1, c2]),
 
   /**
    * Return the sum of vectors `v1, v2.
    */
-  vadd: (v1: VarAD[], v2: VarAD[]): VarAD[] => {
+  vadd: (v1: ad.Num[], v2: ad.Num[]): ad.Num[] => {
     if (v1.length !== v2.length) {
       throw Error("expected vectors of same length");
     }
@@ -644,7 +643,7 @@ export const ops = {
   /**
    * Return the difference of vectors `v1, v2.
    */
-  vsub: (v1: VarAD[], v2: VarAD[]): VarAD[] => {
+  vsub: (v1: ad.Num[], v2: ad.Num[]): ad.Num[] => {
     if (v1.length !== v2.length) {
       throw Error("expected vectors of same length");
     }
@@ -656,16 +655,16 @@ export const ops = {
   /**
    * Return the Euclidean norm squared of vector `v`.
    */
-  vnormsq: (v: VarAD[]): VarAD => {
+  vnormsq: (v: ad.Num[]): ad.Num => {
     const res = v.map((e) => squared(e));
-    return _.reduce(res, (x: VarAD, y) => add(x, y), 0);
+    return _.reduce(res, (x: ad.Num, y) => add(x, y), 0);
     // Note (performance): the use of 0 adds an extra +0 to the comp graph, but lets us prevent undefined if the list is empty
   },
 
   /**
    * Return the Euclidean norm of vector `v`.
    */
-  vnorm: (v: VarAD[]): VarAD => {
+  vnorm: (v: ad.Num[]): ad.Num => {
     const res = ops.vnormsq(v);
     return sqrt(res);
   },
@@ -673,28 +672,28 @@ export const ops = {
   /**
    * Return the vector `v` multiplied by scalar `c`.
    */
-  vmul: (c: VarAD, v: VarAD[]): VarAD[] => {
+  vmul: (c: ad.Num, v: ad.Num[]): ad.Num[] => {
     return v.map((e) => mul(c, e));
   },
 
   /**
    * Return the vector `v`, scaled by `-1`.
    */
-  vneg: (v: VarAD[]): VarAD[] => {
+  vneg: (v: ad.Num[]): ad.Num[] => {
     return ops.vmul(-1, v);
   },
 
   /**
    * Return the vector `v` divided by scalar `c`.
    */
-  vdiv: (v: VarAD[], c: VarAD): VarAD[] => {
+  vdiv: (v: ad.Num[], c: ad.Num): ad.Num[] => {
     return v.map((e) => div(e, c));
   },
 
   /**
    * Return the vector `v`, normalized.
    */
-  vnormalize: (v: VarAD[]): VarAD[] => {
+  vnormalize: (v: ad.Num[]): ad.Num[] => {
     const vsize = add(ops.vnorm(v), EPS_DENOM);
     return ops.vdiv(v, vsize);
   },
@@ -702,7 +701,7 @@ export const ops = {
   /**
    * Return the Euclidean distance between vectors `v` and `w`.
    */
-  vdist: (v: VarAD[], w: VarAD[]): VarAD => {
+  vdist: (v: ad.Num[], w: ad.Num[]): ad.Num => {
     if (v.length !== w.length) {
       throw Error("expected vectors of same length");
     }
@@ -712,7 +711,7 @@ export const ops = {
   /**
    * Return the Euclidean distance squared between vectors `v` and `w`.
    */
-  vdistsq: (v: VarAD[], w: VarAD[]): VarAD => {
+  vdistsq: (v: ad.Num[], w: ad.Num[]): ad.Num => {
     if (v.length !== w.length) {
       throw Error("expected vectors of same length");
     }
@@ -724,13 +723,13 @@ export const ops = {
    * Return the dot product of vectors `v1, v2`.
    * Note: if you want to compute a norm squared, use `vnormsq` instead, it generates a smaller computational graph
    */
-  vdot: (v1: VarAD[], v2: VarAD[]): VarAD => {
+  vdot: (v1: ad.Num[], v2: ad.Num[]): ad.Num => {
     if (v1.length !== v2.length) {
       throw Error("expected vectors of same length");
     }
 
     const res = _.zipWith(v1, v2, mul);
-    return _.reduce(res, (x: VarAD, y) => add(x, y), 0);
+    return _.reduce(res, (x: ad.Num, y) => add(x, y), 0);
   },
 
   /**
@@ -738,7 +737,7 @@ export const ops = {
    * Assumes that both u and v have nonzero magnitude.
    * The returned value will be in the range [0,pi].
    */
-  angleBetween: (u: VarAD[], v: VarAD[]): VarAD => {
+  angleBetween: (u: ad.Num[], v: ad.Num[]): ad.Num => {
     if (u.length !== v.length) {
       throw Error("expected vectors of same length");
     }
@@ -758,7 +757,7 @@ export const ops = {
    * Assumes that both u and v are 2D vectors and have nonzero magnitude.
    * The returned value will be in the range [-pi,pi].
    */
-  angleFrom: (u: VarAD[], v: VarAD[]): VarAD => {
+  angleFrom: (u: ad.Num[], v: ad.Num[]): ad.Num => {
     if (u.length !== v.length) {
       throw Error("expected vectors of same length");
     }
@@ -772,28 +771,28 @@ export const ops = {
   /**
    * Return the sum of elements in vector `v`.
    */
-  vsum: (v: VarAD[]): VarAD => {
-    return _.reduce(v, (x: VarAD, y) => add(x, y), 0);
+  vsum: (v: ad.Num[]): ad.Num => {
+    return _.reduce(v, (x: ad.Num, y) => add(x, y), 0);
   },
 
   /**
    * Return `v + c * u`.
    */
-  vmove: (v: VarAD[], c: VarAD, u: VarAD[]): VarAD[] => {
+  vmove: (v: ad.Num[], c: ad.Num, u: ad.Num[]): ad.Num[] => {
     return ops.vadd(v, ops.vmul(c, u));
   },
 
   /**
    * Rotate a 2D point `[x, y]` by 90 degrees counterclockwise.
    */
-  rot90: ([x, y]: VarAD[]): VarAD[] => {
+  rot90: ([x, y]: ad.Num[]): ad.Num[] => {
     return [neg(y), x];
   },
 
   /**
    * Rotate a 2D point `[x, y]` by a degrees counterclockwise.
    */
-  vrot: ([x, y]: VarAD[], a: VarAD): VarAD[] => {
+  vrot: ([x, y]: ad.Num[], a: ad.Num): ad.Num[] => {
     const angle = div(mul(a, Math.PI), 180);
     const x2 = sub(mul(cos(angle), x), mul(sin(angle), y));
     const y2 = add(mul(sin(angle), x), mul(cos(angle), y));
@@ -803,7 +802,7 @@ export const ops = {
   /**
    * Return 2D determinant/cross product of 2D vectors
    */
-  cross2: (u: VarAD[], v: VarAD[]): VarAD => {
+  cross2: (u: ad.Num[], v: ad.Num[]): ad.Num => {
     if (u.length !== 2 || v.length !== 2) {
       throw Error("expected two 2-vectors");
     }
@@ -813,7 +812,7 @@ export const ops = {
   /**
    * Return 3D cross product of 3D vectors
    */
-  cross3: (u: VarAD[], v: VarAD[]): VarAD[] => {
+  cross3: (u: ad.Num[], v: ad.Num[]): ad.Num[] => {
     if (u.length !== 3 || v.length !== 3) {
       throw Error("expected two 3-vectors");
     }
@@ -829,7 +828,7 @@ export const ops = {
    * From https://github.com/thi-ng/umbrella/blob/develop/packages/vectors/src/angle-between.ts#L11
    * NOTE: This function has not been thoroughly tested
    */
-  angleBetween2: (v: VarAD[], w: VarAD[]): VarAD => {
+  angleBetween2: (v: ad.Num[], w: ad.Num[]): ad.Num => {
     if (v.length !== 2 || w.length !== 2) {
       throw Error("expected two 2-vectors");
     }
@@ -842,14 +841,14 @@ export const fns = {
   /**
    * Return the penalty `max(x, 0)`.
    */
-  toPenalty: (x: VarAD): VarAD => {
+  toPenalty: (x: ad.Num): ad.Num => {
     return squared(max(x, 0));
   },
 
   /**
    * Return the center of a shape.
    */
-  center: (props: any): VarAD[] => {
+  center: (props: any): ad.Num[] => {
     return props.center.contents;
   },
 };
@@ -1088,9 +1087,9 @@ const setWeights = (info: WeightInfo) => {
 export const energyAndGradCompiled = (
   xs: number[],
   xsVars: ad.Input[],
-  energyGraph: VarAD,
+  energyGraph: ad.Num,
   weightInfo: WeightInfo | undefined
-): { graphs: GradGraphs; f: ad.Compiled } => {
+): { graphs: ad.GradGraphs; f: ad.Compiled } => {
   // Set the weight nodes to have the right weight values (may have been updated at some point during the opt)
   if (weightInfo !== undefined) {
     setWeights(weightInfo);
@@ -1099,13 +1098,13 @@ export const energyAndGradCompiled = (
   // Set the leaves of the graph to have the new input values
   setInputs(xsVars, xs);
 
-  // Build an actual graph from the implicit VarAD structure
+  // Build an actual graph from the implicit ad.Num structure
   // Build symbolic gradient of f at xs on the energy graph
   const explicitGraph = primaryGraph(energyGraph);
 
-  const epWeightNode: VarAD | undefined = weightInfo?.epWeightNode; // Generate energy and gradient without weight
+  const epWeightNode: ad.Num | undefined = weightInfo?.epWeightNode; // Generate energy and gradient without weight
 
-  const graphs: GradGraphs = {
+  const graphs: ad.GradGraphs = {
     inputs: xsVars,
     weight: epWeightNode,
   };

--- a/packages/core/src/engine/AutodiffFunctions.ts
+++ b/packages/core/src/engine/AutodiffFunctions.ts
@@ -1,14 +1,13 @@
 import * as ad from "types/ad";
-import { VarAD } from "types/ad";
 
 const binary = (binop: ad.Binary["binop"]) => (
-  v: VarAD,
-  w: VarAD
+  v: ad.Num,
+  w: ad.Num
 ): ad.Binary => ({ tag: "Binary", binop, left: v, right: w });
 
-const nary = (op: ad.Nary["op"], bin: (v: VarAD, w: VarAD) => ad.Binary) => (
-  xs: VarAD[]
-): VarAD => {
+const nary = (op: ad.Nary["op"], bin: (v: ad.Num, w: ad.Num) => ad.Binary) => (
+  xs: ad.Num[]
+): ad.Num => {
   // interestingly, special-casing 1 and 2 args like this actually affects the
   // gradient by a nontrivial amount in some cases
   switch (xs.length) {
@@ -74,7 +73,7 @@ export const minN = nary("minN", min);
  * describes the angle made by a vector (x,y) with the x-axis.
  * Returns a value in radians, in the range [-pi,pi].
  */
-export const atan2 = (y: VarAD, x: VarAD): ad.Binary => ({
+export const atan2 = (y: ad.Num, x: ad.Num): ad.Binary => ({
   tag: "Binary",
   binop: "atan2",
   left: y,
@@ -88,7 +87,7 @@ export const pow = binary("pow");
 
 // --- Unary ops
 
-const unary = (unop: ad.Unary["unop"]) => (v: VarAD): ad.Unary => ({
+const unary = (unop: ad.Unary["unop"]) => (v: ad.Num): ad.Unary => ({
   tag: "Unary",
   unop,
   param: v,
@@ -241,7 +240,7 @@ export const trunc = unary("trunc");
 
 // ------- Discontinuous / noGrad ops
 
-const comp = (binop: ad.Comp["binop"]) => (v: VarAD, w: VarAD): ad.Comp => ({
+const comp = (binop: ad.Comp["binop"]) => (v: ad.Num, w: ad.Num): ad.Comp => ({
   tag: "Comp",
   binop,
   left: v,
@@ -281,7 +280,7 @@ export const or = logic("||");
 /**
  * Return a conditional `if(cond) then v else w`.
  */
-export const ifCond = (cond: ad.Bool, v: VarAD, w: VarAD): ad.Ternary => ({
+export const ifCond = (cond: ad.Bool, v: ad.Num, w: ad.Num): ad.Ternary => ({
   tag: "Ternary",
   cond,
   then: v,
@@ -295,7 +294,7 @@ export const ifCond = (cond: ad.Bool, v: VarAD, w: VarAD): ad.Ternary => ({
  * the coefficient on the term with degree `i` is `coeffs[i]`. Any root with a
  * nonzero imaginary component is replaced with `NaN`.
  */
-export const polyRoots = (coeffs: VarAD[]): VarAD[] => {
+export const polyRoots = (coeffs: ad.Num[]): ad.Num[] => {
   const nexus: ad.PolyRoots = { tag: "PolyRoots", coeffs };
   return coeffs.map((coeff, index) => ({ tag: "Index", index, vec: nexus }));
 };

--- a/packages/core/src/engine/BBox.ts
+++ b/packages/core/src/engine/BBox.ts
@@ -3,7 +3,7 @@ import { IEllipse } from "shapes/Ellipse";
 import { ILine } from "shapes/Line";
 import { IPath } from "shapes/Path";
 import { IRectangle } from "shapes/Rectangle";
-import { isPt2, Pt2, VarAD } from "types/ad";
+import * as ad from "types/ad";
 import { ICenter, IPoly, IRect, IRotate, IScale } from "types/shapes";
 import { ops } from "./Autodiff";
 import {
@@ -23,28 +23,28 @@ import {
 } from "./AutodiffFunctions";
 
 export interface IBBox {
-  width: VarAD;
-  height: VarAD;
-  center: Pt2;
+  width: ad.Num;
+  height: ad.Num;
+  center: ad.Pt2;
 }
 
 interface ICorners {
-  topRight: Pt2;
-  topLeft: Pt2;
-  bottomLeft: Pt2;
-  bottomRight: Pt2;
+  topRight: ad.Pt2;
+  topLeft: ad.Pt2;
+  bottomLeft: ad.Pt2;
+  bottomRight: ad.Pt2;
 }
 
 interface IIntervals {
-  xRange: [VarAD, VarAD];
-  yRange: [VarAD, VarAD];
+  xRange: [ad.Num, ad.Num];
+  yRange: [ad.Num, ad.Num];
 }
 
 interface IEdges {
-  top: [Pt2, Pt2];
-  bot: [Pt2, Pt2];
-  left: [Pt2, Pt2];
-  right: [Pt2, Pt2];
+  top: [ad.Pt2, ad.Pt2];
+  bot: [ad.Pt2, ad.Pt2];
+  left: [ad.Pt2, ad.Pt2];
+  right: [ad.Pt2, ad.Pt2];
 }
 
 export type BBox = IBBox;
@@ -59,7 +59,7 @@ export type Edges = IEdges;
  * Input: A width, height, and center.
  * Output: A new BBox.
  */
-export const bbox = (width: VarAD, height: VarAD, center: Pt2): BBox => {
+export const bbox = (width: ad.Num, height: ad.Num, center: ad.Pt2): BBox => {
   return {
     width,
     height,
@@ -72,7 +72,7 @@ export const corners = (b: BBox): Corners => {
   const halfHeight = div(b.height, 2);
   const nhalfWidth = neg(halfWidth);
   const nhalfHeight = neg(halfHeight);
-  const pts = <Pt2[]>[
+  const pts = <ad.Pt2[]>[
     [halfWidth, halfHeight],
     [nhalfWidth, halfHeight],
     [nhalfWidth, nhalfHeight],
@@ -91,7 +91,7 @@ export const corners = (b: BBox): Corners => {
  * Input: A BBox and an inflation parameter delta.
  * Output: A BBox inflated on all sides by delta.
  */
-export const inflate = (b: BBox, delta: VarAD): BBox => {
+export const inflate = (b: BBox, delta: ad.Num): BBox => {
   return bbox(
     add(b.width, add(delta, delta)),
     add(b.height, add(delta, delta)),
@@ -103,7 +103,7 @@ export const inflate = (b: BBox, delta: VarAD): BBox => {
  * Input: A BBox.
  * Output: The min X of the BBox.
  */
-export const minX = (b: BBox): VarAD => {
+export const minX = (b: BBox): ad.Num => {
   return corners(b).topLeft[0];
 };
 
@@ -111,7 +111,7 @@ export const minX = (b: BBox): VarAD => {
  * Input: A BBox.
  * Output: The max X of the BBox.
  */
-export const maxX = (b: BBox): VarAD => {
+export const maxX = (b: BBox): ad.Num => {
   return corners(b).bottomRight[0];
 };
 
@@ -119,7 +119,7 @@ export const maxX = (b: BBox): VarAD => {
  * Input: A BBox.
  * Output: The min Y of the BBox.
  */
-export const minY = (b: BBox): VarAD => {
+export const minY = (b: BBox): ad.Num => {
   return corners(b).bottomRight[1];
 };
 
@@ -127,7 +127,7 @@ export const minY = (b: BBox): VarAD => {
  * Input: A BBox.
  * Output: The max Y of the BBox.
  */
-export const maxY = (b: BBox): VarAD => {
+export const maxY = (b: BBox): ad.Num => {
   return corners(b).topLeft[1];
 };
 
@@ -135,7 +135,7 @@ export const maxY = (b: BBox): VarAD => {
  * Input: A BBox.
  * Output: The X interval of the BBox.
  */
-export const xRange = (b: BBox): [VarAD, VarAD] => {
+export const xRange = (b: BBox): [ad.Num, ad.Num] => {
   return [minX(b), maxX(b)];
 };
 
@@ -143,7 +143,7 @@ export const xRange = (b: BBox): [VarAD, VarAD] => {
  * Input: A BBox.
  * Output: The Y interval of the BBox.
  */
-export const yRange = (b: BBox): [VarAD, VarAD] => {
+export const yRange = (b: BBox): [ad.Num, ad.Num] => {
   return [minY(b), maxY(b)];
 };
 
@@ -160,30 +160,30 @@ export const edges = (b: BBox): Edges => {
   };
 };
 
-export const bboxFromPoints = (points: Pt2[]): BBox => {
-  const minCorner = points.reduce((corner: Pt2, point: Pt2) => [
+export const bboxFromPoints = (points: ad.Pt2[]): BBox => {
+  const minCorner = points.reduce((corner: ad.Pt2, point: ad.Pt2) => [
     min(corner[0], point[0]),
     min(corner[1], point[1]),
   ]);
-  const maxCorner = points.reduce((corner: Pt2, point: Pt2) => [
+  const maxCorner = points.reduce((corner: ad.Pt2, point: ad.Pt2) => [
     max(corner[0], point[0]),
     max(corner[1], point[1]),
   ]);
   const w = sub(maxCorner[0], minCorner[0]);
   const h = sub(maxCorner[1], minCorner[1]);
   const center = ops.vdiv(ops.vadd(minCorner, maxCorner), 2);
-  if (!isPt2(center)) {
+  if (!ad.isPt2(center)) {
     throw new Error("ops.vadd and ops.vdiv did not preserve dimension");
   }
   return bbox(w, h, center);
 };
 
 export const bboxFromRotatedRect = (
-  center: Pt2,
-  w: VarAD,
-  h: VarAD,
-  clockwise: VarAD,
-  strokeWidth: VarAD
+  center: ad.Pt2,
+  w: ad.Num,
+  h: ad.Num,
+  clockwise: ad.Num,
+  strokeWidth: ad.Num
 ): BBox => {
   const counterclockwise = neg(clockwise);
   const down = ops.vrot([0, -1], counterclockwise);
@@ -202,7 +202,12 @@ export const bboxFromRotatedRect = (
   const botLeft = ops.vadd(topLeft, left);
   const botRight = ops.vadd(topRight, left);
   if (
-    !(isPt2(topLeft) && isPt2(topRight) && isPt2(botLeft) && isPt2(botRight))
+    !(
+      ad.isPt2(topLeft) &&
+      ad.isPt2(topRight) &&
+      ad.isPt2(botLeft) &&
+      ad.isPt2(botRight)
+    )
   ) {
     throw new Error("ops.vadd did not preserve dimension");
   }
@@ -212,7 +217,7 @@ export const bboxFromRotatedRect = (
 
 export const bboxFromCircle = ({ r, center, strokeWidth }: ICircle): BBox => {
   // https://github.com/penrose/penrose/issues/715
-  if (!isPt2(center.contents)) {
+  if (!ad.isPt2(center.contents)) {
     throw new Error(
       `bboxFromCircle expected center to be Pt2, but got length ${center.contents.length}`
     );
@@ -229,7 +234,7 @@ export const bboxFromEllipse = ({
   strokeWidth,
 }: IEllipse): BBox => {
   // https://github.com/penrose/penrose/issues/715
-  if (!isPt2(center.contents)) {
+  if (!ad.isPt2(center.contents)) {
     throw new Error(
       `bboxFromEllipse expected center to be Pt2, but got length ${center.contents.length}`
     );
@@ -251,7 +256,7 @@ export const bboxFromRect = ({
   strokeWidth,
 }: IRectangle): BBox => {
   // https://github.com/penrose/penrose/issues/715
-  if (!isPt2(center.contents)) {
+  if (!ad.isPt2(center.contents)) {
     throw new Error(
       `bboxFromRect expected center to be Pt2, but got length ${center.contents.length}`
     );
@@ -272,7 +277,7 @@ export const bboxFromRectlike = ({
   rotation,
 }: ICenter & IRect & IRotate): BBox => {
   // https://github.com/penrose/penrose/issues/715
-  if (!isPt2(center.contents)) {
+  if (!ad.isPt2(center.contents)) {
     throw new Error(
       `bboxFromRectlike expected center to be Pt2, but got length ${center.contents.length}`
     );
@@ -291,7 +296,7 @@ export const bboxFromPolygon = ({ points, scale }: IPoly & IScale): BBox => {
   return bboxFromPoints(
     points.contents.map((point) => {
       const pt = ops.vmul(scale.contents, point);
-      if (isPt2(pt)) {
+      if (ad.isPt2(pt)) {
         return pt;
       } else {
         throw new Error(
@@ -304,12 +309,12 @@ export const bboxFromPolygon = ({ points, scale }: IPoly & IScale): BBox => {
 
 export const bboxFromLinelike = ({ start, end, strokeWidth }: ILine): BBox => {
   // https://github.com/penrose/penrose/issues/715
-  if (!isPt2(start.contents)) {
+  if (!ad.isPt2(start.contents)) {
     throw new Error(
       `bboxFromLinelike expected start to be Pt2, but got length ${start.contents.length}`
     );
   }
-  if (!isPt2(end.contents)) {
+  if (!ad.isPt2(end.contents)) {
     throw new Error(
       `bboxFromLinelike expected end to be Pt2, but got length ${end.contents.length}`
     );
@@ -326,7 +331,7 @@ export const bboxFromLinelike = ({ start, end, strokeWidth }: ILine): BBox => {
       ops.vadd(end.contents, d),
       ops.vsub(end.contents, d),
     ].map((point) => {
-      if (isPt2(point)) {
+      if (ad.isPt2(point)) {
         return point;
       } else {
         throw new Error("ops did not preserve dimension");
@@ -351,21 +356,21 @@ export const bboxFromPath = ({ d }: IPath): BBox => {
       `bboxFromPath expected first command subpath to be CoordV, but got ${first.tag}`
     );
   }
-  if (!isPt2(first.contents)) {
+  if (!ad.isPt2(first.contents)) {
     throw new Error(
       `bboxFromPath expected cursor to be Pt2, but got length ${first.contents.length}`
     );
   }
-  let cursor: Pt2 = first.contents;
-  let control: Pt2 = cursor; // used by T and S
+  let cursor: ad.Pt2 = first.contents;
+  let control: ad.Pt2 = cursor; // used by T and S
 
-  const points: Pt2[] = [];
+  const points: ad.Pt2[] = [];
   for (const { cmd, contents } of p) {
     const next = cmd === "Z" ? first : contents[contents.length - 1];
     if (next.tag !== "CoordV") {
       throw new Error("bboxFromPath expected next cursor to be CoordV");
     }
-    if (!isPt2(next.contents)) {
+    if (!ad.isPt2(next.contents)) {
       throw new Error("bboxFromPath expected next cursor to be Pt2");
     }
     let nextControl = next.contents;
@@ -376,7 +381,7 @@ export const bboxFromPath = ({ d }: IPath): BBox => {
       points.push(cursor, next.contents);
     } else if (cmd === "Q") {
       const cp = contents[0].contents;
-      if (!isPt2(cp)) {
+      if (!ad.isPt2(cp)) {
         throw new Error("bboxFromPath expected Q cp to be Pt2");
       }
       points.push(cursor, cp, next.contents);
@@ -384,17 +389,17 @@ export const bboxFromPath = ({ d }: IPath): BBox => {
     } else if (cmd === "C") {
       const cp1 = contents[0].contents;
       const cp2 = contents[1].contents;
-      if (!isPt2(cp1)) {
+      if (!ad.isPt2(cp1)) {
         throw new Error("bboxFromPath expected C cp1 to be Pt2");
       }
-      if (!isPt2(cp2)) {
+      if (!ad.isPt2(cp2)) {
         throw new Error("bboxFromPath expected C cp2 to be Pt2");
       }
       points.push(cursor, cp1, cp2, next.contents);
       nextControl = cp2;
     } else if (cmd === "T") {
       const cp = ops.vadd(cursor, ops.vsub(cursor, control));
-      if (!isPt2(cp)) {
+      if (!ad.isPt2(cp)) {
         throw new Error("ops did not preserve dimension");
       }
       points.push(cursor, cp, next.contents);
@@ -402,10 +407,10 @@ export const bboxFromPath = ({ d }: IPath): BBox => {
     } else if (cmd === "S") {
       const cp1 = ops.vadd(cursor, ops.vsub(cursor, control));
       const cp2 = contents[0].contents;
-      if (!isPt2(cp1)) {
+      if (!ad.isPt2(cp1)) {
         throw new Error("ops did not preserve dimension");
       }
-      if (!isPt2(cp2)) {
+      if (!ad.isPt2(cp2)) {
         throw new Error("bboxFromPath expected S cp2 to be Pt2");
       }
       points.push(cursor, cp1, cp2, next.contents);

--- a/packages/core/src/engine/Evaluator.ts
+++ b/packages/core/src/engine/Evaluator.ts
@@ -8,10 +8,10 @@ import {
 } from "engine/EngineUtils";
 import { mapValues } from "lodash";
 // For deep-cloning the translation
-// Note: the translation should not have cycles! If it does, use the approach that `Optimizer` takes to `clone` (clearing the VarADs).
+// Note: the translation should not have cycles! If it does, use the approach that `Optimizer` takes to `clone` (clearing the `ad.Num`s).
 import rfdc from "rfdc";
 import seedrandom from "seedrandom";
-import { OptDebugInfo, VarAD } from "types/ad";
+import * as ad from "types/ad";
 import { A } from "types/ast";
 import { ShapeAD } from "types/shape";
 import { Fn, FnDone, State, VaryMap } from "types/state";
@@ -52,7 +52,7 @@ const log = consola.create({ level: LogLevel.Warn }).withScope("Evaluator");
  */
 export const evalShapes = (rng: seedrandom.prng, s: State): ShapeAD[] => {
   // Update the stale varyingMap from the translation
-  // TODO: Evaluating the shapes for display is still done via interpretation on VarADs; not compiled
+  // TODO: Evaluating the shapes for display is still done via interpretation on `ad.Num`s; not compiled
 
   const varyingValuesDiff = [...s.varyingValues];
   s.varyingMap = genPathMap(s.varyingPaths, varyingValuesDiff);
@@ -70,19 +70,19 @@ export const evalShapes = (rng: seedrandom.prng, s: State): ShapeAD[] => {
   // Insert all varying vals
   const transWithVarying = insertVaryings(s.translation, varyingMapList);
 
-  // Clone translation to use in this top-level call, because it mutates the translation while interpreting the energy function in order to cache/reuse VarAD (computation) results
+  // Clone translation to use in this top-level call, because it mutates the translation while interpreting the energy function in order to cache/reuse ad.Num (computation) results
   const trans = clone(transWithVarying);
 
   // Find out all the GPI expressions in the translation
-  const shapeExprs: IFGPI<VarAD>[] = s.shapePaths.map(
-    (p: Path<A>) => findExprSafe(trans, p) as IFGPI<VarAD>
+  const shapeExprs: IFGPI<ad.Num>[] = s.shapePaths.map(
+    (p: Path<A>) => findExprSafe(trans, p) as IFGPI<ad.Num>
   );
 
   log.info("shapePaths", s.shapePaths.map(prettyPrintPath));
 
   // Evaluate each of the shapes (note: the translation is mutated, not returned)
   const [shapesEvaled]: [ShapeAD[], Translation] = shapeExprs.reduce(
-    ([currShapes, tr]: [ShapeAD[], Translation], e: IFGPI<VarAD>) =>
+    ([currShapes, tr]: [ShapeAD[], Translation], e: IFGPI<ad.Num>) =>
       evalShape(rng, e, tr, s.varyingMap, currShapes, optDebugInfo),
     [[], trans]
   );
@@ -111,7 +111,7 @@ const sameName = <T>(given: Value<T>, expected: string): boolean => {
   return given.contents === expected;
 };
 
-const doneFloat = (n: VarAD): TagExpr<VarAD> => ({
+const doneFloat = (n: ad.Num): TagExpr<ad.Num> => ({
   tag: "Done",
   contents: { tag: "FloatV", contents: n },
 });
@@ -125,10 +125,10 @@ const doneFloat = (n: VarAD): TagExpr<VarAD> => ({
  */
 export const insertVaryings = (
   trans: Translation,
-  varyingMap: [Path<A>, VarAD][]
+  varyingMap: [Path<A>, ad.Num][]
 ): Translation => {
   return varyingMap.reduce(
-    (tr: Translation, [path, val]: [Path<A>, VarAD]) =>
+    (tr: Translation, [path, val]: [Path<A>, ad.Num]) =>
       insertExpr(path, doneFloat(val), tr),
     trans
   );
@@ -145,15 +145,15 @@ export const evalFns = (
   rng: seedrandom.prng,
   fns: Fn[],
   trans: Translation,
-  varyingMap: VaryMap<VarAD>
-): FnDone<VarAD>[] => fns.map((f) => evalFn(rng, f, trans, varyingMap));
+  varyingMap: VaryMap<ad.Num>
+): FnDone<ad.Num>[] => fns.map((f) => evalFn(rng, f, trans, varyingMap));
 
 export const evalFn = (
   rng: seedrandom.prng,
   fn: Fn,
   trans: Translation,
-  varyingMap: VaryMap<VarAD>
-): FnDone<VarAD> => {
+  varyingMap: VaryMap<ad.Num>
+): FnDone<ad.Num> => {
   const noOptDebugInfo = {
     gradient: new Map(),
     gradientPreconditioned: new Map(),
@@ -177,30 +177,30 @@ export const evalFn = (
  */
 export const evalShape = (
   rng: seedrandom.prng,
-  shapeExpr: IFGPI<VarAD>,
+  shapeExpr: IFGPI<ad.Num>,
   trans: Translation,
   varyingVars: VaryMap,
   shapes: ShapeAD[],
-  optDebugInfo: OptDebugInfo
+  optDebugInfo: ad.OptDebugInfo
 ): [ShapeAD[], Translation] => {
   const [shapeType, propExprs] = shapeExpr.contents;
 
   // Make sure all props are evaluated to values instead of shapes
   const props = mapValues(
     propExprs,
-    (prop: TagExpr<VarAD>): Value<VarAD> => {
+    (prop: TagExpr<ad.Num>): Value<ad.Num> => {
       // TODO: Refactor these cases to be more concise
       switch (prop.tag) {
         case "OptEval": {
           // For display, evaluate expressions with autodiff types (incl. varying vars as AD types), then convert to numbers
           // (The tradeoff for using autodiff types is that evaluating the display step will be a little slower, but then we won't have to write two versions of all computations)
-          const res: Value<VarAD> = (evalExpr(
+          const res: Value<ad.Num> = (evalExpr(
             rng,
             prop.contents,
             trans,
             varyingVars,
             optDebugInfo
-          ) as IVal<VarAD>).contents;
+          ) as IVal<ad.Num>).contents;
           return res;
         }
         case "Done": {
@@ -231,12 +231,12 @@ export const evalExprs = (
   rng: seedrandom.prng,
   es: Expr<A>[],
   trans: Translation,
-  varyingVars?: VaryMap<VarAD>,
-  optDebugInfo?: OptDebugInfo
-): ArgVal<VarAD>[] =>
+  varyingVars?: VaryMap<ad.Num>,
+  optDebugInfo?: ad.OptDebugInfo
+): ArgVal<ad.Num>[] =>
   es.map((e) => evalExpr(rng, e, trans, varyingVars, optDebugInfo));
 
-function toFloatVal(a: ArgVal<VarAD>): VarAD {
+function toFloatVal(a: ArgVal<ad.Num>): ad.Num {
   if (a.tag === "Val") {
     const res = a.contents;
     if (res.tag === "FloatV") {
@@ -283,9 +283,9 @@ export const evalExpr = (
   rng: seedrandom.prng,
   e: Expr<A>,
   trans: Translation,
-  varyingVars?: VaryMap<VarAD>,
-  optDebugInfo?: OptDebugInfo
-): ArgVal<VarAD> => {
+  varyingVars?: VaryMap<ad.Num>,
+  optDebugInfo?: ad.OptDebugInfo
+): ArgVal<ad.Num> => {
   // console.log("evalExpr", e);
 
   switch (e.tag) {
@@ -303,7 +303,7 @@ export const evalExpr = (
     }
 
     case "VaryAD": {
-      // This VarAD had already been converted to an Expr as it was inserted in the translation during accesspath initialization; they are only generated by `floatValToExpr`. Now we just convert it back to a value.
+      // This ad.Num had already been converted to an Expr as it was inserted in the translation during accesspath initialization; they are only generated by `floatValToExpr`. Now we just convert it back to a value.
       return { tag: "Val", contents: { tag: "FloatV", contents: e.contents } };
     }
 
@@ -320,7 +320,7 @@ export const evalExpr = (
     case "Fix": {
       const val = e.contents;
 
-      // Don't convert to VarAD if it's already been converted
+      // Don't convert to ad.Num if it's already been converted
       return {
         tag: "Val",
         // Fixed number is stored in translation as number, made differentiable when encountered
@@ -339,7 +339,7 @@ export const evalExpr = (
       return {
         tag: "Val",
         // HACK: coerce the type for now to let the compiler finish
-        contents: evalUOp(uOp, arg as IFloatV<VarAD> | IIntV),
+        contents: evalUOp(uOp, arg as IFloatV<ad.Num> | IIntV),
       };
     }
 
@@ -356,8 +356,8 @@ export const evalExpr = (
 
       const res = evalBinOp(
         binOp,
-        val1.contents as Value<VarAD>,
-        val2.contents as Value<VarAD>
+        val1.contents as Value<ad.Num>,
+        val2.contents as Value<ad.Num>
       );
 
       return {
@@ -499,7 +499,7 @@ export const evalExpr = (
       // COMBAK: Do float to int conversion in a more principled way. For now, convert float to int on demand
       if (v2.contents.tag === "FloatV") {
         // COMBAK: (ISSUE): Indices should not have "Fix"
-        const iObj: VarAD = v2.contents.contents;
+        const iObj: ad.Num = v2.contents.contents;
         if (typeof iObj !== "number") {
           throw Error("only constant vector element indices are supported");
         }
@@ -665,9 +665,9 @@ export const resolvePath = (
   rng: seedrandom.prng,
   path: Path<A>,
   trans: Translation,
-  varyingMap?: VaryMap<VarAD>,
-  optDebugInfo?: OptDebugInfo
-): ArgVal<VarAD> => {
+  varyingMap?: VaryMap<ad.Num>,
+  optDebugInfo?: ad.OptDebugInfo
+): ArgVal<ad.Num> => {
   // HACK: this is a temporary way to consistently compare paths. We will need to make varymap much more efficient
   let varyingVal;
   if (varyingMap) {
@@ -736,13 +736,13 @@ export const resolvePath = (
             // Evaluate each property path and cache the results (so, e.g. the next lookup just returns a Value)
             // `resolve path A.val.x = f(z, y)` ===> `f(z, y) evaluates to c` ===>
             // `set A.val.x = r` ===> `next lookup of A.val.x yields c instead of computing f(z, y)`
-            const val: Value<VarAD> = (evalExpr(
+            const val: Value<ad.Num> = (evalExpr(
               rng,
               propertyPath,
               trans,
               varyingMap,
               optDebugInfo
-            ) as IVal<VarAD>).contents;
+            ) as IVal<ad.Num>).contents;
             insertExpr(propertyPath, { tag: "Done", contents: val }, trans);
             return val;
           } else {
@@ -762,17 +762,17 @@ export const resolvePath = (
         // No need to cache evaluated GPI as each of its individual properties should have been cached on evaluation
         return {
           tag: "GPI",
-          contents: [type, evaledProps] as GPI<VarAD>,
+          contents: [type, evaledProps] as GPI<ad.Num>,
         };
       }
 
       // Otherwise, either evaluate or return the expression
       default: {
-        const expr: TagExpr<VarAD> = gpiOrExpr;
+        const expr: TagExpr<ad.Num> = gpiOrExpr;
 
         if (expr.tag === "OptEval") {
           // Evaluate the expression and cache the results (so, e.g. the next lookup just returns a Value)
-          const res: ArgVal<VarAD> = evalExpr(
+          const res: ArgVal<ad.Num> = evalExpr(
             rng,
             expr.contents,
             trans,
@@ -802,7 +802,7 @@ export const resolvePath = (
 };
 
 // HACK: remove the type wrapper for the argument
-export const argValue = (e: ArgVal<VarAD>) => {
+export const argValue = (e: ArgVal<ad.Num>) => {
   switch (e.tag) {
     case "GPI": // strip the `GPI` tag
       return e.contents;
@@ -811,7 +811,7 @@ export const argValue = (e: ArgVal<VarAD>) => {
   }
 };
 
-export const intToFloat = (v: IIntV): IFloatV<VarAD> => {
+export const intToFloat = (v: IIntV): IFloatV<ad.Num> => {
   return { tag: "FloatV", contents: v.contents };
 };
 
@@ -823,9 +823,9 @@ export const intToFloat = (v: IIntV): IFloatV<VarAD> => {
  */
 export const evalBinOp = (
   op: BinaryOp,
-  v1: Value<VarAD>,
-  v2: Value<VarAD>
-): Value<VarAD> => {
+  v1: Value<ad.Num>,
+  v2: Value<ad.Num>
+): Value<ad.Num> => {
   // Promote int to float
   if (v1.tag === "IntV" && v2.tag === "FloatV") {
     return evalBinOp(op, intToFloat(v1), v2);
@@ -898,7 +898,7 @@ export const evalBinOp = (
 
     return { tag: "IntV", contents: res };
   } else if (v1.tag === "VectorV" && v2.tag === "VectorV") {
-    let res: VarAD[] | undefined;
+    let res: ad.Num[] | undefined;
 
     switch (op) {
       case "BPlus": {
@@ -914,7 +914,7 @@ export const evalBinOp = (
 
     return { tag: "VectorV", contents: res! };
   } else if (v1.tag === "FloatV" && v2.tag === "VectorV") {
-    let res: VarAD[] | undefined;
+    let res: ad.Num[] | undefined;
 
     switch (op) {
       case "Multiply": {
@@ -924,7 +924,7 @@ export const evalBinOp = (
     }
     return { tag: "VectorV", contents: res! };
   } else if (v1.tag === "VectorV" && v2.tag === "FloatV") {
-    let res: VarAD[] | undefined;
+    let res: ad.Num[] | undefined;
 
     switch (op) {
       case "Divide": {
@@ -961,8 +961,8 @@ export const evalBinOp = (
  */
 export const evalUOp = (
   op: "UMinus", // this line will cause a type error if the UnaryOp type changes
-  arg: IFloatV<VarAD> | IIntV | IVectorV<VarAD>
-): Value<VarAD> => {
+  arg: IFloatV<ad.Num> | IIntV | IVectorV<ad.Num>
+): Value<ad.Num> => {
   switch (arg.tag) {
     case "FloatV": {
       return { ...arg, contents: neg(arg.contents) };
@@ -979,7 +979,7 @@ export const evalUOp = (
 // Generate a map from paths to values, where the key is the JSON stringified version of the path
 export function genPathMap<T>(
   paths: Path<A>[],
-  vals: T[] // TODO: Distinguish between VarAD variables and constants?
+  vals: T[] // TODO: Distinguish between ad.Num variables and constants?
 ): Map<string, T> {
   if (!paths || !vals) {
     return new Map(); // Empty, e.g. when the state is decoded, there is no gradient

--- a/packages/core/src/engine/Optimizer.ts
+++ b/packages/core/src/engine/Optimizer.ts
@@ -27,7 +27,6 @@ import { Matrix } from "ml-matrix";
 import rfdc from "rfdc";
 import seedrandom from "seedrandom";
 import * as ad from "types/ad";
-import { OptInfo, VarAD } from "types/ad";
 import { A } from "types/ast";
 import {
   Fn,
@@ -125,7 +124,7 @@ const epConverged2 = (
   return stateChange < epStop || energyChange < epStop;
 };
 
-const applyFn = (f: FnDone<VarAD>, dict: any) => {
+const applyFn = (f: FnDone<ad.Num>, dict: any) => {
   if (dict[f.name]) {
     return dict[f.name](...f.args.map(argValue));
   } else {
@@ -705,7 +704,7 @@ const minimize = (
   lbfgsInfo: LbfgsParams,
   varyingPaths: string[],
   numSteps: number
-): OptInfo => {
+): ad.OptInfo => {
   // TODO: Do a UO convergence check here? Since the EP check is tied to the render cycle...
 
   log.info("-------------------------------------");
@@ -819,37 +818,37 @@ const minimize = (
 };
 
 /**
- * Generate an energy function from the current state (using VarADs only)
+ * Generate an energy function from the current state (using `ad.Num`s only)
  *
  * @param {State} state
- * @returns a function that takes in a list of `VarAD`s and return a `Scalar`
+ * @returns a function that takes in a list of `ad.Num`s and return a `Scalar`
  */
 export const evalEnergyOnCustom = (rng: seedrandom.prng, state: State) => {
   return (
     ...xsVars: ad.Input[]
   ): {
-    energyGraph: VarAD;
+    energyGraph: ad.Num;
     epWeightNode: ad.Input;
   } => {
     // TODO: Could this line be causing a memory leak?
     const { objFns, constrFns, varyingPaths } = state;
 
-    // Clone the translation to use in the `evalFns` top-level calls, because they mutate the translation while interpreting the energy function in order to cache/reuse VarAD (computation) results
-    // Note that we have to do a "round trip" on the translation types, from VarAD to number to VarAD, to clear the computational graph of the VarADs. Otherwise, there may be cycles in the translation (since 1) we run `evalShapes` in `processData`, which mutates the VarADs, and 2) the computational graph contains DAGs and stores both parent and child pointers). Cycles in the translation cause `clone` to be very slow, and anyway, the VarADs should be "fresh" since the point of this function is to build the comp graph from scratch by interpreting the translation.
+    // Clone the translation to use in the `evalFns` top-level calls, because they mutate the translation while interpreting the energy function in order to cache/reuse ad.Num (computation) results
+    // Note that we have to do a "round trip" on the translation types, from ad.Num to number to ad.Num, to clear the computational graph of the `ad.Num`s. Otherwise, there may be cycles in the translation (since 1) we run `evalShapes` in `processData`, which mutates the `ad.Num`s, and 2) the computational graph contains DAGs and stores both parent and child pointers). Cycles in the translation cause `clone` to be very slow, and anyway, the `ad.Num`s should be "fresh" since the point of this function is to build the comp graph from scratch by interpreting the translation.
     const translationInit = clone(makeTranslationNumeric(state.translation));
     const varyingMapList = zip2(varyingPaths, xsVars);
     // Insert varying vals into translation (e.g. VectorAccesses of varying vals are found in the translation, although I guess in practice they should use varyingMap)
     const translation = insertVaryings(translationInit, varyingMapList);
 
     // construct a new varying map
-    const varyingMap: VaryMap<VarAD> = genPathMap(varyingPaths, xsVars);
+    const varyingMap: VaryMap<ad.Num> = genPathMap(varyingPaths, xsVars);
 
     // NOTE: This will mutate the var inputs
     const objEvaled = evalFns(rng, objFns, translation, varyingMap);
     const constrEvaled = evalFns(rng, constrFns, translation, varyingMap);
 
-    const objEngs: VarAD[] = objEvaled.map((o) => applyFn(o, objDict));
-    const constrEngs: VarAD[] = constrEvaled.map((c) =>
+    const objEngs: ad.Num[] = objEvaled.map((o) => applyFn(o, objDict));
+    const constrEngs: ad.Num[] = constrEvaled.map((c) =>
       fns.toPenalty(applyFn(c, constrDict))
     );
 
@@ -864,7 +863,7 @@ export const evalEnergyOnCustom = (rng: seedrandom.prng, state: State) => {
     }
 
     // This is fixed during the whole optimization
-    const constrWeightNode: VarAD = constraintWeight;
+    const constrWeightNode: ad.Num = constraintWeight;
 
     // This changes with the EP round, gets bigger to weight the constraints
     // Therefore it's marked as an input to the generated objective function, which can be partially applied with the ep weight
@@ -873,10 +872,10 @@ export const evalEnergyOnCustom = (rng: seedrandom.prng, state: State) => {
       key: 0, // xsVars keys must start at 1 to accommodate this
     });
 
-    const objEng: VarAD = ops.vsum(objEngs);
-    const constrEng: VarAD = ops.vsum(constrEngs);
+    const objEng: ad.Num = ops.vsum(objEngs);
+    const constrEng: ad.Num = ops.vsum(constrEngs);
     // F(x) = o(x) + c0 * penalty * c(x)
-    const overallEng: VarAD = add(
+    const overallEng: ad.Num = add(
       objEng,
       mul(constrEng, mul(constrWeightNode, epWeightNode))
     );
@@ -900,7 +899,7 @@ export const genOptProblem = (rng: seedrandom.prng, state: State): State => {
   const overallObjective = evalEnergyOnCustom(rng, state);
   const xsVars: ad.Input[] = makeADInputVars(xs, 1); // ep weight is index 0
   const res = overallObjective(...xsVars); // Note: `overallObjective` mutates `xsVars`
-  // `energyGraph` is a VarAD that is a handle to the top of the graph
+  // `energyGraph` is a ad.Num that is a handle to the top of the graph
 
   log.info("interpreted energy graph", res.energyGraph);
   log.info("input vars", xsVars);
@@ -950,26 +949,26 @@ export const genOptProblem = (rng: seedrandom.prng, state: State): State => {
   return { ...state, params: newParams };
 };
 
-// Eval a single function on the state (using VarADs). Based off of `evalEnergyOfCustom` -- see that function for comments.
+// Eval a single function on the state (using `ad.Num`s). Based off of `evalEnergyOfCustom` -- see that function for comments.
 const evalFnOn = (rng: seedrandom.prng, fn: Fn, s: State) => {
   const dict = fn.optType === "ObjFn" ? objDict : constrDict;
 
-  return (...xsVars: ad.Input[]): VarAD => {
+  return (...xsVars: ad.Input[]): ad.Num => {
     const { varyingPaths } = s;
 
     const translationInit = clone(makeTranslationNumeric(s.translation));
     const varyingMapList = zip2(varyingPaths, xsVars);
     const translation = insertVaryings(translationInit, varyingMapList);
-    const varyingMap: VaryMap<VarAD> = genPathMap(varyingPaths, xsVars);
+    const varyingMap: VaryMap<ad.Num> = genPathMap(varyingPaths, xsVars);
 
     // NOTE: This will mutate the var inputs
-    const fnArgsEvaled: FnDone<VarAD> = evalFn(
+    const fnArgsEvaled: FnDone<ad.Num> = evalFn(
       rng,
       fn,
       translation,
       varyingMap
     );
-    const fnEnergy: VarAD = applyFn(fnArgsEvaled, dict);
+    const fnEnergy: ad.Num = applyFn(fnArgsEvaled, dict);
 
     return fnEnergy;
   };
@@ -981,13 +980,13 @@ const genFn = (rng: seedrandom.prng, fn: Fn, s: State): FnCached => {
 
   const overallObjective = evalFnOn(rng, fn, s);
   const xsVars: ad.Input[] = makeADInputVars(xs);
-  const energyGraph: VarAD = overallObjective(...xsVars); // Note: `overallObjective` mutates `xsVars`
+  const energyGraph: ad.Num = overallObjective(...xsVars); // Note: `overallObjective` mutates `xsVars`
 
   const weightInfo: WeightInfo | undefined = undefined;
 
   const { f } = energyAndGradCompiled(xs, xsVars, energyGraph, weightInfo);
 
-  // Note this throws away the energy/gradient graphs (`VarAD`s). Presumably not needed?
+  // Note this throws away the energy/gradient graphs (`ad.Num`s). Presumably not needed?
   return (xs: number[]) => {
     const { primary, gradient } = f(xs);
     return { f: primary, gradf: gradient };

--- a/packages/core/src/renderer/PathBuilder.ts
+++ b/packages/core/src/renderer/PathBuilder.ts
@@ -1,24 +1,24 @@
-import { VarAD } from "types/ad";
+import * as ad from "types/ad";
 import { IPathDataV, ISubPath } from "types/value";
 
 /**
  * Class for building SVG paths
  */
 export class PathBuilder {
-  private path: IPathDataV<VarAD>;
+  private path: IPathDataV<ad.Num>;
   constructor() {
     this.path = {
       tag: "PathDataV",
       contents: [],
     };
   }
-  private newCoord = (x: VarAD, y: VarAD): ISubPath<VarAD> => {
+  private newCoord = (x: ad.Num, y: ad.Num): ISubPath<ad.Num> => {
     return {
       tag: "CoordV",
       contents: [x, y],
     };
   };
-  private newValue = (v: VarAD[]): ISubPath<VarAD> => {
+  private newValue = (v: ad.Num[]): ISubPath<ad.Num> => {
     return {
       tag: "ValueV",
       contents: v,
@@ -30,7 +30,7 @@ export class PathBuilder {
   /**
    * Moves SVG cursor to coordinate [x,y]
    */
-  moveTo = ([x, y]: [VarAD, VarAD]) => {
+  moveTo = ([x, y]: [ad.Num, ad.Num]) => {
     this.path.contents.push({
       cmd: "M",
       contents: [this.newCoord(x, y)],
@@ -51,7 +51,7 @@ export class PathBuilder {
   /**
    * Draws a line to point [x,y]
    */
-  lineTo = ([x, y]: [VarAD, VarAD]) => {
+  lineTo = ([x, y]: [ad.Num, ad.Num]) => {
     this.path.contents.push({
       cmd: "L",
       contents: [this.newCoord(x, y)],
@@ -62,7 +62,10 @@ export class PathBuilder {
    * Draws a quadratic bezier curve ending at [x,y] with one control point
    * at [cpx, cpy]
    */
-  quadraticCurveTo = ([cpx, cpy]: [VarAD, VarAD], [x, y]: [VarAD, VarAD]) => {
+  quadraticCurveTo = (
+    [cpx, cpy]: [ad.Num, ad.Num],
+    [x, y]: [ad.Num, ad.Num]
+  ) => {
     this.path.contents.push({
       cmd: "Q",
       contents: [this.newCoord(cpx, cpy), this.newCoord(x, y)],
@@ -74,9 +77,9 @@ export class PathBuilder {
    * [cpx1, cpy1] and the second control pt at [cpx2, cpy2]
    */
   bezierCurveTo = (
-    [cpx1, cpy1]: [VarAD, VarAD],
-    [cpx2, cpy2]: [VarAD, VarAD],
-    [x, y]: [VarAD, VarAD]
+    [cpx1, cpy1]: [ad.Num, ad.Num],
+    [cpx2, cpy2]: [ad.Num, ad.Num],
+    [x, y]: [ad.Num, ad.Num]
   ) => {
     this.path.contents.push({
       cmd: "C",
@@ -91,7 +94,7 @@ export class PathBuilder {
   /**
    * Shortcut quadratic bezier curve command ending at [x,y]
    */
-  quadraticCurveJoin = ([x, y]: [VarAD, VarAD]) => {
+  quadraticCurveJoin = ([x, y]: [ad.Num, ad.Num]) => {
     this.path.contents.push({
       cmd: "T",
       contents: [this.newCoord(x, y)],
@@ -102,7 +105,7 @@ export class PathBuilder {
    * Shortcut cubic bezier curve command ending at [x, y]. The second control
    * pt is inferred to be the reflection of the first control pt, [cpx, cpy].
    */
-  cubicCurveJoin = ([cpx, cpy]: [VarAD, VarAD], [x, y]: [VarAD, VarAD]) => {
+  cubicCurveJoin = ([cpx, cpy]: [ad.Num, ad.Num], [x, y]: [ad.Num, ad.Num]) => {
     this.path.contents.push({
       cmd: "S",
       contents: [this.newCoord(cpx, cpy), this.newCoord(x, y)],
@@ -116,9 +119,9 @@ export class PathBuilder {
    * @param arcSweep: 0 to rotate CCW, 1 to rotate CW
    */
   arcTo = (
-    [rx, ry]: [VarAD, VarAD],
-    [x, y]: [VarAD, VarAD],
-    [rotation, majorArc, sweep]: VarAD[]
+    [rx, ry]: [ad.Num, ad.Num],
+    [x, y]: [ad.Num, ad.Num],
+    [rotation, majorArc, sweep]: ad.Num[]
   ) => {
     this.path.contents.push({
       cmd: "A",

--- a/packages/core/src/renderer/Resample.ts
+++ b/packages/core/src/renderer/Resample.ts
@@ -9,7 +9,7 @@ import { mapValues } from "lodash";
 import seedrandom from "seedrandom";
 import { Canvas } from "shapes/Samplers";
 import { ShapeDef, shapedefs } from "shapes/Shapes";
-import { VarAD } from "types/ad";
+import * as ad from "types/ad";
 import { A } from "types/ast";
 import { Shape } from "types/shape";
 import { State } from "types/state";
@@ -84,7 +84,7 @@ const sampleProperty = (
   // TODO: don't resample all the properties every time for each property
   const props = shapedef.sampler(rng, canvas);
   if (property in props) {
-    // TODO: don't make VarAD only to immediately convert back to number
+    // TODO: don't make ad.Num only to immediately convert back to number
     return valueAutodiffToNumber(props[property]);
   } else {
     throw new Error(
@@ -166,14 +166,14 @@ export const resampleOnce = (rng: seedrandom.prng, state: State): State => {
   // update the translation with all uninitialized values (converted to `Done` values)
   const uninitMap: [
     Path<A>,
-    TagExpr<VarAD>
+    TagExpr<ad.Num>
   ][] = uninitializedPaths.map((p: Path<A>) => [
     p,
     val2Expr(samplePath(rng, p, shapes, state.varyingInitInfo, state.canvas)),
   ]);
 
   const translation: Translation = uninitMap.reduce(
-    (tr: Translation, [p, e]: [Path<A>, TagExpr<VarAD>]) =>
+    (tr: Translation, [p, e]: [Path<A>, TagExpr<ad.Num>]) =>
       insertExpr(p, e, tr),
     state.translation
   );

--- a/packages/core/src/renderer/Staging.ts
+++ b/packages/core/src/renderer/Staging.ts
@@ -1,10 +1,10 @@
-import { VarAD } from "../types/ad";
+import * as ad from "../types/ad";
 import { Shape } from "../types/shape";
 import { State } from "../types/state";
 import { FieldExpr } from "../types/value";
 
 // local typedefs for ease of typing expressions
-type StringObjPair = [string, { [k: string]: FieldExpr<VarAD> }];
+type StringObjPair = [string, { [k: string]: FieldExpr<ad.Num> }];
 
 /**
  * Returns a list of states, one state per diagram in a series of staged diagrams
@@ -33,8 +33,8 @@ export const getListOfStagedStates = (state: State): State[] => {
 // determines if an object has any GPI tagged properties
 const hasGPIProperties = (elem: StringObjPair) => {
   const arr = elem[1];
-  const objArr: [string, FieldExpr<VarAD>][] = Object.entries(arr);
-  const hasGPIAsTag = (object: [string, FieldExpr<VarAD>]) => {
+  const objArr: [string, FieldExpr<ad.Num>][] = Object.entries(arr);
+  const hasGPIAsTag = (object: [string, FieldExpr<ad.Num>]) => {
     return object[1].tag === "FGPI";
   };
   return (

--- a/packages/core/src/shapes/Circle.ts
+++ b/packages/core/src/shapes/Circle.ts
@@ -1,4 +1,4 @@
-import { VarAD } from "types/ad";
+import * as ad from "types/ad";
 import { ICenter, IFill, INamed, IShape, IStroke } from "types/shapes";
 import { IFloatV } from "types/value";
 import {
@@ -13,7 +13,7 @@ import {
 } from "./Samplers";
 
 export interface ICircle extends INamed, IStroke, IFill, ICenter {
-  r: IFloatV<VarAD>;
+  r: IFloatV<ad.Num>;
 }
 
 export const sampleCircle = (

--- a/packages/core/src/shapes/Ellipse.ts
+++ b/packages/core/src/shapes/Ellipse.ts
@@ -1,4 +1,4 @@
-import { VarAD } from "types/ad";
+import * as ad from "types/ad";
 import { ICenter, IFill, INamed, IShape, IStroke } from "types/shapes";
 import { IFloatV } from "types/value";
 import {
@@ -14,8 +14,8 @@ import {
 } from "./Samplers";
 
 export interface IEllipse extends INamed, IStroke, IFill, ICenter {
-  rx: IFloatV<VarAD>;
-  ry: IFloatV<VarAD>;
+  rx: IFloatV<ad.Num>;
+  ry: IFloatV<ad.Num>;
 }
 
 export const sampleEllipse = (

--- a/packages/core/src/shapes/Line.ts
+++ b/packages/core/src/shapes/Line.ts
@@ -1,4 +1,4 @@
-import { VarAD } from "types/ad";
+import * as ad from "types/ad";
 import { IArrow, INamed, IShape, IStroke } from "types/shapes";
 import { IStrV, IVectorV } from "types/value";
 import {
@@ -11,8 +11,8 @@ import {
 } from "./Samplers";
 
 export interface ILine extends INamed, IStroke, IArrow {
-  start: IVectorV<VarAD>;
-  end: IVectorV<VarAD>;
+  start: IVectorV<ad.Num>;
+  end: IVectorV<ad.Num>;
   strokeLinecap: IStrV;
 }
 

--- a/packages/core/src/shapes/Path.ts
+++ b/packages/core/src/shapes/Path.ts
@@ -1,4 +1,4 @@
-import { VarAD } from "types/ad";
+import * as ad from "types/ad";
 import { IArrow, IFill, INamed, IShape, IStroke } from "types/shapes";
 import { IPathDataV } from "types/value";
 import {
@@ -12,7 +12,7 @@ import {
 } from "./Samplers";
 
 export interface IPath extends INamed, IStroke, IFill, IArrow {
-  d: IPathDataV<VarAD>;
+  d: IPathDataV<ad.Num>;
 }
 
 export const samplePath = (rng: seedrandom.prng, _canvas: Canvas): IPath => ({

--- a/packages/core/src/shapes/Samplers.ts
+++ b/packages/core/src/shapes/Samplers.ts
@@ -1,5 +1,5 @@
 import seedrandom from "seedrandom";
-import { VarAD } from "types/ad";
+import * as ad from "types/ad";
 import {
   Color,
   IBoolV,
@@ -46,7 +46,7 @@ export const makeCanvas = (width: number, height: number): Canvas => ({
   yRange: [-height / 2, height / 2],
 });
 
-export const FloatV = (contents: VarAD): IFloatV<VarAD> => ({
+export const FloatV = (contents: ad.Num): IFloatV<ad.Num> => ({
   tag: "FloatV",
   contents,
 });
@@ -54,7 +54,7 @@ export const IntV = (contents: number): IIntV => ({
   tag: "IntV",
   contents,
 });
-export const BoolV = (contents: boolean): IBoolV<VarAD> => ({
+export const BoolV = (contents: boolean): IBoolV<ad.Num> => ({
   tag: "BoolV",
   contents,
 });
@@ -62,47 +62,49 @@ export const StrV = (contents: string): IStrV => ({
   tag: "StrV",
   contents,
 });
-export const PtV = (contents: VarAD[]): IPtV<VarAD> => ({
+export const PtV = (contents: ad.Num[]): IPtV<ad.Num> => ({
   tag: "PtV",
   contents,
 });
-export const PathDataV = (contents: IPathCmd<VarAD>[]): IPathDataV<VarAD> => ({
+export const PathDataV = (
+  contents: IPathCmd<ad.Num>[]
+): IPathDataV<ad.Num> => ({
   tag: "PathDataV",
   contents,
 });
-export const PtListV = (contents: VarAD[][]): IPtListV<VarAD> => ({
+export const PtListV = (contents: ad.Num[][]): IPtListV<ad.Num> => ({
   tag: "PtListV",
   contents,
 });
-export const ColorV = (contents: Color<VarAD>): IColorV<VarAD> => ({
+export const ColorV = (contents: Color<ad.Num>): IColorV<ad.Num> => ({
   tag: "ColorV",
   contents,
 });
-export const PaletteV = (contents: Color<VarAD>[]): IPaletteV<VarAD> => ({
+export const PaletteV = (contents: Color<ad.Num>[]): IPaletteV<ad.Num> => ({
   tag: "PaletteV",
   contents,
 });
-export const FileV = (contents: string): IFileV<VarAD> => ({
+export const FileV = (contents: string): IFileV<ad.Num> => ({
   tag: "FileV",
   contents,
 });
-export const StyleV = (contents: string): IStyleV<VarAD> => ({
+export const StyleV = (contents: string): IStyleV<ad.Num> => ({
   tag: "StyleV",
   contents,
 });
-export const ListV = (contents: VarAD[]): IListV<VarAD> => ({
+export const ListV = (contents: ad.Num[]): IListV<ad.Num> => ({
   tag: "ListV",
   contents,
 });
-export const VectorV = (contents: VarAD[]): IVectorV<VarAD> => ({
+export const VectorV = (contents: ad.Num[]): IVectorV<ad.Num> => ({
   tag: "VectorV",
   contents,
 });
-export const MatrixV = (contents: VarAD[][]): IMatrixV<VarAD> => ({
+export const MatrixV = (contents: ad.Num[][]): IMatrixV<ad.Num> => ({
   tag: "MatrixV",
   contents,
 });
-export const TupV = (contents: VarAD[]): ITupV<VarAD> => ({
+export const TupV = (contents: ad.Num[]): ITupV<ad.Num> => ({
   tag: "TupV",
   contents,
 });
@@ -111,24 +113,24 @@ export const sampleFloatIn = (
   rng: seedrandom.prng,
   min: number,
   max: number
-): IFloatV<VarAD> => FloatV(randFloat(rng, min, max));
+): IFloatV<ad.Num> => FloatV(randFloat(rng, min, max));
 export const sampleVector = (
   rng: seedrandom.prng,
   canvas: Canvas
-): IVectorV<VarAD> =>
+): IVectorV<ad.Num> =>
   VectorV([randFloat(rng, ...canvas.xRange), randFloat(rng, ...canvas.yRange)]);
 export const sampleWidth = (
   rng: seedrandom.prng,
   canvas: Canvas
-): IFloatV<VarAD> => FloatV(randFloat(rng, 3, canvas.width / 6));
-export const sampleZero = (): IFloatV<VarAD> => FloatV(0);
+): IFloatV<ad.Num> => FloatV(randFloat(rng, 3, canvas.width / 6));
+export const sampleZero = (): IFloatV<ad.Num> => FloatV(0);
 export const sampleHeight = (
   rng: seedrandom.prng,
   canvas: Canvas
-): IFloatV<VarAD> => FloatV(randFloat(rng, 3, canvas.height / 6));
-export const sampleStroke = (rng: seedrandom.prng): IFloatV<VarAD> =>
+): IFloatV<ad.Num> => FloatV(randFloat(rng, 3, canvas.height / 6));
+export const sampleStroke = (rng: seedrandom.prng): IFloatV<ad.Num> =>
   FloatV(randFloat(rng, 0.5, 3));
-export const sampleColor = (rng: seedrandom.prng): IColorV<VarAD> => {
+export const sampleColor = (rng: seedrandom.prng): IColorV<ad.Num> => {
   const [min, max] = [0.1, 0.9];
   return ColorV({
     tag: "RGBA",
@@ -140,6 +142,6 @@ export const sampleColor = (rng: seedrandom.prng): IColorV<VarAD> => {
     ],
   });
 };
-export const sampleBlack = (): IColorV<VarAD> =>
+export const sampleBlack = (): IColorV<ad.Num> =>
   ColorV({ tag: "RGBA", contents: [0, 0, 0, 1] });
-export const sampleNoPaint = (): IColorV<VarAD> => ColorV({ tag: "NONE" });
+export const sampleNoPaint = (): IColorV<ad.Num> => ColorV({ tag: "NONE" });

--- a/packages/core/src/shapes/Shapes.ts
+++ b/packages/core/src/shapes/Shapes.ts
@@ -1,6 +1,6 @@
 import * as BBox from "engine/BBox";
 import seedrandom from "seedrandom";
-import { VarAD } from "types/ad";
+import * as ad from "types/ad";
 import { Value } from "types/value";
 import { Circle, makeCircle, sampleCircle } from "./Circle";
 import { Ellipse, makeEllipse, sampleEllipse } from "./Ellipse";
@@ -18,7 +18,7 @@ import { makeText, sampleText, Text } from "./Text";
 
 // TODO: fix this type, it's too restrictive
 export interface Properties {
-  [k: string]: Value<VarAD>;
+  [k: string]: Value<ad.Num>;
 }
 
 export type Shape =
@@ -44,7 +44,7 @@ export interface ShapeDef {
   ) => Shape;
 
   // TODO: maybe get rid of this?
-  propTags: { [prop: string]: Value<VarAD>["tag"] };
+  propTags: { [prop: string]: Value<ad.Num>["tag"] };
 
   // TODO: make these methods
   bbox: (properties: Properties) => BBox.BBox;

--- a/packages/core/src/shapes/Text.ts
+++ b/packages/core/src/shapes/Text.ts
@@ -1,4 +1,4 @@
-import { VarAD } from "types/ad";
+import * as ad from "types/ad";
 import {
   ICenter,
   IFill,
@@ -40,8 +40,8 @@ export interface IText
   lineHeight: IStrV;
   alignmentBaseline: IStrV;
   dominantBaseline: IStrV;
-  ascent: IFloatV<VarAD>;
-  descent: IFloatV<VarAD>;
+  ascent: IFloatV<ad.Num>;
+  descent: IFloatV<ad.Num>;
 }
 
 export const sampleText = (rng: seedrandom.prng, canvas: Canvas): IText => ({

--- a/packages/core/src/types/ad.ts
+++ b/packages/core/src/types/ad.ts
@@ -39,12 +39,11 @@ import { LbfgsParams } from "./state";
 
 //#region Types for implicit autodiff graph
 
-export type Expr = Bool | VarAD | Vec;
+export type Expr = Bool | Num | Vec;
 
 export type Bool = Comp | Logic;
 
-// this type name is a relic, doesn't follow our current convention
-export type VarAD =
+export type Num =
   | number
   | Input
   | Unary
@@ -57,7 +56,7 @@ export type VarAD =
 export type Vec = PolyRoots;
 
 export interface Input extends InputNode {
-  // HACK: Historically, every VarAD contained a `val` field which would hold
+  // HACK: Historically, every Num contained a `val` field which would hold
   // the "value of this node at the time the computational graph was created".
   // In particular, every function in `engine/AutodiffFunctions` contained code
   // to compute the initial value of a node based on the initial values of its
@@ -86,17 +85,17 @@ export interface Input extends InputNode {
 }
 
 export interface Unary extends UnaryNode {
-  param: VarAD;
+  param: Num;
 }
 
 export interface Binary extends BinaryNode {
-  left: VarAD;
-  right: VarAD;
+  left: Num;
+  right: Num;
 }
 
 export interface Comp extends CompNode {
-  left: VarAD;
-  right: VarAD;
+  left: Num;
+  right: Num;
 }
 
 export interface Logic extends LogicNode {
@@ -106,17 +105,17 @@ export interface Logic extends LogicNode {
 
 export interface Ternary extends TernaryNode {
   cond: Bool;
-  then: VarAD;
-  els: VarAD;
+  then: Num;
+  els: Num;
 }
 
 export interface Nary extends NaryNode {
-  params: VarAD[];
+  params: Num[];
 }
 
 export interface PolyRoots extends PolyRootsNode {
   // coefficients of a monic polynomial with degree `coeffs.length`
-  coeffs: VarAD[];
+  coeffs: Num[];
 }
 
 export interface Index extends IndexNode {
@@ -124,7 +123,7 @@ export interface Index extends IndexNode {
 }
 
 export interface Debug extends DebugNode {
-  node: VarAD;
+  node: Num;
 }
 
 //#endregion
@@ -265,17 +264,15 @@ export type Compiled = (inputs: number[]) => Outputs<number>;
 
 //#region Types for generalizing our system autodiff
 
-export type VecAD = VarAD[];
+export type Pt2 = [Num, Num];
 
-export type Pt2 = [VarAD, VarAD];
-
-export const isPt2 = (vec: VarAD[]): vec is Pt2 => vec.length === 2;
+export const isPt2 = (vec: Num[]): vec is Pt2 => vec.length === 2;
 
 export type GradGraphs = IGradGraphs;
 
 export interface IGradGraphs {
-  inputs: VarAD[];
-  weight: VarAD | undefined; // EP weight, a hyperparameter to both energy and gradient; TODO: generalize to multiple hyperparameters
+  inputs: Num[];
+  weight: Num | undefined; // EP weight, a hyperparameter to both energy and gradient; TODO: generalize to multiple hyperparameters
 }
 
 export type OptInfo = IOptInfo;

--- a/packages/core/src/types/shape.ts
+++ b/packages/core/src/types/shape.ts
@@ -1,8 +1,8 @@
-import { VarAD } from "./ad";
+import * as ad from "./ad";
 import { Value } from "./value";
 
 export type Shape = IShape<number>;
-export type ShapeAD = IShape<VarAD>;
+export type ShapeAD = IShape<ad.Num>;
 
 export type Properties<T> = { [k: string]: Value<T> };
 

--- a/packages/core/src/types/shapes.ts
+++ b/packages/core/src/types/shapes.ts
@@ -1,59 +1,59 @@
-import { VarAD } from "types/ad";
+import * as ad from "types/ad";
 import { IBoolV, IColorV, IFloatV, IPtListV, IStrV, IVectorV } from "./value";
 
 //#region shape hierarchy interfaces
 export interface INamed {
   name: IStrV;
   style: IStrV; // TODO: very temporary; remove this and just use passthrough
-  ensureOnCanvas: IBoolV<VarAD>;
+  ensureOnCanvas: IBoolV<ad.Num>;
 }
 
 export interface IStroke {
-  strokeWidth: IFloatV<VarAD>;
+  strokeWidth: IFloatV<ad.Num>;
   strokeStyle: IStrV;
-  strokeColor: IColorV<VarAD>;
+  strokeColor: IColorV<ad.Num>;
   strokeDasharray: IStrV;
 }
 
 export interface IFill {
-  fillColor: IColorV<VarAD>;
+  fillColor: IColorV<ad.Num>;
 }
 
 export interface ICenter {
-  center: IVectorV<VarAD>; // corresponds to (cx, cy), or other things, in SVG
+  center: IVectorV<ad.Num>; // corresponds to (cx, cy), or other things, in SVG
 }
 
 export interface IRect {
-  width: IFloatV<VarAD>;
-  height: IFloatV<VarAD>;
+  width: IFloatV<ad.Num>;
+  height: IFloatV<ad.Num>;
 }
 
 export interface IArrow {
-  arrowheadSize: IFloatV<VarAD>;
+  arrowheadSize: IFloatV<ad.Num>;
   arrowheadStyle: IStrV;
-  startArrowhead: IBoolV<VarAD>;
-  endArrowhead: IBoolV<VarAD>;
+  startArrowhead: IBoolV<ad.Num>;
+  endArrowhead: IBoolV<ad.Num>;
 }
 
 export interface ICorner {
-  cornerRadius: IFloatV<VarAD>; // note: corresponds to rx in SVG
+  cornerRadius: IFloatV<ad.Num>; // note: corresponds to rx in SVG
 }
 
 // TODO: don't use these
 export interface IRotate {
-  rotation: IFloatV<VarAD>; // about the top-left corner
+  rotation: IFloatV<ad.Num>; // about the top-left corner
 }
 export interface IScale {
-  scale: IFloatV<VarAD>; // doesn't work correctly
+  scale: IFloatV<ad.Num>; // doesn't work correctly
 }
 
 // // TODO: use this
 // export interface ITransform {
-//   matrix: IMatrixV<VarAD>;
+//   matrix: IMatrixV<ad.Num>;
 // }
 
 export interface IPoly {
-  points: IPtListV<VarAD>;
+  points: IPtListV<ad.Num>;
 }
 
 export interface IString {

--- a/packages/core/src/types/state.ts
+++ b/packages/core/src/types/state.ts
@@ -1,7 +1,6 @@
 import { Matrix } from "ml-matrix";
 import { Canvas } from "shapes/Samplers";
 import * as ad from "types/ad";
-import { GradGraphs, VarAD } from "./ad";
 import { A } from "./ast";
 import { Shape } from "./shape";
 import { Expr, Path } from "./style";
@@ -81,7 +80,7 @@ export interface TextData {
 
 export type LabelCache = [string, LabelData][];
 
-export type VaryMap<T = VarAD> = Map<string, T>;
+export type VaryMap<T = ad.Num> = Map<string, T>;
 
 export type FnDone<T> = IFnDone<T>;
 export interface IFnDone<T> {
@@ -148,10 +147,10 @@ export interface IParams {
   // For L-BFGS
   lbfgsInfo: LbfgsParams;
 
-  xsVars: VarAD[]; // Computational graph (leaf vars), from the bottom up
+  xsVars: ad.Num[]; // Computational graph (leaf vars), from the bottom up
 
   // For energy/gradient compilation
-  graphs: GradGraphs;
+  graphs: ad.GradGraphs;
 
   functionsCompiled: boolean;
 
@@ -162,8 +161,8 @@ export interface IParams {
   currObjectiveAndGradient(xs: number[]): FnEvaled;
 
   // `xsVars` are all the leaves of the energy graph
-  energyGraph: VarAD; // This is the top of the energy graph (parent node)
-  epWeightNode: VarAD; // Handle to node for EP weight (so it can be set as the weight changes)
+  energyGraph: ad.Num; // This is the top of the energy graph (parent node)
+  epWeightNode: ad.Num; // Handle to node for EP weight (so it can be set as the weight changes)
 
   // Cached versions of compiling each objective and constraint into a function and gradient
   objFnCache: { [k: string]: FnCached }; // Key is the serialized function name, e.g. `contains(A.shape, B.shape)`

--- a/packages/core/src/types/style.ts
+++ b/packages/core/src/types/style.ts
@@ -1,7 +1,7 @@
 //#region Style AST
 // TODO: unify type name convention (e.g. stop using `I` for interfaces and drop some of the Haskell ported types)
 
-import { VarAD } from "./ad";
+import * as ad from "./ad";
 import { ASTNode, Identifier, IStringLit } from "./ast";
 import { LabelType } from "./substance";
 
@@ -352,7 +352,7 @@ export type IVaryInit<T> = ASTNode<T> & {
 
 export type IVaryAD<T> = ASTNode<T> & {
   tag: "VaryAD";
-  contents: VarAD;
+  contents: ad.Num;
 };
 
 export type PropertyDecl<T> = ASTNode<T> & {

--- a/packages/core/src/types/value.ts
+++ b/packages/core/src/types/value.ts
@@ -1,4 +1,4 @@
-import { VarAD } from "./ad";
+import * as ad from "./ad";
 import { A } from "./ast";
 import { StyleError } from "./errors";
 import { Expr } from "./style";
@@ -26,11 +26,11 @@ export interface IVal<T> {
 export type Field = string;
 export type Name = string;
 export type Property = string;
-export type FExpr = FieldExpr<VarAD>;
+export type FExpr = FieldExpr<ad.Num>;
 export type ShapeTypeStr = string;
 export type PropID = string;
-export type GPIMap = { [k: string]: TagExpr<VarAD> };
-export type FieldDict = { [k: string]: FieldExpr<VarAD> };
+export type GPIMap = { [k: string]: TagExpr<ad.Num> };
+export type FieldDict = { [k: string]: FieldExpr<ad.Num> };
 
 export type StyleOptFn = [string, Expr<A>[]]; // Objective or constraint
 
@@ -38,9 +38,9 @@ export type StyleOptFn = [string, Expr<A>[]]; // Objective or constraint
 /**
  * Translation represents the computational graph compiled from a trio of Penrose programs.
  */
-export type Translation = ITrans<VarAD>;
+export type Translation = ITrans<ad.Num>;
 
-export type Trans = TrMap<VarAD>;
+export type Trans = TrMap<ad.Num>;
 
 export type TrMap<T> = { [k: string]: { [k: string]: FieldExpr<T> } };
 

--- a/packages/core/src/utils/Util.ts
+++ b/packages/core/src/utils/Util.ts
@@ -2,7 +2,7 @@ import * as _ from "lodash";
 import { times } from "lodash";
 import seedrandom from "seedrandom";
 import { ILine } from "shapes/Line";
-import { VarAD } from "types/ad";
+import * as ad from "types/ad";
 import { A } from "types/ast";
 import { Properties } from "types/shape";
 import { Fn, Seeds, State } from "types/state";
@@ -485,7 +485,7 @@ export const prettyPrintFns = (state: State): string[] =>
 //#region autodiff
 
 // From Evaluator
-export const floatVal = (v: VarAD): ArgVal<VarAD> => ({
+export const floatVal = (v: ad.Num): ArgVal<ad.Num> => ({
   tag: "Val",
   contents: {
     tag: "FloatV",
@@ -493,13 +493,13 @@ export const floatVal = (v: VarAD): ArgVal<VarAD> => ({
   },
 });
 
-export const linePts = ({ start, end }: ILine): [VarAD[], VarAD[]] => [
+export const linePts = ({ start, end }: ILine): [ad.Num[], ad.Num[]] => [
   start.contents,
   end.contents,
 ];
 
-export const getStart = ({ start }: ILine): VarAD[] => start.contents;
+export const getStart = ({ start }: ILine): ad.Num[] => start.contents;
 
-export const getEnd = ({ end }: ILine): VarAD[] => end.contents;
+export const getEnd = ({ end }: ILine): ad.Num[] => end.contents;
 
 //#endregion

--- a/packages/core/src/utils/toCustomAD.ts
+++ b/packages/core/src/utils/toCustomAD.ts
@@ -244,7 +244,7 @@ export default function (fileInfo: FileInfo, api: API): string {
   };
   const TYPS: { [k: string]: Transform } = {
     TSNumberKeyword: {
-      newName: "VarAD",
+      newName: "ad.Num",
       transformMethod: TYPSUB, // TYPSUB - method to perform type substitution. This will practically always be the method used to transform any type.
       matchTargetFn: getTypeRefName,
     },

--- a/packages/docs-site/docs/tutorial/constraints.md
+++ b/packages/docs-site/docs/tutorial/constraints.md
@@ -96,10 +96,10 @@ The full list of autodiff functions can be found [here](https://github.com/penro
 
 ### 3. Special Number Types
 
-All numbers are required to be a special type called `VarAD` in order to be valid inputs for autodiff functions. We can convert between normal numbers and `VarAD` using the functions:
+All numbers are required to be a special type called `ad.Num` in order to be valid inputs for autodiff functions. We can convert between normal numbers and `ad.Num` using the functions:
 
-- `varOf: number -> VarAD` or `constOf: number -> VarAD` to convert from a `number` to a `VarAD`. These two functions are interchangeable.
-- `numOf: VarAD -> number` to convert from a `VarAD` to a `number`.
+- `varOf: number -> ad.Num` or `constOf: number -> ad.Num` to convert from a `number` to a `ad.Num`. These two functions are interchangeable.
+- `numOf: ad.Num -> number` to convert from a `ad.Num` to a `number`.
 
 The type `number` represents our common, constant numerical values like `1, 2, 3, ...`. For example, if we need to do `5 + 3` , the equivalent autodiff expression is `add(constOf(5), constOf(3))` or `add(varOf(5), varOf(5))`.
 
@@ -131,7 +131,7 @@ Previously, we've talked about how we convert everything to zero-based inequalit
 
 ### 6. Accessing a Value of a Shape's Field
 
-One common operation is to access the parameter of a shape via `shapeName.propertyName.contents`, which will return a `VarAD`. For example, if you have a circle `c` as input, and you want its radius, `c.r.contents` will give you something like `5.0` (of type `VarAD`).
+One common operation is to access the parameter of a shape via `shapeName.propertyName.contents`, which will return a `ad.Num`. For example, if you have a circle `c` as input, and you want its radius, `c.r.contents` will give you something like `5.0` (of type `ad.Num`).
 
 ## Constraints Example: minSize & maxSize
 
@@ -163,7 +163,7 @@ Going back to our `minSize` function, we see several things in play:
 - **Logic:** We want the input circle to have a minimum size (at least `r = 20`) as the function name suggests, so we want to express our returned answer in terms of energy, where `energy > 0` is bad (the constraint is unsatisfied), and `energy <= 0` is good (the constraint is satisfied). For example, with a small circle of `r = 1`, we will return 19 (not good), whereas with a big circle of `r = 30`, we will return -10, a negative number that satisfies the constraint.
 
 ```typescript
-maxSize: ([shapeType, props]: [string, any], limit: VarAD) => {
+maxSize: ([shapeType, props]: [string, any], limit: ad.Num) => {
   return sub(props.r.contents, div(limit, constOf(2)));
 };
 ```


### PR DESCRIPTION
# Description

Resolves https://github.com/penrose/penrose/pull/906#discussion_r870667825 by renaming or deleting everything remaining in `types/ad` that had an `AD` suffix.. Note that just like #907, this PR does not modify `packages/docs-site/docs/ref/style/functions.mdx` because #927 is not yet resolved.

This PR also renames two functions in `engine/EngineUtils`:

- `valueVarADs` -> `valueADNums`
- `colorVarADs` -> `colorADNums`

# Checklist

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new ESLint warnings
- [x] I have reviewed any generated changes to the `diagrams/` folder