### PR TITLE
chore: Enable Format On Save in VS Code

### DIFF
--- a/penrose.code-workspace
+++ b/penrose.code-workspace
@@ -103,6 +103,7 @@
       "editor.defaultFormatter": "esbenp.prettier-vscode"
     },
 
+    "editor.formatOnSave": true,
     "files.insertFinalNewline": false,
     "files.trimFinalNewlines": false,
     "files.trimTrailingWhitespace": false,


### PR DESCRIPTION
# Description

Previously I left this setting out of our `penrose.code-workspace` file because I was guessing that different people have different preferences about this, but now I think it's more likely that some people simply didn't know this setting exists.

# Checklist

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new ESLint warnings
- [x] I have reviewed any generated changes to the `diagrams/` folder