### PR TITLE
test: Replace fail with throw Error

### DIFF
--- a/packages/core/src/__tests__/overall.test.ts
+++ b/packages/core/src/__tests__/overall.test.ts
@@ -35,14 +35,14 @@ describe("Determinism", () => {
   test("with initial optimization", async () => {
     const resCompile = compileTrio({ substance, style, domain, variation });
     if (resCompile.isErr()) {
-      fail(showError(resCompile.error));
+      throw Error(showError(resCompile.error));
     }
     const stateSample1NotOpt = await prepareState(resCompile.value);
     const svgSample1NotOpt = await render(stateSample1NotOpt);
 
     const resSample1Opt = stepUntilConvergence(stateSample1NotOpt);
     if (resSample1Opt.isErr()) {
-      fail(showError(resSample1Opt.error));
+      throw Error(showError(resSample1Opt.error));
     }
     const stateSample1Opt = resSample1Opt.value;
     const svgSample1Opt = await render(stateSample1Opt);
@@ -52,7 +52,7 @@ describe("Determinism", () => {
 
     const resSample2Opt = stepUntilConvergence(stateSample2NotOpt);
     if (resSample2Opt.isErr()) {
-      fail(showError(resSample2Opt.error));
+      throw Error(showError(resSample2Opt.error));
     }
     const stateSample2Opt = resSample2Opt.value;
     const svgSample2Opt = await render(stateSample2Opt);
@@ -62,7 +62,7 @@ describe("Determinism", () => {
 
     const resSample3Opt = stepUntilConvergence(stateSample3NotOpt);
     if (resSample3Opt.isErr()) {
-      fail(showError(resSample3Opt.error));
+      throw Error(showError(resSample3Opt.error));
     }
     const stateSample3Opt = resSample3Opt.value;
     const svgSample3Opt = await render(stateSample3Opt);
@@ -83,7 +83,7 @@ describe("Determinism", () => {
   test("without initial optimization", async () => {
     const resCompile = compileTrio({ substance, style, domain, variation });
     if (resCompile.isErr()) {
-      fail(showError(resCompile.error));
+      throw Error(showError(resCompile.error));
     }
 
     const state1NotOpt = resample(await prepareState(resCompile.value));
@@ -91,7 +91,7 @@ describe("Determinism", () => {
 
     const resOptimize1 = stepUntilConvergence(state1NotOpt);
     if (resOptimize1.isErr()) {
-      fail(showError(resOptimize1.error));
+      throw Error(showError(resOptimize1.error));
     }
     const state1Opt = resOptimize1.value;
     const svg1Opt = await render(state1Opt);
@@ -103,7 +103,7 @@ describe("Determinism", () => {
 
     const resOptimize2 = stepUntilConvergence(state2NotOpt);
     if (resOptimize2.isErr()) {
-      fail(showError(resOptimize2.error));
+      throw Error(showError(resOptimize2.error));
     }
     const state2Opt = resOptimize2.value;
     const svg2Opt = await render(state2Opt);
@@ -128,7 +128,7 @@ describe("Energy API", () => {
       const stateEvaled = resample(await prepareState(res.value));
       const stateOpt = stepUntilConvergence(stateEvaled);
       if (stateOpt.isErr()) {
-        fail("optimization failed");
+        throw Error("optimization failed");
       }
       const stateOptimized = stateOpt.value;
       const initEng = evalEnergy(stateEvaled);
@@ -199,10 +199,10 @@ describe("Cross-instance energy eval", () => {
         };
         expect(evalEnergy(await prepareState(crossState12))).toBeGreaterThan(0);
       } else {
-        fail("optimization failed");
+        throw Error("optimization failed");
       }
     } else {
-      fail("compilation failed");
+      throw Error("compilation failed");
     }
   });
 });
@@ -225,7 +225,7 @@ describe("Run individual functions", () => {
       const stateEvaled = resample(await prepareState(res.value));
       const stateOpt = stepUntilConvergence(stateEvaled);
       if (stateOpt.isErr()) {
-        fail("optimization failed");
+        throw Error("optimization failed");
       }
       const stateOptimizedValue = stateOpt.value;
 

--- a/packages/core/src/compiler/Domain.test.ts
+++ b/packages/core/src/compiler/Domain.test.ts
@@ -32,7 +32,7 @@ const contextHas = (
     expectedFunctions.forEach((f) => expect(functions.has(f)).toBe(true));
     expectedPredicates.forEach((p) => expect(predicates.has(p)).toBe(true));
   } else {
-    fail(showError(res.error));
+    throw Error(showError(res.error));
   }
 };
 
@@ -69,7 +69,7 @@ describe("Common", () => {
       expect(isSubtype(typeA, typeC, env)).toBe(false);
       expect(isSubtype(typeA, typeB, env)).toBe(false);
     } else {
-      fail(showError(res.error));
+      throw Error(showError(res.error));
     }
   });
 });
@@ -149,7 +149,7 @@ describe("Errors", () => {
       if (printError) console.log(showError(result.error));
       expect(result.error.tag).toBe(errorType);
     } else {
-      fail(`Error ${errorType} was suppoed to occur.`);
+      throw Error(`Error ${errorType} was suppoed to occur.`);
     }
   };
   test("Parse error", () => {

--- a/packages/core/src/compiler/Style.test.ts
+++ b/packages/core/src/compiler/Style.test.ts
@@ -202,11 +202,11 @@ describe("Compiler", () => {
   //   if (selErrs.length > 0) {
   //     const err = `Could not compile. Error(s) in Style while checking selectors`;
   //     console.log([err].concat(selErrs.map((e) => showError(e))));
-  //     fail();
+  //     throw Error();
   //   }
 
   //   if (subss.length !== correctSubsts.length) {
-  //     fail();
+  //     throw Error();
   //   }
 
   //   for (const [res, expected] of _.zip(subss, correctSubsts)) {
@@ -331,7 +331,7 @@ describe("Compiler", () => {
       );
 
       if (!styRes.isOk()) {
-        fail(
+        throw Error(
           `Expected Style program to work without errors. Got error ${styRes.error.errorType}`
         );
       } else {
@@ -352,13 +352,13 @@ describe("Compiler", () => {
     if (result.isErr()) {
       const res: PenroseError = result.error;
       if (res.errorType !== "StyleError") {
-        fail(
+        throw Error(
           `Error ${errorType} was supposed to occur. Got a non-Style error '${res.errorType}'.`
         );
       }
 
       if (res.tag !== "StyleErrorList") {
-        fail(
+        throw Error(
           `Error ${errorType} was supposed to occur. Did not receive a Style list. Got ${res.tag}.`
         );
       }
@@ -369,7 +369,7 @@ describe("Compiler", () => {
 
       expect(res.errors[0].tag).toBe(errorType);
     } else {
-      fail(`Error ${errorType} was supposed to occur.`);
+      throw Error(`Error ${errorType} was supposed to occur.`);
     }
   };
 

--- a/packages/core/src/compiler/Substance.test.ts
+++ b/packages/core/src/compiler/Substance.test.ts
@@ -79,7 +79,7 @@ value X: Set
 
 const envOrError = (prog: string): Env => {
   const res = compileDomain(prog);
-  if (res.isErr()) fail(showError(res.error));
+  if (res.isErr()) throw Error(showError(res.error));
   return res.value;
 };
 
@@ -88,7 +88,7 @@ const compileOrError = (prog: string, env: Env) => {
   if (res.isOk()) {
     return res;
   } else {
-    fail(`unexpected error ${showError(res.error)}`);
+    throw Error(`unexpected error ${showError(res.error)}`);
   }
 };
 
@@ -162,7 +162,9 @@ NoLabel D, E
         expect(label.type).toEqual(type);
       });
     } else {
-      fail("Unexpected error when processing labels: " + showError(res.error));
+      throw Error(
+        "Unexpected error when processing labels: " + showError(res.error)
+      );
     }
   });
 });
@@ -223,7 +225,7 @@ B := AddPoint(p, B)
         ["p", "Point"],
       ]);
     } else {
-      fail(`unexpected error ${showError(res.error)}`);
+      throw Error(`unexpected error ${showError(res.error)}`);
     }
   });
   test("func: constructor", () => {
@@ -242,7 +244,7 @@ l := Cons(A, nil)
         ["nil", "List(Set)"],
       ]);
     } else {
-      fail(`unexpected error ${showError(res.error)}`);
+      throw Error(`unexpected error ${showError(res.error)}`);
     }
   });
   test("deconstructor: plain types", () => {
@@ -302,7 +304,7 @@ describe("Errors", () => {
       if (printError) console.log(showError(result.error));
       expect(result.error.tag).toBe(errorType);
     } else {
-      fail(`Error ${errorType} was suppoed to occur.`);
+      throw Error(`Error ${errorType} was suppoed to occur.`);
     }
   };
   test("parse error", () => {
@@ -601,6 +603,6 @@ const sameAsSource = (
     const strFromAST = prettySubstance(ast);
     expect(strFromAST).toEqual(source);
   } else {
-    fail(`unexpected error ${showError(res.error)}`);
+    throw Error(`unexpected error ${showError(res.error)}`);
   }
 };

--- a/packages/core/src/parser/StyleParser.test.ts
+++ b/packages/core/src/parser/StyleParser.test.ts
@@ -275,7 +275,7 @@ const {
       expect(stringAssign.value.contents).toEqual(
         "abs1232189y790yh97dasyhfda7fhnasopufn9"
       );
-    } else fail("First stmt is not an assignment to string");
+    } else throw Error("First stmt is not an assignment to string");
   });
 
   test("floating point expr", () => {


### PR DESCRIPTION
# Description

This is a followup to #920. As noted in https://github.com/facebook/jest/issues/11698, Jest 27 switched the default runner to one which does not include a `fail` function, but `@types/jest` doesn't reflect this: https://github.com/DefinitelyTyped/DefinitelyTyped/discussions/55803

We didn't notice this until just now while I was working on #984, because #920 itself did not cause any of our tests to `fail`. This PR fixes the issue by replacing `fail` with `throw Error`, as suggested by https://github.com/facebook/jest/issues/11698#issuecomment-922351139.

# Checklist

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new ESLint warnings
- [x] I have reviewed any generated changes to the `diagrams/` folder