### PR TITLE
fix: typo in DeconstructNonconstructor error msg

### DIFF
--- a/packages/core/src/utils/Error.ts
+++ b/packages/core/src/utils/Error.ts
@@ -150,7 +150,7 @@ export const showError = (
     }
     case "DeconstructNonconstructor": {
       const { variable, field } = error.deconstructor;
-      return `Becuase ${variable.value} is not bound to a constructor, ${
+      return `Because ${variable.value} is not bound to a constructor, ${
         variable.value
       }.${field.value} (at ${loc(
         error.deconstructor


### PR DESCRIPTION
Simple typo fix for an error message.