### PR TITLE
fix: issue #1024 exclude name, ensureOnCavas in SVG

### DIFF
--- a/diagrams/allShapes-dashedShapes.svg
+++ b/diagrams/allShapes-dashedShapes.svg
@@ -1,5 +1,5 @@
 <svg version="1.2" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 800 700">
-  <g ensureOnCanvas="true">
+  <g>
     <marker
       id="E.icon-leftArrowhead"
       markerUnits="strokeWidth"
@@ -43,7 +43,7 @@
     ></path>
     <title>E.icon</title>
   </g>
-  <g style="dashed" ensureOnCanvas="true">
+  <g style="dashed">
     <marker
       id="D.icon-leftArrowhead"
       markerUnits="strokeWidth"
@@ -86,7 +86,7 @@
     ></path>
     <title>D.icon</title>
   </g>
-  <g ensureOnCanvas="true">
+  <g>
     <marker
       id="L.icon-leftArrowhead"
       markerUnits="strokeWidth"
@@ -143,7 +143,6 @@
     stroke-linecap="butt"
     rx="0"
     transform="rotate(0, 10.5452332147903, 408.9659586607471)"
-    ensureOnCanvas="true"
   >
     <title>R.icon</title>
   </rect>
@@ -157,11 +156,10 @@
     stroke-width="5"
     stroke-linecap="butt"
     r="34.38682661887841"
-    ensureOnCanvas="true"
   >
     <title>C.icon</title>
   </circle>
-  <g ensureOnCanvas="true">
+  <g>
     <filter id="P.icon-shadow" x="0" y="0" width="200%" height="200%">
       <feOffset result="offOut" in="SourceAlpha" dx="5" dy="5"></feOffset>
       <feGaussianBlur

--- a/diagrams/circle-example-euclidean.svg
+++ b/diagrams/circle-example-euclidean.svg
@@ -1,5 +1,5 @@
 <svg version="1.2" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 800 700">
-  <g style="solid" ensureOnCanvas="true">
+  <g style="solid">
     <marker
       id="EA.icon-leftArrowhead"
       markerUnits="strokeWidth"
@@ -41,7 +41,7 @@
     ></path>
     <title>EA.icon</title>
   </g>
-  <g ensureOnCanvas="true">
+  <g>
     <filter id="Fb.mark-shadow" x="0" y="0" width="200%" height="200%">
       <feOffset result="offOut" in="SourceAlpha" dx="5" dy="5"></feOffset>
       <feGaussianBlur
@@ -67,7 +67,7 @@
     ></path>
     <title>Fb.mark</title>
   </g>
-  <g style="solid" ensureOnCanvas="true">
+  <g style="solid">
     <marker
       id="Fb.icon-leftArrowhead"
       markerUnits="strokeWidth"
@@ -109,7 +109,7 @@
     ></path>
     <title>Fb.icon</title>
   </g>
-  <g ensureOnCanvas="true">
+  <g>
     <filter id="Fd.mark-shadow" x="0" y="0" width="200%" height="200%">
       <feOffset result="offOut" in="SourceAlpha" dx="5" dy="5"></feOffset>
       <feGaussianBlur
@@ -135,7 +135,7 @@
     ></path>
     <title>Fd.mark</title>
   </g>
-  <g style="solid" ensureOnCanvas="true">
+  <g style="solid">
     <marker
       id="Fd.icon-leftArrowhead"
       markerUnits="strokeWidth"
@@ -177,7 +177,7 @@
     ></path>
     <title>Fd.icon</title>
   </g>
-  <g style="solid" ensureOnCanvas="true">
+  <g style="solid">
     <marker
       id="FC.icon-leftArrowhead"
       markerUnits="strokeWidth"
@@ -219,7 +219,7 @@
     ></path>
     <title>FC.icon</title>
   </g>
-  <g style="solid" ensureOnCanvas="true">
+  <g style="solid">
     <marker
       id="FD.icon-leftArrowhead"
       markerUnits="strokeWidth"
@@ -261,7 +261,7 @@
     ></path>
     <title>FD.icon</title>
   </g>
-  <g style="solid" ensureOnCanvas="true">
+  <g style="solid">
     <marker
       id="FB.icon-leftArrowhead"
       markerUnits="strokeWidth"
@@ -303,7 +303,7 @@
     ></path>
     <title>FB.icon</title>
   </g>
-  <g style="solid" ensureOnCanvas="true">
+  <g style="solid">
     <marker
       id="EC.icon-leftArrowhead"
       markerUnits="strokeWidth"
@@ -345,7 +345,7 @@
     ></path>
     <title>EC.icon</title>
   </g>
-  <g style="solid" ensureOnCanvas="true">
+  <g style="solid">
     <marker
       id="AC.icon-leftArrowhead"
       markerUnits="strokeWidth"
@@ -390,7 +390,6 @@
   <g
     transform="rotate(0, 406.3607263945962, 228.21579372933596)translate(406.3607263945962, 228.21579372933596)"
     string="b"
-    ensureOnCanvas="true"
   >
     <title>b.text</title>
     <svg
@@ -436,14 +435,12 @@
     stroke-width="0"
     stroke-linecap="butt"
     r="4"
-    ensureOnCanvas="true"
   >
     <title>b.icon</title>
   </circle>
   <g
     transform="rotate(0, 579.8997199284421, 267.6928240613698)translate(579.8997199284421, 267.6928240613698)"
     string="d"
-    ensureOnCanvas="true"
   >
     <title>d.text</title>
     <svg
@@ -489,14 +486,12 @@
     stroke-width="0"
     stroke-linecap="butt"
     r="4"
-    ensureOnCanvas="true"
   >
     <title>d.icon</title>
   </circle>
   <g
     transform="rotate(0, 526.3677828145509, 186.12665801301586)translate(526.3677828145509, 186.12665801301586)"
     string="F"
-    ensureOnCanvas="true"
   >
     <title>F.text</title>
     <svg
@@ -542,14 +537,12 @@
     stroke-width="0"
     stroke-linecap="butt"
     r="4"
-    ensureOnCanvas="true"
   >
     <title>F.icon</title>
   </circle>
   <g
     transform="rotate(0, 715.9029128292341, 222.05457454065157)translate(715.9029128292341, 222.05457454065157)"
     string="E"
-    ensureOnCanvas="true"
   >
     <title>E.text</title>
     <svg
@@ -594,7 +587,6 @@
     stroke-width="1.75"
     stroke-linecap="butt"
     r="179.93906542154207"
-    ensureOnCanvas="true"
   >
     <title>c.icon</title>
   </circle>
@@ -608,14 +600,12 @@
     stroke-width="0"
     stroke-linecap="butt"
     r="4"
-    ensureOnCanvas="true"
   >
     <title>E.icon</title>
   </circle>
   <g
     transform="rotate(0, 588.357413706449, 325.07923588883625)translate(588.357413706449, 325.07923588883625)"
     string="D"
-    ensureOnCanvas="true"
   >
     <title>D.text</title>
     <svg
@@ -661,14 +651,12 @@
     stroke-width="0"
     stroke-linecap="butt"
     r="4"
-    ensureOnCanvas="true"
   >
     <title>D.icon</title>
   </circle>
   <g
     transform="rotate(0, 451.12593811305163, 314.06761827468546)translate(451.12593811305163, 314.06761827468546)"
     string="C"
-    ensureOnCanvas="true"
   >
     <title>C.text</title>
     <svg
@@ -714,14 +702,12 @@
     stroke-width="0"
     stroke-linecap="butt"
     r="4"
-    ensureOnCanvas="true"
   >
     <title>C.icon</title>
   </circle>
   <g
     transform="rotate(0, 371.8856620890399, 216.05086554310955)translate(371.8856620890399, 216.05086554310955)"
     string="B"
-    ensureOnCanvas="true"
   >
     <title>B.text</title>
     <svg
@@ -767,14 +753,12 @@
     stroke-width="0"
     stroke-linecap="butt"
     r="4"
-    ensureOnCanvas="true"
   >
     <title>B.icon</title>
   </circle>
   <g
     transform="rotate(0, 374.14040954331057, 83.99730703552574)translate(374.14040954331057, 83.99730703552574)"
     string="A"
-    ensureOnCanvas="true"
   >
     <title>A.text</title>
     <svg
@@ -820,7 +804,6 @@
     stroke-width="0"
     stroke-linecap="butt"
     r="4"
-    ensureOnCanvas="true"
   >
     <title>A.icon</title>
   </circle>

--- a/diagrams/collinear-euclidean.svg
+++ b/diagrams/collinear-euclidean.svg
@@ -1,5 +1,5 @@
 <svg version="1.2" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 800 700">
-  <g style="solid" ensureOnCanvas="true">
+  <g style="solid">
     <marker
       id="s2.icon-leftArrowhead"
       markerUnits="strokeWidth"
@@ -43,7 +43,7 @@
     ></path>
     <title>s2.icon</title>
   </g>
-  <g style="solid" ensureOnCanvas="true">
+  <g style="solid">
     <marker
       id="s1.icon-leftArrowhead"
       markerUnits="strokeWidth"
@@ -98,14 +98,12 @@
     stroke-linecap="butt"
     rx="0"
     transform="rotate(0, 50, 0)"
-    ensureOnCanvas="true"
   >
     <title>R.icon</title>
   </rect>
   <g
     transform="rotate(0, 561.5529299404105, 381.68068612465356)translate(561.5529299404105, 381.68068612465356)"
     string="E"
-    ensureOnCanvas="true"
   >
     <title>E.text</title>
     <svg
@@ -151,14 +149,12 @@
     stroke-width="0"
     stroke-linecap="butt"
     r="4"
-    ensureOnCanvas="true"
   >
     <title>E.icon</title>
   </circle>
   <g
     transform="rotate(0, 624.2764160735097, 311.7184549347246)translate(624.2764160735097, 311.7184549347246)"
     string="D"
-    ensureOnCanvas="true"
   >
     <title>D.text</title>
     <svg
@@ -204,14 +200,12 @@
     stroke-width="0"
     stroke-linecap="butt"
     r="4"
-    ensureOnCanvas="true"
   >
     <title>D.icon</title>
   </circle>
   <g
     transform="rotate(0, 431.2075773644264, 321.461700850776)translate(431.2075773644264, 321.461700850776)"
     string="C"
-    ensureOnCanvas="true"
   >
     <title>C.text</title>
     <svg
@@ -257,14 +251,12 @@
     stroke-width="0"
     stroke-linecap="butt"
     r="4"
-    ensureOnCanvas="true"
   >
     <title>C.icon</title>
   </circle>
   <g
     transform="rotate(0, 691.1970506764831, 275.58274173443215)translate(691.1970506764831, 275.58274173443215)"
     string="B"
-    ensureOnCanvas="true"
   >
     <title>B.text</title>
     <svg
@@ -310,14 +302,12 @@
     stroke-width="0"
     stroke-linecap="butt"
     r="4"
-    ensureOnCanvas="true"
   >
     <title>B.icon</title>
   </circle>
   <g
     transform="rotate(0, 627.2505828639477, 92.58347329306376)translate(627.2505828639477, 92.58347329306376)"
     string="A"
-    ensureOnCanvas="true"
   >
     <title>A.text</title>
     <svg
@@ -363,14 +353,12 @@
     stroke-width="0"
     stroke-linecap="butt"
     r="4"
-    ensureOnCanvas="true"
   >
     <title>A.icon</title>
   </circle>
   <g
     transform="rotate(0, 717.72878, 15.42)translate(717.72878, 15.42)"
     string="R"
-    ensureOnCanvas="true"
   >
     <title>R.text</title>
     <svg

--- a/diagrams/congruent-triangles-euclidean.svg
+++ b/diagrams/congruent-triangles-euclidean.svg
@@ -1,5 +1,5 @@
 <svg version="1.2" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 800 700">
-  <g style="solid" ensureOnCanvas="true">
+  <g style="solid">
     <marker
       id="XYZ.RP-leftArrowhead"
       markerUnits="strokeWidth"
@@ -41,7 +41,7 @@
     ></path>
     <title>XYZ.RP</title>
   </g>
-  <g style="solid" ensureOnCanvas="true">
+  <g style="solid">
     <marker
       id="XYZ.QR-leftArrowhead"
       markerUnits="strokeWidth"
@@ -83,7 +83,7 @@
     ></path>
     <title>XYZ.QR</title>
   </g>
-  <g style="solid" ensureOnCanvas="true">
+  <g style="solid">
     <marker
       id="XYZ.PQ-leftArrowhead"
       markerUnits="strokeWidth"
@@ -125,7 +125,7 @@
     ></path>
     <title>XYZ.PQ</title>
   </g>
-  <g style="solid" ensureOnCanvas="true">
+  <g style="solid">
     <marker
       id="UTS.RP-leftArrowhead"
       markerUnits="strokeWidth"
@@ -167,7 +167,7 @@
     ></path>
     <title>UTS.RP</title>
   </g>
-  <g style="solid" ensureOnCanvas="true">
+  <g style="solid">
     <marker
       id="UTS.QR-leftArrowhead"
       markerUnits="strokeWidth"
@@ -209,7 +209,7 @@
     ></path>
     <title>UTS.QR</title>
   </g>
-  <g style="solid" ensureOnCanvas="true">
+  <g style="solid">
     <marker
       id="UTS.PQ-leftArrowhead"
       markerUnits="strokeWidth"
@@ -251,7 +251,7 @@
     ></path>
     <title>UTS.PQ</title>
   </g>
-  <g style="solid" ensureOnCanvas="true">
+  <g style="solid">
     <marker
       id="UTV.RP-leftArrowhead"
       markerUnits="strokeWidth"
@@ -293,7 +293,7 @@
     ></path>
     <title>UTV.RP</title>
   </g>
-  <g style="solid" ensureOnCanvas="true">
+  <g style="solid">
     <marker
       id="UTV.QR-leftArrowhead"
       markerUnits="strokeWidth"
@@ -335,7 +335,7 @@
     ></path>
     <title>UTV.QR</title>
   </g>
-  <g style="solid" ensureOnCanvas="true">
+  <g style="solid">
     <marker
       id="UTV.PQ-leftArrowhead"
       markerUnits="strokeWidth"
@@ -377,7 +377,7 @@
     ></path>
     <title>UTV.PQ</title>
   </g>
-  <g ensureOnCanvas="true">
+  <g>
     <filter id="aZXY.mark-shadow" x="0" y="0" width="200%" height="200%">
       <feOffset result="offOut" in="SourceAlpha" dx="5" dy="5"></feOffset>
       <feGaussianBlur
@@ -403,7 +403,7 @@
     ></path>
     <title>aZXY.mark</title>
   </g>
-  <g style="solid" ensureOnCanvas="true">
+  <g style="solid">
     <marker
       id="aZXY.side2-leftArrowhead"
       markerUnits="strokeWidth"
@@ -445,7 +445,7 @@
     ></path>
     <title>aZXY.side2</title>
   </g>
-  <g style="solid" ensureOnCanvas="true">
+  <g style="solid">
     <marker
       id="aZXY.side1-leftArrowhead"
       markerUnits="strokeWidth"
@@ -487,7 +487,7 @@
     ></path>
     <title>aZXY.side1</title>
   </g>
-  <g ensureOnCanvas="true">
+  <g>
     <filter id="aYZX.mark3-shadow" x="0" y="0" width="200%" height="200%">
       <feOffset result="offOut" in="SourceAlpha" dx="5" dy="5"></feOffset>
       <feGaussianBlur
@@ -513,7 +513,7 @@
     ></path>
     <title>aYZX.mark3</title>
   </g>
-  <g ensureOnCanvas="true">
+  <g>
     <filter id="aYZX.mark2-shadow" x="0" y="0" width="200%" height="200%">
       <feOffset result="offOut" in="SourceAlpha" dx="5" dy="5"></feOffset>
       <feGaussianBlur
@@ -539,7 +539,7 @@
     ></path>
     <title>aYZX.mark2</title>
   </g>
-  <g ensureOnCanvas="true">
+  <g>
     <filter id="aYZX.mark-shadow" x="0" y="0" width="200%" height="200%">
       <feOffset result="offOut" in="SourceAlpha" dx="5" dy="5"></feOffset>
       <feGaussianBlur
@@ -565,7 +565,7 @@
     ></path>
     <title>aYZX.mark</title>
   </g>
-  <g style="solid" ensureOnCanvas="true">
+  <g style="solid">
     <marker
       id="aYZX.side2-leftArrowhead"
       markerUnits="strokeWidth"
@@ -607,7 +607,7 @@
     ></path>
     <title>aYZX.side2</title>
   </g>
-  <g style="solid" ensureOnCanvas="true">
+  <g style="solid">
     <marker
       id="aYZX.side1-leftArrowhead"
       markerUnits="strokeWidth"
@@ -649,7 +649,7 @@
     ></path>
     <title>aYZX.side1</title>
   </g>
-  <g ensureOnCanvas="true">
+  <g>
     <filter id="aXYZ.mark2-shadow" x="0" y="0" width="200%" height="200%">
       <feOffset result="offOut" in="SourceAlpha" dx="5" dy="5"></feOffset>
       <feGaussianBlur
@@ -675,7 +675,7 @@
     ></path>
     <title>aXYZ.mark2</title>
   </g>
-  <g ensureOnCanvas="true">
+  <g>
     <filter id="aXYZ.mark-shadow" x="0" y="0" width="200%" height="200%">
       <feOffset result="offOut" in="SourceAlpha" dx="5" dy="5"></feOffset>
       <feGaussianBlur
@@ -701,7 +701,7 @@
     ></path>
     <title>aXYZ.mark</title>
   </g>
-  <g style="solid" ensureOnCanvas="true">
+  <g style="solid">
     <marker
       id="aXYZ.side2-leftArrowhead"
       markerUnits="strokeWidth"
@@ -743,7 +743,7 @@
     ></path>
     <title>aXYZ.side2</title>
   </g>
-  <g style="solid" ensureOnCanvas="true">
+  <g style="solid">
     <marker
       id="aXYZ.side1-leftArrowhead"
       markerUnits="strokeWidth"
@@ -785,7 +785,7 @@
     ></path>
     <title>aXYZ.side1</title>
   </g>
-  <g ensureOnCanvas="true">
+  <g>
     <filter id="aUTS.mark2-shadow" x="0" y="0" width="200%" height="200%">
       <feOffset result="offOut" in="SourceAlpha" dx="5" dy="5"></feOffset>
       <feGaussianBlur
@@ -811,7 +811,7 @@
     ></path>
     <title>aUTS.mark2</title>
   </g>
-  <g ensureOnCanvas="true">
+  <g>
     <filter id="aUTS.mark-shadow" x="0" y="0" width="200%" height="200%">
       <feOffset result="offOut" in="SourceAlpha" dx="5" dy="5"></feOffset>
       <feGaussianBlur
@@ -837,7 +837,7 @@
     ></path>
     <title>aUTS.mark</title>
   </g>
-  <g style="solid" ensureOnCanvas="true">
+  <g style="solid">
     <marker
       id="aUTS.side2-leftArrowhead"
       markerUnits="strokeWidth"
@@ -879,7 +879,7 @@
     ></path>
     <title>aUTS.side2</title>
   </g>
-  <g style="solid" ensureOnCanvas="true">
+  <g style="solid">
     <marker
       id="aUTS.side1-leftArrowhead"
       markerUnits="strokeWidth"
@@ -921,7 +921,7 @@
     ></path>
     <title>aUTS.side1</title>
   </g>
-  <g style="solid" ensureOnCanvas="true">
+  <g style="solid">
     <marker
       id="aUST.side2-leftArrowhead"
       markerUnits="strokeWidth"
@@ -963,7 +963,7 @@
     ></path>
     <title>aUST.side2</title>
   </g>
-  <g style="solid" ensureOnCanvas="true">
+  <g style="solid">
     <marker
       id="aUST.side1-leftArrowhead"
       markerUnits="strokeWidth"
@@ -1005,7 +1005,7 @@
     ></path>
     <title>aUST.side1</title>
   </g>
-  <g ensureOnCanvas="true">
+  <g>
     <filter id="aTUS.mark3-shadow" x="0" y="0" width="200%" height="200%">
       <feOffset result="offOut" in="SourceAlpha" dx="5" dy="5"></feOffset>
       <feGaussianBlur
@@ -1031,7 +1031,7 @@
     ></path>
     <title>aTUS.mark3</title>
   </g>
-  <g ensureOnCanvas="true">
+  <g>
     <filter id="aTUS.mark2-shadow" x="0" y="0" width="200%" height="200%">
       <feOffset result="offOut" in="SourceAlpha" dx="5" dy="5"></feOffset>
       <feGaussianBlur
@@ -1057,7 +1057,7 @@
     ></path>
     <title>aTUS.mark2</title>
   </g>
-  <g ensureOnCanvas="true">
+  <g>
     <filter id="aTUS.mark-shadow" x="0" y="0" width="200%" height="200%">
       <feOffset result="offOut" in="SourceAlpha" dx="5" dy="5"></feOffset>
       <feGaussianBlur
@@ -1083,7 +1083,7 @@
     ></path>
     <title>aTUS.mark</title>
   </g>
-  <g style="solid" ensureOnCanvas="true">
+  <g style="solid">
     <marker
       id="aTUS.side2-leftArrowhead"
       markerUnits="strokeWidth"
@@ -1125,7 +1125,7 @@
     ></path>
     <title>aTUS.side2</title>
   </g>
-  <g style="solid" ensureOnCanvas="true">
+  <g style="solid">
     <marker
       id="aTUS.side1-leftArrowhead"
       markerUnits="strokeWidth"
@@ -1167,7 +1167,7 @@
     ></path>
     <title>aTUS.side1</title>
   </g>
-  <g style="solid" ensureOnCanvas="true">
+  <g style="solid">
     <marker
       id="ZY.icon-leftArrowhead"
       markerUnits="strokeWidth"
@@ -1209,7 +1209,7 @@
     ></path>
     <title>ZY.icon</title>
   </g>
-  <g ensureOnCanvas="true">
+  <g>
     <filter id="ZY.tick-shadow" x="0" y="0" width="200%" height="200%">
       <feOffset result="offOut" in="SourceAlpha" dx="5" dy="5"></feOffset>
       <feGaussianBlur
@@ -1235,7 +1235,7 @@
     ></path>
     <title>ZY.tick</title>
   </g>
-  <g style="solid" ensureOnCanvas="true">
+  <g style="solid">
     <marker
       id="XY.icon-leftArrowhead"
       markerUnits="strokeWidth"
@@ -1277,7 +1277,7 @@
     ></path>
     <title>XY.icon</title>
   </g>
-  <g ensureOnCanvas="true">
+  <g>
     <filter id="XY.tick-shadow" x="0" y="0" width="200%" height="200%">
       <feOffset result="offOut" in="SourceAlpha" dx="5" dy="5"></feOffset>
       <feGaussianBlur
@@ -1303,7 +1303,7 @@
     ></path>
     <title>XY.tick</title>
   </g>
-  <g style="solid" ensureOnCanvas="true">
+  <g style="solid">
     <marker
       id="XZ.icon-leftArrowhead"
       markerUnits="strokeWidth"
@@ -1345,7 +1345,7 @@
     ></path>
     <title>XZ.icon</title>
   </g>
-  <g ensureOnCanvas="true">
+  <g>
     <filter id="XZ.tick-shadow" x="0" y="0" width="200%" height="200%">
       <feOffset result="offOut" in="SourceAlpha" dx="5" dy="5"></feOffset>
       <feGaussianBlur
@@ -1371,7 +1371,7 @@
     ></path>
     <title>XZ.tick</title>
   </g>
-  <g style="solid" ensureOnCanvas="true">
+  <g style="solid">
     <marker
       id="ST.icon-leftArrowhead"
       markerUnits="strokeWidth"
@@ -1413,7 +1413,7 @@
     ></path>
     <title>ST.icon</title>
   </g>
-  <g ensureOnCanvas="true">
+  <g>
     <filter id="ST.tick-shadow" x="0" y="0" width="200%" height="200%">
       <feOffset result="offOut" in="SourceAlpha" dx="5" dy="5"></feOffset>
       <feGaussianBlur
@@ -1439,7 +1439,7 @@
     ></path>
     <title>ST.tick</title>
   </g>
-  <g style="solid" ensureOnCanvas="true">
+  <g style="solid">
     <marker
       id="US.icon-leftArrowhead"
       markerUnits="strokeWidth"
@@ -1481,7 +1481,7 @@
     ></path>
     <title>US.icon</title>
   </g>
-  <g ensureOnCanvas="true">
+  <g>
     <filter id="US.tick-shadow" x="0" y="0" width="200%" height="200%">
       <feOffset result="offOut" in="SourceAlpha" dx="5" dy="5"></feOffset>
       <feGaussianBlur
@@ -1507,7 +1507,7 @@
     ></path>
     <title>US.tick</title>
   </g>
-  <g style="solid" ensureOnCanvas="true">
+  <g style="solid">
     <marker
       id="UT.icon-leftArrowhead"
       markerUnits="strokeWidth"
@@ -1549,7 +1549,7 @@
     ></path>
     <title>UT.icon</title>
   </g>
-  <g ensureOnCanvas="true">
+  <g>
     <filter id="UT.tick-shadow" x="0" y="0" width="200%" height="200%">
       <feOffset result="offOut" in="SourceAlpha" dx="5" dy="5"></feOffset>
       <feGaussianBlur
@@ -1575,7 +1575,7 @@
     ></path>
     <title>UT.tick</title>
   </g>
-  <g style="solid" ensureOnCanvas="true">
+  <g style="solid">
     <marker
       id="VT.icon-leftArrowhead"
       markerUnits="strokeWidth"
@@ -1617,7 +1617,7 @@
     ></path>
     <title>VT.icon</title>
   </g>
-  <g ensureOnCanvas="true">
+  <g>
     <filter id="VT.tick-shadow" x="0" y="0" width="200%" height="200%">
       <feOffset result="offOut" in="SourceAlpha" dx="5" dy="5"></feOffset>
       <feGaussianBlur
@@ -1643,7 +1643,7 @@
     ></path>
     <title>VT.tick</title>
   </g>
-  <g style="solid" ensureOnCanvas="true">
+  <g style="solid">
     <marker
       id="UV.icon-leftArrowhead"
       markerUnits="strokeWidth"
@@ -1685,7 +1685,7 @@
     ></path>
     <title>UV.icon</title>
   </g>
-  <g ensureOnCanvas="true">
+  <g>
     <filter id="UV.tick-shadow" x="0" y="0" width="200%" height="200%">
       <feOffset result="offOut" in="SourceAlpha" dx="5" dy="5"></feOffset>
       <feGaussianBlur
@@ -1714,7 +1714,6 @@
   <g
     transform="rotate(0, 580.4073291959978, 370.08595314241353)translate(580.4073291959978, 370.08595314241353)"
     string="Z"
-    ensureOnCanvas="true"
   >
     <title>Z.text</title>
     <svg
@@ -1760,14 +1759,12 @@
     stroke-width="0"
     stroke-linecap="butt"
     r="4"
-    ensureOnCanvas="true"
   >
     <title>Z.icon</title>
   </circle>
   <g
     transform="rotate(0, 701.0275825608333, 301.23031347516036)translate(701.0275825608333, 301.23031347516036)"
     string="Y"
-    ensureOnCanvas="true"
   >
     <title>Y.text</title>
     <svg
@@ -1813,14 +1810,12 @@
     stroke-width="0"
     stroke-linecap="butt"
     r="4"
-    ensureOnCanvas="true"
   >
     <title>Y.icon</title>
   </circle>
   <g
     transform="rotate(0, 408.60495201156346, 339.41306932288535)translate(408.60495201156346, 339.41306932288535)"
     string="X"
-    ensureOnCanvas="true"
   >
     <title>X.text</title>
     <svg
@@ -1866,14 +1861,12 @@
     stroke-width="0"
     stroke-linecap="butt"
     r="4"
-    ensureOnCanvas="true"
   >
     <title>X.icon</title>
   </circle>
   <g
     transform="rotate(0, 634.9482096549992, 300.343840366036)translate(634.9482096549992, 300.343840366036)"
     string="V"
-    ensureOnCanvas="true"
   >
     <title>V.text</title>
     <svg
@@ -1919,14 +1912,12 @@
     stroke-width="0"
     stroke-linecap="butt"
     r="4"
-    ensureOnCanvas="true"
   >
     <title>V.icon</title>
   </circle>
   <g
     transform="rotate(0, 593.5227118036482, 116.70821406754875)translate(593.5227118036482, 116.70821406754875)"
     string="T"
-    ensureOnCanvas="true"
   >
     <title>T.text</title>
     <svg
@@ -1972,14 +1963,12 @@
     stroke-width="0"
     stroke-linecap="butt"
     r="4"
-    ensureOnCanvas="true"
   >
     <title>T.icon</title>
   </circle>
   <g
     transform="rotate(0, 358.4369045857339, 364.39694385258076)translate(358.4369045857339, 364.39694385258076)"
     string="S"
-    ensureOnCanvas="true"
   >
     <title>S.text</title>
     <svg
@@ -2025,14 +2014,12 @@
     stroke-width="0"
     stroke-linecap="butt"
     r="4"
-    ensureOnCanvas="true"
   >
     <title>S.icon</title>
   </circle>
   <g
     transform="rotate(0, 472.2887471941858, 208.835179859595)translate(472.2887471941858, 208.835179859595)"
     string="U"
-    ensureOnCanvas="true"
   >
     <title>U.text</title>
     <svg
@@ -2078,7 +2065,6 @@
     stroke-width="0"
     stroke-linecap="butt"
     r="4"
-    ensureOnCanvas="true"
   >
     <title>U.icon</title>
   </circle>

--- a/diagrams/continuousmap-continuousmap.svg
+++ b/diagrams/continuousmap-continuousmap.svg
@@ -2,7 +2,6 @@
   <g
     transform="rotate(0, 477.63485654403405, 291.9826498186605)translate(477.63485654403405, 291.9826498186605)"
     string="f"
-    ensureOnCanvas="true"
   >
     <title>f.text</title>
     <svg
@@ -38,7 +37,7 @@
       </g>
     </svg>
   </g>
-  <g ensureOnCanvas="true">
+  <g>
     <marker
       id="f.icon-leftArrowhead"
       markerUnits="strokeWidth"
@@ -94,14 +93,12 @@
     stroke-linecap="butt"
     rx="0"
     transform="rotate(0, 565.8305550536727, 203.57187366730346)"
-    ensureOnCanvas="true"
   >
     <title>Rm.icon</title>
   </rect>
   <g
     transform="rotate(0, 766.5740743870059, 214.74187366730345)translate(766.5740743870059, 214.74187366730345)"
     string="\mathbb{R}^m"
-    ensureOnCanvas="true"
   >
     <title>Rm.text</title>
     <svg
@@ -160,7 +157,6 @@
     stroke-width="1"
     stroke-linecap="butt"
     r="91.22740396548782"
-    ensureOnCanvas="true"
   >
     <title>B.icon</title>
   </circle>
@@ -175,14 +171,12 @@
     stroke-dasharray="7,5"
     stroke-linecap="butt"
     r="31.12505575915866"
-    ensureOnCanvas="true"
   >
     <title>V.icon</title>
   </circle>
   <g
     transform="rotate(0, 681.6266234085524, 338.8120216431009)translate(681.6266234085524, 338.8120216431009)"
     string="V"
-    ensureOnCanvas="true"
   >
     <title>V.text</title>
     <svg
@@ -221,7 +215,6 @@
   <g
     transform="rotate(0, 642.8022852316777, 387.0894431029373)translate(642.8022852316777, 387.0894431029373)"
     string="B"
-    ensureOnCanvas="true"
   >
     <title>B.text</title>
     <svg
@@ -270,14 +263,12 @@
     stroke-linecap="butt"
     rx="0"
     transform="rotate(0, 165.83055505367264, 203.57187366730346)"
-    ensureOnCanvas="true"
   >
     <title>Rn.icon</title>
   </rect>
   <g
     transform="rotate(0, 368.309169387006, 214.74187366730345)translate(368.309169387006, 214.74187366730345)"
     string="\mathbb{R}^n"
-    ensureOnCanvas="true"
   >
     <title>Rn.text</title>
     <svg
@@ -336,7 +327,6 @@
     stroke-width="1"
     stroke-linecap="butt"
     r="99.15661450818331"
-    ensureOnCanvas="true"
   >
     <title>A.icon</title>
   </circle>
@@ -351,14 +341,12 @@
     stroke-dasharray="7,5"
     stroke-linecap="butt"
     r="54.85613013483959"
-    ensureOnCanvas="true"
   >
     <title>U.icon</title>
   </circle>
   <g
     transform="rotate(0, 242.22781909588252, 333.5063574627136)translate(242.22781909588252, 333.5063574627136)"
     string="f^{-1}(V)"
-    ensureOnCanvas="true"
   >
     <title>U.text</title>
     <svg
@@ -435,7 +423,6 @@
   <g
     transform="rotate(0, 291.810199292552, 396.4545246896622)translate(291.810199292552, 396.4545246896622)"
     string="A"
-    ensureOnCanvas="true"
   >
     <title>A.text</title>
     <svg

--- a/diagrams/hypergraph-hypergraph.svg
+++ b/diagrams/hypergraph-hypergraph.svg
@@ -7,7 +7,6 @@
     stroke="none"
     rx="10"
     ry="22.18372612036552"
-    ensureOnCanvas="true"
   >
     <title>E33.ellipse</title>
   </ellipse>
@@ -21,7 +20,6 @@
     stroke="none"
     rx="0"
     transform="rotate(0, 477.3097297750402, 345.45869592300045)"
-    ensureOnCanvas="true"
   >
     <title>E33.rect</title>
   </rect>
@@ -33,7 +31,6 @@
     stroke="none"
     rx="10"
     ry="16.093862537452377"
-    ensureOnCanvas="true"
   >
     <title>E32.ellipse</title>
   </ellipse>
@@ -47,7 +44,6 @@
     stroke="none"
     rx="0"
     transform="rotate(0, 477.3097297758135, 292.0274982438706)"
-    ensureOnCanvas="true"
   >
     <title>E32.rect</title>
   </rect>
@@ -59,7 +55,6 @@
     stroke="none"
     rx="10"
     ry="11.683287469896513"
-    ensureOnCanvas="true"
   >
     <title>E31.ellipse</title>
   </ellipse>
@@ -73,7 +68,6 @@
     stroke="none"
     rx="0"
     transform="rotate(0, 477.3097297754624, 418.65936671929035)"
-    ensureOnCanvas="true"
   >
     <title>E31.rect</title>
   </rect>
@@ -85,7 +79,6 @@
     stroke="none"
     rx="10"
     ry="21.02833228256567"
-    ensureOnCanvas="true"
   >
     <title>E24.ellipse</title>
   </ellipse>
@@ -99,7 +92,6 @@
     stroke="none"
     rx="0"
     transform="rotate(0, 377.3097309342099, 305.0693244915724)"
-    ensureOnCanvas="true"
   >
     <title>E24.rect</title>
   </rect>
@@ -111,7 +103,6 @@
     stroke="none"
     rx="10"
     ry="13.697436572357162"
-    ensureOnCanvas="true"
   >
     <title>E23.ellipse</title>
   </ellipse>
@@ -125,7 +116,6 @@
     stroke="none"
     rx="0"
     transform="rotate(0, 377.3097309341629, 385.4693088539244)"
-    ensureOnCanvas="true"
   >
     <title>E23.rect</title>
   </rect>
@@ -137,7 +127,6 @@
     stroke="none"
     rx="10"
     ry="13.358792518565174"
-    ensureOnCanvas="true"
   >
     <title>E22.ellipse</title>
   </ellipse>
@@ -151,7 +140,6 @@
     stroke="none"
     rx="0"
     transform="rotate(0, 377.3097309339915, 258.1945571224648)"
-    ensureOnCanvas="true"
   >
     <title>E22.rect</title>
   </rect>
@@ -163,7 +151,6 @@
     stroke="none"
     rx="10"
     ry="9.000002946148633"
-    ensureOnCanvas="true"
   >
     <title>E21.ellipse</title>
   </ellipse>
@@ -177,7 +164,6 @@
     stroke="none"
     rx="0"
     transform="rotate(0, 377.3097309335482, 432.86419010857145)"
-    ensureOnCanvas="true"
   >
     <title>E21.rect</title>
   </rect>
@@ -189,7 +175,6 @@
     stroke="none"
     rx="10"
     ry="10.042027610530589"
-    ensureOnCanvas="true"
   >
     <title>E15.ellipse</title>
   </ellipse>
@@ -203,7 +188,6 @@
     stroke="none"
     rx="0"
     transform="rotate(0, 277.30973471483924, 283.630649307683)"
-    ensureOnCanvas="true"
   >
     <title>E15.rect</title>
   </rect>
@@ -215,7 +199,6 @@
     stroke="none"
     rx="10"
     ry="10.824145585663807"
-    ensureOnCanvas="true"
   >
     <title>E14.ellipse</title>
   </ellipse>
@@ -229,7 +212,6 @@
     stroke="none"
     rx="0"
     transform="rotate(0, 277.30973471645393, 241.9823462550621)"
-    ensureOnCanvas="true"
   >
     <title>E14.rect</title>
   </rect>
@@ -241,7 +223,6 @@
     stroke="none"
     rx="10"
     ry="8.999995411561724"
-    ensureOnCanvas="true"
   >
     <title>E13.ellipse</title>
   </ellipse>
@@ -255,7 +236,6 @@
     stroke="none"
     rx="0"
     transform="rotate(0, 277.3097347187831, 377.9008409563456)"
-    ensureOnCanvas="true"
   >
     <title>E13.rect</title>
   </rect>
@@ -267,7 +247,6 @@
     stroke="none"
     rx="10"
     ry="8.999999597478748"
-    ensureOnCanvas="true"
   >
     <title>E12.ellipse</title>
   </ellipse>
@@ -281,7 +260,6 @@
     stroke="none"
     rx="0"
     transform="rotate(0, 277.3097347310168, 415.90083640750436)"
-    ensureOnCanvas="true"
   >
     <title>E12.rect</title>
   </rect>
@@ -293,7 +271,6 @@
     stroke="none"
     rx="10"
     ry="14.417582684211524"
-    ensureOnCanvas="true"
   >
     <title>E11.ellipse</title>
   </ellipse>
@@ -307,11 +284,10 @@
     stroke="none"
     rx="0"
     transform="rotate(0, 277.3097347259015, 329.0656765934572)"
-    ensureOnCanvas="true"
   >
     <title>E11.rect</title>
   </rect>
-  <g ensureOnCanvas="true">
+  <g>
     <filter id="N9.line3r-shadow" x="0" y="0" width="200%" height="200%">
       <feOffset result="offOut" in="SourceAlpha" dx="5" dy="5"></feOffset>
       <feGaussianBlur
@@ -337,7 +313,7 @@
     ></path>
     <title>N9.line3r</title>
   </g>
-  <g ensureOnCanvas="true">
+  <g>
     <filter id="N9.line23-shadow" x="0" y="0" width="200%" height="200%">
       <feOffset result="offOut" in="SourceAlpha" dx="5" dy="5"></feOffset>
       <feGaussianBlur
@@ -363,7 +339,7 @@
     ></path>
     <title>N9.line23</title>
   </g>
-  <g ensureOnCanvas="true">
+  <g>
     <filter id="N9.line12-shadow" x="0" y="0" width="200%" height="200%">
       <feOffset result="offOut" in="SourceAlpha" dx="5" dy="5"></feOffset>
       <feGaussianBlur
@@ -389,7 +365,7 @@
     ></path>
     <title>N9.line12</title>
   </g>
-  <g ensureOnCanvas="true">
+  <g>
     <filter id="N9.linel1-shadow" x="0" y="0" width="200%" height="200%">
       <feOffset result="offOut" in="SourceAlpha" dx="5" dy="5"></feOffset>
       <feGaussianBlur
@@ -422,7 +398,6 @@
     cy="305.84049789299644"
     stroke="none"
     r="5"
-    ensureOnCanvas="true"
   >
     <title>N9.dotrP</title>
   </circle>
@@ -433,7 +408,6 @@
     cy="305.84049789299644"
     stroke="none"
     r="5"
-    ensureOnCanvas="true"
   >
     <title>N9.dotr</title>
   </circle>
@@ -444,7 +418,6 @@
     cy="379.60261568002676"
     stroke="none"
     r="5"
-    ensureOnCanvas="true"
   >
     <title>N9.dot3P</title>
   </circle>
@@ -455,7 +428,6 @@
     cy="379.60261568002676"
     stroke="none"
     r="5"
-    ensureOnCanvas="true"
   >
     <title>N9.dot3</title>
   </circle>
@@ -466,7 +438,6 @@
     cy="338.1259907130881"
     stroke="none"
     r="5"
-    ensureOnCanvas="true"
   >
     <title>N9.dot2P</title>
   </circle>
@@ -477,7 +448,6 @@
     cy="338.1259907130881"
     stroke="none"
     r="5"
-    ensureOnCanvas="true"
   >
     <title>N9.dot2</title>
   </circle>
@@ -488,7 +458,6 @@
     cy="294.7147054824365"
     stroke="none"
     r="5"
-    ensureOnCanvas="true"
   >
     <title>N9.dot1P</title>
   </circle>
@@ -499,7 +468,6 @@
     cy="294.7147054824365"
     stroke="none"
     r="5"
-    ensureOnCanvas="true"
   >
     <title>N9.dot1</title>
   </circle>
@@ -510,7 +478,6 @@
     cy="257.2386499742978"
     stroke="none"
     r="5"
-    ensureOnCanvas="true"
   >
     <title>N9.dotlP</title>
   </circle>
@@ -521,11 +488,10 @@
     cy="257.2386499742978"
     stroke="none"
     r="5"
-    ensureOnCanvas="true"
   >
     <title>N9.dotl</title>
   </circle>
-  <g ensureOnCanvas="true">
+  <g>
     <filter id="N8.line3r-shadow" x="0" y="0" width="200%" height="200%">
       <feOffset result="offOut" in="SourceAlpha" dx="5" dy="5"></feOffset>
       <feGaussianBlur
@@ -551,7 +517,7 @@
     ></path>
     <title>N8.line3r</title>
   </g>
-  <g ensureOnCanvas="true">
+  <g>
     <filter id="N8.line23-shadow" x="0" y="0" width="200%" height="200%">
       <feOffset result="offOut" in="SourceAlpha" dx="5" dy="5"></feOffset>
       <feGaussianBlur
@@ -577,7 +543,7 @@
     ></path>
     <title>N8.line23</title>
   </g>
-  <g ensureOnCanvas="true">
+  <g>
     <filter id="N8.line12-shadow" x="0" y="0" width="200%" height="200%">
       <feOffset result="offOut" in="SourceAlpha" dx="5" dy="5"></feOffset>
       <feGaussianBlur
@@ -603,7 +569,7 @@
     ></path>
     <title>N8.line12</title>
   </g>
-  <g ensureOnCanvas="true">
+  <g>
     <filter id="N8.linel1-shadow" x="0" y="0" width="200%" height="200%">
       <feOffset result="offOut" in="SourceAlpha" dx="5" dy="5"></feOffset>
       <feGaussianBlur
@@ -636,7 +602,6 @@
     cy="325.9024241418654"
     stroke="none"
     r="5"
-    ensureOnCanvas="true"
   >
     <title>N8.dotrP</title>
   </circle>
@@ -647,7 +612,6 @@
     cy="325.9024241418654"
     stroke="none"
     r="5"
-    ensureOnCanvas="true"
   >
     <title>N8.dotr</title>
   </circle>
@@ -658,7 +622,6 @@
     cy="360.8334356500684"
     stroke="none"
     r="5"
-    ensureOnCanvas="true"
   >
     <title>N8.dot3P</title>
   </circle>
@@ -669,7 +632,6 @@
     cy="360.8334356500684"
     stroke="none"
     r="5"
-    ensureOnCanvas="true"
   >
     <title>N8.dot3</title>
   </circle>
@@ -680,7 +642,6 @@
     cy="317.81724444560047"
     stroke="none"
     r="5"
-    ensureOnCanvas="true"
   >
     <title>N8.dot2P</title>
   </circle>
@@ -691,7 +652,6 @@
     cy="317.81724444560047"
     stroke="none"
     r="5"
-    ensureOnCanvas="true"
   >
     <title>N8.dot2</title>
   </circle>
@@ -702,7 +662,6 @@
     cy="292.6306488768425"
     stroke="none"
     r="5"
-    ensureOnCanvas="true"
   >
     <title>N8.dot1P</title>
   </circle>
@@ -713,7 +672,6 @@
     cy="292.6306488768425"
     stroke="none"
     r="5"
-    ensureOnCanvas="true"
   >
     <title>N8.dot1</title>
   </circle>
@@ -724,7 +682,6 @@
     cy="351.0302320732931"
     stroke="none"
     r="5"
-    ensureOnCanvas="true"
   >
     <title>N8.dotlP</title>
   </circle>
@@ -735,11 +692,10 @@
     cy="351.0302320732931"
     stroke="none"
     r="5"
-    ensureOnCanvas="true"
   >
     <title>N8.dotl</title>
   </circle>
-  <g ensureOnCanvas="true">
+  <g>
     <filter id="N7.line3r-shadow" x="0" y="0" width="200%" height="200%">
       <feOffset result="offOut" in="SourceAlpha" dx="5" dy="5"></feOffset>
       <feGaussianBlur
@@ -765,7 +721,7 @@
     ></path>
     <title>N7.line3r</title>
   </g>
-  <g ensureOnCanvas="true">
+  <g>
     <filter id="N7.line23-shadow" x="0" y="0" width="200%" height="200%">
       <feOffset result="offOut" in="SourceAlpha" dx="5" dy="5"></feOffset>
       <feGaussianBlur
@@ -791,7 +747,7 @@
     ></path>
     <title>N7.line23</title>
   </g>
-  <g ensureOnCanvas="true">
+  <g>
     <filter id="N7.line12-shadow" x="0" y="0" width="200%" height="200%">
       <feOffset result="offOut" in="SourceAlpha" dx="5" dy="5"></feOffset>
       <feGaussianBlur
@@ -817,7 +773,7 @@
     ></path>
     <title>N7.line12</title>
   </g>
-  <g ensureOnCanvas="true">
+  <g>
     <filter id="N7.linel1-shadow" x="0" y="0" width="200%" height="200%">
       <feOffset result="offOut" in="SourceAlpha" dx="5" dy="5"></feOffset>
       <feGaussianBlur
@@ -850,7 +806,6 @@
     cy="402.0466205954193"
     stroke="none"
     r="5"
-    ensureOnCanvas="true"
   >
     <title>N7.dotrP</title>
   </circle>
@@ -861,7 +816,6 @@
     cy="402.0466205954193"
     stroke="none"
     r="5"
-    ensureOnCanvas="true"
   >
     <title>N7.dotr</title>
   </circle>
@@ -872,7 +826,6 @@
     cy="380.82614959747985"
     stroke="none"
     r="5"
-    ensureOnCanvas="true"
   >
     <title>N7.dot3P</title>
   </circle>
@@ -883,7 +836,6 @@
     cy="380.82614959747985"
     stroke="none"
     r="5"
-    ensureOnCanvas="true"
   >
     <title>N7.dot3</title>
   </circle>
@@ -894,7 +846,6 @@
     cy="334.5834194997355"
     stroke="none"
     r="5"
-    ensureOnCanvas="true"
   >
     <title>N7.dot2P</title>
   </circle>
@@ -905,7 +856,6 @@
     cy="334.5834194997355"
     stroke="none"
     r="5"
-    ensureOnCanvas="true"
   >
     <title>N7.dot2</title>
   </circle>
@@ -916,7 +866,6 @@
     cy="254.6306380735017"
     stroke="none"
     r="5"
-    ensureOnCanvas="true"
   >
     <title>N7.dot1P</title>
   </circle>
@@ -927,7 +876,6 @@
     cy="254.6306380735017"
     stroke="none"
     r="5"
-    ensureOnCanvas="true"
   >
     <title>N7.dot1</title>
   </circle>
@@ -938,7 +886,6 @@
     cy="241.98234801986928"
     stroke="none"
     r="5"
-    ensureOnCanvas="true"
   >
     <title>N7.dotlP</title>
   </circle>
@@ -949,11 +896,10 @@
     cy="241.98234801986928"
     stroke="none"
     r="5"
-    ensureOnCanvas="true"
   >
     <title>N7.dotl</title>
   </circle>
-  <g ensureOnCanvas="true">
+  <g>
     <filter id="N6.line3r-shadow" x="0" y="0" width="200%" height="200%">
       <feOffset result="offOut" in="SourceAlpha" dx="5" dy="5"></feOffset>
       <feGaussianBlur
@@ -979,7 +925,7 @@
     ></path>
     <title>N6.line3r</title>
   </g>
-  <g ensureOnCanvas="true">
+  <g>
     <filter id="N6.line23-shadow" x="0" y="0" width="200%" height="200%">
       <feOffset result="offOut" in="SourceAlpha" dx="5" dy="5"></feOffset>
       <feGaussianBlur
@@ -1005,7 +951,7 @@
     ></path>
     <title>N6.line23</title>
   </g>
-  <g ensureOnCanvas="true">
+  <g>
     <filter id="N6.line12-shadow" x="0" y="0" width="200%" height="200%">
       <feOffset result="offOut" in="SourceAlpha" dx="5" dy="5"></feOffset>
       <feGaussianBlur
@@ -1031,7 +977,7 @@
     ></path>
     <title>N6.line12</title>
   </g>
-  <g ensureOnCanvas="true">
+  <g>
     <filter id="N6.linel1-shadow" x="0" y="0" width="200%" height="200%">
       <feOffset result="offOut" in="SourceAlpha" dx="5" dy="5"></feOffset>
       <feGaussianBlur
@@ -1064,7 +1010,6 @@
     cy="278.49490534232336"
     stroke="none"
     r="5"
-    ensureOnCanvas="true"
   >
     <title>N6.dotrP</title>
   </circle>
@@ -1075,7 +1020,6 @@
     cy="278.49490534232336"
     stroke="none"
     r="5"
-    ensureOnCanvas="true"
   >
     <title>N6.dotr</title>
   </circle>
@@ -1086,7 +1030,6 @@
     cy="354.45869390829347"
     stroke="none"
     r="5"
-    ensureOnCanvas="true"
   >
     <title>N6.dot3P</title>
   </circle>
@@ -1097,7 +1040,6 @@
     cy="354.45869390829347"
     stroke="none"
     r="5"
-    ensureOnCanvas="true"
   >
     <title>N6.dot3</title>
   </circle>
@@ -1108,7 +1050,6 @@
     cy="314.06932211428176"
     stroke="none"
     r="5"
-    ensureOnCanvas="true"
   >
     <title>N6.dot2P</title>
   </circle>
@@ -1119,7 +1060,6 @@
     cy="314.06932211428176"
     stroke="none"
     r="5"
-    ensureOnCanvas="true"
   >
     <title>N6.dot2</title>
   </circle>
@@ -1130,7 +1070,6 @@
     cy="250.98234499328782"
     stroke="none"
     r="5"
-    ensureOnCanvas="true"
   >
     <title>N6.dot1P</title>
   </circle>
@@ -1141,7 +1080,6 @@
     cy="250.98234499328782"
     stroke="none"
     r="5"
-    ensureOnCanvas="true"
   >
     <title>N6.dot1</title>
   </circle>
@@ -1152,7 +1090,6 @@
     cy="303.363326419441"
     stroke="none"
     r="5"
-    ensureOnCanvas="true"
   >
     <title>N6.dotlP</title>
   </circle>
@@ -1163,11 +1100,10 @@
     cy="303.363326419441"
     stroke="none"
     r="5"
-    ensureOnCanvas="true"
   >
     <title>N6.dotl</title>
   </circle>
-  <g ensureOnCanvas="true">
+  <g>
     <filter id="N5.line3r-shadow" x="0" y="0" width="200%" height="200%">
       <feOffset result="offOut" in="SourceAlpha" dx="5" dy="5"></feOffset>
       <feGaussianBlur
@@ -1193,7 +1129,7 @@
     ></path>
     <title>N5.line3r</title>
   </g>
-  <g ensureOnCanvas="true">
+  <g>
     <filter id="N5.line23-shadow" x="0" y="0" width="200%" height="200%">
       <feOffset result="offOut" in="SourceAlpha" dx="5" dy="5"></feOffset>
       <feGaussianBlur
@@ -1219,7 +1155,7 @@
     ></path>
     <title>N5.line23</title>
   </g>
-  <g ensureOnCanvas="true">
+  <g>
     <filter id="N5.line12-shadow" x="0" y="0" width="200%" height="200%">
       <feOffset result="offOut" in="SourceAlpha" dx="5" dy="5"></feOffset>
       <feGaussianBlur
@@ -1245,7 +1181,7 @@
     ></path>
     <title>N5.line12</title>
   </g>
-  <g ensureOnCanvas="true">
+  <g>
     <filter id="N5.linel1-shadow" x="0" y="0" width="200%" height="200%">
       <feOffset result="offOut" in="SourceAlpha" dx="5" dy="5"></feOffset>
       <feGaussianBlur
@@ -1278,7 +1214,6 @@
     cy="375.05327155641965"
     stroke="none"
     r="5"
-    ensureOnCanvas="true"
   >
     <title>N5.dotrP</title>
   </circle>
@@ -1289,7 +1224,6 @@
     cy="375.05327155641965"
     stroke="none"
     r="5"
-    ensureOnCanvas="true"
   >
     <title>N5.dotr</title>
   </circle>
@@ -1300,7 +1234,6 @@
     cy="433.02594247748004"
     stroke="none"
     r="5"
-    ensureOnCanvas="true"
   >
     <title>N5.dot3P</title>
   </circle>
@@ -1311,7 +1244,6 @@
     cy="433.02594247748004"
     stroke="none"
     r="5"
-    ensureOnCanvas="true"
   >
     <title>N5.dot3</title>
   </circle>
@@ -1322,7 +1254,6 @@
     cy="403.8641833212312"
     stroke="none"
     r="5"
-    ensureOnCanvas="true"
   >
     <title>N5.dot2P</title>
   </circle>
@@ -1333,7 +1264,6 @@
     cy="403.8641833212312"
     stroke="none"
     r="5"
-    ensureOnCanvas="true"
   >
     <title>N5.dot2</title>
   </circle>
@@ -1344,7 +1274,6 @@
     cy="386.9008343358235"
     stroke="none"
     r="5"
-    ensureOnCanvas="true"
   >
     <title>N5.dot1P</title>
   </circle>
@@ -1355,7 +1284,6 @@
     cy="386.9008343358235"
     stroke="none"
     r="5"
-    ensureOnCanvas="true"
   >
     <title>N5.dot1</title>
   </circle>
@@ -1366,7 +1294,6 @@
     cy="448.9102968943273"
     stroke="none"
     r="5"
-    ensureOnCanvas="true"
   >
     <title>N5.dotlP</title>
   </circle>
@@ -1377,11 +1304,10 @@
     cy="448.9102968943273"
     stroke="none"
     r="5"
-    ensureOnCanvas="true"
   >
     <title>N5.dotl</title>
   </circle>
-  <g ensureOnCanvas="true">
+  <g>
     <filter id="N4.line3r-shadow" x="0" y="0" width="200%" height="200%">
       <feOffset result="offOut" in="SourceAlpha" dx="5" dy="5"></feOffset>
       <feGaussianBlur
@@ -1407,7 +1333,7 @@
     ></path>
     <title>N4.line3r</title>
   </g>
-  <g ensureOnCanvas="true">
+  <g>
     <filter id="N4.line23-shadow" x="0" y="0" width="200%" height="200%">
       <feOffset result="offOut" in="SourceAlpha" dx="5" dy="5"></feOffset>
       <feGaussianBlur
@@ -1433,7 +1359,7 @@
     ></path>
     <title>N4.line23</title>
   </g>
-  <g ensureOnCanvas="true">
+  <g>
     <filter id="N4.line12-shadow" x="0" y="0" width="200%" height="200%">
       <feOffset result="offOut" in="SourceAlpha" dx="5" dy="5"></feOffset>
       <feGaussianBlur
@@ -1459,7 +1385,7 @@
     ></path>
     <title>N4.line12</title>
   </g>
-  <g ensureOnCanvas="true">
+  <g>
     <filter id="N4.linel1-shadow" x="0" y="0" width="200%" height="200%">
       <feOffset result="offOut" in="SourceAlpha" dx="5" dy="5"></feOffset>
       <feGaussianBlur
@@ -1492,7 +1418,6 @@
     cy="241.98291691141236"
     stroke="none"
     r="5"
-    ensureOnCanvas="true"
   >
     <title>N4.dotrP</title>
   </circle>
@@ -1503,7 +1428,6 @@
     cy="241.98291691141236"
     stroke="none"
     r="5"
-    ensureOnCanvas="true"
   >
     <title>N4.dotr</title>
   </circle>
@@ -1514,7 +1438,6 @@
     cy="301.02749722493775"
     stroke="none"
     r="5"
-    ensureOnCanvas="true"
   >
     <title>N4.dot3P</title>
   </circle>
@@ -1525,7 +1448,6 @@
     cy="301.02749722493775"
     stroke="none"
     r="5"
-    ensureOnCanvas="true"
   >
     <title>N4.dot3</title>
   </circle>
@@ -1536,7 +1458,6 @@
     cy="394.46930763845546"
     stroke="none"
     r="5"
-    ensureOnCanvas="true"
   >
     <title>N4.dot2P</title>
   </circle>
@@ -1547,7 +1468,6 @@
     cy="394.46930763845546"
     stroke="none"
     r="5"
-    ensureOnCanvas="true"
   >
     <title>N4.dot2</title>
   </circle>
@@ -1558,7 +1478,6 @@
     cy="424.9008332365015"
     stroke="none"
     r="5"
-    ensureOnCanvas="true"
   >
     <title>N4.dot1P</title>
   </circle>
@@ -1569,7 +1488,6 @@
     cy="424.9008332365015"
     stroke="none"
     r="5"
-    ensureOnCanvas="true"
   >
     <title>N4.dot1</title>
   </circle>
@@ -1580,7 +1498,6 @@
     cy="379.84030711106817"
     stroke="none"
     r="5"
-    ensureOnCanvas="true"
   >
     <title>N4.dotlP</title>
   </circle>
@@ -1591,11 +1508,10 @@
     cy="379.84030711106817"
     stroke="none"
     r="5"
-    ensureOnCanvas="true"
   >
     <title>N4.dotl</title>
   </circle>
-  <g ensureOnCanvas="true">
+  <g>
     <filter id="N3.line3r-shadow" x="0" y="0" width="200%" height="200%">
       <feOffset result="offOut" in="SourceAlpha" dx="5" dy="5"></feOffset>
       <feGaussianBlur
@@ -1621,7 +1537,7 @@
     ></path>
     <title>N3.line3r</title>
   </g>
-  <g ensureOnCanvas="true">
+  <g>
     <filter id="N3.line23-shadow" x="0" y="0" width="200%" height="200%">
       <feOffset result="offOut" in="SourceAlpha" dx="5" dy="5"></feOffset>
       <feGaussianBlur
@@ -1647,7 +1563,7 @@
     ></path>
     <title>N3.line23</title>
   </g>
-  <g ensureOnCanvas="true">
+  <g>
     <filter id="N3.line12-shadow" x="0" y="0" width="200%" height="200%">
       <feOffset result="offOut" in="SourceAlpha" dx="5" dy="5"></feOffset>
       <feGaussianBlur
@@ -1673,7 +1589,7 @@
     ></path>
     <title>N3.line12</title>
   </g>
-  <g ensureOnCanvas="true">
+  <g>
     <filter id="N3.linel1-shadow" x="0" y="0" width="200%" height="200%">
       <feOffset result="offOut" in="SourceAlpha" dx="5" dy="5"></feOffset>
       <feGaussianBlur
@@ -1706,7 +1622,6 @@
     cy="417.12310622299105"
     stroke="none"
     r="5"
-    ensureOnCanvas="true"
   >
     <title>N3.dotrP</title>
   </circle>
@@ -1717,7 +1632,6 @@
     cy="417.12310622299105"
     stroke="none"
     r="5"
-    ensureOnCanvas="true"
   >
     <title>N3.dotr</title>
   </circle>
@@ -1728,7 +1642,6 @@
     cy="315.2152255379454"
     stroke="none"
     r="5"
-    ensureOnCanvas="true"
   >
     <title>N3.dot3P</title>
   </circle>
@@ -1739,7 +1652,6 @@
     cy="315.2152255379454"
     stroke="none"
     r="5"
-    ensureOnCanvas="true"
   >
     <title>N3.dot3</title>
   </circle>
@@ -1750,7 +1662,6 @@
     cy="267.19455655989805"
     stroke="none"
     r="5"
-    ensureOnCanvas="true"
   >
     <title>N3.dot2P</title>
   </circle>
@@ -1761,7 +1672,6 @@
     cy="267.19455655989805"
     stroke="none"
     r="5"
-    ensureOnCanvas="true"
   >
     <title>N3.dot2</title>
   </circle>
@@ -1772,7 +1682,6 @@
     cy="341.5780568952934"
     stroke="none"
     r="5"
-    ensureOnCanvas="true"
   >
     <title>N3.dot1P</title>
   </circle>
@@ -1783,7 +1692,6 @@
     cy="341.5780568952934"
     stroke="none"
     r="5"
-    ensureOnCanvas="true"
   >
     <title>N3.dot1</title>
   </circle>
@@ -1794,7 +1702,6 @@
     cy="410.8971671742391"
     stroke="none"
     r="5"
-    ensureOnCanvas="true"
   >
     <title>N3.dotlP</title>
   </circle>
@@ -1805,11 +1712,10 @@
     cy="410.8971671742391"
     stroke="none"
     r="5"
-    ensureOnCanvas="true"
   >
     <title>N3.dotl</title>
   </circle>
-  <g ensureOnCanvas="true">
+  <g>
     <filter id="N2.line3r-shadow" x="0" y="0" width="200%" height="200%">
       <feOffset result="offOut" in="SourceAlpha" dx="5" dy="5"></feOffset>
       <feGaussianBlur
@@ -1835,7 +1741,7 @@
     ></path>
     <title>N2.line3r</title>
   </g>
-  <g ensureOnCanvas="true">
+  <g>
     <filter id="N2.line23-shadow" x="0" y="0" width="200%" height="200%">
       <feOffset result="offOut" in="SourceAlpha" dx="5" dy="5"></feOffset>
       <feGaussianBlur
@@ -1861,7 +1767,7 @@
     ></path>
     <title>N2.line23</title>
   </g>
-  <g ensureOnCanvas="true">
+  <g>
     <filter id="N2.line12-shadow" x="0" y="0" width="200%" height="200%">
       <feOffset result="offOut" in="SourceAlpha" dx="5" dy="5"></feOffset>
       <feGaussianBlur
@@ -1887,7 +1793,7 @@
     ></path>
     <title>N2.line12</title>
   </g>
-  <g ensureOnCanvas="true">
+  <g>
     <filter id="N2.linel1-shadow" x="0" y="0" width="200%" height="200%">
       <feOffset result="offOut" in="SourceAlpha" dx="5" dy="5"></feOffset>
       <feGaussianBlur
@@ -1920,7 +1826,6 @@
     cy="352.1027649544725"
     stroke="none"
     r="5"
-    ensureOnCanvas="true"
   >
     <title>N2.dotrP</title>
   </circle>
@@ -1931,7 +1836,6 @@
     cy="352.1027649544725"
     stroke="none"
     r="5"
-    ensureOnCanvas="true"
   >
     <title>N2.dotr</title>
   </circle>
@@ -1942,7 +1846,6 @@
     cy="308.7962855670079"
     stroke="none"
     r="5"
-    ensureOnCanvas="true"
   >
     <title>N2.dot3P</title>
   </circle>
@@ -1953,7 +1856,6 @@
     cy="308.7962855670079"
     stroke="none"
     r="5"
-    ensureOnCanvas="true"
   >
     <title>N2.dot3</title>
   </circle>
@@ -1964,7 +1866,6 @@
     cy="275.91214229723676"
     stroke="none"
     r="5"
-    ensureOnCanvas="true"
   >
     <title>N2.dot2P</title>
   </circle>
@@ -1975,7 +1876,6 @@
     cy="275.91214229723676"
     stroke="none"
     r="5"
-    ensureOnCanvas="true"
   >
     <title>N2.dot2</title>
   </circle>
@@ -1986,7 +1886,6 @@
     cy="338.0656751842571"
     stroke="none"
     r="5"
-    ensureOnCanvas="true"
   >
     <title>N2.dot1P</title>
   </circle>
@@ -1997,7 +1896,6 @@
     cy="338.0656751842571"
     stroke="none"
     r="5"
-    ensureOnCanvas="true"
   >
     <title>N2.dot1</title>
   </circle>
@@ -2008,7 +1906,6 @@
     cy="282.59159747148414"
     stroke="none"
     r="5"
-    ensureOnCanvas="true"
   >
     <title>N2.dotlP</title>
   </circle>
@@ -2019,11 +1916,10 @@
     cy="282.59159747148414"
     stroke="none"
     r="5"
-    ensureOnCanvas="true"
   >
     <title>N2.dotl</title>
   </circle>
-  <g ensureOnCanvas="true">
+  <g>
     <filter id="N1.line3r-shadow" x="0" y="0" width="200%" height="200%">
       <feOffset result="offOut" in="SourceAlpha" dx="5" dy="5"></feOffset>
       <feGaussianBlur
@@ -2049,7 +1945,7 @@
     ></path>
     <title>N1.line3r</title>
   </g>
-  <g ensureOnCanvas="true">
+  <g>
     <filter id="N1.line23-shadow" x="0" y="0" width="200%" height="200%">
       <feOffset result="offOut" in="SourceAlpha" dx="5" dy="5"></feOffset>
       <feGaussianBlur
@@ -2075,7 +1971,7 @@
     ></path>
     <title>N1.line23</title>
   </g>
-  <g ensureOnCanvas="true">
+  <g>
     <filter id="N1.line12-shadow" x="0" y="0" width="200%" height="200%">
       <feOffset result="offOut" in="SourceAlpha" dx="5" dy="5"></feOffset>
       <feGaussianBlur
@@ -2101,7 +1997,7 @@
     ></path>
     <title>N1.line12</title>
   </g>
-  <g ensureOnCanvas="true">
+  <g>
     <filter id="N1.linel1-shadow" x="0" y="0" width="200%" height="200%">
       <feOffset result="offOut" in="SourceAlpha" dx="5" dy="5"></feOffset>
       <feGaussianBlur
@@ -2134,7 +2030,6 @@
     cy="450.86146315899316"
     stroke="none"
     r="5"
-    ensureOnCanvas="true"
   >
     <title>N1.dotrP</title>
   </circle>
@@ -2145,7 +2040,6 @@
     cy="450.86146315899316"
     stroke="none"
     r="5"
-    ensureOnCanvas="true"
   >
     <title>N1.dotr</title>
   </circle>
@@ -2156,7 +2050,6 @@
     cy="427.65936553742745"
     stroke="none"
     r="5"
-    ensureOnCanvas="true"
   >
     <title>N1.dot3P</title>
   </circle>
@@ -2167,7 +2060,6 @@
     cy="427.65936553742745"
     stroke="none"
     r="5"
-    ensureOnCanvas="true"
   >
     <title>N1.dot3</title>
   </circle>
@@ -2178,7 +2070,6 @@
     cy="441.86418871475"
     stroke="none"
     r="5"
-    ensureOnCanvas="true"
   >
     <title>N1.dot2P</title>
   </circle>
@@ -2189,7 +2080,6 @@
     cy="441.86418871475"
     stroke="none"
     r="5"
-    ensureOnCanvas="true"
   >
     <title>N1.dot2</title>
   </circle>
@@ -2200,7 +2090,6 @@
     cy="348.9008465120011"
     stroke="none"
     r="5"
-    ensureOnCanvas="true"
   >
     <title>N1.dot1P</title>
   </circle>
@@ -2211,7 +2100,6 @@
     cy="348.9008465120011"
     stroke="none"
     r="5"
-    ensureOnCanvas="true"
   >
     <title>N1.dot1</title>
   </circle>
@@ -2222,7 +2110,6 @@
     cy="324.62365587756346"
     stroke="none"
     r="5"
-    ensureOnCanvas="true"
   >
     <title>N1.dotlP</title>
   </circle>
@@ -2233,7 +2120,6 @@
     cy="324.62365587756346"
     stroke="none"
     r="5"
-    ensureOnCanvas="true"
   >
     <title>N1.dotl</title>
   </circle>

--- a/diagrams/incenter-triangle-euclidean.svg
+++ b/diagrams/incenter-triangle-euclidean.svg
@@ -1,5 +1,5 @@
 <svg version="1.2" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 800 700">
-  <g style="solid" ensureOnCanvas="true">
+  <g style="solid">
     <marker
       id="PLM.RP-leftArrowhead"
       markerUnits="strokeWidth"
@@ -41,7 +41,7 @@
     ></path>
     <title>PLM.RP</title>
   </g>
-  <g style="solid" ensureOnCanvas="true">
+  <g style="solid">
     <marker
       id="PLM.QR-leftArrowhead"
       markerUnits="strokeWidth"
@@ -83,7 +83,7 @@
     ></path>
     <title>PLM.QR</title>
   </g>
-  <g style="solid" ensureOnCanvas="true">
+  <g style="solid">
     <marker
       id="PLM.PQ-leftArrowhead"
       markerUnits="strokeWidth"
@@ -134,11 +134,10 @@
     stroke-width="1.75"
     stroke-linecap="butt"
     r="57.196721426910706"
-    ensureOnCanvas="true"
   >
     <title>JKL.icon</title>
   </circle>
-  <g style="solid" ensureOnCanvas="true">
+  <g style="solid">
     <marker
       id="JKL.RP-leftArrowhead"
       markerUnits="strokeWidth"
@@ -180,7 +179,7 @@
     ></path>
     <title>JKL.RP</title>
   </g>
-  <g style="solid" ensureOnCanvas="true">
+  <g style="solid">
     <marker
       id="JKL.QR-leftArrowhead"
       markerUnits="strokeWidth"
@@ -222,7 +221,7 @@
     ></path>
     <title>JKL.QR</title>
   </g>
-  <g style="solid" ensureOnCanvas="true">
+  <g style="solid">
     <marker
       id="JKL.PQ-leftArrowhead"
       markerUnits="strokeWidth"
@@ -264,7 +263,7 @@
     ></path>
     <title>JKL.PQ</title>
   </g>
-  <g ensureOnCanvas="true">
+  <g>
     <filter id="PML.mark-shadow" x="0" y="0" width="200%" height="200%">
       <feOffset result="offOut" in="SourceAlpha" dx="5" dy="5"></feOffset>
       <feGaussianBlur
@@ -290,7 +289,7 @@
     ></path>
     <title>PML.mark</title>
   </g>
-  <g style="solid" ensureOnCanvas="true">
+  <g style="solid">
     <marker
       id="PML.side2-leftArrowhead"
       markerUnits="strokeWidth"
@@ -332,7 +331,7 @@
     ></path>
     <title>PML.side2</title>
   </g>
-  <g style="solid" ensureOnCanvas="true">
+  <g style="solid">
     <marker
       id="PML.side1-leftArrowhead"
       markerUnits="strokeWidth"
@@ -377,7 +376,6 @@
   <g
     transform="rotate(0, 572.471601864324, 346.4819806620216)translate(572.471601864324, 346.4819806620216)"
     string="m"
-    ensureOnCanvas="true"
   >
     <title>m.text</title>
     <svg
@@ -423,14 +421,12 @@
     stroke-width="0"
     stroke-linecap="butt"
     r="4"
-    ensureOnCanvas="true"
   >
     <title>m.icon</title>
   </circle>
   <g
     transform="rotate(0, 590.0281471729925, 321.1266475454333)translate(590.0281471729925, 321.1266475454333)"
     string="P"
-    ensureOnCanvas="true"
   >
     <title>P.text</title>
     <svg
@@ -476,14 +472,12 @@
     stroke-width="0"
     stroke-linecap="butt"
     r="4"
-    ensureOnCanvas="true"
   >
     <title>P.icon</title>
   </circle>
   <g
     transform="rotate(0, 464.37099288559955, 355.36292535321996)translate(464.37099288559955, 355.36292535321996)"
     string="L"
-    ensureOnCanvas="true"
   >
     <title>L.text</title>
     <svg
@@ -519,7 +513,7 @@
       </g>
     </svg>
   </g>
-  <g style="solid" ensureOnCanvas="true">
+  <g style="solid">
     <marker
       id="KL.icon-leftArrowhead"
       markerUnits="strokeWidth"
@@ -571,14 +565,12 @@
     stroke-width="0"
     stroke-linecap="butt"
     r="4"
-    ensureOnCanvas="true"
   >
     <title>L.icon</title>
   </circle>
   <g
     transform="rotate(0, 649.268712150358, 358.37760650881825)translate(649.268712150358, 358.37760650881825)"
     string="K"
-    ensureOnCanvas="true"
   >
     <title>K.text</title>
     <svg
@@ -624,14 +616,12 @@
     stroke-width="0"
     stroke-linecap="butt"
     r="4"
-    ensureOnCanvas="true"
   >
     <title>K.icon</title>
   </circle>
   <g
     transform="rotate(0, 637.7335815370504, 95.18725735838588)translate(637.7335815370504, 95.18725735838588)"
     string="J"
-    ensureOnCanvas="true"
   >
     <title>J.text</title>
     <svg
@@ -677,7 +667,6 @@
     stroke-width="0"
     stroke-linecap="butt"
     r="4"
-    ensureOnCanvas="true"
   >
     <title>J.icon</title>
   </circle>

--- a/diagrams/lagrange-bases-lagrange-bases.svg
+++ b/diagrams/lagrange-bases-lagrange-bases.svg
@@ -9,11 +9,10 @@
     stroke="none"
     rx="0"
     transform="rotate(0, 0, 0)"
-    ensureOnCanvas="false"
   >
     <title>Global.box</title>
   </rect>
-  <g ensureOnCanvas="false">
+  <g>
     <filter id="e.curveKI-shadow" x="0" y="0" width="200%" height="200%">
       <feOffset result="offOut" in="SourceAlpha" dx="5" dy="5"></feOffset>
       <feGaussianBlur
@@ -39,7 +38,7 @@
     ></path>
     <title>e.curveKI</title>
   </g>
-  <g ensureOnCanvas="false">
+  <g>
     <filter id="e.curveJK-shadow" x="0" y="0" width="200%" height="200%">
       <feOffset result="offOut" in="SourceAlpha" dx="5" dy="5"></feOffset>
       <feGaussianBlur
@@ -65,7 +64,7 @@
     ></path>
     <title>e.curveJK</title>
   </g>
-  <g ensureOnCanvas="false">
+  <g>
     <filter id="e.curveIJ-shadow" x="0" y="0" width="200%" height="200%">
       <feOffset result="offOut" in="SourceAlpha" dx="5" dy="5"></feOffset>
       <feGaussianBlur
@@ -91,7 +90,7 @@
     ></path>
     <title>e.curveIJ</title>
   </g>
-  <g ensureOnCanvas="false">
+  <g>
     <filter id="t2.curveKI-shadow" x="0" y="0" width="200%" height="200%">
       <feOffset result="offOut" in="SourceAlpha" dx="5" dy="5"></feOffset>
       <feGaussianBlur
@@ -117,7 +116,7 @@
     ></path>
     <title>t2.curveKI</title>
   </g>
-  <g ensureOnCanvas="false">
+  <g>
     <filter id="t2.curveJK-shadow" x="0" y="0" width="200%" height="200%">
       <feOffset result="offOut" in="SourceAlpha" dx="5" dy="5"></feOffset>
       <feGaussianBlur
@@ -143,7 +142,7 @@
     ></path>
     <title>t2.curveJK</title>
   </g>
-  <g ensureOnCanvas="false">
+  <g>
     <filter id="t2.curveIJ-shadow" x="0" y="0" width="200%" height="200%">
       <feOffset result="offOut" in="SourceAlpha" dx="5" dy="5"></feOffset>
       <feGaussianBlur
@@ -172,7 +171,6 @@
   <g
     transform="rotate(0, 89.26064917139793, 48.3025786142979)translate(89.26064917139793, 48.3025786142979)"
     string="m_{ki}"
-    ensureOnCanvas="true"
   >
     <title>z.labelText</title>
     <svg
@@ -238,14 +236,12 @@
     stroke-width="1"
     stroke-linecap="butt"
     r="2"
-    ensureOnCanvas="true"
   >
     <title>z.icon</title>
   </circle>
   <g
     transform="rotate(0, 109.08889059476698, 0.7509307881362712)translate(109.08889059476698, 0.7509307881362712)"
     string="m_{jk}"
-    ensureOnCanvas="true"
   >
     <title>y.labelText</title>
     <svg
@@ -311,14 +307,12 @@
     stroke-width="1"
     stroke-linecap="butt"
     r="2"
-    ensureOnCanvas="true"
   >
     <title>y.icon</title>
   </circle>
   <g
     transform="rotate(0, 124.57188759492986, 113.53217649761181)translate(124.57188759492986, 113.53217649761181)"
     string="m_{ij}"
-    ensureOnCanvas="true"
   >
     <title>x.labelText</title>
     <svg
@@ -384,14 +378,12 @@
     stroke-width="1"
     stroke-linecap="butt"
     r="2"
-    ensureOnCanvas="true"
   >
     <title>x.icon</title>
   </circle>
   <g
     transform="rotate(0, 176.72921262790018, 133.94308137023853)translate(176.72921262790018, 133.94308137023853)"
     string="m_{jl}"
-    ensureOnCanvas="true"
   >
     <title>v.labelText</title>
     <svg
@@ -457,14 +449,12 @@
     stroke-width="1"
     stroke-linecap="butt"
     r="2"
-    ensureOnCanvas="true"
   >
     <title>v.icon</title>
   </circle>
   <g
     transform="rotate(0, 153.296069217989, 164.24390572369637)translate(153.296069217989, 164.24390572369637)"
     string="m_{il}"
-    ensureOnCanvas="true"
   >
     <title>u.labelText</title>
     <svg
@@ -530,14 +520,12 @@
     stroke-width="1"
     stroke-linecap="butt"
     r="2"
-    ensureOnCanvas="true"
   >
     <title>u.icon</title>
   </circle>
   <g
     transform="rotate(0, 230.65766967776008, 168.24635135868377)translate(230.65766967776008, 168.24635135868377)"
     string="p_l"
-    ensureOnCanvas="true"
   >
     <title>d.labelText</title>
     <svg
@@ -591,14 +579,12 @@
     cy="169.18707660461976"
     stroke="none"
     r="2.5"
-    ensureOnCanvas="true"
   >
     <title>d.icon</title>
   </circle>
   <g
     transform="rotate(0, 66.2197638008034, 1.1892235792419665)translate(66.2197638008034, 1.1892235792419665)"
     string="p_k"
-    ensureOnCanvas="true"
   >
     <title>c.labelText</title>
     <svg
@@ -652,14 +638,12 @@
     cy="13.854081476506337"
     stroke="none"
     r="2.5"
-    ensureOnCanvas="true"
   >
     <title>c.icon</title>
   </circle>
   <g
     transform="rotate(0, 161.77736258006001, 42.35945573997256)translate(161.77736258006001, 42.35945573997256)"
     string="p_j"
-    ensureOnCanvas="true"
   >
     <title>b.labelText</title>
     <svg
@@ -713,14 +697,12 @@
     cy="58.347473025419674"
     stroke="none"
     r="2.5"
-    ensureOnCanvas="true"
   >
     <title>b.icon</title>
   </circle>
   <g
     transform="rotate(0, 54.48312571193632, 119.25817654525822)translate(54.48312571193632, 119.25817654525822)"
     string="p_i"
-    ensureOnCanvas="true"
   >
     <title>a.labelText</title>
     <svg
@@ -774,7 +756,6 @@
     cy="125.4159621727965"
     stroke="none"
     r="2.5"
-    ensureOnCanvas="true"
   >
     <title>a.icon</title>
   </circle>

--- a/diagrams/midsegment-triangles-euclidean.svg
+++ b/diagrams/midsegment-triangles-euclidean.svg
@@ -1,5 +1,5 @@
 <svg version="1.2" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 800 700">
-  <g style="solid" ensureOnCanvas="true">
+  <g style="solid">
     <marker
       id="GJF.RP-leftArrowhead"
       markerUnits="strokeWidth"
@@ -41,7 +41,7 @@
     ></path>
     <title>GJF.RP</title>
   </g>
-  <g style="solid" ensureOnCanvas="true">
+  <g style="solid">
     <marker
       id="GJF.QR-leftArrowhead"
       markerUnits="strokeWidth"
@@ -83,7 +83,7 @@
     ></path>
     <title>GJF.QR</title>
   </g>
-  <g style="solid" ensureOnCanvas="true">
+  <g style="solid">
     <marker
       id="GJF.PQ-leftArrowhead"
       markerUnits="strokeWidth"
@@ -125,7 +125,7 @@
     ></path>
     <title>GJF.PQ</title>
   </g>
-  <g style="solid" ensureOnCanvas="true">
+  <g style="solid">
     <marker
       id="DEF.RP-leftArrowhead"
       markerUnits="strokeWidth"
@@ -167,7 +167,7 @@
     ></path>
     <title>DEF.RP</title>
   </g>
-  <g style="solid" ensureOnCanvas="true">
+  <g style="solid">
     <marker
       id="DEF.QR-leftArrowhead"
       markerUnits="strokeWidth"
@@ -209,7 +209,7 @@
     ></path>
     <title>DEF.QR</title>
   </g>
-  <g style="solid" ensureOnCanvas="true">
+  <g style="solid">
     <marker
       id="DEF.PQ-leftArrowhead"
       markerUnits="strokeWidth"
@@ -251,7 +251,7 @@
     ></path>
     <title>DEF.PQ</title>
   </g>
-  <g style="solid" ensureOnCanvas="true">
+  <g style="solid">
     <marker
       id="aGFJ.side2-leftArrowhead"
       markerUnits="strokeWidth"
@@ -293,7 +293,7 @@
     ></path>
     <title>aGFJ.side2</title>
   </g>
-  <g style="solid" ensureOnCanvas="true">
+  <g style="solid">
     <marker
       id="aGFJ.side1-leftArrowhead"
       markerUnits="strokeWidth"
@@ -335,7 +335,7 @@
     ></path>
     <title>aGFJ.side1</title>
   </g>
-  <g style="solid" ensureOnCanvas="true">
+  <g style="solid">
     <marker
       id="HK.icon-leftArrowhead"
       markerUnits="strokeWidth"
@@ -377,7 +377,7 @@
     ></path>
     <title>HK.icon</title>
   </g>
-  <g style="solid" ensureOnCanvas="true">
+  <g style="solid">
     <marker
       id="GJ.icon-leftArrowhead"
       markerUnits="strokeWidth"
@@ -422,7 +422,6 @@
   <g
     transform="rotate(0, 534.1580015188998, 172.85956129872804)translate(534.1580015188998, 172.85956129872804)"
     string="K"
-    ensureOnCanvas="true"
   >
     <title>K.text</title>
     <svg
@@ -468,14 +467,12 @@
     stroke-width="0"
     stroke-linecap="butt"
     r="4"
-    ensureOnCanvas="true"
   >
     <title>K.icon</title>
   </circle>
   <g
     transform="rotate(0, 581.4141937352571, 125.24169772681562)translate(581.4141937352571, 125.24169772681562)"
     string="J"
-    ensureOnCanvas="true"
   >
     <title>J.text</title>
     <svg
@@ -521,14 +518,12 @@
     stroke-width="0"
     stroke-linecap="butt"
     r="4"
-    ensureOnCanvas="true"
   >
     <title>J.icon</title>
   </circle>
   <g
     transform="rotate(0, 496.69067985793953, 167.37103389323266)translate(496.69067985793953, 167.37103389323266)"
     string="H"
-    ensureOnCanvas="true"
   >
     <title>H.text</title>
     <svg
@@ -574,14 +569,12 @@
     stroke-width="0"
     stroke-linecap="butt"
     r="4"
-    ensureOnCanvas="true"
   >
     <title>H.icon</title>
   </circle>
   <g
     transform="rotate(0, 467.75741768366413, 261.95038797389776)translate(467.75741768366413, 261.95038797389776)"
     string="G"
-    ensureOnCanvas="true"
   >
     <title>G.text</title>
     <svg
@@ -627,14 +620,12 @@
     stroke-width="0"
     stroke-linecap="butt"
     r="4"
-    ensureOnCanvas="true"
   >
     <title>G.icon</title>
   </circle>
   <g
     transform="rotate(0, 628.9815020611866, 146.73679811676425)translate(628.9815020611866, 146.73679811676425)"
     string="F"
-    ensureOnCanvas="true"
   >
     <title>F.text</title>
     <svg
@@ -680,14 +671,12 @@
     stroke-width="0"
     stroke-linecap="butt"
     r="4"
-    ensureOnCanvas="true"
   >
     <title>F.icon</title>
   </circle>
   <g
     transform="rotate(0, 373.317876439614, 423.2620053843389)translate(373.317876439614, 423.2620053843389)"
     string="E"
-    ensureOnCanvas="true"
   >
     <title>E.text</title>
     <svg
@@ -733,14 +722,12 @@
     stroke-width="0"
     stroke-linecap="butt"
     r="4"
-    ensureOnCanvas="true"
   >
     <title>E.icon</title>
   </circle>
   <g
     transform="rotate(0, 513.1939952336211, 71.42127139031679)translate(513.1939952336211, 71.42127139031679)"
     string="D"
-    ensureOnCanvas="true"
   >
     <title>D.text</title>
     <svg
@@ -786,7 +773,6 @@
     stroke-width="0"
     stroke-linecap="butt"
     r="4"
-    ensureOnCanvas="true"
   >
     <title>D.icon</title>
   </circle>

--- a/diagrams/non-convex-non-convex.svg
+++ b/diagrams/non-convex-non-convex.svg
@@ -5,7 +5,6 @@
     stroke="none"
     transform="scale(1)"
     points="458.6318653865245,326.57914777373577,488.33295619764834,288.78004748798,440.8129519692555,281.91963402517547"
-    ensureOnCanvas="true"
   >
     <title>T3.icon</title>
   </polygon>
@@ -15,7 +14,6 @@
     stroke="none"
     transform="scale(1)"
     points="458.642304096809,326.60517936869974,506.3510925900438,333.1786671517809,488.3656397262402,288.7793733106809"
-    ensureOnCanvas="true"
   >
     <title>T2.icon</title>
   </polygon>
@@ -25,7 +23,6 @@
     stroke="none"
     transform="scale(1)"
     points="458.64822269349196,326.61957566623784,476.75365425444966,371.16903518567,506.22732663159724,333.22780941097653"
-    ensureOnCanvas="true"
   >
     <title>T1.icon</title>
   </polygon>
@@ -35,7 +32,6 @@
     stroke="none"
     transform="scale(1)"
     points="375,280,400,380,350,380,350,345,290,405,260,510,500,430,400,180,80,270"
-    ensureOnCanvas="true"
   >
     <title>M.icon</title>
   </polygon>

--- a/diagrams/parallel-lines-euclidean.svg
+++ b/diagrams/parallel-lines-euclidean.svg
@@ -1,5 +1,5 @@
 <svg version="1.2" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 800 700">
-  <g style="solid" ensureOnCanvas="true">
+  <g style="solid">
     <marker
       id="JKM.side2-leftArrowhead"
       markerUnits="strokeWidth"
@@ -41,7 +41,7 @@
     ></path>
     <title>JKM.side2</title>
   </g>
-  <g style="solid" ensureOnCanvas="true">
+  <g style="solid">
     <marker
       id="JKM.side1-leftArrowhead"
       markerUnits="strokeWidth"
@@ -83,7 +83,7 @@
     ></path>
     <title>JKM.side1</title>
   </g>
-  <g style="solid" ensureOnCanvas="true">
+  <g style="solid">
     <marker
       id="KM.icon-leftArrowhead"
       markerUnits="strokeWidth"
@@ -127,7 +127,7 @@
     ></path>
     <title>KM.icon</title>
   </g>
-  <g ensureOnCanvas="true">
+  <g>
     <filter id="NL.tick1-shadow" x="0" y="0" width="200%" height="200%">
       <feOffset result="offOut" in="SourceAlpha" dx="5" dy="5"></feOffset>
       <feGaussianBlur
@@ -153,7 +153,7 @@
     ></path>
     <title>NL.tick1</title>
   </g>
-  <g style="solid" ensureOnCanvas="true">
+  <g style="solid">
     <marker
       id="NL.icon-leftArrowhead"
       markerUnits="strokeWidth"
@@ -197,7 +197,7 @@
     ></path>
     <title>NL.icon</title>
   </g>
-  <g ensureOnCanvas="true">
+  <g>
     <filter id="JK.tick1-shadow" x="0" y="0" width="200%" height="200%">
       <feOffset result="offOut" in="SourceAlpha" dx="5" dy="5"></feOffset>
       <feGaussianBlur
@@ -223,7 +223,7 @@
     ></path>
     <title>JK.tick1</title>
   </g>
-  <g style="solid" ensureOnCanvas="true">
+  <g style="solid">
     <marker
       id="JK.icon-leftArrowhead"
       markerUnits="strokeWidth"
@@ -270,7 +270,6 @@
   <g
     transform="rotate(0, 695.5138322837058, 319.8484802946404)translate(695.5138322837058, 319.8484802946404)"
     string="N"
-    ensureOnCanvas="true"
   >
     <title>N.text</title>
     <svg
@@ -316,14 +315,12 @@
     stroke-width="0"
     stroke-linecap="butt"
     r="4"
-    ensureOnCanvas="true"
   >
     <title>N.icon</title>
   </circle>
   <g
     transform="rotate(0, 628.711179977662, 339.37985167438313)translate(628.711179977662, 339.37985167438313)"
     string="M"
-    ensureOnCanvas="true"
   >
     <title>M.text</title>
     <svg
@@ -369,14 +366,12 @@
     stroke-width="0"
     stroke-linecap="butt"
     r="4"
-    ensureOnCanvas="true"
   >
     <title>M.icon</title>
   </circle>
   <g
     transform="rotate(0, 359.7926468378335, 373.3354859276828)translate(359.7926468378335, 373.3354859276828)"
     string="L"
-    ensureOnCanvas="true"
   >
     <title>L.text</title>
     <svg
@@ -422,14 +417,12 @@
     stroke-width="0"
     stroke-linecap="butt"
     r="4"
-    ensureOnCanvas="true"
   >
     <title>L.icon</title>
   </circle>
   <g
     transform="rotate(0, 548.3794350208643, 230.44091611539676)translate(548.3794350208643, 230.44091611539676)"
     string="K"
-    ensureOnCanvas="true"
   >
     <title>K.text</title>
     <svg
@@ -475,14 +468,12 @@
     stroke-width="0"
     stroke-linecap="butt"
     r="4"
-    ensureOnCanvas="true"
   >
     <title>K.icon</title>
   </circle>
   <g
     transform="rotate(0, 703.4324850907099, 156.8792782301509)translate(703.4324850907099, 156.8792782301509)"
     string="J"
-    ensureOnCanvas="true"
   >
     <title>J.text</title>
     <svg
@@ -528,7 +519,6 @@
     stroke-width="0"
     stroke-linecap="butt"
     r="4"
-    ensureOnCanvas="true"
   >
     <title>J.icon</title>
   </circle>

--- a/diagrams/persistent-homology-persistent-homology.svg
+++ b/diagrams/persistent-homology-persistent-homology.svg
@@ -6,7 +6,6 @@
     cy="336.9399201011592"
     stroke="none"
     r="52.07322695552145"
-    ensureOnCanvas="true"
   >
     <title>P10.circle3</title>
   </circle>
@@ -17,7 +16,6 @@
     cy="354.4401776376829"
     stroke="none"
     r="52.09534207677081"
-    ensureOnCanvas="true"
   >
     <title>P9.circle3</title>
   </circle>
@@ -28,7 +26,6 @@
     cy="286.73247343579345"
     stroke="none"
     r="52.024016565473744"
-    ensureOnCanvas="true"
   >
     <title>P8.circle3</title>
   </circle>
@@ -39,7 +36,6 @@
     cy="360.21902339439754"
     stroke="none"
     r="52.06637360526497"
-    ensureOnCanvas="true"
   >
     <title>P7.circle3</title>
   </circle>
@@ -50,7 +46,6 @@
     cy="292.1771750244527"
     stroke="none"
     r="52.09432471639102"
-    ensureOnCanvas="true"
   >
     <title>P6.circle3</title>
   </circle>
@@ -61,7 +56,6 @@
     cy="195.0054854678316"
     stroke="none"
     r="52.065139213071944"
-    ensureOnCanvas="true"
   >
     <title>P5.circle3</title>
   </circle>
@@ -72,7 +66,6 @@
     cy="174.58303969197937"
     stroke="none"
     r="52.06727631712183"
-    ensureOnCanvas="true"
   >
     <title>P4.circle3</title>
   </circle>
@@ -83,7 +76,6 @@
     cy="199.0957749165581"
     stroke="none"
     r="52.068046393431544"
-    ensureOnCanvas="true"
   >
     <title>P3.circle3</title>
   </circle>
@@ -94,7 +86,6 @@
     cy="197.04298809741778"
     stroke="none"
     r="52.066308161373954"
-    ensureOnCanvas="true"
   >
     <title>P2.circle3</title>
   </circle>
@@ -105,14 +96,11 @@
     cy="239.80923914118796"
     stroke="none"
     r="52.06188990340551"
-    ensureOnCanvas="true"
   >
     <title>P1.circle3</title>
   </circle>
   <g
     transform="rotate(0, 524.0702664362191, 187.74734923778246)translate(524.0702664362191, 187.74734923778246)"
-    name="P1.shade3"
-    ensureOnCanvas="false"
   >
     <!--?xml version="1.0" encoding="utf-8"?-->
     <!-- Generator: Adobe Illustrator 26.3.1, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
@@ -165,7 +153,6 @@
     cy="336.9399201011592"
     stroke="none"
     r="29.054044549683272"
-    ensureOnCanvas="true"
   >
     <title>P10.circle2</title>
   </circle>
@@ -176,7 +163,6 @@
     cy="354.4401776376829"
     stroke="none"
     r="29.040956576764902"
-    ensureOnCanvas="true"
   >
     <title>P9.circle2</title>
   </circle>
@@ -187,7 +173,6 @@
     cy="286.73247343579345"
     stroke="none"
     r="29.02410565534539"
-    ensureOnCanvas="true"
   >
     <title>P8.circle2</title>
   </circle>
@@ -198,7 +183,6 @@
     cy="360.21902339439754"
     stroke="none"
     r="29.05411104428102"
-    ensureOnCanvas="true"
   >
     <title>P7.circle2</title>
   </circle>
@@ -209,7 +193,6 @@
     cy="292.1771750244527"
     stroke="none"
     r="29.03722597758778"
-    ensureOnCanvas="true"
   >
     <title>P6.circle2</title>
   </circle>
@@ -220,7 +203,6 @@
     cy="195.0054854678316"
     stroke="none"
     r="29.057864004359978"
-    ensureOnCanvas="true"
   >
     <title>P5.circle2</title>
   </circle>
@@ -231,7 +213,6 @@
     cy="174.58303969197937"
     stroke="none"
     r="29.05786461030455"
-    ensureOnCanvas="true"
   >
     <title>P4.circle2</title>
   </circle>
@@ -242,7 +223,6 @@
     cy="199.0957749165581"
     stroke="none"
     r="29.05774066848995"
-    ensureOnCanvas="true"
   >
     <title>P3.circle2</title>
   </circle>
@@ -253,7 +233,6 @@
     cy="197.04298809741778"
     stroke="none"
     r="29.054044954362226"
-    ensureOnCanvas="true"
   >
     <title>P2.circle2</title>
   </circle>
@@ -264,14 +243,11 @@
     cy="239.80923914118796"
     stroke="none"
     r="29.057746188704584"
-    ensureOnCanvas="true"
   >
     <title>P1.circle2</title>
   </circle>
   <g
     transform="rotate(0, 250.66800462920315, 210.75149295248337)translate(250.66800462920315, 210.75149295248337)"
-    name="P1.shade2"
-    ensureOnCanvas="false"
   >
     <!--?xml version="1.0" encoding="utf-8"?-->
     <!-- Generator: Adobe Illustrator 26.3.1, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
@@ -324,7 +300,6 @@
     cy="336.9399201011592"
     stroke="none"
     r="7.954893679376416"
-    ensureOnCanvas="true"
   >
     <title>P10.circle1</title>
   </circle>
@@ -335,7 +310,6 @@
     cy="354.4401776376829"
     stroke="none"
     r="7.954923519875253"
-    ensureOnCanvas="true"
   >
     <title>P9.circle1</title>
   </circle>
@@ -346,7 +320,6 @@
     cy="286.73247343579345"
     stroke="none"
     r="7.954921679635969"
-    ensureOnCanvas="true"
   >
     <title>P8.circle1</title>
   </circle>
@@ -357,7 +330,6 @@
     cy="360.21902339439754"
     stroke="none"
     r="7.954922486813676"
-    ensureOnCanvas="true"
   >
     <title>P7.circle1</title>
   </circle>
@@ -368,7 +340,6 @@
     cy="292.1771750244527"
     stroke="none"
     r="7.954923722196334"
-    ensureOnCanvas="true"
   >
     <title>P6.circle1</title>
   </circle>
@@ -379,7 +350,6 @@
     cy="195.0054854678316"
     stroke="none"
     r="7.954921596281423"
-    ensureOnCanvas="true"
   >
     <title>P5.circle1</title>
   </circle>
@@ -390,7 +360,6 @@
     cy="174.58303969197937"
     stroke="none"
     r="7.95492444223082"
-    ensureOnCanvas="true"
   >
     <title>P4.circle1</title>
   </circle>
@@ -401,7 +370,6 @@
     cy="199.0957749165581"
     stroke="none"
     r="7.954905072136665"
-    ensureOnCanvas="true"
   >
     <title>P3.circle1</title>
   </circle>
@@ -412,7 +380,6 @@
     cy="197.04298809741778"
     stroke="none"
     r="7.954918861759638"
-    ensureOnCanvas="true"
   >
     <title>P2.circle1</title>
   </circle>
@@ -423,14 +390,11 @@
     cy="239.80923914118796"
     stroke="none"
     r="7.952284552698781"
-    ensureOnCanvas="true"
   >
     <title>P1.circle1</title>
   </circle>
   <g
     transform="rotate(0, -0.0020755835688772706, 231.85695458848917)translate(-0.0020755835688772706, 231.85695458848917)"
-    name="P1.shade1"
-    ensureOnCanvas="false"
   >
     <!--?xml version="1.0" encoding="utf-8"?-->
     <!-- Generator: Adobe Illustrator 26.3.1, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
@@ -478,8 +442,6 @@
   </g>
   <g
     transform="rotate(0, 525.5921440677118, 284.8666931456378)translate(525.5921440677118, 284.8666931456378)"
-    name="P10.shade3"
-    ensureOnCanvas="false"
   >
     <!--?xml version="1.0" encoding="utf-8"?-->
     <!-- Generator: Adobe Illustrator 26.3.1, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
@@ -527,8 +489,6 @@
   </g>
   <g
     transform="rotate(0, 252.19374907420593, 307.8858755514759)translate(252.19374907420593, 307.8858755514759)"
-    name="P10.shade2"
-    ensureOnCanvas="false"
   >
     <!--?xml version="1.0" encoding="utf-8"?-->
     <!-- Generator: Adobe Illustrator 26.3.1, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
@@ -576,8 +536,6 @@
   </g>
   <g
     transform="rotate(0, 1.5186342372139263, 328.9850264217828)translate(1.5186342372139263, 328.9850264217828)"
-    name="P10.shade1"
-    ensureOnCanvas="false"
   >
     <!--?xml version="1.0" encoding="utf-8"?-->
     <!-- Generator: Adobe Illustrator 26.3.1, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
@@ -623,7 +581,7 @@
       <circle class="st0" cx="46.4" cy="46.4" r="46.4"></circle>
     </svg>
   </g>
-  <g ensureOnCanvas="true">
+  <g>
     <marker
       id="C3P10P1.line-leftArrowhead"
       markerUnits="strokeWidth"
@@ -667,8 +625,6 @@
   </g>
   <g
     transform="rotate(0, 621.161729666083, 302.3448355609121)translate(621.161729666083, 302.3448355609121)"
-    name="P9.shade3"
-    ensureOnCanvas="false"
   >
     <!--?xml version="1.0" encoding="utf-8"?-->
     <!-- Generator: Adobe Illustrator 26.3.1, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
@@ -716,8 +672,6 @@
   </g>
   <g
     transform="rotate(0, 347.7982404481832, 325.39922106091797)translate(347.7982404481832, 325.39922106091797)"
-    name="P9.shade2"
-    ensureOnCanvas="false"
   >
     <!--?xml version="1.0" encoding="utf-8"?-->
     <!-- Generator: Adobe Illustrator 26.3.1, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
@@ -765,8 +719,6 @@
   </g>
   <g
     transform="rotate(0, 97.1100154300239, 346.48525411780764)translate(97.1100154300239, 346.48525411780764)"
-    name="P9.shade1"
-    ensureOnCanvas="false"
   >
     <!--?xml version="1.0" encoding="utf-8"?-->
     <!-- Generator: Adobe Illustrator 26.3.1, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
@@ -812,7 +764,7 @@
       <circle class="st0" cx="46.4" cy="46.4" r="46.4"></circle>
     </svg>
   </g>
-  <g ensureOnCanvas="true">
+  <g>
     <marker
       id="C3P9P10.line-leftArrowhead"
       markerUnits="strokeWidth"
@@ -856,8 +808,6 @@
   </g>
   <g
     transform="rotate(0, 628.0842096428165, 234.7084568703197)translate(628.0842096428165, 234.7084568703197)"
-    name="P8.shade3"
-    ensureOnCanvas="false"
   >
     <!--?xml version="1.0" encoding="utf-8"?-->
     <!-- Generator: Adobe Illustrator 26.3.1, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
@@ -905,8 +855,6 @@
   </g>
   <g
     transform="rotate(0, 354.6519029066079, 257.70836778044804)translate(354.6519029066079, 257.70836778044804)"
-    name="P8.shade2"
-    ensureOnCanvas="false"
   >
     <!--?xml version="1.0" encoding="utf-8"?-->
     <!-- Generator: Adobe Illustrator 26.3.1, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
@@ -954,8 +902,6 @@
   </g>
   <g
     transform="rotate(0, 103.94682920982073, 278.7775517561575)translate(103.94682920982073, 278.7775517561575)"
-    name="P8.shade1"
-    ensureOnCanvas="false"
   >
     <!--?xml version="1.0" encoding="utf-8"?-->
     <!-- Generator: Adobe Illustrator 26.3.1, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
@@ -1001,7 +947,7 @@
       <circle class="st0" cx="46.4" cy="46.4" r="46.4"></circle>
     </svg>
   </g>
-  <g ensureOnCanvas="true">
+  <g>
     <marker
       id="C3P8P9.line-leftArrowhead"
       markerUnits="strokeWidth"
@@ -1045,8 +991,6 @@
   </g>
   <g
     transform="rotate(0, 691.087964928061, 308.15264978913257)translate(691.087964928061, 308.15264978913257)"
-    name="P7.shade3"
-    ensureOnCanvas="false"
   >
     <!--?xml version="1.0" encoding="utf-8"?-->
     <!-- Generator: Adobe Illustrator 26.3.1, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
@@ -1094,8 +1038,6 @@
   </g>
   <g
     transform="rotate(0, 417.68325475772957, 331.16491235011654)translate(417.68325475772957, 331.16491235011654)"
-    name="P7.shade2"
-    ensureOnCanvas="false"
   >
     <!--?xml version="1.0" encoding="utf-8"?-->
     <!-- Generator: Adobe Illustrator 26.3.1, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
@@ -1143,8 +1085,6 @@
   </g>
   <g
     transform="rotate(0, 167.0081856429644, 352.26410090758384)translate(167.0081856429644, 352.26410090758384)"
-    name="P7.shade1"
-    ensureOnCanvas="false"
   >
     <!--?xml version="1.0" encoding="utf-8"?-->
     <!-- Generator: Adobe Illustrator 26.3.1, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
@@ -1190,7 +1130,7 @@
       <circle class="st0" cx="46.4" cy="46.4" r="46.4"></circle>
     </svg>
   </g>
-  <g ensureOnCanvas="true">
+  <g>
     <marker
       id="C3P7P9.line-leftArrowhead"
       markerUnits="strokeWidth"
@@ -1232,7 +1172,7 @@
     ></path>
     <title>C3P7P9.line</title>
   </g>
-  <g ensureOnCanvas="true">
+  <g>
     <marker
       id="C3P7P8.line-leftArrowhead"
       markerUnits="strokeWidth"
@@ -1276,8 +1216,6 @@
   </g>
   <g
     transform="rotate(0, 695.8118794370877, 240.0828503080617)translate(695.8118794370877, 240.0828503080617)"
-    name="P6.shade3"
-    ensureOnCanvas="false"
   >
     <!--?xml version="1.0" encoding="utf-8"?-->
     <!-- Generator: Adobe Illustrator 26.3.1, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
@@ -1325,8 +1263,6 @@
   </g>
   <g
     transform="rotate(0, 422.46551598153906, 263.1399490468649)translate(422.46551598153906, 263.1399490468649)"
-    name="P6.shade2"
-    ensureOnCanvas="false"
   >
     <!--?xml version="1.0" encoding="utf-8"?-->
     <!-- Generator: Adobe Illustrator 26.3.1, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
@@ -1374,8 +1310,6 @@
   </g>
   <g
     transform="rotate(0, 171.7723940184385, 284.2222513022564)translate(171.7723940184385, 284.2222513022564)"
-    name="P6.shade1"
-    ensureOnCanvas="false"
   >
     <!--?xml version="1.0" encoding="utf-8"?-->
     <!-- Generator: Adobe Illustrator 26.3.1, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
@@ -1421,7 +1355,7 @@
       <circle class="st0" cx="46.4" cy="46.4" r="46.4"></circle>
     </svg>
   </g>
-  <g ensureOnCanvas="true">
+  <g>
     <marker
       id="C3P6P9.line-leftArrowhead"
       markerUnits="strokeWidth"
@@ -1463,7 +1397,7 @@
     ></path>
     <title>C3P6P9.line</title>
   </g>
-  <g ensureOnCanvas="true">
+  <g>
     <marker
       id="C3P6P8.line-leftArrowhead"
       markerUnits="strokeWidth"
@@ -1505,7 +1439,7 @@
     ></path>
     <title>C3P6P8.line</title>
   </g>
-  <g ensureOnCanvas="true">
+  <g>
     <marker
       id="C3P6P7.line-leftArrowhead"
       markerUnits="strokeWidth"
@@ -1549,8 +1483,6 @@
   </g>
   <g
     transform="rotate(0, 695.8627862956845, 142.94034625475965)translate(695.8627862956845, 142.94034625475965)"
-    name="P5.shade3"
-    ensureOnCanvas="false"
   >
     <!--?xml version="1.0" encoding="utf-8"?-->
     <!-- Generator: Adobe Illustrator 26.3.1, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
@@ -1598,8 +1530,6 @@
   </g>
   <g
     transform="rotate(0, 422.4452442621109, 165.94762146347162)translate(422.4452442621109, 165.94762146347162)"
-    name="P5.shade2"
-    ensureOnCanvas="false"
   >
     <!--?xml version="1.0" encoding="utf-8"?-->
     <!-- Generator: Adobe Illustrator 26.3.1, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
@@ -1647,8 +1577,6 @@
   </g>
   <g
     transform="rotate(0, 171.77253268181636, 187.05056387155017)translate(171.77253268181636, 187.05056387155017)"
-    name="P5.shade1"
-    ensureOnCanvas="false"
   >
     <!--?xml version="1.0" encoding="utf-8"?-->
     <!-- Generator: Adobe Illustrator 26.3.1, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
@@ -1694,7 +1622,7 @@
       <circle class="st0" cx="46.4" cy="46.4" r="46.4"></circle>
     </svg>
   </g>
-  <g ensureOnCanvas="true">
+  <g>
     <marker
       id="C3P5P6.line-leftArrowhead"
       markerUnits="strokeWidth"
@@ -1738,8 +1666,6 @@
   </g>
   <g
     transform="rotate(0, 648.9866800175388, 122.51576337485753)translate(648.9866800175388, 122.51576337485753)"
-    name="P4.shade3"
-    ensureOnCanvas="false"
   >
     <!--?xml version="1.0" encoding="utf-8"?-->
     <!-- Generator: Adobe Illustrator 26.3.1, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
@@ -1787,8 +1713,6 @@
   </g>
   <g
     transform="rotate(0, 375.5822785470509, 145.52517508167483)translate(375.5822785470509, 145.52517508167483)"
-    name="P4.shade2"
-    ensureOnCanvas="false"
   >
     <!--?xml version="1.0" encoding="utf-8"?-->
     <!-- Generator: Adobe Illustrator 26.3.1, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
@@ -1836,8 +1760,6 @@
   </g>
   <g
     transform="rotate(0, 124.91096091521656, 166.62811524974853)translate(124.91096091521656, 166.62811524974853)"
-    name="P4.shade1"
-    ensureOnCanvas="false"
   >
     <!--?xml version="1.0" encoding="utf-8"?-->
     <!-- Generator: Adobe Illustrator 26.3.1, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
@@ -1883,7 +1805,7 @@
       <circle class="st0" cx="46.4" cy="46.4" r="46.4"></circle>
     </svg>
   </g>
-  <g ensureOnCanvas="true">
+  <g>
     <marker
       id="C3P4P5.line-leftArrowhead"
       markerUnits="strokeWidth"
@@ -1927,8 +1849,6 @@
   </g>
   <g
     transform="rotate(0, 554.9900846090178, 147.02772852312654)translate(554.9900846090178, 147.02772852312654)"
-    name="P3.shade3"
-    ensureOnCanvas="false"
   >
     <!--?xml version="1.0" encoding="utf-8"?-->
     <!-- Generator: Adobe Illustrator 26.3.1, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
@@ -1976,8 +1896,6 @@
   </g>
   <g
     transform="rotate(0, 281.58101620293246, 170.03803424806816)translate(281.58101620293246, 170.03803424806816)"
-    name="P3.shade2"
-    ensureOnCanvas="false"
   >
     <!--?xml version="1.0" encoding="utf-8"?-->
     <!-- Generator: Adobe Illustrator 26.3.1, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
@@ -2025,8 +1943,6 @@
   </g>
   <g
     transform="rotate(0, 30.909605725663386, 191.14086984442145)translate(30.909605725663386, 191.14086984442145)"
-    name="P3.shade1"
-    ensureOnCanvas="false"
   >
     <!--?xml version="1.0" encoding="utf-8"?-->
     <!-- Generator: Adobe Illustrator 26.3.1, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
@@ -2072,7 +1988,7 @@
       <circle class="st0" cx="46.4" cy="46.4" r="46.4"></circle>
     </svg>
   </g>
-  <g ensureOnCanvas="true">
+  <g>
     <marker
       id="C3P3P4.line-leftArrowhead"
       markerUnits="strokeWidth"
@@ -2114,7 +2030,7 @@
     ></path>
     <title>C3P3P4.line</title>
   </g>
-  <g ensureOnCanvas="true">
+  <g>
     <marker
       id="C3P3P1.line-leftArrowhead"
       markerUnits="strokeWidth"
@@ -2158,8 +2074,6 @@
   </g>
   <g
     transform="rotate(0, 525.0687912568907, 144.9766799360438)translate(525.0687912568907, 144.9766799360438)"
-    name="P2.shade3"
-    ensureOnCanvas="false"
   >
     <!--?xml version="1.0" encoding="utf-8"?-->
     <!-- Generator: Adobe Illustrator 26.3.1, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
@@ -2207,8 +2121,6 @@
   </g>
   <g
     transform="rotate(0, 251.6640388321183, 167.98894314305556)translate(251.6640388321183, 167.98894314305556)"
-    name="P2.shade2"
-    ensureOnCanvas="false"
   >
     <!--?xml version="1.0" encoding="utf-8"?-->
     <!-- Generator: Adobe Illustrator 26.3.1, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
@@ -2256,8 +2168,6 @@
   </g>
   <g
     transform="rotate(0, 0.9888734843450768, 189.08806923565814)translate(0.9888734843450768, 189.08806923565814)"
-    name="P2.shade1"
-    ensureOnCanvas="false"
   >
     <!--?xml version="1.0" encoding="utf-8"?-->
     <!-- Generator: Adobe Illustrator 26.3.1, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
@@ -2303,7 +2213,7 @@
       <circle class="st0" cx="46.4" cy="46.4" r="46.4"></circle>
     </svg>
   </g>
-  <g ensureOnCanvas="true">
+  <g>
     <marker
       id="C3P2P3.line-leftArrowhead"
       markerUnits="strokeWidth"
@@ -2345,7 +2255,7 @@
     ></path>
     <title>C3P2P3.line</title>
   </g>
-  <g ensureOnCanvas="true">
+  <g>
     <marker
       id="C3P1P2.line-leftArrowhead"
       markerUnits="strokeWidth"
@@ -2387,7 +2297,7 @@
     ></path>
     <title>C3P1P2.line</title>
   </g>
-  <g ensureOnCanvas="true">
+  <g>
     <marker
       id="C2P4P5.line-leftArrowhead"
       markerUnits="strokeWidth"
@@ -2429,7 +2339,7 @@
     ></path>
     <title>C2P4P5.line</title>
   </g>
-  <g ensureOnCanvas="true">
+  <g>
     <marker
       id="C2P3P1.line-leftArrowhead"
       markerUnits="strokeWidth"
@@ -2471,7 +2381,7 @@
     ></path>
     <title>C2P3P1.line</title>
   </g>
-  <g ensureOnCanvas="true">
+  <g>
     <marker
       id="C2P2P3.line-leftArrowhead"
       markerUnits="strokeWidth"
@@ -2513,7 +2423,7 @@
     ></path>
     <title>C2P2P3.line</title>
   </g>
-  <g ensureOnCanvas="true">
+  <g>
     <marker
       id="C2P1P2.line-leftArrowhead"
       markerUnits="strokeWidth"
@@ -2562,7 +2472,6 @@
     cy="336.9399201011592"
     stroke="none"
     r="3"
-    ensureOnCanvas="true"
   >
     <title>P10.dot3</title>
   </circle>
@@ -2573,7 +2482,6 @@
     cy="336.9399201011592"
     stroke="none"
     r="3"
-    ensureOnCanvas="true"
   >
     <title>P10.dot2</title>
   </circle>
@@ -2584,7 +2492,6 @@
     cy="336.9399201011592"
     stroke="none"
     r="3"
-    ensureOnCanvas="true"
   >
     <title>P10.dot1</title>
   </circle>
@@ -2595,7 +2502,6 @@
     cy="354.4401776376829"
     stroke="none"
     r="3"
-    ensureOnCanvas="true"
   >
     <title>P9.dot3</title>
   </circle>
@@ -2606,7 +2512,6 @@
     cy="354.4401776376829"
     stroke="none"
     r="3"
-    ensureOnCanvas="true"
   >
     <title>P9.dot2</title>
   </circle>
@@ -2617,7 +2522,6 @@
     cy="354.4401776376829"
     stroke="none"
     r="3"
-    ensureOnCanvas="true"
   >
     <title>P9.dot1</title>
   </circle>
@@ -2628,7 +2532,6 @@
     cy="286.73247343579345"
     stroke="none"
     r="3"
-    ensureOnCanvas="true"
   >
     <title>P8.dot3</title>
   </circle>
@@ -2639,7 +2542,6 @@
     cy="286.73247343579345"
     stroke="none"
     r="3"
-    ensureOnCanvas="true"
   >
     <title>P8.dot2</title>
   </circle>
@@ -2650,7 +2552,6 @@
     cy="286.73247343579345"
     stroke="none"
     r="3"
-    ensureOnCanvas="true"
   >
     <title>P8.dot1</title>
   </circle>
@@ -2661,7 +2562,6 @@
     cy="360.21902339439754"
     stroke="none"
     r="3"
-    ensureOnCanvas="true"
   >
     <title>P7.dot3</title>
   </circle>
@@ -2672,7 +2572,6 @@
     cy="360.21902339439754"
     stroke="none"
     r="3"
-    ensureOnCanvas="true"
   >
     <title>P7.dot2</title>
   </circle>
@@ -2683,7 +2582,6 @@
     cy="360.21902339439754"
     stroke="none"
     r="3"
-    ensureOnCanvas="true"
   >
     <title>P7.dot1</title>
   </circle>
@@ -2694,7 +2592,6 @@
     cy="292.1771750244527"
     stroke="none"
     r="3"
-    ensureOnCanvas="true"
   >
     <title>P6.dot3</title>
   </circle>
@@ -2705,7 +2602,6 @@
     cy="292.1771750244527"
     stroke="none"
     r="3"
-    ensureOnCanvas="true"
   >
     <title>P6.dot2</title>
   </circle>
@@ -2716,7 +2612,6 @@
     cy="292.1771750244527"
     stroke="none"
     r="3"
-    ensureOnCanvas="true"
   >
     <title>P6.dot1</title>
   </circle>
@@ -2727,7 +2622,6 @@
     cy="195.0054854678316"
     stroke="none"
     r="3"
-    ensureOnCanvas="true"
   >
     <title>P5.dot3</title>
   </circle>
@@ -2738,7 +2632,6 @@
     cy="195.0054854678316"
     stroke="none"
     r="3"
-    ensureOnCanvas="true"
   >
     <title>P5.dot2</title>
   </circle>
@@ -2749,7 +2642,6 @@
     cy="195.0054854678316"
     stroke="none"
     r="3"
-    ensureOnCanvas="true"
   >
     <title>P5.dot1</title>
   </circle>
@@ -2760,7 +2652,6 @@
     cy="174.58303969197937"
     stroke="none"
     r="3"
-    ensureOnCanvas="true"
   >
     <title>P4.dot3</title>
   </circle>
@@ -2771,7 +2662,6 @@
     cy="174.58303969197937"
     stroke="none"
     r="3"
-    ensureOnCanvas="true"
   >
     <title>P4.dot2</title>
   </circle>
@@ -2782,7 +2672,6 @@
     cy="174.58303969197937"
     stroke="none"
     r="3"
-    ensureOnCanvas="true"
   >
     <title>P4.dot1</title>
   </circle>
@@ -2793,7 +2682,6 @@
     cy="199.0957749165581"
     stroke="none"
     r="3"
-    ensureOnCanvas="true"
   >
     <title>P3.dot3</title>
   </circle>
@@ -2804,7 +2692,6 @@
     cy="199.0957749165581"
     stroke="none"
     r="3"
-    ensureOnCanvas="true"
   >
     <title>P3.dot2</title>
   </circle>
@@ -2815,7 +2702,6 @@
     cy="199.0957749165581"
     stroke="none"
     r="3"
-    ensureOnCanvas="true"
   >
     <title>P3.dot1</title>
   </circle>
@@ -2826,7 +2712,6 @@
     cy="197.04298809741778"
     stroke="none"
     r="3"
-    ensureOnCanvas="true"
   >
     <title>P2.dot3</title>
   </circle>
@@ -2837,7 +2722,6 @@
     cy="197.04298809741778"
     stroke="none"
     r="3"
-    ensureOnCanvas="true"
   >
     <title>P2.dot2</title>
   </circle>
@@ -2848,7 +2732,6 @@
     cy="197.04298809741778"
     stroke="none"
     r="3"
-    ensureOnCanvas="true"
   >
     <title>P2.dot1</title>
   </circle>
@@ -2859,7 +2742,6 @@
     cy="239.80923914118796"
     stroke="none"
     r="3"
-    ensureOnCanvas="true"
   >
     <title>P1.dot3</title>
   </circle>
@@ -2870,7 +2752,6 @@
     cy="239.80923914118796"
     stroke="none"
     r="3"
-    ensureOnCanvas="true"
   >
     <title>P1.dot2</title>
   </circle>
@@ -2881,14 +2762,12 @@
     cy="239.80923914118796"
     stroke="none"
     r="3"
-    ensureOnCanvas="true"
   >
     <title>P1.dot1</title>
   </circle>
   <g
     transform="rotate(0, 645.9093443337188, 77.31261063309638)translate(645.9093443337188, 77.31261063309638)"
     string="X \oplus B_{\varepsilon_{3}}"
-    ensureOnCanvas="true"
   >
     <title>F.lab3</title>
     <svg
@@ -2967,7 +2846,6 @@
   <g
     transform="rotate(0, 349.1517571382442, 77.37761063309638)translate(349.1517571382442, 77.37761063309638)"
     string="X \oplus B_{\varepsilon_{2}}"
-    ensureOnCanvas="true"
   >
     <title>F.lab2</title>
     <svg
@@ -3046,7 +2924,6 @@
   <g
     transform="rotate(0, 77.37744585166493, 77.37761063309638)translate(77.37744585166493, 77.37761063309638)"
     string="X \oplus B_{\varepsilon_{1}}"
-    ensureOnCanvas="true"
   >
     <title>F.lab1</title>
     <svg
@@ -3125,7 +3002,6 @@
   <g
     transform="rotate(0, 704.6842474486534, 450.64894895191975)translate(704.6842474486534, 450.64894895191975)"
     string="\varepsilon_3"
-    ensureOnCanvas="true"
   >
     <title>F.eps3</title>
     <svg
@@ -3175,7 +3051,6 @@
   <g
     transform="rotate(0, 408.26729843254896, 450.64894895191975)translate(408.26729843254896, 450.64894895191975)"
     string="\varepsilon_2"
-    ensureOnCanvas="true"
   >
     <title>F.eps2</title>
     <svg
@@ -3225,7 +3100,6 @@
   <g
     transform="rotate(0, 136.49298714596966, 450.64894895191975)translate(136.49298714596966, 450.64894895191975)"
     string="\varepsilon_1"
-    ensureOnCanvas="true"
   >
     <title>F.eps1</title>
     <svg
@@ -3275,7 +3149,6 @@
   <g
     transform="rotate(0, 785.6764768108166, 430.64894895191975)translate(785.6764768108166, 430.64894895191975)"
     string="\varepsilon"
-    ensureOnCanvas="true"
   >
     <title>F.eps</title>
     <svg
@@ -3314,7 +3187,6 @@
   <g
     transform="rotate(0, -0.002256810816654742, 430.64894895191975)translate(-0.002256810816654742, 430.64894895191975)"
     string="0"
-    ensureOnCanvas="true"
   >
     <title>F.eps0</title>
     <svg
@@ -3357,7 +3229,6 @@
     cy="445.47894895191973"
     stroke="none"
     r="4"
-    ensureOnCanvas="true"
   >
     <title>F.dot3</title>
   </circle>
@@ -3368,7 +3239,6 @@
     cy="445.47894895191973"
     stroke="none"
     r="4"
-    ensureOnCanvas="true"
   >
     <title>F.dot2</title>
   </circle>
@@ -3379,7 +3249,6 @@
     cy="445.47894895191973"
     stroke="none"
     r="4"
-    ensureOnCanvas="true"
   >
     <title>F.dot1</title>
   </circle>
@@ -3390,11 +3259,10 @@
     cy="445.47894895191973"
     stroke="none"
     r="4"
-    ensureOnCanvas="true"
   >
     <title>F.dot0</title>
   </circle>
-  <g ensureOnCanvas="true">
+  <g>
     <marker
       id="F.axis-leftArrowhead"
       markerUnits="strokeWidth"

--- a/diagrams/small-graph-disjoint-rect-line-horiz.svg
+++ b/diagrams/small-graph-disjoint-rect-line-horiz.svg
@@ -2,7 +2,6 @@
   <g
     transform="rotate(0, 663.3803743716985, 226.90156992130287)translate(663.3803743716985, 226.90156992130287)"
     string="e5"
-    ensureOnCanvas="true"
   >
     <title>e5.text</title>
     <svg
@@ -44,7 +43,7 @@
       </g>
     </svg>
   </g>
-  <g ensureOnCanvas="true">
+  <g>
     <marker
       id="e5.shape-leftArrowhead"
       markerUnits="strokeWidth"
@@ -89,7 +88,6 @@
   <g
     transform="rotate(0, 629.0977857622881, 632.9176764401428)translate(629.0977857622881, 632.9176764401428)"
     string="e4"
-    ensureOnCanvas="true"
   >
     <title>e4.text</title>
     <svg
@@ -131,7 +129,7 @@
       </g>
     </svg>
   </g>
-  <g ensureOnCanvas="true">
+  <g>
     <marker
       id="e4.shape-leftArrowhead"
       markerUnits="strokeWidth"
@@ -176,7 +174,6 @@
   <g
     transform="rotate(0, 265.514866621983, 48.93633806960479)translate(265.514866621983, 48.93633806960479)"
     string="e3"
-    ensureOnCanvas="true"
   >
     <title>e3.text</title>
     <svg
@@ -218,7 +215,7 @@
       </g>
     </svg>
   </g>
-  <g ensureOnCanvas="true">
+  <g>
     <marker
       id="e3.shape-leftArrowhead"
       markerUnits="strokeWidth"
@@ -263,7 +260,6 @@
   <g
     transform="rotate(0, 614.4651426608625, 180.93316706760098)translate(614.4651426608625, 180.93316706760098)"
     string="e2"
-    ensureOnCanvas="true"
   >
     <title>e2.text</title>
     <svg
@@ -305,7 +301,7 @@
       </g>
     </svg>
   </g>
-  <g ensureOnCanvas="true">
+  <g>
     <marker
       id="e2.shape-leftArrowhead"
       markerUnits="strokeWidth"
@@ -350,7 +346,6 @@
   <g
     transform="rotate(0, 604.5073684663705, 474.19115274873775)translate(604.5073684663705, 474.19115274873775)"
     string="e1"
-    ensureOnCanvas="true"
   >
     <title>e1.text</title>
     <svg
@@ -392,7 +387,7 @@
       </g>
     </svg>
   </g>
-  <g ensureOnCanvas="true">
+  <g>
     <marker
       id="e1.shape-leftArrowhead"
       markerUnits="strokeWidth"
@@ -446,7 +441,6 @@
     stroke-linecap="butt"
     rx="0"
     transform="rotate(0, -50, 50)"
-    ensureOnCanvas="true"
   >
     <title>global.box</title>
   </rect>
@@ -462,14 +456,12 @@
     stroke-linecap="butt"
     rx="0"
     transform="rotate(0, 694.4659141614104, 74.73141402859241)"
-    ensureOnCanvas="true"
   >
     <title>v5.shape</title>
   </rect>
   <g
     transform="rotate(0, 735.7683641614104, 145.9014140285924)translate(735.7683641614104, 145.9014140285924)"
     string="v5"
-    ensureOnCanvas="true"
   >
     <title>v5.text</title>
     <svg
@@ -523,14 +515,12 @@
     stroke-linecap="butt"
     rx="0"
     transform="rotate(0, 399.41143689644167, 55.60463000511959)"
-    ensureOnCanvas="true"
   >
     <title>v4.shape</title>
   </rect>
   <g
     transform="rotate(0, 440.7138868964417, 126.77463000511959)translate(440.7138868964417, 126.77463000511959)"
     string="v4"
-    ensureOnCanvas="true"
   >
     <title>v4.text</title>
     <svg
@@ -584,14 +574,12 @@
     stroke-linecap="butt"
     rx="0"
     transform="rotate(0, 251.20733352010262, 485.6759133113061)"
-    ensureOnCanvas="true"
   >
     <title>v3.shape</title>
   </rect>
   <g
     transform="rotate(0, 292.50978352010264, 556.845913311306)translate(292.50978352010264, 556.845913311306)"
     string="v3"
-    ensureOnCanvas="true"
   >
     <title>v3.text</title>
     <svg
@@ -645,14 +633,12 @@
     stroke-linecap="butt"
     rx="0"
     transform="rotate(0, 353.22651941690486, 485.66969549234386)"
-    ensureOnCanvas="true"
   >
     <title>v2.shape</title>
   </rect>
   <g
     transform="rotate(0, 394.5289694169049, 556.8396954923438)translate(394.5289694169049, 556.8396954923438)"
     string="v2"
-    ensureOnCanvas="true"
   >
     <title>v2.text</title>
     <svg
@@ -706,14 +692,12 @@
     stroke-linecap="butt"
     rx="0"
     transform="rotate(0, 197.49623849161344, 313.28306133930454)"
-    ensureOnCanvas="true"
   >
     <title>v1.shape</title>
   </rect>
   <g
     transform="rotate(0, 438.79868849161346, 384.45306133930455)translate(438.79868849161346, 384.45306133930455)"
     string="v1"
-    ensureOnCanvas="true"
   >
     <title>v1.text</title>
     <svg

--- a/diagrams/small-graph-disjoint-rects-large-canvas.svg
+++ b/diagrams/small-graph-disjoint-rects-large-canvas.svg
@@ -11,7 +11,6 @@
     stroke-linecap="butt"
     rx="0"
     transform="rotate(0, 0, 0)"
-    ensureOnCanvas="true"
   >
     <title>global.box</title>
   </rect>
@@ -27,14 +26,12 @@
     stroke-linecap="butt"
     rx="0"
     transform="rotate(0, 483.95769450252453, 74.01015467827506)"
-    ensureOnCanvas="true"
   >
     <title>v5.shape</title>
   </rect>
   <g
     transform="rotate(0, 525.2601445025246, 145.18015467827504)translate(525.2601445025246, 145.18015467827504)"
     string="v5"
-    ensureOnCanvas="true"
   >
     <title>v5.text</title>
     <svg
@@ -88,14 +85,12 @@
     stroke-linecap="butt"
     rx="0"
     transform="rotate(0, 1085.5760706809479, 51.12883427210477)"
-    ensureOnCanvas="true"
   >
     <title>v4.shape</title>
   </rect>
   <g
     transform="rotate(0, 1126.8785206809478, 122.29883427210477)translate(1126.8785206809478, 122.29883427210477)"
     string="v4"
-    ensureOnCanvas="true"
   >
     <title>v4.text</title>
     <svg
@@ -149,14 +144,12 @@
     stroke-linecap="butt"
     rx="0"
     transform="rotate(0, 1486.921711362723, 1.1151177216930819)"
-    ensureOnCanvas="true"
   >
     <title>v3.shape</title>
   </rect>
   <g
     transform="rotate(0, 1528.224161362723, 72.28511772169308)translate(1528.224161362723, 72.28511772169308)"
     string="v3"
-    ensureOnCanvas="true"
   >
     <title>v3.text</title>
     <svg
@@ -210,14 +203,12 @@
     stroke-linecap="butt"
     rx="0"
     transform="rotate(0, 156.83457250159563, 463.86628866585806)"
-    ensureOnCanvas="true"
   >
     <title>v2.shape</title>
   </rect>
   <g
     transform="rotate(0, 198.13702250159562, 535.036288665858)translate(198.13702250159562, 535.036288665858)"
     string="v2"
-    ensureOnCanvas="true"
   >
     <title>v2.text</title>
     <svg
@@ -271,14 +262,12 @@
     stroke-linecap="butt"
     rx="0"
     transform="rotate(0, 136.20348711260567, 1038.9973524812544)"
-    ensureOnCanvas="true"
   >
     <title>v1.shape</title>
   </rect>
   <g
     transform="rotate(0, 277.5059371126057, 1110.1673524812545)translate(277.5059371126057, 1110.1673524812545)"
     string="v1"
-    ensureOnCanvas="true"
   >
     <title>v1.text</title>
     <svg

--- a/diagrams/small-graph-disjoint-rects-small-canvas.svg
+++ b/diagrams/small-graph-disjoint-rects-small-canvas.svg
@@ -11,7 +11,6 @@
     stroke-linecap="butt"
     rx="0"
     transform="rotate(0, 0, 0)"
-    ensureOnCanvas="true"
   >
     <title>global.box</title>
   </rect>
@@ -27,14 +26,12 @@
     stroke-linecap="butt"
     rx="0"
     transform="rotate(0, 100.77054149395585, -1.5441349494034284)"
-    ensureOnCanvas="true"
   >
     <title>v5.shape</title>
   </rect>
   <g
     transform="rotate(0, 142.07299149395584, 69.62586505059657)translate(142.07299149395584, 69.62586505059657)"
     string="v5"
-    ensureOnCanvas="true"
   >
     <title>v5.text</title>
     <svg
@@ -88,14 +85,12 @@
     stroke-linecap="butt"
     rx="0"
     transform="rotate(0, 200.66150990544216, -1.5441314880732762)"
-    ensureOnCanvas="true"
   >
     <title>v4.shape</title>
   </rect>
   <g
     transform="rotate(0, 241.96395990544215, 69.62586851192673)translate(241.96395990544215, 69.62586851192673)"
     string="v4"
-    ensureOnCanvas="true"
   >
     <title>v4.text</title>
     <svg
@@ -149,14 +144,12 @@
     stroke-linecap="butt"
     rx="0"
     transform="rotate(0, 300.5524889713203, 24.654375851897072)"
-    ensureOnCanvas="true"
   >
     <title>v3.shape</title>
   </rect>
   <g
     transform="rotate(0, 341.85493897132034, 95.82437585189707)translate(341.85493897132034, 95.82437585189707)"
     string="v3"
-    ensureOnCanvas="true"
   >
     <title>v3.text</title>
     <svg
@@ -210,14 +203,12 @@
     stroke-linecap="butt"
     rx="0"
     transform="rotate(0, 0.879491610254604, -1.5394722983692617)"
-    ensureOnCanvas="true"
   >
     <title>v2.shape</title>
   </rect>
   <g
     transform="rotate(0, 42.181941610254604, 69.63052770163074)translate(42.181941610254604, 69.63052770163074)"
     string="v2"
-    ensureOnCanvas="true"
   >
     <title>v2.text</title>
     <svg
@@ -271,14 +262,12 @@
     stroke-linecap="butt"
     rx="0"
     transform="rotate(0, 0.9615234561867396, 142.71663886569024)"
-    ensureOnCanvas="true"
   >
     <title>v1.shape</title>
   </rect>
   <g
     transform="rotate(0, 142.26397345618673, 213.88663886569023)translate(142.26397345618673, 213.88663886569023)"
     string="v1"
-    ensureOnCanvas="true"
   >
     <title>v1.text</title>
     <svg

--- a/diagrams/small-graph-disjoint-rects.svg
+++ b/diagrams/small-graph-disjoint-rects.svg
@@ -11,7 +11,6 @@
     stroke-linecap="butt"
     rx="0"
     transform="rotate(0, -50, 50)"
-    ensureOnCanvas="true"
   >
     <title>global.box</title>
   </rect>
@@ -27,14 +26,12 @@
     stroke-linecap="butt"
     rx="0"
     transform="rotate(0, 216.97884725126227, 53.074661711222035)"
-    ensureOnCanvas="true"
   >
     <title>v5.shape</title>
   </rect>
   <g
     transform="rotate(0, 258.2812972512623, 124.24466171122204)translate(258.2812972512623, 124.24466171122204)"
     string="v5"
-    ensureOnCanvas="true"
   >
     <title>v5.text</title>
     <svg
@@ -88,14 +85,12 @@
     stroke-linecap="butt"
     rx="0"
     transform="rotate(0, 517.7880353404739, 57.77516495168106)"
-    ensureOnCanvas="true"
   >
     <title>v4.shape</title>
   </rect>
   <g
     transform="rotate(0, 559.090485340474, 128.94516495168105)translate(559.090485340474, 128.94516495168105)"
     string="v4"
-    ensureOnCanvas="true"
   >
     <title>v4.text</title>
     <svg
@@ -149,14 +144,12 @@
     stroke-linecap="butt"
     rx="0"
     transform="rotate(0, 698.9999984070421, 61.07128387284891)"
-    ensureOnCanvas="true"
   >
     <title>v3.shape</title>
   </rect>
   <g
     transform="rotate(0, 740.3024484070421, 132.2412838728489)translate(740.3024484070421, 132.2412838728489)"
     string="v3"
-    ensureOnCanvas="true"
   >
     <title>v3.text</title>
     <svg
@@ -210,14 +203,12 @@
     stroke-linecap="butt"
     rx="0"
     transform="rotate(0, 53.417286250797815, 241.93314433292903)"
-    ensureOnCanvas="true"
   >
     <title>v2.shape</title>
   </rect>
   <g
     transform="rotate(0, 94.71973625079781, 313.10314433292905)translate(94.71973625079781, 313.10314433292905)"
     string="v2"
-    ensureOnCanvas="true"
   >
     <title>v2.text</title>
     <svg
@@ -271,14 +262,12 @@
     stroke-linecap="butt"
     rx="0"
     transform="rotate(0, 1.000240930416112, 486.07861294262057)"
-    ensureOnCanvas="true"
   >
     <title>v1.shape</title>
   </rect>
   <g
     transform="rotate(0, 242.3026909304161, 557.2486129426205)translate(242.3026909304161, 557.2486129426205)"
     string="v1"
-    ensureOnCanvas="true"
   >
     <title>v1.text</title>
     <svg

--- a/diagrams/tree-venn-3d.svg
+++ b/diagrams/tree-venn-3d.svg
@@ -1,8 +1,6 @@
 <svg version="1.2" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 800 700">
   <g
     transform="rotate(0, 149.12506440144062, 0.05698010310487689)translate(149.12506440144062, 0.05698010310487689)"
-    name="A.shadow"
-    ensureOnCanvas="true"
   >
     <svg
       xmlns="http://www.w3.org/2000/svg"
@@ -41,8 +39,6 @@
   </g>
   <g
     transform="rotate(0, 152.77911819629708, 2.005808793694996)translate(152.77911819629708, 2.005808793694996)"
-    name="A.shading"
-    ensureOnCanvas="true"
   >
     <svg
       xmlns="http://www.w3.org/2000/svg"
@@ -91,14 +87,12 @@
     cy="245.6093951174562"
     stroke="none"
     r="243.6035863237612"
-    ensureOnCanvas="true"
   >
     <title>A.shape</title>
   </circle>
   <g
     transform="rotate(0, 335.2667371598729, 184.71530235722523)translate(335.2667371598729, 184.71530235722523)"
     string="A"
-    ensureOnCanvas="true"
   >
     <title>A.text</title>
     <svg
@@ -136,8 +130,6 @@
   </g>
   <g
     transform="rotate(0, 254.81265014091855, 304.933374108782)translate(254.81265014091855, 304.933374108782)"
-    name="C.shadow"
-    ensureOnCanvas="true"
   >
     <svg
       xmlns="http://www.w3.org/2000/svg"
@@ -176,8 +168,6 @@
   </g>
   <g
     transform="rotate(0, 255.82672020565468, 305.4742114766412)translate(255.82672020565468, 305.4742114766412)"
-    name="C.shading"
-    ensureOnCanvas="true"
   >
     <svg
       xmlns="http://www.w3.org/2000/svg"
@@ -226,14 +216,12 @@
     cy="373.0788824590486"
     stroke="none"
     r="67.6046709824074"
-    ensureOnCanvas="true"
   >
     <title>C.shape</title>
   </circle>
   <g
     transform="rotate(0, 307.42369233784433, 356.3993080350703)translate(307.42369233784433, 356.3993080350703)"
     string="C"
-    ensureOnCanvas="true"
   >
     <title>C.text</title>
     <svg
@@ -271,8 +259,6 @@
   </g>
   <g
     transform="rotate(0, 278.5569876594177, 318.13448909223274)translate(278.5569876594177, 318.13448909223274)"
-    name="G.shadow"
-    ensureOnCanvas="true"
   >
     <svg
       xmlns="http://www.w3.org/2000/svg"
@@ -311,8 +297,6 @@
   </g>
   <g
     transform="rotate(0, 278.8571110090506, 318.2945548787036)translate(278.8571110090506, 318.2945548787036)"
-    name="G.shading"
-    ensureOnCanvas="true"
   >
     <svg
       xmlns="http://www.w3.org/2000/svg"
@@ -361,14 +345,12 @@
     cy="338.30277818756196"
     stroke="none"
     r="20.00822330885834"
-    ensureOnCanvas="true"
   >
     <title>G.shape</title>
   </circle>
   <g
     transform="rotate(0, 293.86326559441346, 333.343141865327)translate(293.86326559441346, 333.343141865327)"
     string="G"
-    ensureOnCanvas="true"
   >
     <title>G.text</title>
     <svg
@@ -406,8 +388,6 @@
   </g>
   <g
     transform="rotate(0, 321.21072226003946, 314.3870158784112)translate(321.21072226003946, 314.3870158784112)"
-    name="F.shadow"
-    ensureOnCanvas="true"
   >
     <svg
       xmlns="http://www.w3.org/2000/svg"
@@ -446,8 +426,6 @@
   </g>
   <g
     transform="rotate(0, 321.51150154595496, 314.5474314975661)translate(321.51150154595496, 314.5474314975661)"
-    name="F.shading"
-    ensureOnCanvas="true"
   >
     <svg
       xmlns="http://www.w3.org/2000/svg"
@@ -496,14 +474,12 @@
     cy="334.5993838919341"
     stroke="none"
     r="20.051952394367994"
-    ensureOnCanvas="true"
   >
     <title>F.shape</title>
   </circle>
   <g
     transform="rotate(0, 336.3486316399235, 329.67512767591006)translate(336.3486316399235, 329.67512767591006)"
     string="F"
-    ensureOnCanvas="true"
   >
     <title>F.text</title>
     <svg
@@ -541,8 +517,6 @@
   </g>
   <g
     transform="rotate(0, 382.8369948897035, 353.8058325825915)translate(382.8369948897035, 353.8058325825915)"
-    name="B.shadow"
-    ensureOnCanvas="true"
   >
     <svg
       xmlns="http://www.w3.org/2000/svg"
@@ -581,8 +555,6 @@
   </g>
   <g
     transform="rotate(0, 383.7597242606488, 354.2979549137624)translate(383.7597242606488, 354.2979549137624)"
-    name="B.shading"
-    ensureOnCanvas="true"
   >
     <svg
       xmlns="http://www.w3.org/2000/svg"
@@ -631,14 +603,12 @@
     cy="415.8132463101179"
     stroke="none"
     r="61.515291396355515"
-    ensureOnCanvas="true"
   >
     <title>B.shape</title>
   </circle>
   <g
     transform="rotate(0, 430.4475600280418, 400.78128541269)translate(430.4475600280418, 400.78128541269)"
     string="B"
-    ensureOnCanvas="true"
   >
     <title>B.text</title>
     <svg
@@ -676,8 +646,6 @@
   </g>
   <g
     transform="rotate(0, 390.1476054099487, 384.680724131423)translate(390.1476054099487, 384.680724131423)"
-    name="E.shadow"
-    ensureOnCanvas="true"
   >
     <svg
       xmlns="http://www.w3.org/2000/svg"
@@ -716,8 +684,6 @@
   </g>
   <g
     transform="rotate(0, 390.44760367833635, 384.84072320789636)translate(390.44760367833635, 384.84072320789636)"
-    name="E.shading"
-    ensureOnCanvas="true"
   >
     <svg
       xmlns="http://www.w3.org/2000/svg"
@@ -766,14 +732,12 @@
     cy="404.8406077670693"
     stroke="none"
     r="19.99988455917291"
-    ensureOnCanvas="true"
   >
     <title>E.shape</title>
   </circle>
   <g
     transform="rotate(0, 405.0943627607588, 399.33735288897907)translate(405.0943627607588, 399.33735288897907)"
     string="E"
-    ensureOnCanvas="true"
   >
     <title>E.text</title>
     <svg
@@ -811,8 +775,6 @@
   </g>
   <g
     transform="rotate(0, 461.1992506717864, 391.14483724243155)translate(461.1992506717864, 391.14483724243155)"
-    name="D.shadow"
-    ensureOnCanvas="true"
   >
     <svg
       xmlns="http://www.w3.org/2000/svg"
@@ -851,8 +813,6 @@
   </g>
   <g
     transform="rotate(0, 461.4993423129691, 391.304886117729)translate(461.4993423129691, 391.304886117729)"
-    name="D.shading"
-    ensureOnCanvas="true"
   >
     <svg
       xmlns="http://www.w3.org/2000/svg"
@@ -901,14 +861,12 @@
     cy="411.31099552990725"
     stroke="none"
     r="20.006109412178258"
-    ensureOnCanvas="true"
   >
     <title>D.shape</title>
   </circle>
   <g
     transform="rotate(0, 476.5634122102169, 406.1799548584155)translate(476.5634122102169, 406.1799548584155)"
     string="D"
-    ensureOnCanvas="true"
   >
     <title>D.text</title>
     <svg

--- a/diagrams/tree-venn.svg
+++ b/diagrams/tree-venn.svg
@@ -6,7 +6,6 @@
     cy="408.28508092368395"
     stroke="none"
     r="276.8530657797345"
-    ensureOnCanvas="true"
   >
     <title>A.icon</title>
   </circle>
@@ -17,7 +16,6 @@
     cy="391.44962562078734"
     stroke="none"
     r="102.29097188972086"
-    ensureOnCanvas="true"
   >
     <title>C.icon</title>
   </circle>
@@ -28,14 +26,12 @@
     cy="428.61096134694526"
     stroke="none"
     r="32.9906223439819"
-    ensureOnCanvas="true"
   >
     <title>G.icon</title>
   </circle>
   <g
     transform="rotate(0, 393.39428562136584, 413.2835741171541)translate(393.39428562136584, 413.2835741171541)"
     string="G"
-    ensureOnCanvas="true"
   >
     <title>G.text</title>
     <svg
@@ -78,14 +74,12 @@
     cy="353.9406554497937"
     stroke="none"
     r="31.542928697341104"
-    ensureOnCanvas="true"
   >
     <title>F.icon</title>
   </circle>
   <g
     transform="rotate(0, 392.1257749008922, 338.71840582746444)translate(392.1257749008922, 338.71840582746444)"
     string="F"
-    ensureOnCanvas="true"
   >
     <title>F.text</title>
     <svg
@@ -128,7 +122,6 @@
     cy="278.4329865929171"
     stroke="none"
     r="113.63856076451177"
-    ensureOnCanvas="true"
   >
     <title>B.icon</title>
   </circle>
@@ -139,14 +132,12 @@
     cy="335.4609653074101"
     stroke="none"
     r="36.742533958244685"
-    ensureOnCanvas="true"
   >
     <title>E.icon</title>
   </circle>
   <g
     transform="rotate(0, 559.2583356218165, 320.12430898702706)translate(559.2583356218165, 320.12430898702706)"
     string="E"
-    ensureOnCanvas="true"
   >
     <title>E.text</title>
     <svg
@@ -189,14 +180,12 @@
     cy="273.949071096277"
     stroke="none"
     r="30.770461226133392"
-    ensureOnCanvas="true"
   >
     <title>D.icon</title>
   </circle>
   <g
     transform="rotate(0, 522.1416166564886, 258.61220471817404)translate(522.1416166564886, 258.61220471817404)"
     string="D"
-    ensureOnCanvas="true"
   >
     <title>D.text</title>
     <svg
@@ -235,7 +224,6 @@
   <g
     transform="rotate(0, 341.28769123417646, 376.1267735758373)translate(341.28769123417646, 376.1267735758373)"
     string="C"
-    ensureOnCanvas="true"
   >
     <title>C.text</title>
     <svg
@@ -274,7 +262,6 @@
   <g
     transform="rotate(0, 599.7068245657263, 263.13323540542194)translate(599.7068245657263, 263.13323540542194)"
     string="B"
-    ensureOnCanvas="true"
   >
     <title>B.text</title>
     <svg
@@ -313,7 +300,6 @@
   <g
     transform="rotate(0, 510.0777683723065, 393.00004347058206)translate(510.0777683723065, 393.00004347058206)"
     string="A"
-    ensureOnCanvas="true"
   >
     <title>A.text</title>
     <svg

--- a/diagrams/two-vectors-perp-vectors-dashed.svg
+++ b/diagrams/two-vectors-perp-vectors-dashed.svg
@@ -1,5 +1,5 @@
 <svg version="1.2" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 800 700">
-  <g ensureOnCanvas="true">
+  <g>
     <filter
       id="$LOCAL_block6_subst0.perpMark-shadow"
       x="0"
@@ -32,7 +32,7 @@
     ></path>
     <title>$LOCAL_block6_subst0.perpMark</title>
   </g>
-  <g ensureOnCanvas="true">
+  <g>
     <marker
       id="v.arrow-leftArrowhead"
       markerUnits="strokeWidth"
@@ -76,7 +76,7 @@
     ></path>
     <title>v.arrow</title>
   </g>
-  <g style="solid" ensureOnCanvas="true">
+  <g style="solid">
     <marker
       id="V.yAxis-leftArrowhead"
       markerUnits="strokeWidth"
@@ -120,7 +120,7 @@
     ></path>
     <title>V.yAxis</title>
   </g>
-  <g style="solid" ensureOnCanvas="true">
+  <g style="solid">
     <marker
       id="V.xAxis-leftArrowhead"
       markerUnits="strokeWidth"
@@ -167,7 +167,6 @@
   <g
     transform="rotate(0, 316.63631178457103, 177.84064714442584)translate(316.63631178457103, 177.84064714442584)"
     string="v"
-    ensureOnCanvas="true"
   >
     <title>v.text</title>
     <svg
@@ -203,7 +202,7 @@
       </g>
     </svg>
   </g>
-  <g ensureOnCanvas="true">
+  <g>
     <marker
       id="u.arrow-leftArrowhead"
       markerUnits="strokeWidth"
@@ -250,7 +249,6 @@
   <g
     transform="rotate(0, 562.698922747047, 261.1244122596918)translate(562.698922747047, 261.1244122596918)"
     string="u"
-    ensureOnCanvas="true"
   >
     <title>u.text</title>
     <svg
@@ -289,7 +287,6 @@
   <g
     transform="rotate(0, 218.20973, 166.17)translate(218.20973, 166.17)"
     string="V"
-    ensureOnCanvas="true"
   >
     <title>V.text</title>
     <svg
@@ -334,7 +331,6 @@
     stroke="none"
     rx="0"
     transform="rotate(0, 225, 175)"
-    ensureOnCanvas="true"
   >
     <title>V.background</title>
   </rect>

--- a/packages/core/src/renderer/AttrHelper.ts
+++ b/packages/core/src/renderer/AttrHelper.ts
@@ -30,7 +30,11 @@ export const attrAutoFillSvg = (
   attrAlreadyMapped: string[]
 ): void => {
   // Internal properties to never auto-map to SVG
-  const attrToNeverAutoMap: string[] = ["strokeStyle"];
+  const attrToNeverAutoMap: string[] = [
+    "strokeStyle",
+    "name",
+    "ensureOnCanvas",
+  ];
 
   // Merge the mapped and never-map properties.  Convert to Set
   const attrToNotAutoMap = new Set<string>(
@@ -39,7 +43,11 @@ export const attrAutoFillSvg = (
 
   // Map unknown/unseen attributes with values to SVG output.
   // This is the "escape hatch" for properties we don't support.
-  // NOTE: `style` is handled as a special case, because some of the built-in properties will write to it __and__ the user should be able to append to it. Therefore, we check if there's an existing value in `style` and append to it if true.
+  //
+  // NOTE: `style` is handled as a special case, because some of
+  // the built-in properties will write to it __and__ the user
+  // should be able to append to it. Therefore, we check if there's
+  // an existing value in `style` and append to it if true.
   for (const propName in properties) {
     const propValue: string = properties[propName].contents.toString();
 


### PR DESCRIPTION
# Description

Fixes issue #1024 

This year we added svg-passthrough functionality, which allows unknown properties to be passed through to the SVG output.  Around this time, we also renamed most internal Style properties to correspond with the SVG names so most properties could flow right through the renderer into the SVG.  This approach eliminated code and make life easier for the Style developer who happens to already be familiar with SVG.

The tradeoff is that we sometimes have properties that are purely internal that we do not want to "leak" into the SVG.  This is implemented as an exclusion list in AttrHelper.ts.  Issue #1024 observes leakage of two internal-only properties, `name` and `ensureOnCanvas`.  This PR adds these two properties to the exclusion list to elide them from the SVG output.

# Implementation strategy and design decisions

Updated exclusion list in AttrHelper.ts.  Updated the rendered diagram set, which now lacks the `name` and `ensureOnCanvas` properties in the SVG output.  This diagram set is the current means by which we catch unintended changes to rendered properties.  

# Checklist

- [X] I have commented my code, particularly in hard-to-understand areas
- [X] My changes generate no new ESLint warnings
- [X] I have reviewed any generated changes to the `diagrams/` folder
