### PR TITLE
build: run `build` automatically before `install-global` in `@penrose/roger`

### DIFF
--- a/packages/roger/package.json
+++ b/packages/roger/package.json
@@ -61,7 +61,8 @@
     "postpack": "shx rm -f oclif.manifest.json",
     "prepack": "yarn build && oclif manifest && oclif readme",
     "version": "oclif readme && git add README.md",
-    "install-global": "npm link",
+    "preinstall-global": "yarn build",
+    "install-global": "yarn link",
     "clean": "rimraf dist"
   },
   "engines": {


### PR DESCRIPTION
# Description

In the [wiki](https://github.com/penrose/penrose/wiki/Building-and-running), we instructed users to run `yarn install-global` immediately after `yarn`. But `roger` also needs to build to the `dist` folder for the `watch` command to work. This PR adds a `preinstall-global` script to call `yarn build` first.

NOTE: this PR also changes from `npm link` to `yarn link` for `install-global`. If you experience issues with running `roger`. Please run `npm unlink` in `packages/roger` and run `yarn install-global` again.
