### PR TITLE
feat: add debug mode setting to `@penrose/editor`

### DIFF
--- a/packages/editor/src/App.tsx
+++ b/packages/editor/src/App.tsx
@@ -56,6 +56,7 @@ export const layoutModel = Model.fromJson({
     },
     {
       type: "border",
+      className: "debugBorder",
       location: "right",
       children: [
         {

--- a/packages/editor/src/components/Settings.tsx
+++ b/packages/editor/src/components/Settings.tsx
@@ -17,6 +17,21 @@ export default function Settings() {
     <div>
       <div>
         <label>
+          debug mode{" "}
+          <input
+            type="checkbox"
+            checked={settings.contents.debugMode}
+            onChange={(e) =>
+              setSettings((state) => ({
+                ...state,
+                debugMode: e.target.checked,
+              }))
+            }
+          />
+        </label>
+      </div>
+      <div>
+        <label>
           vim mode{" "}
           <input
             type="checkbox"

--- a/packages/editor/src/state/atoms.ts
+++ b/packages/editor/src/state/atoms.ts
@@ -359,8 +359,6 @@ const settingsEffect: AtomEffect<Settings> = ({ setSelf, onSet }) => {
 };
 const debugModeEffect: AtomEffect<Settings> = ({ onSet }) => {
   onSet((newValue, _, isReset) => {
-    console.log(newValue);
-
     layoutModel.visitNodes((node) => {
       if (
         node.getType() === "border" &&


### PR DESCRIPTION
# Description

`@penrose/editor` current displays the debug tabs on the right regardless if it's in production or development mode. This PR adds an explicit "debug mode" checkbox in the "settings" tab. This option is on by default in local dev mode and off in production. Currently, checking this box will display the debug tabs on the right:

![image](https://user-images.githubusercontent.com/11740102/170787876-12fefc85-31de-4d28-9fd6-c528af8dab74.png)

Un-checking it hides them:

![image](https://user-images.githubusercontent.com/11740102/170787917-4ac1eafd-22eb-4cbf-8dce-19badf42261d.png)

If the user drags one of the tabs out of the right tab group, unchecking the box will not hide it. Not sure if it's a bug or feature:

![image](https://user-images.githubusercontent.com/11740102/170788041-b46ca49c-6ef6-49b4-b062-9c39e0369a59.png)


# Implementation strategy and design decisions

* Added a flag in `Settings`
* Added a `onSet` effect for hiding/showing the right border group


# Checklist

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new ESLint warnings
- [x] I have reviewed any generated changes to the `diagrams/` folder


