### PR TITLE
feat: resolve image paths in `@penrose/editor`

### DIFF
--- a/packages/core/src/renderer/Renderer.ts
+++ b/packages/core/src/renderer/Renderer.ts
@@ -174,15 +174,19 @@ export const RenderStatic = async (
   svg.setAttribute("version", "1.2");
   svg.setAttribute("xmlns", "http://www.w3.org/2000/svg");
   svg.setAttribute("viewBox", `0 0 ${canvas.width} ${canvas.height}`);
-  for (const shape of shapes) {
-    svg.appendChild(
-      await RenderShape({
+  return Promise.all(
+    shapes.map((shape) =>
+      RenderShape({
         shape,
         labels,
         canvasSize: canvas.size,
         pathResolver,
       })
-    );
-  }
-  return svg;
+    )
+  ).then((renderedShapes) => {
+    for (const shape of renderedShapes) {
+      svg.appendChild(shape);
+    }
+    return svg;
+  });
 };

--- a/packages/core/src/types/io.ts
+++ b/packages/core/src/types/io.ts
@@ -16,6 +16,7 @@ export interface Trio {
  * Schema for the registry of working examples
  */
 export interface Registry {
+  root: string;
   substances: { [subID: string]: { name: string; URI: string } };
   styles: { [styID: string]: { name: string; URI: string } };
   domains: { [domID: string]: { name: string; URI: string } };

--- a/packages/editor/src/App.tsx
+++ b/packages/editor/src/App.tsx
@@ -1,7 +1,11 @@
 import { Action, Actions, Layout, Model, TabNode } from "flexlayout-react";
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useRef } from "react";
 import toast from "react-hot-toast";
-import { useRecoilCallback, useRecoilValueLoadable } from "recoil";
+import {
+  useRecoilCallback,
+  useRecoilState,
+  useRecoilValueLoadable,
+} from "recoil";
 import CompGraph from "./components/CompGraph";
 import DiagramOptions from "./components/DiagramOptions";
 import DiagramPanel from "./components/DiagramPanel";
@@ -14,24 +18,15 @@ import Settings from "./components/Settings";
 import StateInspector from "./components/StateInspector";
 import TopBar from "./components/TopBar";
 import {
+  currentRogerState,
   currentWorkspaceState,
   fileContentsSelector,
   localFilesState,
+  RogerState,
   settingsState,
   Workspace,
 } from "./state/atoms";
 import { useCheckURL } from "./state/callbacks";
-
-export type RogerState =
-  | {
-      kind: "disconnected";
-    }
-  | {
-      kind: "connected";
-      substance: string[];
-      style: string[];
-      domain: string[];
-    };
 
 export const layoutModel = Model.fromJson({
   global: {
@@ -135,9 +130,9 @@ export const layoutModel = Model.fromJson({
 
 function App() {
   const ws = useRef<WebSocket | null>(null);
-  const [rogerState, setRogerState] = useState<RogerState>({
-    kind: "disconnected",
-  });
+  const [rogerState, setRogerState] = useRecoilState<RogerState>(
+    currentRogerState
+  );
 
   const panelFactory = useCallback(
     (node: TabNode) => {
@@ -225,7 +220,7 @@ function App() {
       const parsed = JSON.parse(e.data);
       switch (parsed.kind) {
         case "files":
-          setRogerState({ kind: "connected", ...parsed.files });
+          setRogerState({ kind: "connected", ...parsed.files, ws: ws.current });
           break;
         case "file_change":
           updatedFile(parsed.fileName, parsed.contents);

--- a/packages/editor/src/App.tsx
+++ b/packages/editor/src/App.tsx
@@ -205,12 +205,18 @@ function App() {
   const connectRoger = useCallback(() => {
     ws.current = new WebSocket("ws://localhost:9160");
     ws.current.onclose = () => {
-      toast.error("Roger connection closed");
-      console.warn("Roger connection closed");
+      if (rogerState.kind === "connected") {
+        setRogerState({ kind: "disconnected" });
+        toast.error("Roger connection closed");
+        console.warn("Roger connection closed");
+      }
     };
     ws.current.onerror = (e) => {
-      console.error("Couldn't connect to Roger", e);
-      toast.error("Couldn't connect to Roger");
+      if (rogerState.kind === "connected") {
+        setRogerState({ kind: "disconnected" });
+        console.error("Couldn't connect to Roger", e);
+        toast.error("Couldn't connect to Roger");
+      }
     };
     ws.current.onopen = () => {
       toast.success("Connected to Roger");

--- a/packages/editor/src/components/DiagramPanel.tsx
+++ b/packages/editor/src/components/DiagramPanel.tsx
@@ -6,7 +6,7 @@ import {
 } from "@penrose/core";
 import { useEffect, useRef, useState } from "react";
 import toast from "react-hot-toast";
-import { useRecoilCallback, useRecoilState } from "recoil";
+import { useRecoilCallback, useRecoilState, useRecoilValue } from "recoil";
 import {
   diagramState,
   WorkspaceMetadata,
@@ -40,6 +40,7 @@ export default function DiagramPanel() {
   const [diagram, setDiagram] = useRecoilState(diagramState);
   const { state, error, metadata } = diagram;
   const [showEasterEgg, setShowEasterEgg] = useState(false);
+  const { location } = useRecoilValue(workspaceMetadataSelector);
 
   const requestRef = useRef<number>();
 
@@ -48,7 +49,7 @@ export default function DiagramPanel() {
     if (state !== null && cur !== null) {
       (async () => {
         // render the current frame
-        const rendered = await RenderStatic(state, async () => undefined);
+        const rendered = await RenderStatic(state, pathResolver);
         if (cur.firstElementChild) {
           cur.replaceChild(rendered, cur.firstElementChild);
         } else {
@@ -127,6 +128,22 @@ export default function DiagramPanel() {
     },
     [state]
   );
+
+  const pathResolver = async (relativePath: string): Promise<string> => {
+    switch (location.kind) {
+      case "example":
+        const fileURL = new URL(relativePath, location.root).href;
+
+        const fileReq = await fetch(fileURL);
+        return fileReq.text();
+      case "roger":
+      case "gist":
+      // TODO: publish images in the gist
+      case "local":
+        // TODO: cache images in local storage?
+        return "";
+    }
+  };
 
   return (
     <div>

--- a/packages/editor/src/components/DiagramPanel.tsx
+++ b/packages/editor/src/components/DiagramPanel.tsx
@@ -7,6 +7,7 @@ import {
 import { useEffect, useRef, useState } from "react";
 import toast from "react-hot-toast";
 import { useRecoilCallback, useRecoilState, useRecoilValue } from "recoil";
+import { v4 as uuid } from "uuid";
 import {
   currentRogerState,
   diagramState,
@@ -143,17 +144,21 @@ export default function DiagramPanel() {
       case "roger": {
         if (rogerState.kind === "connected") {
           const { ws } = rogerState;
-          // TODO: do path joining in a more principled way
-          const fileURL = location.root + relativePath;
           return new Promise((resolve /*, reject*/) => {
+            const token = uuid();
             ws.addEventListener("message", (e) => {
               const parsed = JSON.parse(e.data);
-              if (parsed.kind === "file_change") {
+              if (parsed.kind === "file_change" && parsed.token === token) {
                 return resolve(parsed.contents);
               }
             });
             ws.send(
-              JSON.stringify({ kind: "retrieve_file", fileName: fileURL })
+              JSON.stringify({
+                kind: "retrieve_file_from_style",
+                relativePath,
+                stylePath: location.style,
+                token,
+              })
             );
           });
         }

--- a/packages/editor/src/components/RogerPanel.tsx
+++ b/packages/editor/src/components/RogerPanel.tsx
@@ -30,7 +30,15 @@ export default function RogerPanel({
           ...state,
           metadata: {
             ...state.metadata,
-            location: { kind: "roger" as const },
+            location: {
+              kind: "roger" as const,
+              // TODO: only set the root of the location if a style file is selected
+              // TODO: do path processing in a more principled way
+              root: val.substring(
+                0,
+                Math.max(val.lastIndexOf("\\"), val.lastIndexOf("/")) + 1
+              ),
+            },
             id: uuid(),
           },
           files,

--- a/packages/editor/src/components/RogerPanel.tsx
+++ b/packages/editor/src/components/RogerPanel.tsx
@@ -61,7 +61,14 @@ export default function RogerPanel({
     }
   }, [rogerState.kind]);
   if (rogerState.kind === "disconnected") {
-    return <h1>disconnected</h1>;
+    return (
+      <div>
+        <h1>Local development mode</h1>
+        <p>
+          Run <code>roger watch</code> to start serving your local Penrose trio.
+        </p>
+      </div>
+    );
   }
   return (
     <div>

--- a/packages/editor/src/components/RogerPanel.tsx
+++ b/packages/editor/src/components/RogerPanel.tsx
@@ -26,6 +26,17 @@ export default function RogerPanel({
           style: files.style.name,
           domain: files.domain.name,
         });
+        const { location } = state.metadata;
+
+        const fileLocations =
+          location.kind === "roger"
+            ? { ...location, [key]: val }
+            : {
+                substance: undefined,
+                style: undefined,
+                domain: undefined,
+              };
+
         return {
           ...state,
           metadata: {
@@ -34,10 +45,7 @@ export default function RogerPanel({
               kind: "roger" as const,
               // TODO: only set the root of the location if a style file is selected
               // TODO: do path processing in a more principled way
-              root: val.substring(
-                0,
-                Math.max(val.lastIndexOf("\\"), val.lastIndexOf("/")) + 1
-              ),
+              ...fileLocations,
             },
             id: uuid(),
           },

--- a/packages/editor/src/state/atoms.ts
+++ b/packages/editor/src/state/atoms.ts
@@ -43,7 +43,10 @@ export type WorkspaceLocation =
       kind: "example";
       root: string; // URL to the parent folder of the Style file
     }
-  | { kind: "roger" };
+  | {
+      kind: "roger";
+      root: string; // URL to the parent folder of the Style file
+    };
 
 export type WorkspaceMetadata = {
   name: string;
@@ -71,6 +74,18 @@ export type Workspace = {
 export type LocalWorkspaces = {
   [id: string]: WorkspaceMetadata;
 };
+
+export type RogerState =
+  | {
+      kind: "disconnected";
+    }
+  | {
+      kind: "connected";
+      ws: WebSocket;
+      substance: string[];
+      style: string[];
+      domain: string[];
+    };
 
 const localFilesEffect: AtomEffect<LocalWorkspaces> = ({ setSelf, onSet }) => {
   setSelf(
@@ -179,6 +194,11 @@ export const currentWorkspaceState = atom<Workspace>({
     },
   },
   effects: [saveWorkspaceEffect, syncFilenamesEffect],
+});
+
+export const currentRogerState = atom<RogerState>({
+  key: "currentRogerState",
+  default: { kind: "disconnected" },
 });
 
 /**

--- a/packages/editor/src/state/atoms.ts
+++ b/packages/editor/src/state/atoms.ts
@@ -45,7 +45,9 @@ export type WorkspaceLocation =
     }
   | {
       kind: "roger";
-      root: string; // URL to the parent folder of the Style file
+      style?: string; // path to the Style file
+      substance?: string; // path to the Substance file
+      domain?: string; // path to the Domain file
     };
 
 export type WorkspaceMetadata = {

--- a/packages/editor/src/state/atoms.ts
+++ b/packages/editor/src/state/atoms.ts
@@ -41,6 +41,7 @@ export type WorkspaceLocation =
   | GistLocation
   | {
       kind: "example";
+      root: string; // URL to the parent folder of the Style file
     }
   | { kind: "roger" };
 

--- a/packages/editor/src/state/callbacks.ts
+++ b/packages/editor/src/state/callbacks.ts
@@ -72,33 +72,6 @@ const _compileDiagram = async (
   );
 };
 
-export const stepDiagram = async (
-  stepSize: number,
-  initialState: PenroseState,
-  set: any
-) => {
-  const steppingLoading = toast.loading("Stepping...");
-  let currentState = initialState;
-  while (!stateConverged(currentState)) {
-    const stepResult = stepStateSafe(currentState, stepSize);
-    if (stepResult.isErr()) {
-      set(diagramState, (state: Diagram) => ({
-        ...state,
-        error: stepResult.error,
-      }));
-      return;
-    } else {
-      set(diagramState, (state: Diagram) => ({
-        ...state,
-        error: null,
-        state: stepResult.value,
-      }));
-      currentState = stepResult.value;
-    }
-  }
-  toast.dismiss(steppingLoading);
-};
-
 export const useStepDiagram = () =>
   useRecoilCallback(({ set }) => () =>
     set(diagramState, (diagram: Diagram) => {

--- a/packages/editor/src/state/callbacks.ts
+++ b/packages/editor/src/state/callbacks.ts
@@ -70,38 +70,33 @@ const _compileDiagram = async (
       state: initialState,
     })
   );
-  _stepDiagram(autostep, stepSize, initialState, set);
 };
 
-export const _stepDiagram = async (
-  autostep: boolean,
+export const stepDiagram = async (
   stepSize: number,
   initialState: PenroseState,
   set: any
 ) => {
-  if (autostep) {
-    const steppingLoading = toast.loading("Stepping...");
-    let currentState = initialState;
-    while (!stateConverged(currentState)) {
-      const stepResult = stepStateSafe(currentState, stepSize);
-      if (stepResult.isErr()) {
-        set(diagramState, (state: Diagram) => ({
-          ...state,
-          error: stepResult.error,
-        }));
-        return;
-      } else {
-        await new Promise((r) => setTimeout(r, 1));
-        set(diagramState, (state: Diagram) => ({
-          ...state,
-          error: null,
-          state: stepResult.value,
-        }));
-        currentState = stepResult.value;
-      }
+  const steppingLoading = toast.loading("Stepping...");
+  let currentState = initialState;
+  while (!stateConverged(currentState)) {
+    const stepResult = stepStateSafe(currentState, stepSize);
+    if (stepResult.isErr()) {
+      set(diagramState, (state: Diagram) => ({
+        ...state,
+        error: stepResult.error,
+      }));
+      return;
+    } else {
+      set(diagramState, (state: Diagram) => ({
+        ...state,
+        error: null,
+        state: stepResult.value,
+      }));
+      currentState = stepResult.value;
     }
-    toast.dismiss(steppingLoading);
   }
+  toast.dismiss(steppingLoading);
 };
 
 export const useStepDiagram = () =>
@@ -155,8 +150,6 @@ export const useResampleDiagram = () =>
       state: resampled,
     }));
     toast.dismiss(resamplingLoading);
-    const { autostep, stepSize } = diagram.metadata;
-    _stepDiagram(autostep, stepSize, resampled, set);
   });
 
 const _saveLocally = (set: any) => {

--- a/packages/editor/src/state/callbacks.ts
+++ b/packages/editor/src/state/callbacks.ts
@@ -32,8 +32,6 @@ const _compileDiagram = async (
   style: string,
   domain: string,
   variation: string,
-  autostep: boolean,
-  stepSize: number,
   set: any
 ) => {
   const compiledDomain = compileDomain(domain);
@@ -96,8 +94,6 @@ export const useCompileDiagram = () =>
       styleFile,
       domainFile,
       diagram.metadata.variation,
-      diagram.metadata.autostep,
-      diagram.metadata.stepSize,
       set
     );
   });
@@ -170,8 +166,6 @@ export const useLoadLocalWorkspace = () =>
       loadedWorkspace.files.style.contents,
       loadedWorkspace.files.domain.contents,
       uuid(),
-      true,
-      10000, // COMBAK: figure out the right default
       set
     );
   });
@@ -191,6 +185,10 @@ export const useLoadExampleWorkspace = () =>
     const domain = await domainReq.text();
     const style = await styleReq.text();
     const substance = await substanceReq.text();
+    const styleParentURI = trio.styleURI.substring(
+      0,
+      trio.styleURI.lastIndexOf("/") + 1
+    );
     set(currentWorkspaceState, {
       metadata: {
         id: uuid(),
@@ -199,6 +197,7 @@ export const useLoadExampleWorkspace = () =>
         editorVersion: 0.1,
         location: {
           kind: "example",
+          root: styleParentURI,
         },
         forkedFromGist: null,
       },
@@ -218,15 +217,7 @@ export const useLoadExampleWorkspace = () =>
       },
     });
     reset(diagramState);
-    await _compileDiagram(
-      substance,
-      style,
-      domain,
-      trio.variation,
-      true,
-      10000, // COMBAK: figure out the right default
-      set
-    );
+    await _compileDiagram(substance, style, domain, trio.variation, set);
   });
 
 export const useCheckURL = () =>

--- a/packages/editor/src/state/callbacks.ts
+++ b/packages/editor/src/state/callbacks.ts
@@ -1,12 +1,9 @@
 import {
   compileDomain,
   compileTrio,
-  PenroseState,
   prepareState,
   resample,
-  stateConverged,
   stepState,
-  stepStateSafe,
   Trio,
   variationSeeds,
 } from "@penrose/core";

--- a/packages/roger/src/commands/watch.ts
+++ b/packages/roger/src/commands/watch.ts
@@ -72,7 +72,6 @@ export default class Watch extends Command {
             break;
           case "retrieve_file_from_style":
             const { stylePath, relativePath, token } = parsed;
-            console.log(`resolving image ${relativePath} from ${stylePath}`);
             const parentDir = parse(stylePath).dir;
             const joined = resolve(parentDir, relativePath);
             this.broadcastFileChange(joined, token);


### PR DESCRIPTION
# Description

Related issue/PR: #1000

This PR adds support for Style-included images for (1) `roger` local development mode and (2) the example registry. We assume that image paths in Style are relative to the Style file parent directory, and they are all relative paths, not absolute ones. 

First, `WorkspaceLocation` now keeps necessary data for file path resolution. Then for (1), we send a `retrieve_file_from_style` packet via the websocket connection (now a part of `RogerState` managed by Recoil), and resolve the image on `file_change` response with the same token. For (2), we keep track of the directory that the Style program is in and construct the URL for the image by calling `new URL`. 


# Checklist

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new ESLint warnings
- [x] I have reviewed any generated changes to the `diagrams/` folder

# Open questions

* `roger` will not perform HTTP requests and only does local file fetching
* Similarly, (2) doesn't resolve absolute URLs
* All image request are not memorized, which could cause performance problems 
