### PR TITLE
refactor: Remove I prefix from all types

### DIFF
--- a/packages/browser-ui/src/App.tsx
+++ b/packages/browser-ui/src/App.tsx
@@ -77,14 +77,14 @@ export const DownloadSVG = (
 
 const LOCALSTORAGE_SETTINGS = "browser-ui-settings-penrose";
 
-export interface ISettings {
+export interface Settings {
   showInspector: boolean;
   autostep: boolean;
   autoStepSize: number;
   variation: string;
 }
 
-interface ICanvasState {
+interface CanvasState {
   currentState: PenroseState | undefined; // NOTE: if the backend is not connected, data will be undefined
   error: PenroseError | undefined;
   processedInitial: boolean;
@@ -92,13 +92,13 @@ interface ICanvasState {
   history: PenroseState[];
   files: FileSocketResult | undefined;
   connected: boolean;
-  settings: ISettings;
+  settings: Settings;
   fileSocket: FileSocket | undefined;
 }
 
 const socketAddress = "ws://localhost:9160";
-class App extends React.Component<unknown, ICanvasState> {
-  public readonly state: ICanvasState = {
+class App extends React.Component<unknown, CanvasState> {
+  public readonly state: CanvasState = {
     currentState: undefined,
     fileSocket: undefined,
     error: undefined,
@@ -190,7 +190,7 @@ class App extends React.Component<unknown, ICanvasState> {
       );
     }
   };
-  public setSettings = (settings: ISettings): void => {
+  public setSettings = (settings: Settings): void => {
     this.setState({ settings });
     localStorage.setItem(LOCALSTORAGE_SETTINGS, JSON.stringify(settings));
   };

--- a/packages/browser-ui/src/inspector/Inspector.tsx
+++ b/packages/browser-ui/src/inspector/Inspector.tsx
@@ -1,30 +1,30 @@
 import { PenroseError, PenroseState } from "@penrose/core";
 import { Tab, TabList, TabPanel, TabPanels, Tabs } from "@reach/tabs";
 import "@reach/tabs/styles.css";
-import { ISettings } from "App";
+import { Settings } from "App";
 import * as React from "react";
 import ErrorBoundary from "./ErrorBoundary";
-import IViewProps from "./views/IViewProps";
 import viewMap from "./views/viewMap";
+import ViewProps from "./views/ViewProps";
 
-interface IProps {
+interface Props {
   currentState: PenroseState | undefined;
   history: PenroseState[];
   error: PenroseError | undefined;
   onClose(): void;
   modCanvas(state: PenroseState): void;
-  settings: ISettings;
-  setSettings(ISettings): void;
+  settings: Settings;
+  setSettings(settings: Settings): void;
   reset(): void;
 }
 
-export interface IInspectState {
+export interface InspectState {
   // connectionLog: Array<ConnectionStatus | string>;
   selectedFrame: number;
   selectedView: number;
 }
 
-class Inspector extends React.Component<IProps, IInspectState> {
+class Inspector extends React.Component<Props, InspectState> {
   public readonly state = {
     // connectionLog: [],
     selectedFrame: -1,
@@ -56,7 +56,7 @@ class Inspector extends React.Component<IProps, IInspectState> {
       setSettings,
       reset,
     } = this.props;
-    const commonProps: IViewProps = {
+    const commonProps: ViewProps = {
       selectFrame: this.selectFrame,
       // frame: currentFrame,
       frame: currentState, // HACK: since history is disabled, we pass in the current state so the tab always shows the current state

--- a/packages/browser-ui/src/inspector/README.md
+++ b/packages/browser-ui/src/inspector/README.md
@@ -4,7 +4,7 @@ The inspector is a resizable pane in the "vanilla" Penrose renderer that provide
 
 You can think of each inspector view as a variation on the original Canvas svg renderer; both have access to the same data but present it in different ways.
 
-Each view in the inspector is indexed in `views/viewMap.tsx`. The key is the name that appears as a tab in the pane and the value is the component class of that view. Every view has access to the same data and events defined in `views/IViewProps.tsx`.
+Each view in the inspector is indexed in `views/viewMap.tsx`. The key is the name that appears as a tab in the pane and the value is the component class of that view. Every view has access to the same data and events defined in `views/ViewProps.tsx`.
 
 ## Data
 
@@ -18,7 +18,7 @@ This interaction model is handy but annoying to deal with when you're implementi
 
 ## Adding a view
 
-Make a new component that accepts `IViewProps`, and then put it in `views/viewMap.tsx`.
+Make a new component that accepts `ViewProps`, and then put it in `views/viewMap.tsx`.
 
 A useful library component is `import { ObjectInspector } from "react-inspector";`, which gives a chrome-style JSON tree you can inspect.
 
@@ -63,5 +63,5 @@ After creating the mod file, add it to `mod/defmap.tsx`.
 
 ### Mod
 
-- The `pathData` attribute is only modifiable if it contains a list of `IPt`. Currently does not work with Bezier curves.
-- If the types in `types.d.ts` change form, `LabeledInput.tsx` will likely need to be modified. For example, if the structure of `IPathData` is changed, attempting to modify the `pathData` attribute will result in a crash.
+- The `pathData` attribute is only modifiable if it contains a list of `Pt`. Currently does not work with Bezier curves.
+- If the types in `types.d.ts` change form, `LabeledInput.tsx` will likely need to be modified. For example, if the structure of `PathData` is changed, attempting to modify the `pathData` attribute will result in a crash.

--- a/packages/browser-ui/src/inspector/views/CompGraph.tsx
+++ b/packages/browser-ui/src/inspector/views/CompGraph.tsx
@@ -1,6 +1,6 @@
 // TODO: This is the file with the most final version of CompGraph vis
 
-import { IState } from "@penrose/core/build/dist/types/state";
+import { State } from "@penrose/core/build/dist/types/state";
 import cytoscape from "cytoscape";
 import * as React from "react";
 import {
@@ -9,7 +9,7 @@ import {
   toGraphOpt,
   traverseUnique,
 } from "./GraphUtils";
-import IViewProps from "./IViewProps";
+import ViewProps from "./ViewProps";
 
 // TODO: Style edges to DOF vs edges to constants differently
 
@@ -62,7 +62,7 @@ const style = [
   },
 ];
 
-const makeGraph = (frame: IState, value: string): PGraph => {
+const makeGraph = (frame: State, value: string): PGraph => {
   let graph;
 
   if (value === "opt") {
@@ -89,9 +89,7 @@ const makeGraph = (frame: IState, value: string): PGraph => {
   return graph;
 };
 
-const CompGraph: React.FC<IViewProps> = ({
-  frame /*,history*/,
-}: IViewProps) => {
+const CompGraph: React.FC<ViewProps> = ({ frame /*,history*/ }: ViewProps) => {
   if (!frame) {
     return (
       <div style={{ padding: "1em", fontSize: "1em", color: "#4f4f4f" }}>

--- a/packages/browser-ui/src/inspector/views/Errors.tsx
+++ b/packages/browser-ui/src/inspector/views/Errors.tsx
@@ -1,7 +1,7 @@
 import { showError } from "@penrose/core";
 import * as React from "react";
-import IViewProps from "./IViewProps";
-const Errors: React.FC<IViewProps> = ({ error }: IViewProps) => {
+import ViewProps from "./ViewProps";
+const Errors: React.FC<ViewProps> = ({ error }: ViewProps) => {
   if (!error) {
     return (
       <div style={{ padding: "1em", fontSize: "1em", color: "#4f4f4f" }}>

--- a/packages/browser-ui/src/inspector/views/Frames.tsx
+++ b/packages/browser-ui/src/inspector/views/Frames.tsx
@@ -1,8 +1,8 @@
 import * as React from "react";
 import { ObjectInspector } from "react-inspector";
-import IViewProps from "./IViewProps";
+import ViewProps from "./ViewProps";
 // https://goessner.net/articles/JsonPath/
-class Frames extends React.Component<IViewProps> {
+class Frames extends React.Component<ViewProps> {
   public render(): JSX.Element {
     const { /*history,*/ frame } = this.props;
     if (frame === undefined) {

--- a/packages/browser-ui/src/inspector/views/LogView.tsx
+++ b/packages/browser-ui/src/inspector/views/LogView.tsx
@@ -1,6 +1,6 @@
 import * as React from "react";
 import styled from "styled-components";
-import IViewProps from "./IViewProps";
+import ViewProps from "./ViewProps";
 
 const LogLine = styled.li`
   list-style-type: none;
@@ -11,7 +11,7 @@ const LogLine = styled.li`
   border-bottom: 1px solid gray;
 `;
 
-class LogView extends React.Component<IViewProps> {
+class LogView extends React.Component<ViewProps> {
   public render() {
     // const { connectionLog } = this.props;
     return <ul style={{ padding: 0 }}></ul>;

--- a/packages/browser-ui/src/inspector/views/Mod.tsx
+++ b/packages/browser-ui/src/inspector/views/Mod.tsx
@@ -1,15 +1,15 @@
 import { PenroseState, Value } from "@penrose/core";
 import makeViewBoxes from "inspector/makeViewBoxes";
 import * as React from "react";
-import IViewProps from "./IViewProps";
 import AttrPicker from "./mod/AttrPicker";
 import defmap from "./mod/defmap";
+import ViewProps from "./ViewProps";
 
-interface IState {
+interface State {
   selectedShape: number;
 }
 
-class Mod extends React.Component<IViewProps, IState> {
+class Mod extends React.Component<ViewProps, State> {
   public readonly state = { selectedShape: 0 };
   public setSelectedShape = (key: number) => {
     this.setState({ selectedShape: key });

--- a/packages/browser-ui/src/inspector/views/Opt.tsx
+++ b/packages/browser-ui/src/inspector/views/Opt.tsx
@@ -2,11 +2,11 @@ import { evalFns, normList, prettyPrintFn } from "@penrose/core";
 import { zipWith } from "lodash";
 import * as React from "react";
 import DataTable from "react-data-table-component";
-import IViewProps from "./IViewProps";
+import ViewProps from "./ViewProps";
 
 export const EPS = 10e-3;
 
-const Opt: React.FC<IViewProps> = ({ frame /*, history*/ }: IViewProps) => {
+const Opt: React.FC<ViewProps> = ({ frame /*, history*/ }: ViewProps) => {
   if (!frame) {
     return (
       <div style={{ padding: "1em", fontSize: "1em", color: "#4f4f4f" }}>

--- a/packages/browser-ui/src/inspector/views/Settings.tsx
+++ b/packages/browser-ui/src/inspector/views/Settings.tsx
@@ -1,10 +1,10 @@
 import * as React from "react";
-import IViewProps from "./IViewProps";
-const Settings: React.FC<IViewProps> = ({
+import ViewProps from "./ViewProps";
+const Settings: React.FC<ViewProps> = ({
   settings,
   setSettings,
   reset,
-}: IViewProps) => {
+}: ViewProps) => {
   const onAutostepChange = React.useCallback(
     (e) => {
       setSettings({ ...settings, autoStepSize: parseInt(e.target.value, 10) });

--- a/packages/browser-ui/src/inspector/views/ShapeView.tsx
+++ b/packages/browser-ui/src/inspector/views/ShapeView.tsx
@@ -1,13 +1,13 @@
 import * as React from "react";
 import { ObjectInspector } from "react-inspector";
 import makeViewBoxes from "../../inspector/makeViewBoxes";
-import IViewProps from "./IViewProps";
+import ViewProps from "./ViewProps";
 
-interface IState {
+interface State {
   selectedShape: number;
 }
 
-class ShapeView extends React.Component<IViewProps, IState> {
+class ShapeView extends React.Component<ViewProps, State> {
   public readonly state = { selectedShape: -1 };
   public setSelectedShape = (key: number): void => {
     this.setState({ selectedShape: key });

--- a/packages/browser-ui/src/inspector/views/Timeline.tsx
+++ b/packages/browser-ui/src/inspector/views/Timeline.tsx
@@ -2,7 +2,7 @@ import { PenroseState, RenderStatic } from "@penrose/core";
 import * as React from "react";
 import { useEffect, useRef, useState } from "react";
 import styled from "styled-components";
-import IViewProps from "./IViewProps";
+import ViewProps from "./ViewProps";
 
 const TimelineStyled = styled.ul`
   background-color: rgba(0, 0, 0, 0.05);
@@ -36,7 +36,7 @@ const TimelineItem = styled.li<any>`
   box-shadow: rgba(0, 0, 0, 0.2) 0px 2px 3px 0px;
 `;
 
-function Timeline({ frameIndex, history, selectFrame }: IViewProps) {
+function Timeline({ frameIndex, history, selectFrame }: ViewProps) {
   const ref = useRef<any>(null);
   useEffect(() => {
     if (history.length !== history.length && ref.current !== null) {

--- a/packages/browser-ui/src/inspector/views/ViewProps.tsx
+++ b/packages/browser-ui/src/inspector/views/ViewProps.tsx
@@ -1,7 +1,7 @@
 import { PenroseError, PenroseState } from "@penrose/core";
-import { ISettings } from "App";
+import { Settings } from "App";
 
-export interface IViewProps {
+export interface ViewProps {
   // Switches the current frame to index in history
   selectFrame(frame: number): void;
   // Gives access to the full history of frames
@@ -12,8 +12,8 @@ export interface IViewProps {
   frameIndex: number;
   modShapes(state: PenroseState): void; // todo - null check
   error: PenroseError | undefined;
-  settings: ISettings;
-  setSettings(settings: ISettings): void;
+  settings: Settings;
+  setSettings(settings: Settings): void;
   reset(): void;
 }
-export default IViewProps;
+export default ViewProps;

--- a/packages/browser-ui/src/inspector/views/mod/AttrPicker.tsx
+++ b/packages/browser-ui/src/inspector/views/mod/AttrPicker.tsx
@@ -2,20 +2,20 @@ import { Canvas, Shape, Value } from "@penrose/core";
 import * as React from "react";
 import LabeledInput from "./LabeledInput";
 
-interface IProps {
+interface Props {
   shape: Shape;
-  sAttrs: IShapeDef;
+  sAttrs: ShapeDef;
   modAttr(attrname: string, attrval: Value.Value<any>): void;
   canvas: Canvas;
 }
 
-interface IShapeDef {
+interface ShapeDef {
   shapeType: string;
   properties: any;
 }
 
 // Q - should this update shape properties in state? not really necessary functionally but maybe ideologically
-class AttrPicker extends React.Component<IProps> {
+class AttrPicker extends React.Component<Props> {
   public render() {
     const { sAttrs, shape, modAttr, canvas } = this.props;
     if (!sAttrs.hasOwnProperty("properties")) {

--- a/packages/browser-ui/src/inspector/views/mod/LabeledInput.tsx
+++ b/packages/browser-ui/src/inspector/views/mod/LabeledInput.tsx
@@ -2,8 +2,8 @@ import { Canvas, toSvgPaintProperty, Value } from "@penrose/core";
 import { cloneDeep, round } from "lodash";
 import * as React from "react";
 
-interface IProps {
-  inputProps: IInputProps;
+interface Props {
+  inputProps: InputProps;
   eAttr: string;
   eValue: Value.Value<any>; // is this the best typing?
   modAttr(attrname: string, attrval: Value.Value<any>): void;
@@ -21,7 +21,7 @@ type InputType =
   | "url"
   | "ptrange";
 
-interface IInputProps {
+interface InputProps {
   inputType: InputType;
   showValue?: "true" | "false";
   min?: string;
@@ -56,11 +56,11 @@ const toCanvas = (jsonVal: string, canvas: Canvas): string => {
   }
 };
 
-class LabeledInput extends React.Component<IProps> {
+class LabeledInput extends React.Component<Props> {
   public readonly state = {
     eValue: this.props.eValue,
   };
-  public componentDidUpdate(prevProps: IProps) {
+  public componentDidUpdate(prevProps: Props) {
     if (this.props !== prevProps) {
       this.setState({
         eValue: this.props.eValue,
@@ -74,7 +74,7 @@ class LabeledInput extends React.Component<IProps> {
       | number
       | Value.Color<number>
       | boolean
-      | Value.ISubPath<number>[]
+      | Value.SubPath<number>[]
   ) => {
     const newstate = {
       eValue: {
@@ -216,12 +216,12 @@ class LabeledInput extends React.Component<IProps> {
     // todo - refactor the whole file so you can call makerange() and makelabel() with params
     return (
       <React.Fragment>
-        {subpaths.map((subpath: Value.IPathCmd<number>, index: number) => {
+        {subpaths.map((subpath: Value.PathCmd<number>, index: number) => {
           const ptarray = subpath.contents;
           // note - prob will crash on bezier stuff
           return (
             <React.Fragment key={"S" + index}>
-              {ptarray.map((pt: Value.ISubPath<number>, subindex: number) => {
+              {ptarray.map((pt: Value.SubPath<number>, subindex: number) => {
                 // todo clean up following lines
                 const xid = [
                   "S",

--- a/packages/browser-ui/src/ui/ButtonBar.tsx
+++ b/packages/browser-ui/src/ui/ButtonBar.tsx
@@ -1,7 +1,7 @@
 import * as React from "react";
 import { FileSocketResult } from "./FileSocket";
 
-interface IProps {
+interface Props {
   converged: boolean;
   autostep: boolean;
   initial: boolean;
@@ -22,7 +22,7 @@ interface IProps {
   resample(): void;
   reconnect(): void;
 }
-class ButtonBar extends React.Component<IProps> {
+class ButtonBar extends React.Component<Props> {
   public render(): JSX.Element {
     const {
       converged,

--- a/packages/components/src/Embed.tsx
+++ b/packages/components/src/Embed.tsx
@@ -2,7 +2,7 @@ import React, { CSSProperties } from "react";
 import "./Embed.css";
 import Logo from "./icons/Logo";
 import Resample from "./icons/Resample";
-import { ISimpleProps, Simple } from "./Simple";
+import { Simple, SimpleProps } from "./Simple";
 
 const footerStyle: CSSProperties = {
   display: "flex",
@@ -36,14 +36,14 @@ const Heart = () => (
   </span>
 );
 
-interface IEmbedState {
+interface EmbedState {
   variation: string;
 }
 
-// variation from ISimpleProps is just the initial variation; the actual
+// variation from SimpleProps is just the initial variation; the actual
 // variation is stored in state, can be changed by resampling
-class Embed extends React.Component<ISimpleProps, IEmbedState> {
-  constructor(props: ISimpleProps) {
+class Embed extends React.Component<SimpleProps, EmbedState> {
+  constructor(props: SimpleProps) {
     super(props);
     this.state = { variation: props.variation };
   }

--- a/packages/components/src/Simple.tsx
+++ b/packages/components/src/Simple.tsx
@@ -15,7 +15,7 @@ import {
 import React from "react";
 import fetchResolver from "./fetchPathResolver";
 
-export interface ISimpleProps {
+export interface SimpleProps {
   domain: string;
   substance: string;
   style: string;
@@ -24,16 +24,16 @@ export interface ISimpleProps {
   animate?: boolean; // considered false by default
 }
 
-export interface ISimpleState {
+export interface SimpleState {
   error?: PenroseError;
 }
 
-class Simple extends React.Component<ISimpleProps, ISimpleState> {
+class Simple extends React.Component<SimpleProps, SimpleState> {
   readonly canvasRef = React.createRef<HTMLDivElement>();
   penroseState: PenroseState | undefined = undefined;
   timerID: number | undefined = undefined; // for animation
 
-  constructor(props: ISimpleProps) {
+  constructor(props: SimpleProps) {
     super(props);
     this.state = {
       error: undefined,
@@ -82,7 +82,7 @@ class Simple extends React.Component<ISimpleProps, ISimpleState> {
     this.timerID = window.setInterval(() => this.tick(), 1000 / 60);
   };
 
-  componentDidUpdate = async (prevProps: ISimpleProps) => {
+  componentDidUpdate = async (prevProps: SimpleProps) => {
     // re-compile if the programs change
     if (
       this.props.domain !== prevProps.domain ||

--- a/packages/core/src/compiler/Style.ts
+++ b/packages/core/src/compiler/Style.ts
@@ -45,18 +45,18 @@ import {
 } from "types/errors";
 import { Fn, OptType, Params, State } from "types/state";
 import {
+  AccessPath,
   BindingForm,
   Block,
+  CompApp,
+  ConstrFn,
   DeclPattern,
   Expr,
   GPIDecl,
   Header,
   HeaderBlock,
-  IAccessPath,
-  ICompApp,
-  IConstrFn,
-  ILayering,
-  IObjFn,
+  Layering,
+  ObjFn,
   Path,
   PredArg,
   PropertyDecl,
@@ -83,13 +83,13 @@ import {
   TypeConsApp,
 } from "types/substance";
 import {
+  FGPI,
   Field,
   FieldDict,
   FieldExpr,
   GPIMap,
   GPIProps,
-  IFGPI,
-  IOptEval,
+  OptEval,
   Property,
   PropID,
   ShapeTypeStr,
@@ -1890,7 +1890,7 @@ const checkGPIInfo = (selEnv: SelEnv, expr: GPIDecl<A>): StyleResults => {
 // Check that every function, objective, and constraint exists (below) -- parametrically over the kind of function
 const checkFunctionName = (
   selEnv: SelEnv,
-  expr: ICompApp<A> | IObjFn<A> | IConstrFn<A>
+  expr: CompApp<A> | ObjFn<A> | ConstrFn<A>
 ): StyleResults => {
   const fnDict = FN_DICT[expr.tag];
   const fnNames: string[] = _.keys(fnDict); // Names of built-in functions of that kind
@@ -2350,7 +2350,7 @@ const findNestedVarying = (e: TagExpr<ad.Num>, p: Path<A>): Path<A>[] => {
         .map((e: Expr<A>, i): [Expr<A>, number] => [e, i])
         .filter((e: [Expr<A>, number]): boolean => isVarying(e[0]))
         .map(
-          ([, i]: [Expr<A>, number]): IAccessPath<A> => ({
+          ([, i]: [Expr<A>, number]): AccessPath<A> => ({
             nodeType: "SyntheticStyle",
             tag: "AccessPath",
             path: p,
@@ -2615,7 +2615,7 @@ const convertFns = (fns: Either<StyleOptFn, StyleOptFn>[]): [Fn[], Fn[]] => {
 
 // Extract number from a more complicated type
 // also ported from `lookupPaths`
-const getNum = (e: TagExpr<ad.Num> | IFGPI<ad.Num>): number => {
+const getNum = (e: TagExpr<ad.Num> | FGPI<ad.Num>): number => {
   switch (e.tag) {
     case "OptEval": {
       if (e.contents.tag === "Fix") {
@@ -2852,7 +2852,7 @@ const initShape = (
         contents: shapeName,
       },
     };
-    const gpi: IFGPI<ad.Num> = {
+    const gpi: FGPI<ad.Num> = {
       tag: "FGPI",
       contents: [stype, instantiatedGPIProps],
     };
@@ -2874,12 +2874,12 @@ const findLayeringExpr = (
   name: string,
   field: Field,
   fexpr: FieldExpr<ad.Num>,
-  acc: ILayering<A>[]
-): ILayering<A>[] => {
+  acc: Layering<A>[]
+): Layering<A>[] => {
   if (fexpr.tag === "FExpr") {
     if (fexpr.contents.tag === "OptEval") {
       if (fexpr.contents.contents.tag === "Layering") {
-        const layering: ILayering<A> = fexpr.contents.contents;
+        const layering: Layering<A> = fexpr.contents.contents;
         return [layering].concat(acc);
       }
     }
@@ -2887,7 +2887,7 @@ const findLayeringExpr = (
   return acc;
 };
 
-const findLayeringExprs = (tr: Translation): ILayering<A>[] => {
+const findLayeringExprs = (tr: Translation): Layering<A>[] => {
   return foldSubObjs(findLayeringExpr, tr);
 };
 
@@ -2900,7 +2900,7 @@ const lookupGPIName = (p: Path<A>, tr: Translation): string => {
   }
 };
 
-const findNames = (e: ILayering<A>, tr: Translation): [string, string] => [
+const findNames = (e: Layering<A>, tr: Translation): [string, string] => [
   lookupGPIName(e.below, tr),
   lookupGPIName(e.above, tr),
 ];
@@ -2966,7 +2966,7 @@ const computeShapeOrdering = (tr: Translation): string[] => {
   const partialOrderings: [
     string,
     string
-  ][] = layeringExprs.map((e: ILayering<A>): [string, string] =>
+  ][] = layeringExprs.map((e: Layering<A>): [string, string] =>
     findNames(e, tr)
   );
 
@@ -3124,7 +3124,7 @@ export const parseStyle = (p: string): Result<StyProg<C>, ParseError> => {
 
 //#region Checking translation
 
-const isStyErr = (res: TagExpr<ad.Num> | IFGPI<ad.Num> | StyleError): boolean =>
+const isStyErr = (res: TagExpr<ad.Num> | FGPI<ad.Num> | StyleError): boolean =>
   res.tag !== "FGPI" && !isTagExpr(res);
 
 const findPathsExpr = <T>(expr: Expr<T>): Path<T>[] => {
@@ -3210,8 +3210,8 @@ const findPathsField = (
       const propExprs: Expr<A>[] = Object.entries(fexpr.contents[1])
         .map((e) => e[1])
         .filter((e: TagExpr<ad.Num>): boolean => e.tag === "OptEval")
-        .map((e) => e as IOptEval<ad.Num>) // Have to cast because TypeScript doesn't know the type changed from the filter above
-        .map((e: IOptEval<ad.Num>): Expr<A> => e.contents);
+        .map((e) => e as OptEval<ad.Num>) // Have to cast because TypeScript doesn't know the type changed from the filter above
+        .map((e: OptEval<ad.Num>): Expr<A> => e.contents);
       const res: Path<A>[] = _.flatMap(propExprs, findPathsExpr);
       return acc.concat(res);
     }

--- a/packages/core/src/contrib/Functions.ts
+++ b/packages/core/src/contrib/Functions.ts
@@ -53,13 +53,13 @@ import * as ad from "types/ad";
 import {
   ArgVal,
   Color,
-  IColorV,
-  IFloatV,
-  IPathDataV,
-  IPtListV,
-  IStrV,
-  ITupV,
-  IVectorV,
+  ColorV,
+  FloatV,
+  PathDataV,
+  PtListV,
+  StrV,
+  TupV,
+  VectorV,
 } from "types/value";
 import { getStart, linePts, randFloat } from "utils/Util";
 
@@ -84,7 +84,7 @@ export const compDict = {
     end: [ad.Num, ad.Num],
     curveHeight: ad.Num,
     padding: ad.Num
-  ): IPathDataV<ad.Num> => {
+  ): PathDataV<ad.Num> => {
     // Two vectors for moving from `start` to the control point: `unit` is the direction of vector [start, end] (along the line passing through both labels) and `normalVec` is perpendicular to `unit` through the `rot90` operation.
     const unit: ad.Num[] = ops.vnormalize(ops.vsub(start, end));
     const normalVec: ad.Num[] = rot90(toPt(unit));
@@ -112,7 +112,7 @@ export const compDict = {
     _context: Context,
     optDebugInfo: ad.OptDebugInfo,
     varName: string
-  ): IFloatV<ad.Num> => {
+  ): FloatV<ad.Num> => {
     if (
       !optDebugInfo ||
       !("gradient" in optDebugInfo) ||
@@ -151,7 +151,7 @@ export const compDict = {
     _context: Context,
     optDebugInfo: ad.OptDebugInfo,
     varName: string
-  ): IFloatV<ad.Num> => {
+  ): FloatV<ad.Num> => {
     if (
       !optDebugInfo ||
       !("gradientPreconditioned" in optDebugInfo) ||
@@ -185,7 +185,7 @@ export const compDict = {
   /**
    * Return `i`th element of list `xs, assuming lists only hold floats.
    */
-  get: (_context: Context, xs: ad.Num[], i: number): IFloatV<ad.Num> => {
+  get: (_context: Context, xs: ad.Num[], i: number): FloatV<ad.Num> => {
     const res = xs[i];
     return {
       tag: "FloatV",
@@ -202,7 +202,7 @@ export const compDict = {
     g: ad.Num,
     b: ad.Num,
     a: ad.Num
-  ): IColorV<ad.Num> => {
+  ): ColorV<ad.Num> => {
     return {
       tag: "ColorV",
       contents: {
@@ -217,7 +217,7 @@ export const compDict = {
     color1: Color<ad.Num>,
     color2: Color<ad.Num>,
     level: ad.Num
-  ): IColorV<ad.Num> => {
+  ): ColorV<ad.Num> => {
     const half = div(level, 2);
     const even = eq(half, trunc(half)); // autodiff doesn't have a mod operator
     if (!(color1.tag === "RGBA" && color2.tag === "RGBA")) {
@@ -247,7 +247,7 @@ export const compDict = {
     s: ad.Num,
     v: ad.Num,
     a: ad.Num
-  ): IColorV<ad.Num> => {
+  ): ColorV<ad.Num> => {
     return {
       tag: "ColorV",
       contents: {
@@ -260,7 +260,7 @@ export const compDict = {
   /**
    * Return a paint of none (no paint)
    */
-  none: (_context: Context): IColorV<ad.Num> => {
+  none: (_context: Context): ColorV<ad.Num> => {
     return {
       tag: "ColorV",
       contents: {
@@ -272,7 +272,7 @@ export const compDict = {
   /**
    * Return `acosh(x)`.
    */
-  acosh: (_context: Context, x: ad.Num): IFloatV<ad.Num> => {
+  acosh: (_context: Context, x: ad.Num): FloatV<ad.Num> => {
     return {
       tag: "FloatV",
       contents: acosh(x),
@@ -282,7 +282,7 @@ export const compDict = {
   /**
    * Return `acos(x)`.
    */
-  acos: (_context: Context, x: ad.Num): IFloatV<ad.Num> => {
+  acos: (_context: Context, x: ad.Num): FloatV<ad.Num> => {
     return {
       tag: "FloatV",
       contents: acos(x),
@@ -292,7 +292,7 @@ export const compDict = {
   /**
    * Return `asin(x)`.
    */
-  asin: (_context: Context, x: ad.Num): IFloatV<ad.Num> => {
+  asin: (_context: Context, x: ad.Num): FloatV<ad.Num> => {
     return {
       tag: "FloatV",
       contents: asin(x),
@@ -302,7 +302,7 @@ export const compDict = {
   /**
    * Return `asinh(x)`.
    */
-  asinh: (_context: Context, x: ad.Num): IFloatV<ad.Num> => {
+  asinh: (_context: Context, x: ad.Num): FloatV<ad.Num> => {
     return {
       tag: "FloatV",
       contents: asinh(x),
@@ -312,7 +312,7 @@ export const compDict = {
   /**
    * Return `atan(x)`.
    */
-  atan: (_context: Context, x: ad.Num): IFloatV<ad.Num> => {
+  atan: (_context: Context, x: ad.Num): FloatV<ad.Num> => {
     return {
       tag: "FloatV",
       contents: atan(x),
@@ -322,7 +322,7 @@ export const compDict = {
   /**
    * Return `atan2(y,x)`.
    */
-  atan2: (_context: Context, x: ad.Num, y: ad.Num): IFloatV<ad.Num> => {
+  atan2: (_context: Context, x: ad.Num, y: ad.Num): FloatV<ad.Num> => {
     return {
       tag: "FloatV",
       contents: atan2(y, x),
@@ -332,7 +332,7 @@ export const compDict = {
   /**
    * Return `atanh(x)`.
    */
-  atanh: (_context: Context, x: ad.Num): IFloatV<ad.Num> => {
+  atanh: (_context: Context, x: ad.Num): FloatV<ad.Num> => {
     return {
       tag: "FloatV",
       contents: atanh(x),
@@ -342,7 +342,7 @@ export const compDict = {
   /**
    * Return `cbrt(x)`.
    */
-  cbrt: (_context: Context, x: ad.Num): IFloatV<ad.Num> => {
+  cbrt: (_context: Context, x: ad.Num): FloatV<ad.Num> => {
     return {
       tag: "FloatV",
       contents: cbrt(x),
@@ -352,7 +352,7 @@ export const compDict = {
   /**
    * Return `ceil(x)`.
    */
-  ceil: (_context: Context, x: ad.Num): IFloatV<ad.Num> => {
+  ceil: (_context: Context, x: ad.Num): FloatV<ad.Num> => {
     return {
       tag: "FloatV",
       contents: ceil(x),
@@ -362,7 +362,7 @@ export const compDict = {
   /**
    * Return `cos(x)`.
    */
-  cos: (_context: Context, x: ad.Num): IFloatV<ad.Num> => {
+  cos: (_context: Context, x: ad.Num): FloatV<ad.Num> => {
     return {
       tag: "FloatV",
       contents: cos(x),
@@ -372,7 +372,7 @@ export const compDict = {
   /**
    * Return `cosh(x)`.
    */
-  cosh: (_context: Context, x: ad.Num): IFloatV<ad.Num> => {
+  cosh: (_context: Context, x: ad.Num): FloatV<ad.Num> => {
     return {
       tag: "FloatV",
       contents: cosh(x),
@@ -382,7 +382,7 @@ export const compDict = {
   /**
    * Return `exp(x)`.
    */
-  exp: (_context: Context, x: ad.Num): IFloatV<ad.Num> => {
+  exp: (_context: Context, x: ad.Num): FloatV<ad.Num> => {
     return {
       tag: "FloatV",
       contents: exp(x),
@@ -392,7 +392,7 @@ export const compDict = {
   /**
    * Return `expm1(x)`.
    */
-  expm1: (_context: Context, x: ad.Num): IFloatV<ad.Num> => {
+  expm1: (_context: Context, x: ad.Num): FloatV<ad.Num> => {
     return {
       tag: "FloatV",
       contents: expm1(x),
@@ -402,7 +402,7 @@ export const compDict = {
   /**
    * Return `floor(x)`.
    */
-  floor: (_context: Context, x: ad.Num): IFloatV<ad.Num> => {
+  floor: (_context: Context, x: ad.Num): FloatV<ad.Num> => {
     return {
       tag: "FloatV",
       contents: floor(x),
@@ -412,7 +412,7 @@ export const compDict = {
   /**
    * Return `log(x)`.
    */
-  log: (_context: Context, x: ad.Num): IFloatV<ad.Num> => {
+  log: (_context: Context, x: ad.Num): FloatV<ad.Num> => {
     return {
       tag: "FloatV",
       contents: ln(x),
@@ -422,7 +422,7 @@ export const compDict = {
   /**
    * Return `log2(x)`.
    */
-  log2: (_context: Context, x: ad.Num): IFloatV<ad.Num> => {
+  log2: (_context: Context, x: ad.Num): FloatV<ad.Num> => {
     return {
       tag: "FloatV",
       contents: log2(x),
@@ -432,7 +432,7 @@ export const compDict = {
   /**
    * Return `log10(x)`.
    */
-  log10: (_context: Context, x: ad.Num): IFloatV<ad.Num> => {
+  log10: (_context: Context, x: ad.Num): FloatV<ad.Num> => {
     return {
       tag: "FloatV",
       contents: log10(x),
@@ -442,7 +442,7 @@ export const compDict = {
   /**
    * Return `log1p(x)`.
    */
-  log1p: (_context: Context, x: ad.Num): IFloatV<ad.Num> => {
+  log1p: (_context: Context, x: ad.Num): FloatV<ad.Num> => {
     return {
       tag: "FloatV",
       contents: log1p(x),
@@ -452,7 +452,7 @@ export const compDict = {
   /**
    * Return `pow(x,y)`.
    */
-  pow: (_context: Context, x: ad.Num, y: ad.Num): IFloatV<ad.Num> => {
+  pow: (_context: Context, x: ad.Num, y: ad.Num): FloatV<ad.Num> => {
     return {
       tag: "FloatV",
       contents: pow(x, y),
@@ -462,7 +462,7 @@ export const compDict = {
   /**
    * Return `round(x)`.
    */
-  round: (_context: Context, x: ad.Num): IFloatV<ad.Num> => {
+  round: (_context: Context, x: ad.Num): FloatV<ad.Num> => {
     return {
       tag: "FloatV",
       contents: round(x),
@@ -472,7 +472,7 @@ export const compDict = {
   /**
    * Return `sign(x)`.
    */
-  sign: (_context: Context, x: ad.Num): IFloatV<ad.Num> => {
+  sign: (_context: Context, x: ad.Num): FloatV<ad.Num> => {
     return {
       tag: "FloatV",
       contents: sign(x),
@@ -482,7 +482,7 @@ export const compDict = {
   /**
    * Return `sin(x)`.
    */
-  sin: (_context: Context, x: ad.Num): IFloatV<ad.Num> => {
+  sin: (_context: Context, x: ad.Num): FloatV<ad.Num> => {
     return {
       tag: "FloatV",
       contents: sin(x),
@@ -492,7 +492,7 @@ export const compDict = {
   /**
    * Return `sinh(x)`.
    */
-  sinh: (_context: Context, x: ad.Num): IFloatV<ad.Num> => {
+  sinh: (_context: Context, x: ad.Num): FloatV<ad.Num> => {
     return {
       tag: "FloatV",
       contents: sinh(x),
@@ -502,7 +502,7 @@ export const compDict = {
   /**
    * Return `tan(x)`.
    */
-  tan: (_context: Context, x: ad.Num): IFloatV<ad.Num> => {
+  tan: (_context: Context, x: ad.Num): FloatV<ad.Num> => {
     return {
       tag: "FloatV",
       contents: tan(x),
@@ -512,7 +512,7 @@ export const compDict = {
   /**
    * Return `tanh(x)`.
    */
-  tanh: (_context: Context, x: ad.Num): IFloatV<ad.Num> => {
+  tanh: (_context: Context, x: ad.Num): FloatV<ad.Num> => {
     return {
       tag: "FloatV",
       contents: tanh(x),
@@ -522,7 +522,7 @@ export const compDict = {
   /**
    * Return `trunc(x)`.
    */
-  trunc: (_context: Context, x: ad.Num): IFloatV<ad.Num> => {
+  trunc: (_context: Context, x: ad.Num): FloatV<ad.Num> => {
     return {
       tag: "FloatV",
       contents: trunc(x),
@@ -532,7 +532,7 @@ export const compDict = {
   /**
    * Return the dot product of `v` and `w`.
    */
-  dot: (_context: Context, v: ad.Num[], w: ad.Num[]): IFloatV<ad.Num> => {
+  dot: (_context: Context, v: ad.Num[], w: ad.Num[]): FloatV<ad.Num> => {
     return {
       tag: "FloatV",
       contents: ops.vdot(v, w),
@@ -542,10 +542,7 @@ export const compDict = {
   /**
    * Return the length of the line or arrow shape `[type, props]`.
    */
-  lineLength: (
-    _context: Context,
-    [, props]: [string, any]
-  ): IFloatV<ad.Num> => {
+  lineLength: (_context: Context, [, props]: [string, any]): FloatV<ad.Num> => {
     const [p1, p2] = linePts(props);
     return {
       tag: "FloatV",
@@ -556,7 +553,7 @@ export const compDict = {
   /**
    * Return the length of the line or arrow shape `[type, props]`.
    */
-  len: (_context: Context, [, props]: [string, any]): IFloatV<ad.Num> => {
+  len: (_context: Context, [, props]: [string, any]): FloatV<ad.Num> => {
     const [p1, p2] = linePts(props);
     return {
       tag: "FloatV",
@@ -567,7 +564,7 @@ export const compDict = {
   /**
    * Concatenate a list of strings
    */
-  concat: (_context: Context, ...strings: string[]): IStrV => {
+  concat: (_context: Context, ...strings: string[]): StrV => {
     return {
       tag: "StrV",
       contents: strings.join(""),
@@ -577,7 +574,7 @@ export const compDict = {
   /**
    * Return the normalized version of vector `v`.
    */
-  normalize: (_context: Context, v: ad.Num[]): IVectorV<ad.Num> => {
+  normalize: (_context: Context, v: ad.Num[]): VectorV<ad.Num> => {
     return {
       tag: "VectorV",
       contents: ops.vnormalize(v),
@@ -591,7 +588,7 @@ export const compDict = {
     _context: Context,
     pathType: string,
     pts: ad.Pt2[]
-  ): IPathDataV<ad.Num> => {
+  ): PathDataV<ad.Num> => {
     const path = new PathBuilder();
     const [start, ...tailpts] = pts;
     path.moveTo(start);
@@ -607,7 +604,7 @@ export const compDict = {
     _context: Context,
     pathType: string,
     pts: ad.Pt2[]
-  ): IPathDataV<ad.Num> => {
+  ): PathDataV<ad.Num> => {
     const path = new PathBuilder();
     const [start, cp, second, ...tailpts] = pts;
     path.moveTo(start);
@@ -624,7 +621,7 @@ export const compDict = {
     _context: Context,
     pathType: string,
     pts: ad.Pt2[]
-  ): IPathDataV<ad.Num> => {
+  ): PathDataV<ad.Num> => {
     const path = new PathBuilder();
     const [start, cp1, cp2, second, ...tailpts] = pts;
     path.moveTo(start);
@@ -644,7 +641,7 @@ export const compDict = {
     t: string,
     padding: ad.Num,
     barSize: ad.Num
-  ): IPtListV<ad.Num> => {
+  ): PtListV<ad.Num> => {
     const [start1, end1] = linePts(s1);
     const [start2, end2] = linePts(s2);
 
@@ -668,7 +665,7 @@ export const compDict = {
     t: string,
     padding: ad.Num,
     size: ad.Num
-  ): IPtListV<ad.Num> => {
+  ): PtListV<ad.Num> => {
     const dir = ops.vnormalize(ops.vsub(end, start));
     const normalDir = rot90(toPt(dir));
     const base = t === "start" ? start : end;
@@ -702,7 +699,7 @@ export const compDict = {
     rotation: ad.Num,
     largeArc: ad.Num,
     arcSweep: ad.Num
-  ): IPathDataV<ad.Num> => {
+  ): PathDataV<ad.Num> => {
     const path = new PathBuilder();
     path.moveTo(start).arcTo(radius, end, [rotation, largeArc, arcSweep]);
     if (pathType === "closed") path.closePath();
@@ -728,7 +725,7 @@ export const compDict = {
     rotation: ad.Num,
     largeArc: ad.Num,
     arcSweep: ad.Num
-  ): IPathDataV<ad.Num> => {
+  ): PathDataV<ad.Num> => {
     const path = new PathBuilder();
     path
       .moveTo(start)
@@ -749,7 +746,7 @@ export const compDict = {
     p1: ad.Num[],
     p2: ad.Num[],
     r: ad.Num
-  ): IVectorV<ad.Num> => {
+  ): VectorV<ad.Num> => {
     // find unit vector pointing towards v2
     const unit = ops.vnormalize(ops.vsub(p2, p1));
     return { tag: "VectorV", contents: ops.vmove(p1, r, unit) };
@@ -766,7 +763,7 @@ export const compDict = {
     [x1, y1]: ad.Num[],
     start: ad.Pt2,
     end: ad.Pt2
-  ): IFloatV<ad.Num> => {
+  ): FloatV<ad.Num> => {
     const st = ops.vnormalize([sub(start[0], x1), sub(start[1], y1)]);
     const en = ops.vnormalize([sub(end[0], x1), sub(end[1], y1)]);
     const cross = ops.cross2(st, en);
@@ -784,7 +781,7 @@ export const compDict = {
     _context: Context,
     u: ad.Num[],
     v: ad.Num[]
-  ): IFloatV<ad.Num> => {
+  ): FloatV<ad.Num> => {
     const theta = ops.angleBetween(u, v);
     return {
       tag: "FloatV",
@@ -796,7 +793,7 @@ export const compDict = {
    * Assumes that both u and v are 2D vectors and have nonzero magnitude.
    * The returned value will be in the range [-pi,pi].
    */
-  angleFrom: (_context: Context, u: ad.Num[], v: ad.Num[]): IFloatV<ad.Num> => {
+  angleFrom: (_context: Context, u: ad.Num[], v: ad.Num[]): FloatV<ad.Num> => {
     const theta = ops.angleFrom(u, v);
     return {
       tag: "FloatV",
@@ -806,7 +803,7 @@ export const compDict = {
   /**
    * Return the 2D cross product of `u` and `v`, equal to the determinant of the 2x2 matrix [u v]
    */
-  cross2D: (_context: Context, u: ad.Num[], v: ad.Num[]): IFloatV<ad.Num> => {
+  cross2D: (_context: Context, u: ad.Num[], v: ad.Num[]): FloatV<ad.Num> => {
     const det = sub(mul(u[0], v[1]), mul(u[1], v[0]));
     return {
       tag: "FloatV",
@@ -823,7 +820,7 @@ export const compDict = {
     a1: ad.Num[],
     b0: ad.Num[],
     b1: ad.Num[]
-  ): IVectorV<ad.Num> => {
+  ): VectorV<ad.Num> => {
     const A0 = [a0[0], a0[1], 1];
     const A1 = [a1[0], a1[1], 1];
     const B0 = [b0[0], b0[1], 1];
@@ -842,7 +839,7 @@ export const compDict = {
     _context: Context,
     start: ad.Num[],
     end: ad.Num[]
-  ): IVectorV<ad.Num> => {
+  ): VectorV<ad.Num> => {
     const midpointLoc = ops.vmul(0.5, ops.vadd(start, end));
     return {
       tag: "VectorV",
@@ -856,7 +853,7 @@ export const compDict = {
     _context: Context,
     [t1, s1]: [string, any],
     padding: ad.Num
-  ): ITupV<ad.Num> => {
+  ): TupV<ad.Num> => {
     if (t1 === "Arrow" || t1 === "Line") {
       const [start, end] = linePts(s1);
       // TODO: Cache these operations in Style!
@@ -877,7 +874,7 @@ export const compDict = {
     [t1, s1]: [string, any],
     padding: ad.Num,
     ticks: ad.Num
-  ): IPtListV<ad.Num> => {
+  ): PtListV<ad.Num> => {
     if (t1 === "Arrow" || t1 === "Line") {
       // tickPlacement(padding, ticks);
       const [start, end] = linePts(s1);
@@ -907,7 +904,7 @@ export const compDict = {
     pt2: ad.Num[],
     pt3: ad.Num[],
     padding: ad.Num
-  ): IVectorV<ad.Num> => {
+  ): VectorV<ad.Num> => {
     // unit vector towards first corner
     const vec1unit = ops.vnormalize(ops.vsub(pt2, pt1));
     const normalDir = ops.vneg(rot90v(vec1unit)); // rot90 rotates CW, neg to point in CCW direction
@@ -945,7 +942,7 @@ export const compDict = {
     spacing: ad.Num,
     numTicks: ad.Num,
     tickLength: ad.Num
-  ): IPathDataV<ad.Num> => {
+  ): PathDataV<ad.Num> => {
     if (typeof numTicks !== "number") {
       throw Error("numTicks must be a constant");
     }
@@ -979,7 +976,7 @@ export const compDict = {
     [t2, s2]: [string, any],
     intersection: ad.Pt2,
     len: ad.Num
-  ): IPathDataV<ad.Num> => {
+  ): PathDataV<ad.Num> => {
     if (
       (t1 === "Arrow" || t1 === "Line") &&
       (t2 === "Arrow" || t2 === "Line")
@@ -1009,7 +1006,7 @@ export const compDict = {
     start: ad.Num[],
     end: ad.Num[],
     [t1, s1]: [string, any]
-  ): IFloatV<ad.Num> => {
+  ): FloatV<ad.Num> => {
     // if (s1.rotation.contents) { throw Error("assumed AABB"); }
     if (!shapedefs[t1].isRectlike) {
       throw Error("expected rect-like shape");
@@ -1047,7 +1044,7 @@ export const compDict = {
     [t1, l1]: any,
     [t2, l2]: any,
     [t3, l3]: any
-  ): IPathDataV<ad.Num> => {
+  ): PathDataV<ad.Num> => {
     if (t1 === "Line" && t2 === "Line" && t3 === "Line") {
       const path = new PathBuilder();
       return path
@@ -1065,7 +1062,7 @@ export const compDict = {
   /**
    * Return the average of floats `x` and `y`.
    */
-  average2: (_context: Context, x: ad.Num, y: ad.Num): IFloatV<ad.Num> => {
+  average2: (_context: Context, x: ad.Num, y: ad.Num): FloatV<ad.Num> => {
     return {
       tag: "FloatV",
       contents: div(add(x, y), 2),
@@ -1075,7 +1072,7 @@ export const compDict = {
   /**
    * Return the average of the floats in the list `xs`.
    */
-  average: (_context: Context, xs: ad.Num[]): IFloatV<ad.Num> => {
+  average: (_context: Context, xs: ad.Num[]): FloatV<ad.Num> => {
     return {
       tag: "FloatV",
       contents: div(addN(xs), max(1, xs.length)),
@@ -1086,7 +1083,7 @@ export const compDict = {
   /**
    * Return the normalized version of vector `v`.
    */
-  unit: (_context: Context, v: ad.Num[]): IVectorV<ad.Num> => {
+  unit: (_context: Context, v: ad.Num[]): VectorV<ad.Num> => {
     return {
       tag: "VectorV",
       contents: ops.vnormalize(v),
@@ -1100,7 +1097,7 @@ export const compDict = {
     context: Context,
     alpha: ad.Num,
     colorType: string
-  ): IColorV<ad.Num> => {
+  ): ColorV<ad.Num> => {
     if (colorType === "rgb") {
       const rgb = range(3).map(() => randFloat(context.rng, 0.1, 0.9));
 
@@ -1130,7 +1127,7 @@ export const compDict = {
     _context: Context,
     color: Color<ad.Num>,
     frac: ad.Num
-  ): IColorV<ad.Num> => {
+  ): ColorV<ad.Num> => {
     // If paint=none, opacity is irreelevant
     if (color.tag === "NONE") {
       return {
@@ -1153,7 +1150,7 @@ export const compDict = {
   /**
    * Multiply a matrix `m` and a vector `v` (where `v` is implicitly treated as a column vector).
    */
-  mul: (_context: Context, m: ad.Num[][], v: ad.Num[]): IVectorV<ad.Num> => {
+  mul: (_context: Context, m: ad.Num[][], v: ad.Num[]): VectorV<ad.Num> => {
     if (!m.length) {
       throw Error("empty matrix");
     }
@@ -1177,7 +1174,7 @@ export const compDict = {
     a: ad.Num[],
     b: ad.Num[],
     c: ad.Num[]
-  ): IVectorV<ad.Num> => {
+  ): VectorV<ad.Num> => {
     const x = ops.vmul(1 / 3, ops.vadd(a, ops.vadd(b, c)));
     return {
       tag: "VectorV",
@@ -1193,7 +1190,7 @@ export const compDict = {
     p: ad.Num[],
     q: ad.Num[],
     r: ad.Num[]
-  ): IVectorV<ad.Num> => {
+  ): VectorV<ad.Num> => {
     // edge vectors
     const u = ops.vsub(r, q);
     const v = ops.vsub(p, r);
@@ -1235,7 +1232,7 @@ export const compDict = {
     p: ad.Num[],
     q: ad.Num[],
     r: ad.Num[]
-  ): IFloatV<ad.Num> => {
+  ): FloatV<ad.Num> => {
     // side lengths
     const a = ops.vnorm(ops.vsub(r, q));
     const b = ops.vnorm(ops.vsub(p, r));
@@ -1273,7 +1270,7 @@ export const compDict = {
     p: ad.Num[],
     q: ad.Num[],
     r: ad.Num[]
-  ): IVectorV<ad.Num> => {
+  ): VectorV<ad.Num> => {
     // side lengths
     const a = ops.vnorm(ops.vsub(r, q));
     const b = ops.vnorm(ops.vsub(p, r));
@@ -1305,7 +1302,7 @@ export const compDict = {
     p: ad.Num[],
     q: ad.Num[],
     r: ad.Num[]
-  ): IFloatV<ad.Num> => {
+  ): FloatV<ad.Num> => {
     // side lengths
     const a = ops.vnorm(ops.vsub(r, q));
     const b = ops.vnorm(ops.vsub(p, r));
@@ -1328,42 +1325,42 @@ export const compDict = {
   /**
    * Return the square of the number `x`.
    */
-  sqr: (_context: Context, x: ad.Num): IFloatV<ad.Num> => {
+  sqr: (_context: Context, x: ad.Num): FloatV<ad.Num> => {
     return { tag: "FloatV", contents: squared(x) };
   },
 
   /**
    * Return the square root of the number `x`. (NOTE: if `x < 0`, you may get `NaN`s)
    */
-  sqrt: (_context: Context, x: ad.Num): IFloatV<ad.Num> => {
+  sqrt: (_context: Context, x: ad.Num): FloatV<ad.Num> => {
     return { tag: "FloatV", contents: sqrt(x) };
   },
 
   /**
    * Return the max of the numbers `x`, `y`.
    */
-  max: (_context: Context, x: ad.Num, y: ad.Num): IFloatV<ad.Num> => {
+  max: (_context: Context, x: ad.Num, y: ad.Num): FloatV<ad.Num> => {
     return { tag: "FloatV", contents: max(x, y) };
   },
 
   /**
    * Return the min of the numbers `x`, `y`.
    */
-  min: (_context: Context, x: ad.Num, y: ad.Num): IFloatV<ad.Num> => {
+  min: (_context: Context, x: ad.Num, y: ad.Num): FloatV<ad.Num> => {
     return { tag: "FloatV", contents: min(x, y) };
   },
 
   /**
    * Return the absolute value of the number `x`.
    */
-  abs: (_context: Context, x: ad.Num): IFloatV<ad.Num> => {
+  abs: (_context: Context, x: ad.Num): FloatV<ad.Num> => {
     return { tag: "FloatV", contents: absVal(x) };
   },
 
   /**
    * Convert the angle `theta` from degrees to radians.
    */
-  toRadians: (_context: Context, theta: ad.Num): IFloatV<ad.Num> => {
+  toRadians: (_context: Context, theta: ad.Num): FloatV<ad.Num> => {
     return {
       tag: "FloatV",
       contents: mul(Math.PI / 180, theta),
@@ -1373,7 +1370,7 @@ export const compDict = {
   /**
    * Convert the angle `theta` from radians to degrees.
    */
-  toDegrees: (_context: Context, theta: ad.Num): IFloatV<ad.Num> => {
+  toDegrees: (_context: Context, theta: ad.Num): FloatV<ad.Num> => {
     return {
       tag: "FloatV",
       contents: mul(180 / Math.PI, theta),
@@ -1383,39 +1380,39 @@ export const compDict = {
   /**
    * Return the Euclidean norm of the vector `v`.
    */
-  norm: (_context: Context, v: ad.Num[]): IFloatV<ad.Num> => {
+  norm: (_context: Context, v: ad.Num[]): FloatV<ad.Num> => {
     return { tag: "FloatV", contents: ops.vnorm(v) };
   },
 
   /**
    * Return the Euclidean norm squared of the vector `v`.
    */
-  normsq: (_context: Context, v: ad.Num[]): IFloatV<ad.Num> => {
+  normsq: (_context: Context, v: ad.Num[]): FloatV<ad.Num> => {
     return { tag: "FloatV", contents: ops.vnormsq(v) };
   },
 
   /**
    * Return the Euclidean distance between the vectors `v` and `w`.
    */
-  vdist: (_context: Context, v: ad.Num[], w: ad.Num[]): IFloatV<ad.Num> => {
+  vdist: (_context: Context, v: ad.Num[], w: ad.Num[]): FloatV<ad.Num> => {
     return { tag: "FloatV", contents: ops.vdist(v, w) };
   },
 
-  vmul: (_context: Context, s: ad.Num, v: ad.Num[]): IVectorV<ad.Num> => {
+  vmul: (_context: Context, s: ad.Num, v: ad.Num[]): VectorV<ad.Num> => {
     return { tag: "VectorV", contents: ops.vmul(s, v) };
   },
 
   /**
    * Return the Euclidean distance squared between the vectors `v` and `w`.
    */
-  vdistsq: (_context: Context, v: ad.Num[], w: ad.Num[]): IFloatV<ad.Num> => {
+  vdistsq: (_context: Context, v: ad.Num[], w: ad.Num[]): FloatV<ad.Num> => {
     return { tag: "FloatV", contents: ops.vdistsq(v, w) };
   },
 
   /**
    * Return the angle made by the vector `v` with the positive x-axis.
    */
-  angleOf: (_context: Context, v: ad.Num[]): IFloatV<ad.Num> => {
+  angleOf: (_context: Context, v: ad.Num[]): FloatV<ad.Num> => {
     return { tag: "FloatV", contents: atan2(v[1], v[0]) };
   },
 
@@ -1424,7 +1421,7 @@ export const compDict = {
   /**
    * Base e of the natural logarithm.
    */
-  MathE: (_context: Context): IFloatV<ad.Num> => {
+  MathE: (_context: Context): FloatV<ad.Num> => {
     return {
       tag: "FloatV",
       contents: Math.E,
@@ -1434,7 +1431,7 @@ export const compDict = {
   /**
    * Ratio of the circumference of a circle to its diameter.
    */
-  MathPI: (_context: Context): IFloatV<ad.Num> => {
+  MathPI: (_context: Context): FloatV<ad.Num> => {
     return {
       tag: "FloatV",
       contents: Math.PI,
@@ -1446,7 +1443,7 @@ export const compDict = {
   /**
    * Rotate a 2D vector `v` by 90 degrees counterclockwise.
    */
-  rot90: (_context: Context, v: ad.Num[]): IVectorV<ad.Num> => {
+  rot90: (_context: Context, v: ad.Num[]): VectorV<ad.Num> => {
     if (v.length !== 2) {
       throw Error("expected 2D vector in `rot90`");
     }
@@ -1461,7 +1458,7 @@ export const compDict = {
     _context: Context,
     v: ad.Num[],
     theta: ad.Num
-  ): IVectorV<ad.Num> => {
+  ): VectorV<ad.Num> => {
     if (v.length !== 2) {
       throw Error("expected 2D vector in `rotateBy`");
     }
@@ -1500,7 +1497,7 @@ const perpPathFlat = (
   [startR, endR]: [ad.Num[], ad.Num[]],
   [startL, endL]: [ad.Num[], ad.Num[]]
 ): [ad.Num[], ad.Num[], ad.Num[]] => {
-  // perpPathFlat :: Autofloat a => a -> (Pt2 a, Pt2 a) -> (Pt2 a, Pt2 a) -> (Pt2 a, Pt2 a, Pt2 a)
+  // perpPathFlat :: Autofloat a => a -> (ad.Pt2 a, ad.Pt2 a) -> (ad.Pt2 a, ad.Pt2 a) -> (ad.Pt2 a, ad.Pt2 a, ad.Pt2 a)
   // perpPathFlat size (startR, endR) (startL, endL) =
   //   let dirR = normalize' $ endR -: startR
   //       dirL = normalize' $ endL -: startL

--- a/packages/core/src/contrib/Functions.ts
+++ b/packages/core/src/contrib/Functions.ts
@@ -1497,7 +1497,7 @@ const perpPathFlat = (
   [startR, endR]: [ad.Num[], ad.Num[]],
   [startL, endL]: [ad.Num[], ad.Num[]]
 ): [ad.Num[], ad.Num[], ad.Num[]] => {
-  // perpPathFlat :: Autofloat a => a -> (ad.Pt2 a, ad.Pt2 a) -> (ad.Pt2 a, ad.Pt2 a) -> (ad.Pt2 a, ad.Pt2 a, ad.Pt2 a)
+  // perpPathFlat :: Autofloat a => a -> (Pt2 a, Pt2 a) -> (Pt2 a, Pt2 a) -> (Pt2 a, Pt2 a, Pt2 a)
   // perpPathFlat size (startR, endR) (startL, endL) =
   //   let dirR = normalize' $ endR -: startR
   //       dirL = normalize' $ endL -: startL

--- a/packages/core/src/contrib/__testfixtures__/TestShapes.input.ts
+++ b/packages/core/src/contrib/__testfixtures__/TestShapes.input.ts
@@ -4,11 +4,11 @@ import { makeLine } from "shapes/Line";
 import { makePolygon } from "shapes/Polygon";
 import { makeRectangle } from "shapes/Rectangle";
 import {
-  FloatV,
+  floatV,
   makeCanvas,
-  PtListV,
+  ptListV,
   sampleBlack,
-  VectorV,
+  vectorV,
 } from "shapes/Samplers";
 
 const rng = seedrandom("TestShapes.input");
@@ -21,10 +21,10 @@ export const _rectangles = [
   { center: [0, 300], width: 200, height: 200 },
 ].map((x) =>
   makeRectangle(rng, canvas, {
-    center: VectorV(x.center),
-    width: FloatV(x.width),
-    height: FloatV(x.height),
-    strokeWidth: FloatV(0),
+    center: vectorV(x.center),
+    width: floatV(x.width),
+    height: floatV(x.height),
+    strokeWidth: floatV(0),
     strokeColor: sampleBlack(),
   })
 );
@@ -39,9 +39,9 @@ export const _circles = [
   { center: [150, 150], r: 100 },
 ].map((x) =>
   makeCircle(rng, canvas, {
-    r: FloatV(x.r),
-    center: VectorV(x.center),
-    strokeWidth: FloatV(0),
+    r: floatV(x.r),
+    center: vectorV(x.center),
+    strokeWidth: floatV(0),
     strokeColor: sampleBlack(),
   })
 );
@@ -53,9 +53,9 @@ export const _lines = [
   { start: [200, 400], end: [300, 100] },
 ].map((x) =>
   makeLine(rng, canvas, {
-    start: VectorV(x.start),
-    end: VectorV(x.end),
-    strokeWidth: FloatV(0),
+    start: vectorV(x.start),
+    end: vectorV(x.end),
+    strokeWidth: floatV(0),
   })
 );
 
@@ -91,7 +91,7 @@ export const _polygons = [
   ],
 ].map((pts) =>
   makePolygon(rng, canvas, {
-    points: PtListV(pts),
-    scale: FloatV(1),
+    points: ptListV(pts),
+    scale: floatV(1),
   })
 );

--- a/packages/core/src/contrib/__tests__/Queries.test.ts
+++ b/packages/core/src/contrib/__tests__/Queries.test.ts
@@ -14,11 +14,11 @@ import { makePath } from "shapes/Path";
 import { makePolygon } from "shapes/Polygon";
 import { makeRectangle } from "shapes/Rectangle";
 import {
-  FloatV,
+  floatV,
   makeCanvas,
-  PtListV,
+  ptListV,
   sampleBlack,
-  VectorV,
+  vectorV,
 } from "shapes/Samplers";
 import { Pt2 } from "types/ad";
 
@@ -31,10 +31,10 @@ const shapes: [string, any][] = [
   [
     "Rectangle",
     makeRectangle(rng, canvas, {
-      center: VectorV([11, 22]),
-      width: FloatV(44),
-      height: FloatV(44),
-      strokeWidth: FloatV(0),
+      center: vectorV([11, 22]),
+      width: floatV(44),
+      height: floatV(44),
+      strokeWidth: floatV(0),
       strokeColor: sampleBlack(),
     }),
   ],
@@ -42,9 +42,9 @@ const shapes: [string, any][] = [
   [
     "Circle",
     makeCircle(rng, canvas, {
-      r: FloatV(22),
-      center: VectorV([11, 22]),
-      strokeWidth: FloatV(0),
+      r: floatV(22),
+      center: vectorV([11, 22]),
+      strokeWidth: floatV(0),
       strokeColor: sampleBlack(),
     }),
   ],
@@ -52,10 +52,10 @@ const shapes: [string, any][] = [
   [
     "Ellipse",
     makeEllipse(rng, canvas, {
-      rx: FloatV(22),
-      ry: FloatV(22),
-      center: VectorV([11, 22]),
-      strokeWidth: FloatV(0),
+      rx: floatV(22),
+      ry: floatV(22),
+      center: vectorV([11, 22]),
+      strokeWidth: floatV(0),
       strokeColor: sampleBlack(),
     }),
   ],
@@ -74,21 +74,21 @@ const shapes: [string, any][] = [
   [
     "Line",
     makeLine(rng, canvas, {
-      start: VectorV([-11, 0]),
-      end: VectorV([33, 44]),
-      strokeWidth: FloatV(0),
+      start: vectorV([-11, 0]),
+      end: vectorV([33, 44]),
+      strokeWidth: floatV(0),
     }),
   ],
   // shapes[5]
   [
     "Polygon",
     makePolygon(rng, canvas, {
-      points: PtListV([
+      points: ptListV([
         [-11, 0],
         [33, 0],
         [33, 44],
       ]),
-      scale: FloatV(1),
+      scale: floatV(1),
     }),
   ],
 ];

--- a/packages/core/src/engine/BBox.test.ts
+++ b/packages/core/src/engine/BBox.test.ts
@@ -9,13 +9,13 @@ import { makePolygon } from "shapes/Polygon";
 import { makePolyline } from "shapes/Polyline";
 import { makeRectangle } from "shapes/Rectangle";
 import {
-  FloatV,
+  floatV,
   makeCanvas,
-  PtListV,
+  ptListV,
   sampleBlack,
-  VectorV,
+  vectorV,
 } from "shapes/Samplers";
-import { IPoly, IScale } from "types/shapes";
+import { Poly, Scale } from "types/shapes";
 import { genCode, secondaryGraph } from "./Autodiff";
 import {
   BBox,
@@ -48,8 +48,8 @@ const expectBbox = (
   expect(y).toBeCloseTo(expected.center[1]);
 };
 
-const polyProps = (): IPoly & IScale => ({
-  points: PtListV(
+const polyProps = (): Poly & Scale => ({
+  points: ptListV(
     // https://en.wikipedia.org/wiki/Polygon#/media/File:Assorted_polygons.svg
     [
       [564, 24],
@@ -66,15 +66,15 @@ const polyProps = (): IPoly & IScale => ({
       [528, 129],
     ]
   ),
-  scale: FloatV(0.5),
+  scale: floatV(0.5),
 });
 
 describe("bbox", () => {
   test("Circle", () => {
     const shape = makeCircle(seedrandom("bbox Circle"), canvas, {
-      r: FloatV(100),
-      center: VectorV([42, 121]),
-      strokeWidth: FloatV(50),
+      r: floatV(100),
+      center: vectorV([42, 121]),
+      strokeWidth: floatV(50),
       strokeColor: sampleBlack(),
     });
     expectBbox(bboxFromCircle(shape), {
@@ -86,10 +86,10 @@ describe("bbox", () => {
 
   test("Ellipse", () => {
     const shape = makeEllipse(seedrandom("bbox Ellipse"), canvas, {
-      rx: FloatV(200),
-      ry: FloatV(100),
-      center: VectorV([42, 121]),
-      strokeWidth: FloatV(50),
+      rx: floatV(200),
+      ry: floatV(100),
+      center: vectorV([42, 121]),
+      strokeWidth: floatV(50),
       strokeColor: sampleBlack(),
     });
     expectBbox(bboxFromEllipse(shape), {
@@ -101,10 +101,10 @@ describe("bbox", () => {
 
   test("Rectangle", () => {
     const shape = makeRectangle(seedrandom("bbox Rectangle"), canvas, {
-      center: VectorV([0, 0]),
-      width: FloatV(150),
-      height: FloatV(200),
-      strokeWidth: FloatV(50),
+      center: vectorV([0, 0]),
+      width: floatV(150),
+      height: floatV(200),
+      strokeWidth: floatV(50),
       strokeColor: sampleBlack(),
     });
     expectBbox(bboxFromRect(shape), {
@@ -138,9 +138,9 @@ describe("bbox", () => {
 
   test("Image", () => {
     const shape = makeImage(seedrandom("bbox Image"), canvas, {
-      center: VectorV([0, 0]),
-      width: FloatV(150),
-      height: FloatV(200),
+      center: vectorV([0, 0]),
+      width: floatV(150),
+      height: floatV(200),
     });
     expectBbox(bboxFromRectlike(shape), {
       width: 150,
@@ -151,9 +151,9 @@ describe("bbox", () => {
 
   test("Line", () => {
     const shape = makeLine(seedrandom("bbox Line"), canvas, {
-      start: VectorV([-300, 200]),
-      end: VectorV([100, -150]),
-      strokeWidth: FloatV(50),
+      start: vectorV([-300, 200]),
+      end: vectorV([100, -150]),
+      strokeWidth: floatV(50),
     });
     expectBbox(bboxFromLinelike(shape), {
       width: 432.925,

--- a/packages/core/src/engine/BBox.ts
+++ b/packages/core/src/engine/BBox.ts
@@ -1,10 +1,10 @@
-import { ICircle } from "shapes/Circle";
-import { IEllipse } from "shapes/Ellipse";
-import { ILine } from "shapes/Line";
-import { IPath } from "shapes/Path";
-import { IRectangle } from "shapes/Rectangle";
+import { CircleProps } from "shapes/Circle";
+import { EllipseProps } from "shapes/Ellipse";
+import { LineProps } from "shapes/Line";
+import { PathProps } from "shapes/Path";
+import { RectangleProps } from "shapes/Rectangle";
 import * as ad from "types/ad";
-import { ICenter, IPoly, IRect, IRotate, IScale } from "types/shapes";
+import { Center, Poly, Rect, Rotate, Scale } from "types/shapes";
 import { ops } from "./Autodiff";
 import {
   absVal,
@@ -22,38 +22,30 @@ import {
   sub,
 } from "./AutodiffFunctions";
 
-export interface IBBox {
+export interface BBox {
   width: ad.Num;
   height: ad.Num;
   center: ad.Pt2;
 }
 
-interface ICorners {
+export interface Corners {
   topRight: ad.Pt2;
   topLeft: ad.Pt2;
   bottomLeft: ad.Pt2;
   bottomRight: ad.Pt2;
 }
 
-interface IIntervals {
+export interface Intervals {
   xRange: [ad.Num, ad.Num];
   yRange: [ad.Num, ad.Num];
 }
 
-interface IEdges {
+export interface Edges {
   top: [ad.Pt2, ad.Pt2];
   bot: [ad.Pt2, ad.Pt2];
   left: [ad.Pt2, ad.Pt2];
   right: [ad.Pt2, ad.Pt2];
 }
-
-export type BBox = IBBox;
-
-export type Corners = ICorners;
-
-export type Intervals = IIntervals;
-
-export type Edges = IEdges;
 
 /**
  * Input: A width, height, and center.
@@ -215,7 +207,11 @@ export const bboxFromRotatedRect = (
   return bboxFromPoints([topLeft, topRight, botLeft, botRight]);
 };
 
-export const bboxFromCircle = ({ r, center, strokeWidth }: ICircle): BBox => {
+export const bboxFromCircle = ({
+  r,
+  center,
+  strokeWidth,
+}: CircleProps): BBox => {
   // https://github.com/penrose/penrose/issues/715
   if (!ad.isPt2(center.contents)) {
     throw new Error(
@@ -232,7 +228,7 @@ export const bboxFromEllipse = ({
   ry,
   center,
   strokeWidth,
-}: IEllipse): BBox => {
+}: EllipseProps): BBox => {
   // https://github.com/penrose/penrose/issues/715
   if (!ad.isPt2(center.contents)) {
     throw new Error(
@@ -254,7 +250,7 @@ export const bboxFromRect = ({
   height,
   center,
   strokeWidth,
-}: IRectangle): BBox => {
+}: RectangleProps): BBox => {
   // https://github.com/penrose/penrose/issues/715
   if (!ad.isPt2(center.contents)) {
     throw new Error(
@@ -275,7 +271,7 @@ export const bboxFromRectlike = ({
   width,
   height,
   rotation,
-}: ICenter & IRect & IRotate): BBox => {
+}: Center & Rect & Rotate): BBox => {
   // https://github.com/penrose/penrose/issues/715
   if (!ad.isPt2(center.contents)) {
     throw new Error(
@@ -292,7 +288,7 @@ export const bboxFromRectlike = ({
   );
 };
 
-export const bboxFromPolygon = ({ points, scale }: IPoly & IScale): BBox => {
+export const bboxFromPolygon = ({ points, scale }: Poly & Scale): BBox => {
   return bboxFromPoints(
     points.contents.map((point) => {
       const pt = ops.vmul(scale.contents, point);
@@ -307,7 +303,11 @@ export const bboxFromPolygon = ({ points, scale }: IPoly & IScale): BBox => {
   );
 };
 
-export const bboxFromLinelike = ({ start, end, strokeWidth }: ILine): BBox => {
+export const bboxFromLinelike = ({
+  start,
+  end,
+  strokeWidth,
+}: LineProps): BBox => {
   // https://github.com/penrose/penrose/issues/715
   if (!ad.isPt2(start.contents)) {
     throw new Error(
@@ -340,7 +340,7 @@ export const bboxFromLinelike = ({ start, end, strokeWidth }: ILine): BBox => {
   );
 };
 
-export const bboxFromPath = ({ d }: IPath): BBox => {
+export const bboxFromPath = ({ d }: PathProps): BBox => {
   const p = d.contents;
   if (p.length < 1) {
     throw new Error("bboxFromPath expected pathData to be nonempty");

--- a/packages/core/src/engine/EngineUtils.ts
+++ b/packages/core/src/engine/EngineUtils.ts
@@ -16,32 +16,32 @@ import {
 import { StyleError, Warning } from "types/errors";
 import { Shape, ShapeAD } from "types/shape";
 import { LbfgsParams } from "types/state";
-import { AnnoFloat, Expr, IVector, Path, PropertyDecl } from "types/style";
+import { AnnoFloat, Expr, Path, PropertyDecl, Vector } from "types/style";
 import {
   Color,
+  ColorV,
+  FGPI,
   FieldExpr,
+  FloatV,
   GPIExpr,
-  IColorV,
-  IFGPI,
-  IFloatV,
-  IHMatrixV,
-  IListV,
-  ILListV,
-  IMatrixV,
-  IPaletteV,
-  IPathCmd,
-  IPathDataV,
-  IPtListV,
-  IPtV,
-  ISubPath,
-  ITrans,
-  ITupV,
-  IVectorV,
+  HMatrixV,
+  ListV,
+  LListV,
+  MatrixV,
+  PaletteV,
+  PathCmd,
+  PathDataV,
   PropID,
+  PtListV,
+  PtV,
   ShapeTypeStr,
+  SubPath,
   TagExpr,
+  Trans,
   Translation,
+  TupV,
   Value,
+  VectorV,
 } from "types/value";
 import { showError } from "utils/Error";
 import { safe } from "utils/Util";
@@ -85,63 +85,63 @@ export function mapTupNested<T, S>(f: (arg: T) => S, t: T[][]): S[][] {
 
 // Mapping over values
 
-function mapFloat<T, S>(f: (arg: T) => S, v: IFloatV<T>): IFloatV<S> {
+function mapFloat<T, S>(f: (arg: T) => S, v: FloatV<T>): FloatV<S> {
   return {
     tag: "FloatV",
     contents: f(v.contents),
   };
 }
 
-function mapPt<T, S>(f: (arg: T) => S, v: IPtV<T>): IPtV<S> {
+function mapPt<T, S>(f: (arg: T) => S, v: PtV<T>): PtV<S> {
   return {
     tag: "PtV",
     contents: mapTuple(f, v.contents),
   };
 }
 
-function mapPtList<T, S>(f: (arg: T) => S, v: IPtListV<T>): IPtListV<S> {
+function mapPtList<T, S>(f: (arg: T) => S, v: PtListV<T>): PtListV<S> {
   return {
     tag: "PtListV",
     contents: mapTupNested(f, v.contents),
   };
 }
 
-function mapList<T, S>(f: (arg: T) => S, v: IListV<T>): IListV<S> {
+function mapList<T, S>(f: (arg: T) => S, v: ListV<T>): ListV<S> {
   return {
     tag: "ListV",
     contents: v.contents.map(f),
   };
 }
 
-function mapVector<T, S>(f: (arg: T) => S, v: IVectorV<T>): IVectorV<S> {
+function mapVector<T, S>(f: (arg: T) => S, v: VectorV<T>): VectorV<S> {
   return {
     tag: "VectorV",
     contents: v.contents.map(f),
   };
 }
 
-function mapTup<T, S>(f: (arg: T) => S, v: ITupV<T>): ITupV<S> {
+function mapTup<T, S>(f: (arg: T) => S, v: TupV<T>): TupV<S> {
   return {
     tag: "TupV",
     contents: mapTuple(f, v.contents),
   };
 }
 
-function mapLList<T, S>(f: (arg: T) => S, v: ILListV<T>): ILListV<S> {
+function mapLList<T, S>(f: (arg: T) => S, v: LListV<T>): LListV<S> {
   return {
     tag: "LListV",
     contents: v.contents.map((e) => e.map(f)),
   };
 }
 
-function mapMatrix<T, S>(f: (arg: T) => S, v: IMatrixV<T>): IMatrixV<S> {
+function mapMatrix<T, S>(f: (arg: T) => S, v: MatrixV<T>): MatrixV<S> {
   return {
     tag: "MatrixV",
     contents: v.contents.map((e) => e.map(f)),
   };
 }
 
-function mapHMatrix<T, S>(f: (arg: T) => S, v: IHMatrixV<T>): IHMatrixV<S> {
+function mapHMatrix<T, S>(f: (arg: T) => S, v: HMatrixV<T>): HMatrixV<S> {
   const m = v.contents;
   return {
     tag: "HMatrixV",
@@ -158,14 +158,14 @@ function mapHMatrix<T, S>(f: (arg: T) => S, v: IHMatrixV<T>): IHMatrixV<S> {
 }
 
 // convert all `ad.Num`s to numbers for use in Shape def
-function mapPathData<T, S>(f: (arg: T) => S, v: IPathDataV<T>): IPathDataV<S> {
+function mapPathData<T, S>(f: (arg: T) => S, v: PathDataV<T>): PathDataV<S> {
   return {
     tag: "PathDataV",
-    contents: v.contents.map((pathCmd: IPathCmd<T>) => {
+    contents: v.contents.map((pathCmd: PathCmd<T>) => {
       return {
         cmd: pathCmd.cmd,
         contents: pathCmd.contents.map(
-          (subCmd: ISubPath<T>): ISubPath<S> => {
+          (subCmd: SubPath<T>): SubPath<S> => {
             return {
               tag: subCmd.tag,
               contents: mapTuple(f, subCmd.contents),
@@ -188,14 +188,14 @@ function mapColorInner<T, S>(f: (arg: T) => S, v: Color<T>): Color<S> {
   }
 }
 
-function mapColor<T, S>(f: (arg: T) => S, v: IColorV<T>): IColorV<S> {
+function mapColor<T, S>(f: (arg: T) => S, v: ColorV<T>): ColorV<S> {
   return {
     tag: "ColorV",
     contents: mapColorInner(f, v.contents),
   };
 }
 
-function mapPalette<T, S>(f: (arg: T) => S, v: IPaletteV<T>): IPaletteV<S> {
+function mapPalette<T, S>(f: (arg: T) => S, v: PaletteV<T>): PaletteV<S> {
   return {
     tag: "PaletteV",
     contents: v.contents.map((e) => mapColorInner(f, e)),
@@ -366,8 +366,8 @@ export function mapGPIExpr<T, S>(f: (arg: T) => S, e: GPIExpr<T>): GPIExpr<S> {
 
 export function mapTranslation<T, S>(
   f: (arg: T) => S,
-  trans: ITrans<T>
-): ITrans<S> {
+  trans: Trans<T>
+): Trans<S> {
   const newTrMap: [string, { [k: string]: FieldExpr<S> }][] = Object.entries(
     trans.trMap
   ).map(([name, fdict]) => {
@@ -397,7 +397,7 @@ export function mapTranslation<T, S>(
   };
 }
 
-export const makeTranslationNumeric = (trans: Translation): ITrans<number> => {
+export const makeTranslationNumeric = (trans: Translation): Trans<number> => {
   return mapTranslation(numOf, trans);
 };
 
@@ -468,7 +468,7 @@ const mkPropertyDict = (
 // TODO: Test this
 export const insertGPI = (
   path: Path<A>,
-  gpi: IFGPI<ad.Num>,
+  gpi: FGPI<ad.Num>,
   trans: Translation
 ): Translation => {
   let name, field;
@@ -496,7 +496,7 @@ const defaultVec2 = (): Expr<A> => {
     ...dummyASTNode({}, "SyntheticStyle"),
     tag: "Vary",
   };
-  const v2: IVector<A> = {
+  const v2: Vector<A> = {
     ...dummyASTNode({}, "SyntheticStyle"),
     tag: "Vector",
     contents: [e1, e2],
@@ -784,7 +784,7 @@ export const insertExpr = (
           [name, field, prop] = [ip.name, ip.field, ip.property];
           const gpi = trans.trMap[name.contents.value][
             field.value
-          ] as IFGPI<ad.Num>;
+          ] as FGPI<ad.Num>;
           const [gpiType, properties] = gpi.contents;
 
           // Right now, a property may not have been initialized (e.g. during the Style interpretation phase, when we are creating a translation).
@@ -917,7 +917,7 @@ export const isTagExpr = (
 export const findExprSafe = (
   trans: Translation,
   path: Path<A>
-): TagExpr<ad.Num> | IFGPI<ad.Num> => {
+): TagExpr<ad.Num> | FGPI<ad.Num> => {
   const res = findExpr(trans, path);
   if (res.tag !== "FGPI" && !isTagExpr(res)) {
     // Is an error
@@ -938,7 +938,7 @@ export const findExprSafe = (
 export const findExpr = (
   trans: Translation,
   path: Path<A>
-): TagExpr<ad.Num> | IFGPI<ad.Num> | StyleError => {
+): TagExpr<ad.Num> | FGPI<ad.Num> | StyleError => {
   let name, field, prop;
 
   switch (path.tag) {

--- a/packages/core/src/engine/PropagateUpdate.ts
+++ b/packages/core/src/engine/PropagateUpdate.ts
@@ -2,7 +2,7 @@ import { exprToNumber, insertExpr } from "engine/EngineUtils";
 import { A } from "types/ast";
 import { Shape } from "types/shape";
 import { LabelCache, State } from "types/state";
-import { IPropertyPath, Path } from "types/style";
+import { Path, PropertyPath } from "types/style";
 import { Translation, Value } from "types/value";
 import { retrieveLabel } from "utils/CollectLabels";
 
@@ -14,7 +14,7 @@ import { retrieveLabel } from "utils/CollectLabels";
  */
 // the `any` is to accomodate `collectLabels` storing updated property values in a new property that's not in the type system
 const findShapeProperty = (shapes: any, path: Path<A>): Value<number> | any => {
-  const getProperty = (path: IPropertyPath<A>) => {
+  const getProperty = (path: PropertyPath<A>) => {
     const [subName, field, prop]: [string, string, string] = [
       path.name.contents.value,
       path.field.value,

--- a/packages/core/src/parser/Domain.ne
+++ b/packages/core/src/parser/Domain.ne
@@ -7,7 +7,7 @@
 import * as moo from "moo";
 import { concat, compact, flatten, last } from 'lodash'
 import { optional, tokensIn, basicSymbols, rangeOf, rangeBetween, rangeFrom, nth, convertTokenId } from 'parser/ParserUtil'
-import { C, ConcreteNode, IStringLit } from "types/ast";
+import { C, ConcreteNode, StringLit } from "types/ast";
 import { DomainProg, TypeDecl, PredicateDecl, FunctionDecl, ConstructorDecl, PreludeDecl, NotationDecl, SubTypeDecl, TypeConstructor, Type, Arg, Prop } from "types/domain";
 
 // NOTE: ordering matters here. Top patterns get matched __first__
@@ -227,7 +227,7 @@ prop -> "Prop" {%
 # Common 
 
 string_lit -> %string_literal {%
-  ([d]): IStringLit<C> => ({
+  ([d]): StringLit<C> => ({
     ...nodeData,
     ...rangeOf(d),
     tag: 'StringLit',

--- a/packages/core/src/parser/Substance.ne
+++ b/packages/core/src/parser/Substance.ne
@@ -8,7 +8,7 @@
 import * as moo from "moo";
 import { concat, compact, flatten, last } from 'lodash'
 import { optional, basicSymbols, rangeOf, rangeBetween, rangeFrom, nth, convertTokenId } from 'parser/ParserUtil'
-import { C, ConcreteNode, Identifier, IStringLit } from "types/ast";
+import { C, ConcreteNode, Identifier, StringLit } from "types/ast";
 import { SubProg, SubStmt, Decl, Bind, ApplyPredicate, Deconstructor, Func, EqualExprs, EqualPredicates, LabelDecl, NoLabel, AutoLabel, LabelOption, TypeConsApp } from "types/substance";
 
 
@@ -219,7 +219,7 @@ type_arg_list -> _ "(" _ sepBy1[type_constructor, ","] _ ")" {%
 # Common 
 
 string_lit -> %string_literal {%
-  ([d]): IStringLit<C> => ({
+  ([d]): StringLit<C> => ({
     ...nodeData,
     ...rangeOf(d),
     tag: 'StringLit',
@@ -228,7 +228,7 @@ string_lit -> %string_literal {%
 %}
 
 tex_literal -> %tex_literal {% 
-  ([d]): IStringLit<C> => ({
+  ([d]): StringLit<C> => ({
     ...nodeData,
     ...rangeOf(d),
     tag: 'StringLit',

--- a/packages/core/src/renderer/AttrHelper.ts
+++ b/packages/core/src/renderer/AttrHelper.ts
@@ -4,7 +4,7 @@
  */
 
 import { Shape } from "types/shape";
-import { IColorV, IFloatV, IPtListV, IStrV, IVectorV } from "types/value";
+import { ColorV, FloatV, PtListV, StrV, VectorV } from "types/value";
 import { toFontRule } from "utils/CollectLabels";
 import { toScreen, toSvgOpacityProperty, toSvgPaintProperty } from "utils/Util";
 import { attrMapSvg } from "./AttrMapSvg";
@@ -71,7 +71,7 @@ export const attrAutoFillSvg = (
  * Maps fillColor --> fill, fill-opacity
  */
 export const attrFill = ({ properties }: Shape, elem: SVGElement): string[] => {
-  const color = properties.fillColor as IColorV<number>;
+  const color = properties.fillColor as ColorV<number>;
   const alpha = toSvgOpacityProperty(color.contents);
 
   elem.setAttribute("fill", toSvgPaintProperty(color.contents));
@@ -92,7 +92,7 @@ export const attrCenter = (
   canvasSize: [number, number],
   elem: SVGElement
 ): string[] => {
-  const center = properties.center as IVectorV<number>;
+  const center = properties.center as VectorV<number>;
   const [x, y] = toScreen(center.contents as [number, number], canvasSize);
   elem.setAttribute("cx", x.toString());
   elem.setAttribute("cy", y.toString());
@@ -124,10 +124,10 @@ export const attrTransformCoords = (
   canvasSize: [number, number],
   elem: SVGElement
 ): string[] => {
-  const center = properties.center as IVectorV<number>;
+  const center = properties.center as VectorV<number>;
   const [x, y] = toScreen(center.contents as [number, number], canvasSize);
-  const w = properties.width as IFloatV<number>;
-  const h = properties.height as IFloatV<number>;
+  const w = properties.width as FloatV<number>;
+  const h = properties.height as FloatV<number>;
   let transform = elem.getAttribute("transform");
   transform =
     transform === null
@@ -146,10 +146,10 @@ export const attrXY = (
   canvasSize: [number, number],
   elem: SVGElement
 ): string[] => {
-  const center = properties.center as IVectorV<number>;
+  const center = properties.center as VectorV<number>;
   const [x, y] = toScreen(center.contents as [number, number], canvasSize);
-  const w = properties.width as IFloatV<number>;
-  const h = properties.height as IFloatV<number>;
+  const w = properties.width as FloatV<number>;
+  const h = properties.height as FloatV<number>;
   elem.setAttribute("x", (x - w.contents / 2).toString());
   elem.setAttribute("y", (y - h.contents / 2).toString());
 
@@ -169,10 +169,10 @@ export const attrRotation = (
   canvasSize: [number, number],
   elem: SVGElement
 ): string[] => {
-  const w = properties.width as IFloatV<number>;
-  const h = properties.height as IFloatV<number>;
+  const w = properties.width as FloatV<number>;
+  const h = properties.height as FloatV<number>;
   const center = properties.center;
-  const rotation = (properties.rotation as IFloatV<number>).contents;
+  const rotation = (properties.rotation as FloatV<number>).contents;
   const [x, y] = toScreen(center.contents as [number, number], canvasSize);
   let transform = elem.getAttribute("transform");
   transform =
@@ -189,8 +189,8 @@ export const attrRotation = (
  * Maps width, height --> width, height
  */
 export const attrWH = ({ properties }: Shape, elem: SVGElement): string[] => {
-  const w = properties.width as IFloatV<number>;
-  const h = properties.height as IFloatV<number>;
+  const w = properties.width as FloatV<number>;
+  const h = properties.height as FloatV<number>;
   elem.setAttribute("width", w.contents.toString());
   elem.setAttribute("height", h.contents.toString());
 
@@ -204,7 +204,7 @@ export const attrCornerRadius = (
   { properties }: Shape,
   elem: SVGElement
 ): string[] => {
-  const rx = properties.cornerRadius as IFloatV<number>;
+  const rx = properties.cornerRadius as FloatV<number>;
   elem.setAttribute("rx", rx.contents.toString());
 
   return ["cornerRadius"]; // Return array of input properties programatically mapped
@@ -217,7 +217,7 @@ export const attrPathData = (
   { properties }: Shape,
   elem: SVGElement
 ): string[] => {
-  const d = properties.data as IStrV;
+  const d = properties.data as StrV;
   elem.setAttribute("d", d.contents.toString());
 
   return ["data"]; // Return array of input properties programatically mapped
@@ -230,7 +230,7 @@ export const attrString = (
   { properties }: Shape,
   elem: SVGElement
 ): string[] => {
-  const str = properties.string as IStrV;
+  const str = properties.string as StrV;
   const text = document.createTextNode(str.contents.toString());
   elem.appendChild(text);
 
@@ -252,7 +252,7 @@ export const attrStroke = (
   // Keep a list of which input properties we programatically mapped
   const attrMapped: string[] = [];
 
-  const strokeColor = properties.strokeColor as IColorV<number>;
+  const strokeColor = properties.strokeColor as ColorV<number>;
   const strokeAlpha = toSvgOpacityProperty(strokeColor.contents);
   const thickness = properties.strokeWidth.contents;
   elem.setAttribute("stroke", toSvgPaintProperty(strokeColor.contents));
@@ -269,7 +269,7 @@ export const attrStroke = (
     ) {
       elem.setAttribute(
         "stroke-dasharray",
-        (properties.strokeDasharray as IStrV).contents
+        (properties.strokeDasharray as StrV).contents
       );
     } else if (
       "strokeStyle" in properties &&
@@ -285,7 +285,7 @@ export const attrStroke = (
     ) {
       elem.setAttribute(
         "stroke-linecap",
-        (properties.strokeLinecap as IStrV).contents
+        (properties.strokeLinecap as StrV).contents
       );
     } else {
       elem.setAttribute("stroke-linecap", "butt");
@@ -303,7 +303,7 @@ export const attrTitle = (
   { properties }: Shape,
   elem: SVGElement
 ): string[] => {
-  const name = properties.name as IStrV;
+  const name = properties.name as StrV;
   const title = document.createElementNS("http://www.w3.org/2000/svg", "title");
   title.textContent = name.contents;
   elem.appendChild(title);
@@ -344,7 +344,7 @@ export const attrPolyPoints = (
   canvasSize: [number, number],
   elem: SVGElement
 ): string[] => {
-  const points = shape.properties.points as IPtListV<number>;
+  const points = shape.properties.points as PtListV<number>;
   const pointsTransformed = points.contents.map((p: number[]) =>
     toScreen(p as [number, number], canvasSize)
   );

--- a/packages/core/src/renderer/Equation.ts
+++ b/packages/core/src/renderer/Equation.ts
@@ -1,4 +1,4 @@
-import { IStrV } from "types/value";
+import { StrV } from "types/value";
 import { retrieveLabel } from "utils/CollectLabels";
 import {
   attrAutoFillSvg,
@@ -21,7 +21,7 @@ const Equation = ({ shape, canvasSize, labels }: ShapeProps): SVGGElement => {
   attrToNotAutoMap.push(...attrTransformCoords(shape, canvasSize, elem));
   attrToNotAutoMap.push(...attrTitle(shape, elem));
 
-  const name = shape.properties.name as IStrV;
+  const name = shape.properties.name as StrV;
   const retrievedLabel = retrieveLabel(name.contents, labels);
   attrToNotAutoMap.push("name");
 
@@ -41,7 +41,7 @@ const Equation = ({ shape, canvasSize, labels }: ShapeProps): SVGGElement => {
     renderedLabel
       .getElementsByTagName("g")[0]
       .setAttribute("stroke-width", "0");
-    const fontSize = shape.properties.fontSize as IStrV;
+    const fontSize = shape.properties.fontSize as StrV;
     renderedLabel.setAttribute(
       "style",
       `font-size: ${fontSize.contents.toString()}`

--- a/packages/core/src/renderer/Image.ts
+++ b/packages/core/src/renderer/Image.ts
@@ -1,4 +1,4 @@
-import { IStrV } from "types/value";
+import { StrV } from "types/value";
 import {
   attrAutoFillSvg,
   attrRotation,
@@ -18,7 +18,7 @@ const Image = async ({
   const attrToNotAutoMap: string[] = [];
 
   // Map/Fill the shape attributes while keeping track of input properties mapped
-  const path = (shape.properties.href as IStrV).contents;
+  const path = (shape.properties.href as StrV).contents;
   let rawSVG = await pathResolver(path);
   if (rawSVG === undefined) {
     console.error(`Could not resolve image path ${path}`);
@@ -42,7 +42,7 @@ const Image = async ({
           `[*|href="#${node.id}"]:not([href])`
         );
         users.forEach((user) => {
-          const unique = `${(shape.properties.name as IStrV).contents}-ns-${
+          const unique = `${(shape.properties.name as StrV).contents}-ns-${
             node.id
           }`;
           user.setAttributeNS(

--- a/packages/core/src/renderer/Line.ts
+++ b/packages/core/src/renderer/Line.ts
@@ -1,5 +1,5 @@
 import { Shape } from "types/shape";
-import { IColorV, IFloatV, IStrV, IVectorV } from "types/value";
+import { ColorV, FloatV, StrV, VectorV } from "types/value";
 import {
   arrowheads,
   round2,
@@ -45,15 +45,15 @@ const makeRoomForArrows = (shape: Shape): [number[][], string[]] => {
   // Keep a list of which input properties we programatically mapped
   const attrMapped: string[] = [];
 
-  const [lineSX, lineSY] = (shape.properties.start as IVectorV<number>)
+  const [lineSX, lineSY] = (shape.properties.start as VectorV<number>)
     .contents as [number, number];
-  const [lineEX, lineEY] = (shape.properties.end as IVectorV<number>)
+  const [lineEX, lineEY] = (shape.properties.end as VectorV<number>)
     .contents as [number, number];
 
-  const arrowheadStyle = (shape.properties.arrowheadStyle as IStrV).contents;
-  const arrowheadSize = (shape.properties.arrowheadSize as IFloatV<number>)
+  const arrowheadStyle = (shape.properties.arrowheadStyle as StrV).contents;
+  const arrowheadSize = (shape.properties.arrowheadSize as FloatV<number>)
     .contents;
-  const thickness = (shape.properties.strokeWidth as IFloatV<number>).contents;
+  const thickness = (shape.properties.strokeWidth as FloatV<number>).contents;
   attrMapped.push(
     "start",
     "end",
@@ -111,16 +111,16 @@ const Line = ({ shape, canvasSize }: ShapeProps): SVGGElement => {
   const [ex, ey] = toScreen([arrowEX, arrowEY], canvasSize);
   const path = `M ${sx} ${sy} L ${ex} ${ey}`;
   const color = toSvgPaintProperty(
-    (shape.properties.strokeColor as IColorV<number>).contents
+    (shape.properties.strokeColor as ColorV<number>).contents
   );
-  const thickness = (shape.properties.strokeWidth as IFloatV<number>).contents;
+  const thickness = (shape.properties.strokeWidth as FloatV<number>).contents;
   const opacity = toSvgOpacityProperty(
-    (shape.properties.strokeColor as IColorV<number>).contents
+    (shape.properties.strokeColor as ColorV<number>).contents
   );
   const leftArrowId = shape.properties.name.contents + "-leftArrowhead";
   const rightArrowId = shape.properties.name.contents + "-rightArrowhead";
-  const arrowheadStyle = (shape.properties.arrowheadStyle as IStrV).contents;
-  const arrowheadSize = (shape.properties.arrowheadSize as IFloatV<number>)
+  const arrowheadStyle = (shape.properties.arrowheadStyle as StrV).contents;
+  const arrowheadSize = (shape.properties.arrowheadSize as FloatV<number>)
     .contents;
 
   const elem = document.createElementNS("http://www.w3.org/2000/svg", "g");
@@ -146,7 +146,7 @@ const Line = ({ shape, canvasSize }: ShapeProps): SVGGElement => {
 
   // Opacity and width only relevant if stroke is present
   if (
-    (shape.properties.strokeColor as IColorV<number>).contents.tag !== "NONE"
+    (shape.properties.strokeColor as ColorV<number>).contents.tag !== "NONE"
   ) {
     pathElem.setAttribute("stroke-opacity", opacity.toString());
     pathElem.setAttribute("stroke-width", thickness.toString());
@@ -160,7 +160,7 @@ const Line = ({ shape, canvasSize }: ShapeProps): SVGGElement => {
   ) {
     pathElem.setAttribute(
       "stroke-dasharray",
-      (shape.properties.strokeDasharray as IStrV).contents
+      (shape.properties.strokeDasharray as StrV).contents
     );
   } else if (shape.properties.strokeStyle.contents === "dashed") {
     pathElem.setAttribute("stroke-dasharray", DASH_ARRAY.toString());
@@ -173,7 +173,7 @@ const Line = ({ shape, canvasSize }: ShapeProps): SVGGElement => {
   ) {
     pathElem.setAttribute(
       "stroke-linecap",
-      (shape.properties.strokeLinecap as IStrV).contents
+      (shape.properties.strokeLinecap as StrV).contents
     );
   } else {
     pathElem.setAttribute("stroke-linecap", "butt"); // same default as SVG

--- a/packages/core/src/renderer/Path.ts
+++ b/packages/core/src/renderer/Path.ts
@@ -1,12 +1,12 @@
 import { flatten } from "lodash";
-import { IColorV, IFloatV, IPathCmd, IStrV, ISubPath } from "types/value";
+import { ColorV, FloatV, PathCmd, StrV, SubPath } from "types/value";
 import { toScreen, toSvgOpacityProperty, toSvgPaintProperty } from "utils/Util";
 import { attrAutoFillSvg, attrTitle, DASH_ARRAY } from "./AttrHelper";
 import { arrowHead } from "./Line";
 import { ShapeProps } from "./Renderer";
 
 const toPathString = (
-  pathData: IPathCmd<number>[],
+  pathData: PathCmd<number>[],
   canvasSize: [number, number]
 ) =>
   pathData
@@ -18,8 +18,8 @@ const toPathString = (
       }
       const pathStr = flatten(
         // the `number[]` type annotation is necessary to ensure that a compile
-        // error occurs here if more `ISubPath` subtypes are added in the future
-        contents.map((c: ISubPath<number>): number[] => {
+        // error occurs here if more `SubPath` subtypes are added in the future
+        contents.map((c: SubPath<number>): number[] => {
           switch (c.tag) {
             case "CoordV": {
               return toScreen(c.contents as [number, number], canvasSize);
@@ -62,22 +62,21 @@ export const Path = ({ shape, canvasSize }: ShapeProps): SVGGElement => {
   const rightArrowId = shape.properties.name.contents + "-rightArrowhead";
   const shadowId = shape.properties.name.contents + "-shadow";
   const elem = document.createElementNS("http://www.w3.org/2000/svg", "g");
-  const strokeWidth = (shape.properties.strokeWidth as IFloatV<number>)
-    .contents;
+  const strokeWidth = (shape.properties.strokeWidth as FloatV<number>).contents;
   const strokeColor = toSvgPaintProperty(
-    (shape.properties.strokeColor as IColorV<number>).contents
+    (shape.properties.strokeColor as ColorV<number>).contents
   );
   const strokeOpacity = toSvgOpacityProperty(
-    (shape.properties.strokeColor as IColorV<number>).contents
+    (shape.properties.strokeColor as ColorV<number>).contents
   );
   const fillColor = toSvgPaintProperty(
-    (shape.properties.fillColor as IColorV<number>).contents
+    (shape.properties.fillColor as ColorV<number>).contents
   );
   const fillOpacity = toSvgOpacityProperty(
-    (shape.properties.fillColor as IColorV<number>).contents
+    (shape.properties.fillColor as ColorV<number>).contents
   );
-  const arrowheadStyle = (shape.properties.arrowheadStyle as IStrV).contents;
-  const arrowheadSize = (shape.properties.arrowheadSize as IFloatV<number>)
+  const arrowheadStyle = (shape.properties.arrowheadStyle as StrV).contents;
+  const arrowheadSize = (shape.properties.arrowheadSize as FloatV<number>)
     .contents;
 
   // Keep track of which input properties we programatically mapped
@@ -123,14 +122,14 @@ export const Path = ({ shape, canvasSize }: ShapeProps): SVGGElement => {
 
   // Stroke opacity and width only relevant if paint is present
   if (
-    (shape.properties.strokeColor as IColorV<number>).contents.tag !== "NONE"
+    (shape.properties.strokeColor as ColorV<number>).contents.tag !== "NONE"
   ) {
     path.setAttribute("stroke-width", strokeWidth.toString());
     path.setAttribute("stroke-opacity", strokeOpacity.toString());
     attrToNotAutoMap.push("strokeColor", "strokeWidth");
   }
   // Fill opacity only relevant if paint is present
-  if ((shape.properties.fillColor as IColorV<number>).contents.tag !== "NONE") {
+  if ((shape.properties.fillColor as ColorV<number>).contents.tag !== "NONE") {
     path.setAttribute("fill-opacity", fillOpacity.toString());
     attrToNotAutoMap.push("fillColor");
   }
@@ -141,7 +140,7 @@ export const Path = ({ shape, canvasSize }: ShapeProps): SVGGElement => {
   ) {
     path.setAttribute(
       "stroke-dasharray",
-      (shape.properties.strokeDasharray as IStrV).contents
+      (shape.properties.strokeDasharray as StrV).contents
     );
   } else if (shape.properties.strokeStyle.contents === "dashed") {
     path.setAttribute("stroke-dasharray", DASH_ARRAY.toString());

--- a/packages/core/src/renderer/PathBuilder.ts
+++ b/packages/core/src/renderer/PathBuilder.ts
@@ -1,24 +1,24 @@
 import * as ad from "types/ad";
-import { IPathDataV, ISubPath } from "types/value";
+import { PathDataV, SubPath } from "types/value";
 
 /**
  * Class for building SVG paths
  */
 export class PathBuilder {
-  private path: IPathDataV<ad.Num>;
+  private path: PathDataV<ad.Num>;
   constructor() {
     this.path = {
       tag: "PathDataV",
       contents: [],
     };
   }
-  private newCoord = (x: ad.Num, y: ad.Num): ISubPath<ad.Num> => {
+  private newCoord = (x: ad.Num, y: ad.Num): SubPath<ad.Num> => {
     return {
       tag: "CoordV",
       contents: [x, y],
     };
   };
-  private newValue = (v: ad.Num[]): ISubPath<ad.Num> => {
+  private newValue = (v: ad.Num[]): SubPath<ad.Num> => {
     return {
       tag: "ValueV",
       contents: v,

--- a/packages/core/src/renderer/Renderer.ts
+++ b/packages/core/src/renderer/Renderer.ts
@@ -7,7 +7,7 @@
 import { shapedefs } from "shapes/Shapes";
 import { Shape } from "types/shape";
 import { LabelCache, State } from "types/state";
-import { IStrV } from "types/value";
+import { StrV } from "types/value";
 import { dragUpdate } from "./dragUtils";
 import shapeMap from "./shapeMap";
 
@@ -109,7 +109,7 @@ export const DraggableShape = async (
       g.setAttribute("opacity", "1");
       document.removeEventListener("mouseup", onMouseUp);
       document.removeEventListener("mousemove", onMouseMove);
-      onDrag((shapeProps.shape.properties.name as IStrV).contents, dx, dy);
+      onDrag((shapeProps.shape.properties.name as StrV).contents, dx, dy);
     };
     document.addEventListener("mouseup", onMouseUp);
     document.addEventListener("mousemove", onMouseMove);

--- a/packages/core/src/renderer/Text.ts
+++ b/packages/core/src/renderer/Text.ts
@@ -1,4 +1,4 @@
-import { IStrV, IVectorV } from "types/value";
+import { StrV, VectorV } from "types/value";
 import { retrieveLabel } from "utils/CollectLabels";
 import { toScreen } from "utils/Util";
 import {
@@ -29,10 +29,10 @@ const Text = ({ shape, canvasSize, labels }: ShapeProps): SVGTextElement => {
   attrToNotAutoMap.push(...attrFont(shape, elem));
 
   // Get width/height of the text if available
-  const name = shape.properties.name as IStrV;
+  const name = shape.properties.name as StrV;
   const retrievedLabel = retrieveLabel(name.contents, labels);
   // Directly render the text with [x, y] in screen coordinates without transforming them using `width` and `height`
-  const center = shape.properties.center as IVectorV<number>;
+  const center = shape.properties.center as VectorV<number>;
   const [x, y] = toScreen(center.contents as [number, number], canvasSize);
   if (retrievedLabel && retrievedLabel.tag === "TextData") {
     // adjust the y-coordinate of the text center s.t. it's the center of the bbox

--- a/packages/core/src/shapes/Circle.ts
+++ b/packages/core/src/shapes/Circle.ts
@@ -1,43 +1,43 @@
 import * as ad from "types/ad";
-import { ICenter, IFill, INamed, IShape, IStroke } from "types/shapes";
-import { IFloatV } from "types/value";
+import { Center, Fill, Named, Shape, Stroke } from "types/shapes";
+import { FloatV } from "types/value";
 import {
-  BoolV,
+  boolV,
   Canvas,
   sampleColor,
   sampleNoPaint,
   sampleVector,
   sampleWidth,
   sampleZero,
-  StrV,
+  strV,
 } from "./Samplers";
 
-export interface ICircle extends INamed, IStroke, IFill, ICenter {
-  r: IFloatV<ad.Num>;
+export interface CircleProps extends Named, Stroke, Fill, Center {
+  r: FloatV<ad.Num>;
 }
 
 export const sampleCircle = (
   rng: seedrandom.prng,
   canvas: Canvas
-): ICircle => ({
-  name: StrV("defaultCircle"),
-  style: StrV(""),
+): CircleProps => ({
+  name: strV("defaultCircle"),
+  style: strV(""),
   strokeWidth: sampleZero(),
-  strokeStyle: StrV("solid"),
+  strokeStyle: strV("solid"),
   strokeColor: sampleNoPaint(),
-  strokeDasharray: StrV(""),
+  strokeDasharray: strV(""),
   fillColor: sampleColor(rng),
   center: sampleVector(rng, canvas),
   r: sampleWidth(rng, canvas),
-  ensureOnCanvas: BoolV(true),
+  ensureOnCanvas: boolV(true),
 });
 
-export type Circle = IShape & { shapeType: "Circle" } & ICircle;
+export type Circle = Shape & { shapeType: "Circle" } & CircleProps;
 
 export const makeCircle = (
   rng: seedrandom.prng,
   canvas: Canvas,
-  properties: Partial<ICircle>
+  properties: Partial<CircleProps>
 ): Circle => ({
   ...sampleCircle(rng, canvas),
   ...properties,

--- a/packages/core/src/shapes/Ellipse.ts
+++ b/packages/core/src/shapes/Ellipse.ts
@@ -1,8 +1,8 @@
 import * as ad from "types/ad";
-import { ICenter, IFill, INamed, IShape, IStroke } from "types/shapes";
-import { IFloatV } from "types/value";
+import { Center, Fill, Named, Shape, Stroke } from "types/shapes";
+import { FloatV } from "types/value";
 import {
-  BoolV,
+  boolV,
   Canvas,
   sampleColor,
   sampleHeight,
@@ -10,37 +10,37 @@ import {
   sampleVector,
   sampleWidth,
   sampleZero,
-  StrV,
+  strV,
 } from "./Samplers";
 
-export interface IEllipse extends INamed, IStroke, IFill, ICenter {
-  rx: IFloatV<ad.Num>;
-  ry: IFloatV<ad.Num>;
+export interface EllipseProps extends Named, Stroke, Fill, Center {
+  rx: FloatV<ad.Num>;
+  ry: FloatV<ad.Num>;
 }
 
 export const sampleEllipse = (
   rng: seedrandom.prng,
   canvas: Canvas
-): IEllipse => ({
-  name: StrV("defaultEllipse"),
-  style: StrV(""),
+): EllipseProps => ({
+  name: strV("defaultEllipse"),
+  style: strV(""),
   strokeWidth: sampleZero(),
-  strokeStyle: StrV("solid"),
+  strokeStyle: strV("solid"),
   strokeColor: sampleNoPaint(),
-  strokeDasharray: StrV(""),
+  strokeDasharray: strV(""),
   fillColor: sampleColor(rng),
   center: sampleVector(rng, canvas),
   rx: sampleWidth(rng, canvas),
   ry: sampleHeight(rng, canvas),
-  ensureOnCanvas: BoolV(true),
+  ensureOnCanvas: boolV(true),
 });
 
-export type Ellipse = IShape & { shapeType: "Ellipse" } & IEllipse;
+export type Ellipse = Shape & { shapeType: "Ellipse" } & EllipseProps;
 
 export const makeEllipse = (
   rng: seedrandom.prng,
   canvas: Canvas,
-  properties: Partial<IEllipse>
+  properties: Partial<EllipseProps>
 ): Ellipse => ({
   ...sampleEllipse(rng, canvas),
   ...properties,

--- a/packages/core/src/shapes/Equation.ts
+++ b/packages/core/src/shapes/Equation.ts
@@ -1,51 +1,43 @@
+import { Center, Fill, Named, Rect, Rotate, Shape, String } from "types/shapes";
 import {
-  ICenter,
-  IFill,
-  INamed,
-  IRect,
-  IRotate,
-  IShape,
-  IString,
-} from "types/shapes";
-import {
-  BoolV,
+  boolV,
   Canvas,
   sampleBlack,
   sampleVector,
   sampleZero,
-  StrV,
+  strV,
 } from "./Samplers";
 
-export interface IEquation
-  extends INamed,
-    IFill,
-    ICenter,
-    IRect,
-    IRotate,
-    IString {}
+export interface EquationProps
+  extends Named,
+    Fill,
+    Center,
+    Rect,
+    Rotate,
+    String {}
 
 export const sampleEquation = (
   rng: seedrandom.prng,
   canvas: Canvas
-): IEquation => ({
-  name: StrV("defaultEquation"),
-  style: StrV(""),
+): EquationProps => ({
+  name: strV("defaultEquation"),
+  style: strV(""),
   fillColor: sampleBlack(),
   center: sampleVector(rng, canvas),
   width: sampleZero(),
   height: sampleZero(),
   rotation: sampleZero(),
-  string: StrV("defaultLabelText"),
-  fontSize: StrV("12pt"),
-  ensureOnCanvas: BoolV(true),
+  string: strV("defaultLabelText"),
+  fontSize: strV("12pt"),
+  ensureOnCanvas: boolV(true),
 });
 
-export type Equation = IShape & { shapeType: "Equation" } & IEquation;
+export type Equation = Shape & { shapeType: "Equation" } & EquationProps;
 
 export const makeEquation = (
   rng: seedrandom.prng,
   canvas: Canvas,
-  properties: Partial<IEquation>
+  properties: Partial<EquationProps>
 ): Equation => ({
   ...sampleEquation(rng, canvas),
   ...properties,

--- a/packages/core/src/shapes/Image.ts
+++ b/packages/core/src/shapes/Image.ts
@@ -1,39 +1,42 @@
-import { ICenter, INamed, IRect, IRotate, IShape } from "types/shapes";
-import { IStrV } from "types/value";
+import { Center, Named, Rect, Rotate, Shape } from "types/shapes";
+import { StrV } from "types/value";
 import {
-  BoolV,
+  boolV,
   Canvas,
   sampleHeight,
   sampleVector,
   sampleWidth,
   sampleZero,
-  StrV,
+  strV,
 } from "./Samplers";
 
-export interface IImage extends INamed, ICenter, IRect, IRotate {
-  href: IStrV;
+export interface ImageProps extends Named, Center, Rect, Rotate {
+  href: StrV;
   // note, SVG also has these two attributes:
   // https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/crossorigin
   // https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/preserveAspectRatio
 }
 
-export const sampleImage = (rng: seedrandom.prng, canvas: Canvas): IImage => ({
-  name: StrV("defaultImage"),
-  style: StrV(""),
+export const sampleImage = (
+  rng: seedrandom.prng,
+  canvas: Canvas
+): ImageProps => ({
+  name: strV("defaultImage"),
+  style: strV(""),
   center: sampleVector(rng, canvas),
   width: sampleWidth(rng, canvas),
   height: sampleHeight(rng, canvas),
   rotation: sampleZero(),
-  href: StrV("defaultImage"),
-  ensureOnCanvas: BoolV(true),
+  href: strV("defaultImage"),
+  ensureOnCanvas: boolV(true),
 });
 
-export type Image = IShape & { shapeType: "Image" } & IImage;
+export type Image = Shape & { shapeType: "Image" } & ImageProps;
 
 export const makeImage = (
   rng: seedrandom.prng,
   canvas: Canvas,
-  properties: Partial<IImage>
+  properties: Partial<ImageProps>
 ): Image => ({
   ...sampleImage(rng, canvas),
   ...properties,

--- a/packages/core/src/shapes/Line.ts
+++ b/packages/core/src/shapes/Line.ts
@@ -1,44 +1,47 @@
 import * as ad from "types/ad";
-import { IArrow, INamed, IShape, IStroke } from "types/shapes";
-import { IStrV, IVectorV } from "types/value";
+import { Arrow, Named, Shape, Stroke } from "types/shapes";
+import { StrV, VectorV } from "types/value";
 import {
-  BoolV,
+  boolV,
   Canvas,
-  FloatV,
+  floatV,
   sampleColor,
   sampleVector,
-  StrV,
+  strV,
 } from "./Samplers";
 
-export interface ILine extends INamed, IStroke, IArrow {
-  start: IVectorV<ad.Num>;
-  end: IVectorV<ad.Num>;
-  strokeLinecap: IStrV;
+export interface LineProps extends Named, Stroke, Arrow {
+  start: VectorV<ad.Num>;
+  end: VectorV<ad.Num>;
+  strokeLinecap: StrV;
 }
 
-export const sampleLine = (rng: seedrandom.prng, canvas: Canvas): ILine => ({
-  name: StrV("defaultLine"),
-  style: StrV(""),
-  strokeWidth: FloatV(1),
-  strokeStyle: StrV("solid"),
+export const sampleLine = (
+  rng: seedrandom.prng,
+  canvas: Canvas
+): LineProps => ({
+  name: strV("defaultLine"),
+  style: strV(""),
+  strokeWidth: floatV(1),
+  strokeStyle: strV("solid"),
   strokeColor: sampleColor(rng),
-  strokeDasharray: StrV(""),
-  arrowheadSize: FloatV(1),
-  arrowheadStyle: StrV("arrowhead-2"),
-  startArrowhead: BoolV(false),
-  endArrowhead: BoolV(false),
+  strokeDasharray: strV(""),
+  arrowheadSize: floatV(1),
+  arrowheadStyle: strV("arrowhead-2"),
+  startArrowhead: boolV(false),
+  endArrowhead: boolV(false),
   start: sampleVector(rng, canvas),
   end: sampleVector(rng, canvas),
-  strokeLinecap: StrV(""),
-  ensureOnCanvas: BoolV(true),
+  strokeLinecap: strV(""),
+  ensureOnCanvas: boolV(true),
 });
 
-export type Line = IShape & { shapeType: "Line" } & ILine;
+export type Line = Shape & { shapeType: "Line" } & LineProps;
 
 export const makeLine = (
   rng: seedrandom.prng,
   canvas: Canvas,
-  properties: Partial<ILine>
+  properties: Partial<LineProps>
 ): Line => ({
   ...sampleLine(rng, canvas),
   ...properties,

--- a/packages/core/src/shapes/Path.ts
+++ b/packages/core/src/shapes/Path.ts
@@ -1,42 +1,45 @@
 import * as ad from "types/ad";
-import { IArrow, IFill, INamed, IShape, IStroke } from "types/shapes";
-import { IPathDataV } from "types/value";
+import { Arrow, Fill, Named, Shape, Stroke } from "types/shapes";
+import { PathDataV } from "types/value";
 import {
-  BoolV,
+  boolV,
   Canvas,
-  FloatV,
-  PathDataV,
+  floatV,
+  pathDataV,
   sampleColor,
   sampleNoPaint,
-  StrV,
+  strV,
 } from "./Samplers";
 
-export interface IPath extends INamed, IStroke, IFill, IArrow {
-  d: IPathDataV<ad.Num>;
+export interface PathProps extends Named, Stroke, Fill, Arrow {
+  d: PathDataV<ad.Num>;
 }
 
-export const samplePath = (rng: seedrandom.prng, _canvas: Canvas): IPath => ({
-  name: StrV("defaultPath"),
-  style: StrV(""),
-  strokeWidth: FloatV(1),
-  strokeStyle: StrV("solid"),
+export const samplePath = (
+  rng: seedrandom.prng,
+  _canvas: Canvas
+): PathProps => ({
+  name: strV("defaultPath"),
+  style: strV(""),
+  strokeWidth: floatV(1),
+  strokeStyle: strV("solid"),
   strokeColor: sampleColor(rng),
-  strokeDasharray: StrV(""),
+  strokeDasharray: strV(""),
   fillColor: sampleNoPaint(),
-  arrowheadSize: FloatV(1),
-  arrowheadStyle: StrV("arrowhead-2"),
-  startArrowhead: BoolV(false),
-  endArrowhead: BoolV(false),
-  d: PathDataV([]),
-  ensureOnCanvas: BoolV(true),
+  arrowheadSize: floatV(1),
+  arrowheadStyle: strV("arrowhead-2"),
+  startArrowhead: boolV(false),
+  endArrowhead: boolV(false),
+  d: pathDataV([]),
+  ensureOnCanvas: boolV(true),
 });
 
-export type Path = IShape & { shapeType: "Path" } & IPath;
+export type Path = Shape & { shapeType: "Path" } & PathProps;
 
 export const makePath = (
   rng: seedrandom.prng,
   canvas: Canvas,
-  properties: Partial<IPath>
+  properties: Partial<PathProps>
 ): Path => ({
   ...samplePath(rng, canvas),
   ...properties,

--- a/packages/core/src/shapes/Polygon.ts
+++ b/packages/core/src/shapes/Polygon.ts
@@ -1,43 +1,43 @@
-import { IFill, INamed, IPoly, IScale, IShape, IStroke } from "types/shapes";
+import { Fill, Named, Poly, Scale, Shape, Stroke } from "types/shapes";
 import {
-  BoolV,
+  boolV,
   Canvas,
-  FloatV,
-  PtListV,
+  floatV,
+  ptListV,
   sampleColor,
   sampleNoPaint,
   sampleZero,
-  StrV,
+  strV,
 } from "./Samplers";
 
-export interface IPolygon extends INamed, IStroke, IFill, IScale, IPoly {}
+export interface PolygonProps extends Named, Stroke, Fill, Scale, Poly {}
 
 export const samplePolygon = (
   rng: seedrandom.prng,
   _canvas: Canvas
-): IPolygon => ({
-  name: StrV("defaultPolygon"),
-  style: StrV(""),
+): PolygonProps => ({
+  name: strV("defaultPolygon"),
+  style: strV(""),
   strokeWidth: sampleZero(),
-  strokeStyle: StrV("solid"),
+  strokeStyle: strV("solid"),
   strokeColor: sampleNoPaint(),
-  strokeDasharray: StrV(""),
+  strokeDasharray: strV(""),
   fillColor: sampleColor(rng),
-  scale: FloatV(1),
-  points: PtListV([
+  scale: floatV(1),
+  points: ptListV([
     [0, 0],
     [0, 10],
     [10, 0],
   ]),
-  ensureOnCanvas: BoolV(true),
+  ensureOnCanvas: boolV(true),
 });
 
-export type Polygon = IShape & { shapeType: "Polygon" } & IPolygon;
+export type Polygon = Shape & { shapeType: "Polygon" } & PolygonProps;
 
 export const makePolygon = (
   rng: seedrandom.prng,
   canvas: Canvas,
-  properties: Partial<IPolygon>
+  properties: Partial<PolygonProps>
 ): Polygon => ({
   ...samplePolygon(rng, canvas),
   ...properties,

--- a/packages/core/src/shapes/Polyline.ts
+++ b/packages/core/src/shapes/Polyline.ts
@@ -1,42 +1,42 @@
-import { IFill, INamed, IPoly, IScale, IShape, IStroke } from "types/shapes";
+import { Fill, Named, Poly, Scale, Shape, Stroke } from "types/shapes";
 import {
-  BoolV,
+  boolV,
   Canvas,
-  FloatV,
-  PtListV,
+  floatV,
+  ptListV,
   sampleBlack,
   sampleNoPaint,
-  StrV,
+  strV,
 } from "./Samplers";
 
-export interface IPolyline extends INamed, IStroke, IFill, IScale, IPoly {}
+export interface PolylineProps extends Named, Stroke, Fill, Scale, Poly {}
 
 export const samplePolyline = (
   _rng: seedrandom.prng,
   _canvas: Canvas
-): IPolyline => ({
-  name: StrV("defaultPolyline"),
-  style: StrV(""),
-  strokeWidth: FloatV(1),
-  strokeStyle: StrV("solid"),
+): PolylineProps => ({
+  name: strV("defaultPolyline"),
+  style: strV(""),
+  strokeWidth: floatV(1),
+  strokeStyle: strV("solid"),
   strokeColor: sampleBlack(),
-  strokeDasharray: StrV(""),
+  strokeDasharray: strV(""),
   fillColor: sampleNoPaint(),
-  scale: FloatV(1),
-  points: PtListV([
+  scale: floatV(1),
+  points: ptListV([
     [0, 0],
     [0, 10],
     [10, 0],
   ]),
-  ensureOnCanvas: BoolV(true),
+  ensureOnCanvas: boolV(true),
 });
 
-export type Polyline = IShape & { shapeType: "Polyline" } & IPolyline;
+export type Polyline = Shape & { shapeType: "Polyline" } & PolylineProps;
 
 export const makePolyline = (
   rng: seedrandom.prng,
   canvas: Canvas,
-  properties: Partial<IPolyline>
+  properties: Partial<PolylineProps>
 ): Polyline => ({
   ...samplePolyline(rng, canvas),
   ...properties,

--- a/packages/core/src/shapes/Rectangle.ts
+++ b/packages/core/src/shapes/Rectangle.ts
@@ -1,15 +1,15 @@
 import {
-  ICenter,
-  ICorner,
-  IFill,
-  INamed,
-  IRect,
-  IRotate,
-  IShape,
-  IStroke,
+  Center,
+  Corner,
+  Fill,
+  Named,
+  Rect,
+  Rotate,
+  Shape,
+  Stroke,
 } from "types/shapes";
 import {
-  BoolV,
+  boolV,
   Canvas,
   sampleColor,
   sampleHeight,
@@ -17,44 +17,43 @@ import {
   sampleVector,
   sampleWidth,
   sampleZero,
-  StrV,
+  strV,
 } from "./Samplers";
 
-// not to be confused with IRect... need to rename maybe?
-export interface IRectangle
-  extends INamed,
-    IStroke,
-    IFill,
-    ICenter,
-    IRotate,
-    IRect,
-    ICorner {}
+export interface RectangleProps
+  extends Named,
+    Stroke,
+    Fill,
+    Center,
+    Rotate,
+    Rect,
+    Corner {}
 
 export const sampleRectangle = (
   rng: seedrandom.prng,
   canvas: Canvas
-): IRectangle => ({
-  name: StrV("defaultRectangle"),
-  style: StrV(""),
+): RectangleProps => ({
+  name: strV("defaultRectangle"),
+  style: strV(""),
   strokeWidth: sampleZero(),
-  strokeStyle: StrV("solid"),
+  strokeStyle: strV("solid"),
   strokeColor: sampleNoPaint(),
-  strokeDasharray: StrV(""),
+  strokeDasharray: strV(""),
   fillColor: sampleColor(rng),
   center: sampleVector(rng, canvas),
   width: sampleWidth(rng, canvas),
   height: sampleHeight(rng, canvas),
   cornerRadius: sampleZero(),
   rotation: sampleZero(),
-  ensureOnCanvas: BoolV(true),
+  ensureOnCanvas: boolV(true),
 });
 
-export type Rectangle = IShape & { shapeType: "Rectangle" } & IRectangle;
+export type Rectangle = Shape & { shapeType: "Rectangle" } & RectangleProps;
 
 export const makeRectangle = (
   rng: seedrandom.prng,
   canvas: Canvas,
-  properties: Partial<IRectangle>
+  properties: Partial<RectangleProps>
 ): Rectangle => ({
   ...sampleRectangle(rng, canvas),
   ...properties,

--- a/packages/core/src/shapes/Samplers.ts
+++ b/packages/core/src/shapes/Samplers.ts
@@ -1,23 +1,23 @@
 import seedrandom from "seedrandom";
 import * as ad from "types/ad";
 import {
+  BoolV,
   Color,
-  IBoolV,
-  IColorV,
-  IFileV,
-  IFloatV,
-  IIntV,
-  IListV,
-  IMatrixV,
-  IPaletteV,
-  IPathCmd,
-  IPathDataV,
-  IPtListV,
-  IPtV,
-  IStrV,
-  IStyleV,
-  ITupV,
-  IVectorV,
+  ColorV,
+  FileV,
+  FloatV,
+  IntV,
+  ListV,
+  MatrixV,
+  PaletteV,
+  PathCmd,
+  PathDataV,
+  PtListV,
+  PtV,
+  StrV,
+  StyleV,
+  TupV,
+  VectorV,
 } from "types/value";
 import { randFloat } from "utils/Util";
 
@@ -28,15 +28,13 @@ type Range = [number, number];
 // export const canvasSize: [number, number] = [800, 700];
 // export const canvasXRange: Range = [-canvasSize[0] / 2, canvasSize[0] / 2];
 // export const canvasYRange: Range = [-canvasSize[1] / 2, canvasSize[1] / 2];
-export interface ICanvas {
+export interface Canvas {
   width: number;
   height: number;
   size: [number, number];
   xRange: Range;
   yRange: Range;
 }
-
-export type Canvas = ICanvas;
 
 export const makeCanvas = (width: number, height: number): Canvas => ({
   width,
@@ -46,65 +44,63 @@ export const makeCanvas = (width: number, height: number): Canvas => ({
   yRange: [-height / 2, height / 2],
 });
 
-export const FloatV = (contents: ad.Num): IFloatV<ad.Num> => ({
+export const floatV = (contents: ad.Num): FloatV<ad.Num> => ({
   tag: "FloatV",
   contents,
 });
-export const IntV = (contents: number): IIntV => ({
+export const intV = (contents: number): IntV => ({
   tag: "IntV",
   contents,
 });
-export const BoolV = (contents: boolean): IBoolV<ad.Num> => ({
+export const boolV = (contents: boolean): BoolV<ad.Num> => ({
   tag: "BoolV",
   contents,
 });
-export const StrV = (contents: string): IStrV => ({
+export const strV = (contents: string): StrV => ({
   tag: "StrV",
   contents,
 });
-export const PtV = (contents: ad.Num[]): IPtV<ad.Num> => ({
+export const ptV = (contents: ad.Num[]): PtV<ad.Num> => ({
   tag: "PtV",
   contents,
 });
-export const PathDataV = (
-  contents: IPathCmd<ad.Num>[]
-): IPathDataV<ad.Num> => ({
+export const pathDataV = (contents: PathCmd<ad.Num>[]): PathDataV<ad.Num> => ({
   tag: "PathDataV",
   contents,
 });
-export const PtListV = (contents: ad.Num[][]): IPtListV<ad.Num> => ({
+export const ptListV = (contents: ad.Num[][]): PtListV<ad.Num> => ({
   tag: "PtListV",
   contents,
 });
-export const ColorV = (contents: Color<ad.Num>): IColorV<ad.Num> => ({
+export const colorV = (contents: Color<ad.Num>): ColorV<ad.Num> => ({
   tag: "ColorV",
   contents,
 });
-export const PaletteV = (contents: Color<ad.Num>[]): IPaletteV<ad.Num> => ({
+export const paletteV = (contents: Color<ad.Num>[]): PaletteV<ad.Num> => ({
   tag: "PaletteV",
   contents,
 });
-export const FileV = (contents: string): IFileV<ad.Num> => ({
+export const fileV = (contents: string): FileV<ad.Num> => ({
   tag: "FileV",
   contents,
 });
-export const StyleV = (contents: string): IStyleV<ad.Num> => ({
+export const styleV = (contents: string): StyleV<ad.Num> => ({
   tag: "StyleV",
   contents,
 });
-export const ListV = (contents: ad.Num[]): IListV<ad.Num> => ({
+export const listV = (contents: ad.Num[]): ListV<ad.Num> => ({
   tag: "ListV",
   contents,
 });
-export const VectorV = (contents: ad.Num[]): IVectorV<ad.Num> => ({
+export const vectorV = (contents: ad.Num[]): VectorV<ad.Num> => ({
   tag: "VectorV",
   contents,
 });
-export const MatrixV = (contents: ad.Num[][]): IMatrixV<ad.Num> => ({
+export const matrixV = (contents: ad.Num[][]): MatrixV<ad.Num> => ({
   tag: "MatrixV",
   contents,
 });
-export const TupV = (contents: ad.Num[]): ITupV<ad.Num> => ({
+export const tupV = (contents: ad.Num[]): TupV<ad.Num> => ({
   tag: "TupV",
   contents,
 });
@@ -113,26 +109,26 @@ export const sampleFloatIn = (
   rng: seedrandom.prng,
   min: number,
   max: number
-): IFloatV<ad.Num> => FloatV(randFloat(rng, min, max));
+): FloatV<ad.Num> => floatV(randFloat(rng, min, max));
 export const sampleVector = (
   rng: seedrandom.prng,
   canvas: Canvas
-): IVectorV<ad.Num> =>
-  VectorV([randFloat(rng, ...canvas.xRange), randFloat(rng, ...canvas.yRange)]);
+): VectorV<ad.Num> =>
+  vectorV([randFloat(rng, ...canvas.xRange), randFloat(rng, ...canvas.yRange)]);
 export const sampleWidth = (
   rng: seedrandom.prng,
   canvas: Canvas
-): IFloatV<ad.Num> => FloatV(randFloat(rng, 3, canvas.width / 6));
-export const sampleZero = (): IFloatV<ad.Num> => FloatV(0);
+): FloatV<ad.Num> => floatV(randFloat(rng, 3, canvas.width / 6));
+export const sampleZero = (): FloatV<ad.Num> => floatV(0);
 export const sampleHeight = (
   rng: seedrandom.prng,
   canvas: Canvas
-): IFloatV<ad.Num> => FloatV(randFloat(rng, 3, canvas.height / 6));
-export const sampleStroke = (rng: seedrandom.prng): IFloatV<ad.Num> =>
-  FloatV(randFloat(rng, 0.5, 3));
-export const sampleColor = (rng: seedrandom.prng): IColorV<ad.Num> => {
+): FloatV<ad.Num> => floatV(randFloat(rng, 3, canvas.height / 6));
+export const sampleStroke = (rng: seedrandom.prng): FloatV<ad.Num> =>
+  floatV(randFloat(rng, 0.5, 3));
+export const sampleColor = (rng: seedrandom.prng): ColorV<ad.Num> => {
   const [min, max] = [0.1, 0.9];
-  return ColorV({
+  return colorV({
     tag: "RGBA",
     contents: [
       randFloat(rng, min, max),
@@ -142,6 +138,6 @@ export const sampleColor = (rng: seedrandom.prng): IColorV<ad.Num> => {
     ],
   });
 };
-export const sampleBlack = (): IColorV<ad.Num> =>
-  ColorV({ tag: "RGBA", contents: [0, 0, 0, 1] });
-export const sampleNoPaint = (): IColorV<ad.Num> => ColorV({ tag: "NONE" });
+export const sampleBlack = (): ColorV<ad.Num> =>
+  colorV({ tag: "RGBA", contents: [0, 0, 0, 1] });
+export const sampleNoPaint = (): ColorV<ad.Num> => colorV({ tag: "NONE" });

--- a/packages/core/src/shapes/Text.ts
+++ b/packages/core/src/shapes/Text.ts
@@ -1,56 +1,59 @@
 import * as ad from "types/ad";
 import {
-  ICenter,
-  IFill,
-  INamed,
-  IRect,
-  IRotate,
-  IShape,
-  IString,
-  IStroke,
+  Center,
+  Fill,
+  Named,
+  Rect,
+  Rotate,
+  Shape,
+  String,
+  Stroke,
 } from "types/shapes";
-import { IFloatV, IStrV } from "types/value";
+import { FloatV, StrV } from "types/value";
 import {
-  BoolV,
+  boolV,
   Canvas,
   sampleColor,
   sampleNoPaint,
   sampleVector,
   sampleZero,
-  StrV,
+  strV,
 } from "./Samplers";
 
-export interface IText
-  extends INamed,
-    IStroke,
-    IFill,
-    ICenter, // the center of the bounding box of the text
-    IRect,
-    IRotate,
-    IString {
+export interface TextProps
+  extends Named,
+    Stroke,
+    Fill,
+    Center, // the center of the bounding box of the text
+    Rect,
+    Rotate,
+    String {
   // TODO; pare down this set of attributes
-  visibility: IStrV;
-  fontFamily: IStrV;
-  fontSizeAdjust: IStrV;
-  fontStretch: IStrV;
-  fontStyle: IStrV;
-  fontVariant: IStrV;
-  fontWeight: IStrV;
-  textAnchor: IStrV;
-  lineHeight: IStrV;
-  alignmentBaseline: IStrV;
-  dominantBaseline: IStrV;
-  ascent: IFloatV<ad.Num>;
-  descent: IFloatV<ad.Num>;
+  visibility: StrV;
+  fontFamily: StrV;
+  fontSizeAdjust: StrV;
+  fontStretch: StrV;
+  fontStyle: StrV;
+  fontVariant: StrV;
+  fontWeight: StrV;
+  textAnchor: StrV;
+  lineHeight: StrV;
+  alignmentBaseline: StrV;
+  dominantBaseline: StrV;
+  ascent: FloatV<ad.Num>;
+  descent: FloatV<ad.Num>;
 }
 
-export const sampleText = (rng: seedrandom.prng, canvas: Canvas): IText => ({
-  name: StrV("defaultText"),
-  style: StrV(""),
+export const sampleText = (
+  rng: seedrandom.prng,
+  canvas: Canvas
+): TextProps => ({
+  name: strV("defaultText"),
+  style: strV(""),
   strokeWidth: sampleZero(),
-  strokeStyle: StrV("solid"),
+  strokeStyle: strV("solid"),
   strokeColor: sampleNoPaint(),
-  strokeDasharray: StrV(""),
+  strokeDasharray: strV(""),
   fillColor: sampleColor(rng),
   center: sampleVector(rng, canvas),
   width: sampleZero(),
@@ -58,29 +61,29 @@ export const sampleText = (rng: seedrandom.prng, canvas: Canvas): IText => ({
   ascent: sampleZero(),
   descent: sampleZero(),
   rotation: sampleZero(),
-  string: StrV("defaultText"),
-  visibility: StrV(""),
-  fontFamily: StrV("sans-serif"),
-  fontSize: StrV("12px"),
-  fontSizeAdjust: StrV(""),
-  fontStretch: StrV(""),
-  fontStyle: StrV(""),
-  fontVariant: StrV(""),
-  fontWeight: StrV(""),
-  lineHeight: StrV(""),
-  textAnchor: StrV("middle"),
+  string: strV("defaultText"),
+  visibility: strV(""),
+  fontFamily: strV("sans-serif"),
+  fontSize: strV("12px"),
+  fontSizeAdjust: strV(""),
+  fontStretch: strV(""),
+  fontStyle: strV(""),
+  fontVariant: strV(""),
+  fontWeight: strV(""),
+  lineHeight: strV(""),
+  textAnchor: strV("middle"),
   // NOTE: both `alignmentBaseline` and `dominantBaseline` are necessary for browser support. For instance, Firefox only respects the latter.
-  alignmentBaseline: StrV("alphabetic"),
-  dominantBaseline: StrV("alphabetic"),
-  ensureOnCanvas: BoolV(true),
+  alignmentBaseline: strV("alphabetic"),
+  dominantBaseline: strV("alphabetic"),
+  ensureOnCanvas: boolV(true),
 });
 
-export type Text = IShape & { shapeType: "Text" } & IText;
+export type Text = Shape & { shapeType: "Text" } & TextProps;
 
 export const makeText = (
   rng: seedrandom.prng,
   canvas: Canvas,
-  properties: Partial<IText>
+  properties: Partial<TextProps>
 ): Text => ({
   ...sampleText(rng, canvas),
   ...properties,

--- a/packages/core/src/synthesis/Mutation.ts
+++ b/packages/core/src/synthesis/Mutation.ts
@@ -37,7 +37,7 @@ export type MutationGroup = Mutation[];
 export type Mutation = Add | Delete | Update;
 export type MutationType = Mutation["tag"];
 
-export interface IMutation {
+export interface MutationBase {
   tag: MutationType;
   additionalMutations?: Mutation[];
   mutate: (
@@ -57,23 +57,23 @@ export type Update =
   | ChangeStmtType
   | ChangeExprType;
 
-export interface Add extends IMutation {
+export interface Add extends MutationBase {
   tag: "Add";
   stmt: SubStmt<A>;
 }
-export interface Delete extends IMutation {
+export interface Delete extends MutationBase {
   tag: "Delete";
   stmt: SubStmt<A>;
 }
 
-export interface SwapStmtArgs extends IMutation {
+export interface SwapStmtArgs extends MutationBase {
   tag: "SwapStmtArgs";
   stmt: ApplyPredicate<A>;
   elem1: number;
   elem2: number;
 }
 
-export interface SwapExprArgs extends IMutation {
+export interface SwapExprArgs extends MutationBase {
   tag: "SwapExprArgs";
   stmt: Bind<A>;
   expr: ArgExpr<A>;
@@ -81,14 +81,14 @@ export interface SwapExprArgs extends IMutation {
   elem2: number;
 }
 
-export interface SwapInStmtArgs extends IMutation {
+export interface SwapInStmtArgs extends MutationBase {
   tag: "SwapInStmtArgs";
   stmt: ApplyPredicate<A>;
   elem: number;
   swap: Identifier<A>;
 }
 
-export interface SwapInExprArgs extends IMutation {
+export interface SwapInExprArgs extends MutationBase {
   tag: "SwapInExprArgs";
   stmt: Bind<A>;
   expr: ArgExpr<A>;
@@ -96,26 +96,26 @@ export interface SwapInExprArgs extends IMutation {
   swap: Identifier<A>;
 }
 
-export interface ReplaceStmtName extends IMutation {
+export interface ReplaceStmtName extends MutationBase {
   tag: "ReplaceStmtName";
   stmt: ApplyPredicate<A>;
   newName: string;
 }
 
-export interface ReplaceExprName extends IMutation {
+export interface ReplaceExprName extends MutationBase {
   tag: "ReplaceExprName";
   stmt: Bind<A>;
   expr: ArgExpr<A>;
   newName: string;
 }
-export interface ChangeStmtType extends IMutation {
+export interface ChangeStmtType extends MutationBase {
   tag: "ChangeStmtType";
   stmt: ApplyPredicate<A>;
   newStmt: SubStmt<A>;
   additionalMutations: Mutation[];
 }
 
-export interface ChangeExprType extends IMutation {
+export interface ChangeExprType extends MutationBase {
   tag: "ChangeExprType";
   stmt: Bind<A>;
   expr: ArgExpr<A>;

--- a/packages/core/src/types/ad.ts
+++ b/packages/core/src/types/ad.ts
@@ -268,17 +268,13 @@ export type Pt2 = [Num, Num];
 
 export const isPt2 = (vec: Num[]): vec is Pt2 => vec.length === 2;
 
-export type GradGraphs = IGradGraphs;
-
-export interface IGradGraphs {
+export interface GradGraphs {
   inputs: Num[];
   weight: Num | undefined; // EP weight, a hyperparameter to both energy and gradient; TODO: generalize to multiple hyperparameters
 }
 
-export type OptInfo = IOptInfo;
 // Returned after a call to `minimize`
-
-export interface IOptInfo {
+export interface OptInfo {
   xs: number[];
   energyVal: number;
   normGrad: number;
@@ -288,11 +284,9 @@ export interface IOptInfo {
   failed: boolean;
 }
 
-export type OptDebugInfo = IOptDebugInfo;
-
 export type NumMap = Map<string, number>;
 
-export interface IOptDebugInfo {
+export interface OptDebugInfo {
   gradient: NumMap;
   gradientPreconditioned: NumMap;
 }

--- a/packages/core/src/types/ast.ts
+++ b/packages/core/src/types/ast.ts
@@ -44,7 +44,7 @@ export type Identifier<T> = ASTNode<T> & {
   type: string; // meta-info: either `value` or `type-identifier` according to the parser
   value: string; // the actual value
 };
-export type IStringLit<T> = ASTNode<T> & {
+export type StringLit<T> = ASTNode<T> & {
   tag: "StringLit";
   contents: string;
 };

--- a/packages/core/src/types/domain.ts
+++ b/packages/core/src/types/domain.ts
@@ -2,7 +2,7 @@
 
 import { Graph } from "graphlib";
 import { Map } from "immutable";
-import { A, ASTNode, C, Identifier, IStringLit } from "./ast";
+import { A, ASTNode, C, Identifier, StringLit } from "./ast";
 import { ApplyConstructor, TypeConsApp } from "./substance";
 
 export type Var<T> = Identifier<T>;
@@ -79,8 +79,8 @@ export type PreludeDecl<T> = ASTNode<T> & {
 // TODO: check if string type is enough
 export type NotationDecl<T> = ASTNode<T> & {
   tag: "NotationDecl";
-  from: IStringLit<T>;
-  to: IStringLit<T>;
+  from: StringLit<T>;
+  to: StringLit<T>;
 };
 export type SubTypeDecl<T> = ASTNode<T> & {
   tag: "SubTypeDecl";

--- a/packages/core/src/types/shape.ts
+++ b/packages/core/src/types/shape.ts
@@ -1,15 +1,15 @@
 import * as ad from "./ad";
 import { Value } from "./value";
 
-export type Shape = IShape<number>;
-export type ShapeAD = IShape<ad.Num>;
+export type Shape = GenericShape<number>;
+export type ShapeAD = GenericShape<ad.Num>;
 
 export type Properties<T> = { [k: string]: Value<T> };
 
 /**
  * A shape (Graphical Primitive Instance, aka GPI) in penrose has a type (_e.g._ `Circle`) and a set of properties (_e.g._ `center`). This type is specifically used for rendering. See {@link GPI} for the version used for the runtime.
  */
-interface IShape<T> {
+interface GenericShape<T> {
   shapeType: string;
   properties: Properties<T>;
 }

--- a/packages/core/src/types/shapes.ts
+++ b/packages/core/src/types/shapes.ts
@@ -1,67 +1,67 @@
 import * as ad from "types/ad";
-import { IBoolV, IColorV, IFloatV, IPtListV, IStrV, IVectorV } from "./value";
+import { BoolV, ColorV, FloatV, PtListV, StrV, VectorV } from "./value";
 
 //#region shape hierarchy interfaces
-export interface INamed {
-  name: IStrV;
-  style: IStrV; // TODO: very temporary; remove this and just use passthrough
-  ensureOnCanvas: IBoolV<ad.Num>;
+export interface Named {
+  name: StrV;
+  style: StrV; // TODO: very temporary; remove this and just use passthrough
+  ensureOnCanvas: BoolV<ad.Num>;
 }
 
-export interface IStroke {
-  strokeWidth: IFloatV<ad.Num>;
-  strokeStyle: IStrV;
-  strokeColor: IColorV<ad.Num>;
-  strokeDasharray: IStrV;
+export interface Stroke {
+  strokeWidth: FloatV<ad.Num>;
+  strokeStyle: StrV;
+  strokeColor: ColorV<ad.Num>;
+  strokeDasharray: StrV;
 }
 
-export interface IFill {
-  fillColor: IColorV<ad.Num>;
+export interface Fill {
+  fillColor: ColorV<ad.Num>;
 }
 
-export interface ICenter {
-  center: IVectorV<ad.Num>; // corresponds to (cx, cy), or other things, in SVG
+export interface Center {
+  center: VectorV<ad.Num>; // corresponds to (cx, cy), or other things, in SVG
 }
 
-export interface IRect {
-  width: IFloatV<ad.Num>;
-  height: IFloatV<ad.Num>;
+export interface Rect {
+  width: FloatV<ad.Num>;
+  height: FloatV<ad.Num>;
 }
 
-export interface IArrow {
-  arrowheadSize: IFloatV<ad.Num>;
-  arrowheadStyle: IStrV;
-  startArrowhead: IBoolV<ad.Num>;
-  endArrowhead: IBoolV<ad.Num>;
+export interface Arrow {
+  arrowheadSize: FloatV<ad.Num>;
+  arrowheadStyle: StrV;
+  startArrowhead: BoolV<ad.Num>;
+  endArrowhead: BoolV<ad.Num>;
 }
 
-export interface ICorner {
-  cornerRadius: IFloatV<ad.Num>; // note: corresponds to rx in SVG
+export interface Corner {
+  cornerRadius: FloatV<ad.Num>; // note: corresponds to rx in SVG
 }
 
 // TODO: don't use these
-export interface IRotate {
-  rotation: IFloatV<ad.Num>; // about the top-left corner
+export interface Rotate {
+  rotation: FloatV<ad.Num>; // about the top-left corner
 }
-export interface IScale {
-  scale: IFloatV<ad.Num>; // doesn't work correctly
+export interface Scale {
+  scale: FloatV<ad.Num>; // doesn't work correctly
 }
 
 // // TODO: use this
-// export interface ITransform {
-//   matrix: IMatrixV<ad.Num>;
+// export interface Transform {
+//   matrix: MatrixV<ad.Num>;
 // }
 
-export interface IPoly {
-  points: IPtListV<ad.Num>;
+export interface Poly {
+  points: PtListV<ad.Num>;
 }
 
-export interface IString {
-  string: IStrV;
-  fontSize: IStrV;
+export interface String {
+  string: StrV;
+  fontSize: StrV;
 }
 
-export interface IShape {
+export interface Shape {
   shapeType: string;
 }
 

--- a/packages/core/src/types/state.ts
+++ b/packages/core/src/types/state.ts
@@ -4,12 +4,12 @@ import * as ad from "types/ad";
 import { A } from "./ast";
 import { Shape } from "./shape";
 import { Expr, Path } from "./style";
-import { ArgVal, IFloatV, Translation } from "./value";
+import { ArgVal, FloatV, Translation } from "./value";
 
 /**
  * The diagram state modeling the original Haskell types
  */
-export interface IState {
+export interface State {
   seeds: Seeds;
   varyingPaths: Path<A>[];
   varyingInitInfo: { [pathStr: string]: number }; // These are the values the style writer set initially
@@ -31,7 +31,6 @@ export interface IState {
   varyingMap: VaryMap;
   canvas: Canvas;
 }
-export type State = IState;
 
 // Some compDict functions (currently only sampleColor) need a prng, so we need
 // to keep a seed around in the state to allow us to recreate it at every step
@@ -65,36 +64,33 @@ export interface Seeds {
 export type LabelData = EquationData | TextData;
 export interface EquationData {
   tag: "EquationData";
-  width: IFloatV<number>;
-  height: IFloatV<number>;
+  width: FloatV<number>;
+  height: FloatV<number>;
   rendered: HTMLElement;
 }
 
 export interface TextData {
   tag: "TextData";
-  width: IFloatV<number>;
-  height: IFloatV<number>;
-  descent: IFloatV<number>;
-  ascent: IFloatV<number>;
+  width: FloatV<number>;
+  height: FloatV<number>;
+  descent: FloatV<number>;
+  ascent: FloatV<number>;
 }
 
 export type LabelCache = [string, LabelData][];
 
 export type VaryMap<T = ad.Num> = Map<string, T>;
 
-export type FnDone<T> = IFnDone<T>;
-export interface IFnDone<T> {
+export interface FnDone<T> {
   name: string;
   args: ArgVal<T>[];
   optType: OptType;
 }
 
-export type Fn = IFn;
-
 /**
  * Generic export interface for constraint or objective functions
  */
-export interface IFn {
+export interface Fn {
   fname: string;
   fargs: Expr<A>[];
   optType: OptType;
@@ -108,10 +104,8 @@ export type OptStatus =
   | "EPConverged"
   | "Error";
 
-export type LbfgsParams = ILbfgsParams;
-
 // `n` is the size of the varying state
-export interface ILbfgsParams {
+export interface LbfgsParams {
   lastState: Matrix | undefined; // nx1 (col vec)
   lastGrad: Matrix | undefined; // nx1 (col vec)
   s_list: Matrix[]; // list of nx1 col vecs
@@ -125,9 +119,7 @@ export interface FnEvaled {
   gradf: number[];
 }
 
-export type Params = IParams;
-
-export interface IParams {
+export interface Params {
   optStatus: OptStatus;
   /** Constraint weight for exterior point method **/
   weight: number;
@@ -172,9 +164,7 @@ export interface IParams {
 // Just the compiled function and its grad, with no weights for EP/constraints/penalties, etc.
 export type FnCached = (xs: number[]) => FnEvaled;
 
-export type WeightInfo = IWeightInfo;
-
-export interface IWeightInfo {
+export interface WeightInfo {
   epWeightNode: ad.Input;
   epWeight: number;
 }

--- a/packages/core/src/types/style.ts
+++ b/packages/core/src/types/style.ts
@@ -2,7 +2,7 @@
 // TODO: unify type name convention (e.g. stop using `I` for interfaces and drop some of the Haskell ported types)
 
 import * as ad from "./ad";
-import { ASTNode, Identifier, IStringLit } from "./ast";
+import { ASTNode, Identifier, StringLit } from "./ast";
 import { LabelType } from "./substance";
 
 /** Top level type for Style AST */
@@ -81,41 +81,37 @@ export type PredArg<T> = SEBind<T> | RelPred<T>;
 
 // NOTE: the original type is unnecessarily nested and contain type constructor, which is deprecated.
 export type StyT<T> = Identifier<T>;
-// type StyT = ISTTypeVar | ISTCtor;
+// type StyT = STTypeVar | STCtor;
 
-export type ISTTypeVar<T> = ASTNode<T> & {
+export type STTypeVar<T> = ASTNode<T> & {
   tag: "STTypeVar";
   contents: STypeVar<T>;
 };
 
-export type ISTCtor<T> = ASTNode<T> & {
+export type STCtor<T> = ASTNode<T> & {
   tag: "STCtor";
   contents: STypeCtor<T>;
 };
 
-export type STypeVar<T> = ISTypeVar<T>;
-
-export type ISTypeVar<T> = ASTNode<T> & {
+export type STypeVar<T> = ASTNode<T> & {
   tag: "STypeVar";
   typeVarNameS: string;
 };
 
-export type STypeCtor<T> = ISTypeCtor<T>;
-
-export type ISTypeCtor<T> = ASTNode<T> & {
+export type STypeCtor<T> = ASTNode<T> & {
   tag: "STypeCtor";
   nameConsS: string;
   argConsS: SArg<T>[];
 };
 
-export type SArg<T> = ISAVar<T> | ISAT<T>;
+export type SArg<T> = SAVar<T> | SAT<T>;
 
-export type ISAVar<T> = ASTNode<T> & {
+export type SAVar<T> = ASTNode<T> & {
   tag: "SAVar";
   contents: BindingForm<T>;
 };
 
-export type ISAT<T> = ASTNode<T> & {
+export type SAT<T> = ASTNode<T> & {
   tag: "SAT";
   contents: StyT<T>;
 };
@@ -149,7 +145,7 @@ export type SEFuncOrValCons<T> = ASTNode<T> & {
   args: SelExpr<T>[];
 };
 
-export type Stmt<T> = PathAssign<T> | IOverride<T> | Delete<T> | IAnonAssign<T>;
+export type Stmt<T> = PathAssign<T> | Override<T> | Delete<T> | AnonAssign<T>;
 
 export type PathAssign<T> = ASTNode<T> & {
   tag: "PathAssign";
@@ -158,7 +154,7 @@ export type PathAssign<T> = ASTNode<T> & {
   value: Expr<T>;
 };
 
-export type IOverride<T> = ASTNode<T> & {
+export type Override<T> = ASTNode<T> & {
   tag: "Override";
   path: Path<T>;
   value: Expr<T>;
@@ -169,19 +165,19 @@ export type Delete<T> = ASTNode<T> & {
   contents: Path<T>;
 };
 
-export type IAnonAssign<T> = ASTNode<T> & {
+export type AnonAssign<T> = ASTNode<T> & {
   tag: "AnonAssign";
   contents: Expr<T>;
 };
 
-export type StyType<T> = ITypeOf<T> | IListOf<T>;
+export type StyType<T> = TypeOf<T> | ListOf<T>;
 
-export type ITypeOf<T> = ASTNode<T> & {
+export type TypeOf<T> = ASTNode<T> & {
   tag: "TypeOf";
   contents: string;
 };
 
-export type IListOf<T> = ASTNode<T> & {
+export type ListOf<T> = ASTNode<T> & {
   tag: "ListOf";
   contents: string;
 };
@@ -199,63 +195,63 @@ export type StyVar<T> = ASTNode<T> & {
 };
 
 export type Expr<T> =
-  // | IIntLit<T>
+  // | IntLit<T>
   | AnnoFloat<T>
-  | IStringLit<T>
-  | IBoolLit<T>
+  | StringLit<T>
+  | BoolLit<T>
   | Path<T> // NOTE: changed from EPath
-  | ICompApp<T>
-  | IObjFn<T>
-  | IConstrFn<T>
-  // | IAvoidFn<T> // TODO: unimplemented
-  | IBinOp<T>
-  | IUOp<T>
-  | IList<T>
-  | ITuple<T>
-  | IVector<T>
-  | IMatrix<T>
-  | IVectorAccess<T>
-  | IMatrixAccess<T>
-  | IListAccess<T>
+  | CompApp<T>
+  | ObjFn<T>
+  | ConstrFn<T>
+  // | AvoidFn<T> // TODO: unimplemented
+  | BinOp<T>
+  | UOp<T>
+  | List<T>
+  | Tuple<T>
+  | Vector<T>
+  | Matrix<T>
+  | VectorAccess<T>
+  | MatrixAccess<T>
+  | ListAccess<T>
   | GPIDecl<T>
-  | ILayering<T>
-  | IPluginAccess<T>;
-// | IThenOp<T>; // TODO: deprecated transformation exprs
+  | Layering<T>
+  | PluginAccess<T>;
+// | ThenOp<T>; // TODO: deprecated transformation exprs
 
-export type IIntLit<T> = ASTNode<T> & {
+export type IntLit<T> = ASTNode<T> & {
   tag: "IntLit";
   contents: number;
 };
 
-// export type IAFloat<T> = ASTNode<T> & {
+// export type AFloat<T> = ASTNode<T> & {
 //     tag: "AFloat";
 //     contents: AnnoFloat<T>;
 // };
 
-export type IBoolLit<T> = ASTNode<T> & {
+export type BoolLit<T> = ASTNode<T> & {
   tag: "BoolLit";
   contents: boolean;
 };
 
-export type ICompApp<T> = ASTNode<T> & {
+export type CompApp<T> = ASTNode<T> & {
   tag: "CompApp";
   name: Identifier<T>;
   args: Expr<T>[];
 };
 
-export type IObjFn<T> = ASTNode<T> & {
+export type ObjFn<T> = ASTNode<T> & {
   tag: "ObjFn";
   name: Identifier<T>;
   args: Expr<T>[];
 };
 
-export type IConstrFn<T> = ASTNode<T> & {
+export type ConstrFn<T> = ASTNode<T> & {
   tag: "ConstrFn";
   name: Identifier<T>;
   args: Expr<T>[];
 };
 
-export type IAvoidFn<T> = ASTNode<T> & {
+export type AvoidFn<T> = ASTNode<T> & {
   tag: "AvoidFn";
   contents: [string, Expr<T>[]];
 };
@@ -264,49 +260,49 @@ export type BinaryOp = "BPlus" | "BMinus" | "Multiply" | "Divide" | "Exp";
 
 // NOTE: unary + operator not parsed, as they don't change values
 export type UnaryOp = "UMinus";
-export type IBinOp<T> = ASTNode<T> & {
+export type BinOp<T> = ASTNode<T> & {
   tag: "BinOp";
   op: BinaryOp;
   left: Expr<T>;
   right: Expr<T>;
 };
-export type IUOp<T> = ASTNode<T> & {
+export type UOp<T> = ASTNode<T> & {
   tag: "UOp";
   op: UnaryOp;
   arg: Expr<T>;
 };
 
-export type IList<T> = ASTNode<T> & {
+export type List<T> = ASTNode<T> & {
   tag: "List";
   contents: Expr<T>[];
 };
 
-export type ITuple<T> = ASTNode<T> & {
+export type Tuple<T> = ASTNode<T> & {
   tag: "Tuple";
   contents: [Expr<T>, Expr<T>];
 };
 
-export type IVector<T> = ASTNode<T> & {
+export type Vector<T> = ASTNode<T> & {
   tag: "Vector";
   contents: Expr<T>[];
 };
 
-export type IMatrix<T> = ASTNode<T> & {
+export type Matrix<T> = ASTNode<T> & {
   tag: "Matrix";
   contents: Expr<T>[];
 };
 
-export type IVectorAccess<T> = ASTNode<T> & {
+export type VectorAccess<T> = ASTNode<T> & {
   tag: "VectorAccess";
   contents: [Path<T>, Expr<T>];
 };
 
-export type IMatrixAccess<T> = ASTNode<T> & {
+export type MatrixAccess<T> = ASTNode<T> & {
   tag: "MatrixAccess";
   contents: [Path<T>, Expr<T>[]];
 };
 
-export type IListAccess<T> = ASTNode<T> & {
+export type ListAccess<T> = ASTNode<T> & {
   tag: "ListAccess";
   contents: [Path<T>, number];
 };
@@ -317,40 +313,40 @@ export type GPIDecl<T> = ASTNode<T> & {
   properties: PropertyDecl<T>[];
 };
 
-export type ILayering<T> = ASTNode<T> & {
+export type Layering<T> = ASTNode<T> & {
   tag: "Layering";
   below: Path<T>;
   above: Path<T>;
 };
 
-export type IPluginAccess<T> = ASTNode<T> & {
+export type PluginAccess<T> = ASTNode<T> & {
   tag: "PluginAccess";
   contents: [string, Expr<T>, Expr<T>];
 };
 
-export type IThenOp<T> = ASTNode<T> & {
+export type ThenOp<T> = ASTNode<T> & {
   tag: "ThenOp";
   contents: [Expr<T>, Expr<T>];
 };
 
-export type AnnoFloat<T> = IFix<T> | IVary<T> | IVaryInit<T> | IVaryAD<T>;
+export type AnnoFloat<T> = Fix<T> | Vary<T> | VaryInit<T> | VaryAD<T>;
 
-export type IFix<T> = ASTNode<T> & {
+export type Fix<T> = ASTNode<T> & {
   tag: "Fix";
   contents: number;
 };
 
-export type IVary<T> = ASTNode<T> & {
+export type Vary<T> = ASTNode<T> & {
   tag: "Vary";
 };
 
 // Varying float that is initialized at some number as specified by the style-writer
-export type IVaryInit<T> = ASTNode<T> & {
+export type VaryInit<T> = ASTNode<T> & {
   tag: "VaryInit";
   contents: number;
 };
 
-export type IVaryAD<T> = ASTNode<T> & {
+export type VaryAD<T> = ASTNode<T> & {
   tag: "VaryAD";
   contents: ad.Num;
 };
@@ -363,41 +359,40 @@ export type PropertyDecl<T> = ASTNode<T> & {
 
 // TODO: check how the evaluator/compiler should interact with ASTNode
 export type Path<T> =
-  | IFieldPath<T>
-  | IPropertyPath<T>
-  | IAccessPath<T>
+  | FieldPath<T>
+  | PropertyPath<T>
+  | AccessPath<T>
   | LocalVar<T>
-  | IInternalLocalVar<T>;
+  | InternalLocalVar<T>;
 // LocalVar is only used internally by the compiler
 // Unused
-// | ITypePropertyPath<T>;
+// | TypePropertyPath<T>;
 
-export type IFieldPath<T> = ASTNode<T> & {
+export type FieldPath<T> = ASTNode<T> & {
   tag: "FieldPath";
   name: BindingForm<T>;
   field: Identifier<T>;
 };
 
-export type IPropertyPath<T> = ASTNode<T> & {
+export type PropertyPath<T> = ASTNode<T> & {
   tag: "PropertyPath";
   name: BindingForm<T>;
   field: Identifier<T>;
   property: Identifier<T>;
 };
 
-export type IAccessPath<T> = ASTNode<T> & {
+export type AccessPath<T> = ASTNode<T> & {
   tag: "AccessPath";
   path: Path<T>;
   indices: Expr<T>[];
 };
 
-// COMBAK: This is named inconsistently since the parser calls it `LocalVar`, should be ILocalVar
 export type LocalVar<T> = ASTNode<T> & {
   tag: "LocalVar";
   contents: Identifier<T>;
 };
 
-export type IInternalLocalVar<T> = ASTNode<T> & {
+export type InternalLocalVar<T> = ASTNode<T> & {
   // Note, better to not extend ASTNode as it's only used internally by compiler, but breaks parser otherwise
   tag: "InternalLocalVar";
   contents: string;

--- a/packages/core/src/types/styleSemantics.ts
+++ b/packages/core/src/types/styleSemantics.ts
@@ -13,19 +13,19 @@ import { BindingForm, Header, StyT } from "./style";
 // }
 // TODO why doesn't this work
 
-export type ProgType = ISubProgT | IStyProgT;
+export type ProgType = SubProgT | StyProgT;
 
-export interface ISubProgT {
+export interface SubProgT {
   tag: "SubProgT";
 }
 
-export interface IStyProgT {
+export interface StyProgT {
   tag: "StyProgT";
 }
 
 // g ::= B => |T
 // Assumes nullary type constructors (i.e. Style type = Substance type)
-export interface ISelEnv {
+export interface SelEnv {
   // COMBAK: k is a BindingForm that was stringified; maybe it should be a Map with BindingForm as key?
   // Variable => Type
   sTypeVarMap: { [k: string]: StyT<A> }; // B : |T
@@ -37,8 +37,6 @@ export interface ISelEnv {
   errors: StyleErrors;
 }
 // Currently used to track if any Substance variables appear in a selector but not a Substance program (in which case, we skip the block)
-
-export type SelEnv = ISelEnv;
 
 //#endregion
 //#region Selector dynamic semantics (matching)

--- a/packages/core/src/types/substance.ts
+++ b/packages/core/src/types/substance.ts
@@ -1,5 +1,5 @@
 import { Map } from "immutable";
-import { A, ASTNode, Identifier, IStringLit } from "./ast";
+import { A, ASTNode, Identifier, StringLit } from "./ast";
 import { Env, TypeConstructor } from "./domain";
 
 export type SubRes = [SubstanceEnv, Env];
@@ -40,7 +40,7 @@ export interface LabelValue {
 export type LabelDecl<T> = ASTNode<T> & {
   tag: "LabelDecl";
   variable: Identifier<T>;
-  label: IStringLit<T>;
+  label: StringLit<T>;
   labelType: LabelType;
 };
 
@@ -92,7 +92,7 @@ export type SubExpr<T> =
   | ApplyConstructor<T>
   | Func<T> // NOTE: there's no syntactic difference between function and consturctor, so the parser will parse both into this type first
   | Deconstructor<T>
-  | IStringLit<T>;
+  | StringLit<T>;
 
 export type Func<T> = ASTNode<T> & {
   tag: "Func";
@@ -133,10 +133,3 @@ export type ApplyPredicate<T> = ASTNode<T> & {
 };
 
 export type SubPredArg<T> = SubExpr<T> | ApplyPredicate<T>; // NOTE: the parser only parse nested preds into `Func`, but the checker will look up and fix the type dynamically
-
-//#endregion
-//#region Substance context
-// export type SubOut = ISubOut;
-// export type ISubOut = [SubProg, [VarEnv, SubEnv], LabelMap];
-// export type SubEnv = ISubEnv;
-//#endregion

--- a/packages/core/src/types/value.ts
+++ b/packages/core/src/types/value.ts
@@ -4,21 +4,20 @@ import { StyleError } from "./errors";
 import { Expr } from "./style";
 
 /**
- * The input parameters to computations/objectives/constraints in Style. It can be either an entire shape (`IGPI`) or a value (`IVal`).
+ * The input parameters to computations/objectives/constraints in Style. It can be either an entire shape (`GPI`) or a value (`Val`).
  */
-export type ArgVal<T> = IGPI<T> | IVal<T>;
+export type ArgVal<T> = GPI<T> | Val<T>;
 
-export interface IGPI<T> {
+export interface GPI<T> {
   tag: "GPI";
-  contents: GPI<T>;
+
+  /**
+   * A shape (Graphical Primitive Instance, aka GPI) in penrose has a type (_e.g._ `Circle`) and a set of properties (_e.g._ `center`). Each property this a value tagged with its type.
+   */
+  contents: [string, { [k: string]: Value<T> }];
 }
 
-/**
- * A shape (Graphical Primitive Instance, aka GPI) in penrose has a type (_e.g._ `Circle`) and a set of properties (_e.g._ `center`). Each property this a value tagged with its type.
- */
-export type GPI<T> = [string, { [k: string]: Value<T> }];
-
-export interface IVal<T> {
+export interface Val<T> {
   tag: "Val";
   contents: Value<T>;
 }
@@ -26,7 +25,6 @@ export interface IVal<T> {
 export type Field = string;
 export type Name = string;
 export type Property = string;
-export type FExpr = FieldExpr<ad.Num>;
 export type ShapeTypeStr = string;
 export type PropID = string;
 export type GPIMap = { [k: string]: TagExpr<ad.Num> };
@@ -38,26 +36,24 @@ export type StyleOptFn = [string, Expr<A>[]]; // Objective or constraint
 /**
  * Translation represents the computational graph compiled from a trio of Penrose programs.
  */
-export type Translation = ITrans<ad.Num>;
-
-export type Trans = TrMap<ad.Num>;
+export type Translation = Trans<ad.Num>;
 
 export type TrMap<T> = { [k: string]: { [k: string]: FieldExpr<T> } };
 
-export interface ITrans<T> {
+export interface Trans<T> {
   // TODO: compGraph
   trMap: TrMap<T>;
   warnings: StyleError[];
 }
 
-export type FieldExpr<T> = IFExpr<T> | IFGPI<T>;
+export type FieldExpr<T> = FExpr<T> | FGPI<T>;
 
-export interface IFExpr<T> {
+export interface FExpr<T> {
   tag: "FExpr";
   contents: TagExpr<T>;
 }
 
-export interface IFGPI<T> {
+export interface FGPI<T> {
   tag: "FGPI";
   contents: GPIExpr<T>;
 }
@@ -65,19 +61,19 @@ export interface IFGPI<T> {
 export type GPIProps<T> = { [k: string]: TagExpr<T> };
 
 export type GPIExpr<T> = [string, { [k: string]: TagExpr<T> }];
-export type TagExpr<T> = IOptEval<T> | IDone<T> | IPending<T>;
+export type TagExpr<T> = OptEval<T> | Done<T> | Pending<T>;
 
-export interface IOptEval<T> {
+export interface OptEval<T> {
   tag: "OptEval";
   contents: Expr<A>;
 }
 
-export interface IDone<T> {
+export interface Done<T> {
   tag: "Done";
   contents: Value<T>;
 }
 
-export interface IPending<T> {
+export interface Pending<T> {
   tag: "Pending";
   contents: Value<T>;
 }
@@ -86,121 +82,121 @@ export interface IPending<T> {
  * A value in the penrose system.
  */
 export type Value<T> =
-  | IFloatV<T>
-  | IIntV
-  | IBoolV<T>
-  | IStrV
-  | IPtV<T>
-  | IPathDataV<T>
-  | IPtListV<T>
-  | IColorV<T>
-  | IPaletteV<T>
-  | IFileV<T>
-  | IStyleV<T>
-  | IListV<T>
-  | IVectorV<T>
-  | IMatrixV<T>
-  | ITupV<T>
-  | ILListV<T>
-  | IHMatrixV<T>;
+  | FloatV<T>
+  | IntV
+  | BoolV<T>
+  | StrV
+  | PtV<T>
+  | PathDataV<T>
+  | PtListV<T>
+  | ColorV<T>
+  | PaletteV<T>
+  | FileV<T>
+  | StyleV<T>
+  | ListV<T>
+  | VectorV<T>
+  | MatrixV<T>
+  | TupV<T>
+  | LListV<T>
+  | HMatrixV<T>;
 
 // Unused
-// interface ITypePropertyPath {
+// interface TypePropertyPath {
 //   tag: "TypePropertyPath";
 // }
 
 /** A floating point number **/
-export interface IFloatV<T> {
+export interface FloatV<T> {
   tag: "FloatV";
   contents: T;
 }
 
 /** An integer **/
-export interface IIntV {
+export interface IntV {
   tag: "IntV";
   contents: number;
 }
 
 /** A boolean expression (`True` or `False`) **/
-export interface IBoolV<T> {
+export interface BoolV<T> {
   tag: "BoolV";
   contents: boolean;
 }
 
 /** A string literal **/
-export interface IStrV {
+export interface StrV {
   tag: "StrV";
   contents: string;
 }
 
 /** A point in 2D **/
-export interface IPtV<T> {
+export interface PtV<T> {
   tag: "PtV";
   contents: T[];
 }
 
 /** A path, similar to an [SVG path](https://developer.mozilla.org/en-US/docs/Web/SVG/Tutorial/Paths) **/
-export interface IPathDataV<T> {
+export interface PathDataV<T> {
   tag: "PathDataV";
-  contents: IPathCmd<T>[];
+  contents: PathCmd<T>[];
 }
 
 /** A list of points **/
-export interface IPtListV<T> {
+export interface PtListV<T> {
   tag: "PtListV";
   contents: T[][];
 }
 
 /** A list of colors **/
-export interface IPaletteV<T> {
+export interface PaletteV<T> {
   tag: "PaletteV";
   contents: Color<T>[];
 }
 
 /** A color encoded in RGB or HSV **/
-export interface IColorV<T> {
+export interface ColorV<T> {
   tag: "ColorV";
   contents: Color<T>;
 }
 
 /** A path to a file **/
-export interface IFileV<T> {
+export interface FileV<T> {
   tag: "FileV";
   contents: string;
 }
 
 /** A string literal for shape styling (e.g. `dotted`) **/
-export interface IStyleV<T> {
+export interface StyleV<T> {
   tag: "StyleV";
   contents: string;
 }
 
 /** A list **/
-export interface IListV<T> {
+export interface ListV<T> {
   tag: "ListV";
   contents: T[];
 }
 
 /** A vector of floating-point numbers **/
-export interface IVectorV<T> {
+export interface VectorV<T> {
   tag: "VectorV";
   contents: T[];
 }
 
 /** A 2D matrix **/
-export interface IMatrixV<T> {
+export interface MatrixV<T> {
   tag: "MatrixV";
   contents: T[][];
 }
 
 /** A 2-tuple **/
-export interface ITupV<T> {
+export interface TupV<T> {
   tag: "TupV";
   contents: T[];
 }
 
 /** A list of lists **/
-export interface ILListV<T> {
+export interface LListV<T> {
   tag: "LListV";
   contents: T[][];
 }
@@ -208,14 +204,12 @@ export interface ILListV<T> {
 /**
  * @deprecated
  */
-export interface IHMatrixV<T> {
+export interface HMatrixV<T> {
   tag: "HMatrixV";
   contents: HMatrix<T>;
 }
 
-export type HMatrix<T> = IHMatrix<T>;
-
-export interface IHMatrix<T> {
+export interface HMatrix<T> {
   xScale: T;
   xSkew: T;
   ySkew: T;
@@ -224,36 +218,36 @@ export interface IHMatrix<T> {
   dy: T;
 }
 
-export type Color<T> = IRGBA<T> | IHSVA<T> | INoPaint;
+export type Color<T> = RGBA<T> | HSVA<T> | NoPaint;
 
-export interface IRGBA<T> {
+export interface RGBA<T> {
   tag: "RGBA";
   contents: T[];
 }
 
-export interface IHSVA<T> {
+export interface HSVA<T> {
   tag: "HSVA";
   contents: T[];
 }
 
-export interface INoPaint {
+export interface NoPaint {
   tag: "NONE";
 }
 
 // SVG spec types
-export type ISubPath<T> = IValueV<T> | ICoordV<T>;
+export type SubPath<T> = ValueV<T> | CoordV<T>;
 
-export interface IPathCmd<T> {
+export interface PathCmd<T> {
   cmd: string;
-  contents: ISubPath<T>[];
+  contents: SubPath<T>[];
 }
 
-export interface IValueV<T> {
+export interface ValueV<T> {
   tag: "ValueV";
   contents: T[];
 }
 
-export interface ICoordV<T> {
+export interface CoordV<T> {
   tag: "CoordV";
   contents: T[];
 }

--- a/packages/core/src/utils/CollectLabels.ts
+++ b/packages/core/src/utils/CollectLabels.ts
@@ -7,7 +7,7 @@ import { SVG } from "mathjax-full/js/output/svg.js";
 import { PenroseError } from "types/errors";
 import { Shape } from "types/shape";
 import { EquationData, LabelCache, LabelData, TextData } from "types/state";
-import { IFloatV } from "types/value";
+import { FloatV } from "types/value";
 import { err, ok, Result } from "./Error";
 
 // https://github.com/mathjax/MathJax-demos-node/blob/master/direct/tex2svg
@@ -102,7 +102,7 @@ export const retrieveLabel = (
   }
 };
 
-const floatV = (contents: number): IFloatV<number> => ({
+const floatV = (contents: number): FloatV<number> => ({
   tag: "FloatV",
   contents,
 });

--- a/packages/core/src/utils/Util.ts
+++ b/packages/core/src/utils/Util.ts
@@ -1,7 +1,7 @@
 import * as _ from "lodash";
 import { times } from "lodash";
 import seedrandom from "seedrandom";
-import { ILine } from "shapes/Line";
+import { LineProps } from "shapes/Line";
 import * as ad from "types/ad";
 import { A } from "types/ast";
 import { Properties } from "types/shape";
@@ -493,13 +493,13 @@ export const floatVal = (v: ad.Num): ArgVal<ad.Num> => ({
   },
 });
 
-export const linePts = ({ start, end }: ILine): [ad.Num[], ad.Num[]] => [
+export const linePts = ({ start, end }: LineProps): [ad.Num[], ad.Num[]] => [
   start.contents,
   end.contents,
 ];
 
-export const getStart = ({ start }: ILine): ad.Num[] => start.contents;
+export const getStart = ({ start }: LineProps): ad.Num[] => start.contents;
 
-export const getEnd = ({ end }: ILine): ad.Num[] => end.contents;
+export const getEnd = ({ end }: LineProps): ad.Num[] => end.contents;
 
 //#endregion

--- a/packages/panels/src/reducer.ts
+++ b/packages/panels/src/reducer.ts
@@ -32,14 +32,14 @@ export interface GithubUser {
   access_token: string;
   avatar: string;
 }
-export interface ISettings {
+export interface Settings {
   githubUser: GithubUser | undefined;
   vimMode: boolean;
 }
 
 export interface State {
   openPanes: PaneState;
-  settings: ISettings;
+  settings: Settings;
   currentInstance: CurrentInstance;
 }
 


### PR DESCRIPTION
# Description

Currently we have many types whose name is prefixed with `I`. This PR renames all of them. Many were `interface`s that were also aliased via a `type` without the `I` prefix, in which case the latter could simply be removed. A few needed to be renamed a bit more carefully, such as some types (and functions) in `packages/core/src/shapes/`, and a couple in `packages/core/src/types/value.ts`.

# Checklist

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new ESLint warnings
- [x] I have reviewed any generated changes to the `diagrams/` folder