### PR TITLE
fix: selector matching `n^m` complexity

### DIFF
--- a/packages/core/src/compiler/Style.ts
+++ b/packages/core/src/compiler/Style.ts
@@ -120,7 +120,7 @@ import {
 import { checkTypeConstructor, isDeclaredSubtype } from "./Domain";
 
 const log = consola
-  .create({ level: LogLevel.Debug })
+  .create({ level: LogLevel.Warn })
   .withScope("Style Compiler");
 
 //#region consts

--- a/packages/core/src/compiler/Style.ts
+++ b/packages/core/src/compiler/Style.ts
@@ -21,7 +21,7 @@ import {
   propertiesOf,
 } from "engine/EngineUtils";
 import { alg, Edge, Graph } from "graphlib";
-import _, { range } from "lodash";
+import _, { range, some } from "lodash";
 import nearley from "nearley";
 import { lastLocation } from "parser/ParserUtil";
 import styleGrammar from "parser/StyleParser";
@@ -120,7 +120,7 @@ import {
 import { checkTypeConstructor, isDeclaredSubtype } from "./Domain";
 
 const log = consola
-  .create({ level: LogLevel.Warn })
+  .create({ level: LogLevel.Debug })
   .withScope("Style Compiler");
 
 //#region consts
@@ -1348,7 +1348,16 @@ const merge = (s1: Subst[], s2: Subst[]): Subst[] => {
   if (s1.length === 0) {
     return s2;
   }
-  return cartesianProduct(s1, s2).map(([a, b]: Subst[]) => combine(a, b));
+  return cartesianProduct(s1, s2)
+    .filter(([a, b]: Subst[]) => uniqueSubsts(a, b))
+    .map(([a, b]: Subst[]) => combine(a, b));
+};
+
+// check if two substitutions map to the same substance objects
+const uniqueSubsts = (a: Subst, b: Subst): boolean => {
+  const aVals = Object.values(a);
+  const bVals = Object.values(b);
+  return !some(aVals, (a) => bVals.includes(a));
 };
 
 // Judgment 9. G; theta |- T <| |T
@@ -1426,10 +1435,8 @@ const matchDecl = (
   const res = merge(
     initSubsts,
     newSubsts.filter((x): x is Subst => x !== undefined)
-  ); // TODO inline
-  // COMBAK: Inline this
-  // console.log("substs to combine:", initSubsts, justs(newSubsts));
-  // console.log("res", res);
+  );
+  log.debug("substs to combine:", initSubsts, newSubsts);
   return res;
 };
 
@@ -1463,6 +1470,7 @@ const findSubstsSel = (
       const rels = safeContentsList(sel.where);
       const initSubsts: Subst[] = [];
       const rawSubsts = matchDecls(varEnv, subProg, decls, initSubsts);
+      log.debug("total number of raw substs: ", rawSubsts.length);
       const substCandidates = rawSubsts.filter((subst) =>
         fullSubst(selEnv, subst)
       );
@@ -2024,6 +2032,7 @@ const translatePair = (
         selEnv,
       ]);
       log.debug("Translating block", hb, "with substitutions", substs);
+      log.debug("total number of substs", substs.length);
       return translateSubstsBlock(trans, numbered(substs), [
         hb.block,
         blockNum,


### PR DESCRIPTION
# Description

Related issue/PR: #566 

This PR slightly improves the performance of the selector matching algorithm. The current implementation enumerates all possible substitutions for each type declaration in the selector head position, and return a Cartesian product with all previous substitutions found. For example, take the following sub/sty pair:
```
-- .sub
T t1, t2, t3, t4

-- .sty
T s1, s2 {
}
```

Current impl will produce `4^2 = 16` substitutions. However, it would include cases such as `{s1: t1, s2: t1}` because the Cartesian product doesn't produce a bijection. 

Instead, this PR adds a duplicate check in `cartesianProduct`, and now this step of selector matching will be `n choose m` time instead of `n^m`, which is [asymptotically faster](https://proofwiki.org/wiki/N_Choose_k_is_not_greater_than_n%5Ek).

A bigger rewrite of the selector matching dynamics will happen later. This is just a small step to get bigger examples in the registry compile a bit faster.

# Examples with steps to reproduce them

`lagrange-bases-lagrange-bases` in https://82210426.penrose-72l.pages.dev/try

# Checklist

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new ESLint warnings
- [x] I have reviewed any generated changes to the `diagrams/` folder



