### PR TITLE
build: Fix VS Code type errors in core tests

### DIFF
--- a/packages/core/tsconfig.json
+++ b/packages/core/tsconfig.json
@@ -67,7 +67,6 @@
     "docs",
     "dist",
     "src/__tests__",
-    "src/**/*.test.ts",
     "src/__testfixtures__",
     "scripts",
     "acceptance-tests",

--- a/packages/examples/package.json
+++ b/packages/examples/package.json
@@ -3,6 +3,7 @@
   "version": "1.3.0",
   "private": true,
   "scripts": {
-    "build": "node build.js"
+    "build": "node build.js",
+    "typecheck": "yarn build"
   }
 }


### PR DESCRIPTION
# Description

#981 caused all the test files in `@penrose/core` to give type errors on all the `import`s. This PR fixes that.

# Checklist

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new ESLint warnings
- [x] I have reviewed any generated changes to the `diagrams/` folder