### PR TITLE
fix: Add Support for images with absolute URLs

### DIFF
--- a/packages/automator/index.tsx
+++ b/packages/automator/index.tsx
@@ -126,8 +126,12 @@ const singleProcess = async (
     // Handle absolute URLs
     if (/^(http|https):\/\/[^ "]+$/.test(filePath)) {
       const fileURL = new URL(filePath).href;
-      const fileReq = await fetch(fileURL);
-      return fileReq.text();
+      try {
+        const fileReq = await fetch(fileURL);
+        return fileReq.text();
+      } catch (e) {
+        return undefined;
+      }
     }
 
     // Relative paths

--- a/packages/automator/index.tsx
+++ b/packages/automator/index.tsx
@@ -14,6 +14,7 @@ import convertHrtime from "convert-hrtime";
 import { randomBytes } from "crypto";
 import * as fs from "fs";
 import neodoc from "neodoc";
+import fetch from "node-fetch";
 import { dirname, join, parse, resolve } from "path";
 import * as prettier from "prettier";
 import uniqid from "uniqid";
@@ -122,6 +123,14 @@ const singleProcess = async (
   const listOfCanvasData: string[] = [];
   let canvas;
   const resolvePath = async (filePath: string) => {
+    // Handle absolute URLs
+    if (/^(http|https):\/\/[^ "]+$/.test(filePath)) {
+      const fileURL = new URL(filePath).href;
+      const fileReq = await fetch(fileURL);
+      return fileReq.text();
+    }
+
+    // Relative paths
     const parentDir = parse(join(prefix, sty)).dir;
     const joined = resolve(parentDir, filePath);
     return fs.readFileSync(joined, "utf8").toString();

--- a/packages/editor/src/components/DiagramPanel.tsx
+++ b/packages/editor/src/components/DiagramPanel.tsx
@@ -135,7 +135,7 @@ export default function DiagramPanel() {
   const pathResolver = async (
     relativePath: string
   ): Promise<string | undefined> => {
-    // Handle absolute paths
+    // Handle absolute URLs
     if (/^(http|https):\/\/[^ "]+$/.test(relativePath)) {
       const fileURL = new URL(relativePath).href;
       const fileReq = await fetch(fileURL);

--- a/packages/editor/src/components/DiagramPanel.tsx
+++ b/packages/editor/src/components/DiagramPanel.tsx
@@ -135,6 +135,14 @@ export default function DiagramPanel() {
   const pathResolver = async (
     relativePath: string
   ): Promise<string | undefined> => {
+    // Handle absolute paths
+    if (/^(http|https):\/\/[^ "]+$/.test(relativePath)) {
+      const fileURL = new URL(relativePath).href;
+      const fileReq = await fetch(fileURL);
+      return fileReq.text();
+    }
+
+    // Handle relative paths
     switch (location.kind) {
       case "example": {
         const fileURL = new URL(relativePath, location.root).href;

--- a/packages/editor/src/components/DiagramPanel.tsx
+++ b/packages/editor/src/components/DiagramPanel.tsx
@@ -138,8 +138,12 @@ export default function DiagramPanel() {
     // Handle absolute URLs
     if (/^(http|https):\/\/[^ "]+$/.test(relativePath)) {
       const fileURL = new URL(relativePath).href;
-      const fileReq = await fetch(fileURL);
-      return fileReq.text();
+      try {
+        const fileReq = await fetch(fileURL);
+        return fileReq.text();
+      } catch (e) {
+        return undefined;
+      }
     }
 
     // Handle relative paths

--- a/packages/examples/src/set-theory-domain/venn-3d.sty
+++ b/packages/examples/src/set-theory-domain/venn-3d.sty
@@ -12,11 +12,11 @@ Set x {
         center : x.shape.center 
         width : x.shape.r * 2.0
         height : x.shape.r * 2.0
-        href : "shading.svg"
+        href : "https://raw.githubusercontent.com/penrose/penrose/main/packages/examples/src/set-theory-domain/shading.svg"
     }
 
     x.shadow = Image {
-        href : "shadow.svg"
+        href : "https://raw.githubusercontent.com/penrose/penrose/main/packages/examples/src/set-theory-domain/shadow.svg"
         width : x.shape.r * 2.15
         height : x.shape.r * 2.22
         center : (x.shape.center[0] + 0.03 * x.shading.width, x.shape.center[1] - 0.051 * x.shading.height)


### PR DESCRIPTION
# Description

Fixes issue #1032

This PR provides support for absolute image URLs in Style programs within the IDE and Automator.  When a URL is absolute, it is fetched directly and thus bypasses the normal example/roger/local/gist handlers.

# Implementation strategy and design decisions

Detect and handle absolute image URLs.  Only handle relative URLs using the existing logic in the IDE and Automator.

# Checklist

- [X] I have commented my code, particularly in hard-to-understand areas
- [X] My changes generate no new ESLint warnings
- [X] I have reviewed any generated changes to the `diagrams/` folder

# Open questions

- Local image fetching in the IDE is currently marked as TODO.  See issue #1035.  This needs to be implemented in a separate PR.
- Absolute image resolution in the IDE does not use a proxy to bypass CORS.  If the web server hosting the image does not provide headers indicating a cross-origin request is allowed (e.g., `Access-Control-Allow-Origin: *`) then the browser will not fulfill the request and the placeholder image will be displayed instead.
