### PR TITLE
feat: Fake 3d linear algebra examples

### DIFF
--- a/diagrams/3d-projection-fake-3d-linear-algebra.svg
+++ b/diagrams/3d-projection-fake-3d-linear-algebra.svg
@@ -1,0 +1,239 @@
+<svg version="1.2" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 5 5">
+  <g>
+    <marker
+      id="`u`.shape-leftArrowhead"
+      markerUnits="strokeWidth"
+      markerWidth="9.95"
+      markerHeight="8.12"
+      viewBox="0 0 9.95 8.12"
+      refX="2.36"
+      refY="4.06"
+      orient="auto-start-reverse"
+    >
+      <path
+        d="M9.95 4.06 0 8.12 2.36 4.06 0 0 9.95 4.06z"
+        fill="#000000"
+        fill-opacity="255"
+      ></path>
+    </marker>
+    <marker
+      id="`u`.shape-rightArrowhead"
+      markerUnits="strokeWidth"
+      markerWidth="9.95"
+      markerHeight="8.12"
+      viewBox="0 0 9.95 8.12"
+      refX="2.36"
+      refY="4.06"
+      orient="auto-start-reverse"
+    >
+      <path
+        d="M9.95 4.06 0 8.12 2.36 4.06 0 0 9.95 4.06z"
+        fill="#000000"
+        fill-opacity="255"
+      ></path>
+    </marker>
+    <path
+      d="M 2.5 2.5 L 3.711497622563123 0.07700475487375424"
+      stroke-opacity="255"
+      stroke-width="0.01"
+      stroke="#000000"
+      stroke-linecap="butt"
+      marker-end="url(#`u`.shape-rightArrowhead)"
+    ></path>
+    <title>`u`.shape</title>
+  </g>
+  <circle
+    fill="#000000"
+    fill-opacity="255"
+    cx="2.5"
+    cy="2.5"
+    stroke="none"
+    r="0.02"
+  >
+    <title>`S`.shape</title>
+  </circle>
+  <g>
+    <marker
+      id="`v`.shape-leftArrowhead"
+      markerUnits="strokeWidth"
+      markerWidth="9.95"
+      markerHeight="8.12"
+      viewBox="0 0 9.95 8.12"
+      refX="2.36"
+      refY="4.06"
+      orient="auto-start-reverse"
+    >
+      <path
+        d="M9.95 4.06 0 8.12 2.36 4.06 0 0 9.95 4.06z"
+        fill="#000000"
+        fill-opacity="255"
+      ></path>
+    </marker>
+    <marker
+      id="`v`.shape-rightArrowhead"
+      markerUnits="strokeWidth"
+      markerWidth="9.95"
+      markerHeight="8.12"
+      viewBox="0 0 9.95 8.12"
+      refX="2.36"
+      refY="4.06"
+      orient="auto-start-reverse"
+    >
+      <path
+        d="M9.95 4.06 0 8.12 2.36 4.06 0 0 9.95 4.06z"
+        fill="#000000"
+        fill-opacity="255"
+      ></path>
+    </marker>
+    <path
+      d="M 2.5 2.5 L 3.4850041790697577 3.032978714771518"
+      stroke-opacity="255"
+      stroke-width="0.01"
+      stroke="#000000"
+      stroke-linecap="butt"
+      marker-end="url(#`v`.shape-rightArrowhead)"
+    ></path>
+    <title>`v`.shape</title>
+  </g>
+  <polygon
+    fill="#bbb866"
+    fill-opacity="0.5"
+    stroke="#000000"
+    stroke-opacity="255"
+    stroke-width="0.01"
+    stroke-linecap="butt"
+    transform="scale(1)"
+    points="1.1666666666666665,3.166666666666667,0.2777777777777777,0.9444444444444444,3.8333333333333335,1.8333333333333333,4.722222222222222,4.055555555555555"
+  >
+    <title>`P`.shape</title>
+  </polygon>
+  <g>
+    <marker
+      id="`w`.shape-leftArrowhead"
+      markerUnits="strokeWidth"
+      markerWidth="9.95"
+      markerHeight="8.12"
+      viewBox="0 0 9.95 8.12"
+      refX="2.36"
+      refY="4.06"
+      orient="auto-start-reverse"
+    >
+      <path
+        d="M9.95 4.06 0 8.12 2.36 4.06 0 0 9.95 4.06z"
+        fill="#000000"
+        fill-opacity="255"
+      ></path>
+    </marker>
+    <marker
+      id="`w`.shape-rightArrowhead"
+      markerUnits="strokeWidth"
+      markerWidth="9.95"
+      markerHeight="8.12"
+      viewBox="0 0 9.95 8.12"
+      refX="2.36"
+      refY="4.06"
+      orient="auto-start-reverse"
+    >
+      <path
+        d="M9.95 4.06 0 8.12 2.36 4.06 0 0 9.95 4.06z"
+        fill="#000000"
+        fill-opacity="255"
+      ></path>
+    </marker>
+    <path
+      d="M 2.5 2.5 L 4.7419023395593705 0.6280422379705279"
+      stroke-opacity="255"
+      stroke-width="0.01"
+      stroke="#000000"
+      stroke-linecap="butt"
+      marker-end="url(#`w`.shape-rightArrowhead)"
+    ></path>
+    <title>`w`.shape</title>
+  </g>
+  <g>
+    <marker
+      id="`w`.dashed_u-leftArrowhead"
+      markerUnits="strokeWidth"
+      markerWidth="9.95"
+      markerHeight="8.12"
+      viewBox="0 0 9.95 8.12"
+      refX="2.36"
+      refY="4.06"
+      orient="auto-start-reverse"
+    >
+      <path
+        d="M9.95 4.06 0 8.12 2.36 4.06 0 0 9.95 4.06z"
+        fill="#e5dede"
+        fill-opacity="0.5"
+      ></path>
+    </marker>
+    <marker
+      id="`w`.dashed_u-rightArrowhead"
+      markerUnits="strokeWidth"
+      markerWidth="9.95"
+      markerHeight="8.12"
+      viewBox="0 0 9.95 8.12"
+      refX="2.36"
+      refY="4.06"
+      orient="auto-start-reverse"
+    >
+      <path
+        d="M9.95 4.06 0 8.12 2.36 4.06 0 0 9.95 4.06z"
+        fill="#e5dede"
+        fill-opacity="0.5"
+      ></path>
+    </marker>
+    <path
+      d="M 3.7478113665177197 0.004377266964560977 L 4.804231208237483 0.5759984859026124"
+      stroke-opacity="0.5"
+      stroke-width="0.01"
+      stroke="#e5dede"
+      stroke-dasharray="7,5"
+      stroke-linecap="butt"
+    ></path>
+    <title>`w`.dashed_u</title>
+  </g>
+  <g>
+    <marker
+      id="`w`.dashed_v-leftArrowhead"
+      markerUnits="strokeWidth"
+      markerWidth="9.95"
+      markerHeight="8.12"
+      viewBox="0 0 9.95 8.12"
+      refX="2.36"
+      refY="4.06"
+      orient="auto-start-reverse"
+    >
+      <path
+        d="M9.95 4.06 0 8.12 2.36 4.06 0 0 9.95 4.06z"
+        fill="#cbd7bb"
+        fill-opacity="0.5"
+      ></path>
+    </marker>
+    <marker
+      id="`w`.dashed_v-rightArrowhead"
+      markerUnits="strokeWidth"
+      markerWidth="9.95"
+      markerHeight="8.12"
+      viewBox="0 0 9.95 8.12"
+      refX="2.36"
+      refY="4.06"
+      orient="auto-start-reverse"
+    >
+      <path
+        d="M9.95 4.06 0 8.12 2.36 4.06 0 0 9.95 4.06z"
+        fill="#cbd7bb"
+        fill-opacity="0.5"
+      ></path>
+    </marker>
+    <path
+      d="M 3.556419841719763 3.0716212189380516 L 4.804231208237483 0.5759984859026124"
+      stroke-opacity="0.5"
+      stroke-width="0.01"
+      stroke="#cbd7bb"
+      stroke-dasharray="7,5"
+      stroke-linecap="butt"
+    ></path>
+    <title>`w`.dashed_v</title>
+  </g>
+</svg>

--- a/packages/examples/src/fake-3d-linear-algebra/fake3d.dsl
+++ b/packages/examples/src/fake-3d-linear-algebra/fake3d.dsl
@@ -1,0 +1,11 @@
+type AmbientSpace
+type Hyperplane
+type Vector
+
+predicate HyperplaneInAmbientSpace(Hyperplane, AmbientSpace)
+predicate VectorInAmbientSpace(Vector, AmbientSpace)
+predicate VectorInHyperplane(Vector, Hyperplane, AmbientSpace)
+predicate VectorOrthogonalToHyperplane(Vector, Hyperplane, AmbientSpace)
+predicate VectorOrthogonalToVector(Vector, Vector, AmbientSpace)
+
+function addV(Vector, Vector) -> Vector

--- a/packages/examples/src/fake-3d-linear-algebra/fake3d.sty
+++ b/packages/examples/src/fake-3d-linear-algebra/fake3d.sty
@@ -1,0 +1,97 @@
+canvas {
+    width = 5
+    height = 5
+}
+
+forall AmbientSpace S {
+    S.origin = (0., 0., 0.)
+    S.vp = (0.5, 1, 1) -- viewpoint
+    S.origin_proj_vp = S.origin - (dot(S.origin, S.vp) / normsq(S.vp)) * S.vp
+    S.origin_proj_2d = (S.origin_proj_vp[0], S.origin_proj_vp[1])
+    S.shape = Circle {
+      center : S.origin_proj_2d
+      r : .02
+      fillColor : rgba(0, 0, 0, 255)
+    }
+}
+
+forall Hyperplane P; AmbientSpace S
+where HyperplaneInAmbientSpace(P, S) {
+    P.normal_vector = (0, 0, 1)
+
+    vec3 vertex1 = (-2, -2, 0)
+    vec3 vertex2 = (-2, 2, 0)
+    vec3 vertex3 = (2, 2, 0)
+    vec3 vertex4 = (2, -2, 0)
+
+    vec3 vertex1_o = vertex1 - (dot(vertex1, P.normal_vector) / normsq(P.normal_vector)) * P.normal_vector
+    vec3 vertex2_o = vertex2 - (dot(vertex2, P.normal_vector) / normsq(P.normal_vector)) * P.normal_vector
+    vec3 vertex3_o = vertex3 - (dot(vertex3, P.normal_vector) / normsq(P.normal_vector)) * P.normal_vector
+    vec3 vertex4_o = vertex4 - (dot(vertex4, P.normal_vector) / normsq(P.normal_vector)) * P.normal_vector
+
+    vec3 vertex1_proj_vp = vertex1_o - (dot(vertex1_o, S.vp) / normsq(S.vp)) * S.vp
+    vec3 vertex2_proj_vp = vertex2_o - (dot(vertex2_o, S.vp) / normsq(S.vp)) * S.vp
+    vec3 vertex3_proj_vp = vertex3_o - (dot(vertex3_o, S.vp) / normsq(S.vp)) * S.vp
+    vec3 vertex4_proj_vp = vertex4_o - (dot(vertex4_o, S.vp) / normsq(S.vp)) * S.vp
+
+  P.shape = Polygon {
+    strokeWidth : .01
+    strokeColor : rgba(0., 0., 0., 255.)
+    points : [(vertex1_proj_vp[0], vertex1_proj_vp[1]), (vertex2_proj_vp[0], vertex2_proj_vp[1]), (vertex3_proj_vp[0], vertex3_proj_vp[1]), (vertex4_proj_vp[0], vertex4_proj_vp[1])]
+  }
+}
+
+forall Vector v; AmbientSpace S
+where VectorInAmbientSpace(v, S) {
+  v.vec = (?, ?, ?)
+
+  vec3 vec_endpoint_proj_vp = v.vec - (dot(v.vec, S.vp) / normsq(S.vp)) * S.vp
+
+  v.shape = Line {
+    start: S.origin_proj_2d
+    end: (vec_endpoint_proj_vp[0], vec_endpoint_proj_vp[1])
+    strokeWidth : 0.01
+    endArrowhead : true
+    strokeColor : rgba(0, 0, 0, 255.)
+  }
+}
+
+forall Vector v; Hyperplane P; AmbientSpace S
+where VectorInHyperplane(v, P, S) {
+  ensure inRange(v.vec[0], -2, 2)
+  ensure inRange(v.vec[1], -2, 2)
+  ensure equal(v.vec[2], 0)
+  ensure equal(dot(v.vec, P.normal_vector), 0)
+}
+
+forall Vector v; Hyperplane P; AmbientSpace S
+where VectorOrthogonalToHyperplane(v, P, S) {
+  scalar multiplier = ?
+  override v.vec = multiplier * P.normal_vector
+  encourage repel(v.shape, S.shape, 0.01)
+}
+
+forall Vector v; Vector u; AmbientSpace S
+where VectorOrthogonalToVector(v, u, S) {
+  encourage nonDegenerateAngle(v.shape, S.shape, u.shape, 500)
+}
+
+forall Vector u; Vector v; Vector w; AmbientSpace S
+where w := addV(u, v); VectorInAmbientSpace(u, S); VectorInAmbientSpace(v, S); VectorInAmbientSpace(w, S) {
+  override w.vec = u.vec + v.vec
+
+  w.dashed_u = Line {
+    start: v.shape.end
+    end: w.shape.end
+    endArrowhead : false
+    strokeStyle : "dashed"
+    strokeWidth : .01
+  }
+  w.dashed_v = Line {
+    start: u.shape.end
+    end: w.shape.end
+    endArrowhead : false
+    strokeStyle : "dashed"
+    strokeWidth : .01
+  }
+}

--- a/packages/examples/src/fake-3d-linear-algebra/projection.sub
+++ b/packages/examples/src/fake-3d-linear-algebra/projection.sub
@@ -1,0 +1,22 @@
+AmbientSpace S
+
+Hyperplane P
+
+HyperplaneInAmbientSpace(P, S)
+
+Vector v
+
+VectorInAmbientSpace(v, S)
+VectorInHyperplane(v, P, S)
+
+Vector u
+
+VectorInAmbientSpace(u, S)
+VectorOrthogonalToHyperplane(u, P, S)
+VectorOrthogonalToVector(u, v, S)
+
+Vector w := addV(v, u)
+VectorInAmbientSpace(w, S)
+
+
+AutoLabel All

--- a/packages/examples/src/registry.json
+++ b/packages/examples/src/registry.json
@@ -162,6 +162,12 @@
       "style": "shape-distance",
       "domain": "shape-distance",
       "variation": "GalapagosLocust418"
+    },
+    {
+      "substance": "3d-projection",
+      "style": "fake-3d-linear-algebra",
+      "domain": "fake-3d-linear-algebra",
+      "variation": "ConceptualMeerkat694"
     }
   ],
   "domains": {
@@ -212,6 +218,10 @@
     "shape-distance": {
       "name": "Signed Distance Function",
       "URI": "shape-distance/shapes.dsl"
+    },
+    "fake-3d-linear-algebra": {
+      "name": "Fake 3d Linear Algebra",
+      "URI": "fake-3d-linear-algebra/fake3d.dsl"
     }
   },
   "styles": {
@@ -308,6 +318,11 @@
       "domain": "shape-distance",
       "name": "Sign Distance Functions",
       "URI": "shape-distance/shape-distance.sty"
+    },
+    "fake-3d-linear-algebra": {
+      "domain": "fake-3d-linear-algebra",
+      "name": "Fake 3d Linear Algebra",
+      "URI": "fake-3d-linear-algebra/fake3d.sty"
     }
   },
   "substances": {
@@ -430,6 +445,11 @@
       "domain": "shape-distance",
       "name": "Points around a Line",
       "URI": "shape-distance/hundred-points-around-line.sub"
+    },
+    "3d-projection": {
+      "domain": "fake-3d-linear-algebra",
+      "name": "Projection onto Subspace and its Orthogonal Complement",
+      "URI": "fake-3d-linear-algebra/projection.sub"
     }
   }
 }


### PR DESCRIPTION
DSL and STY files that can draw rudimentary pseudo-3d diagrams from linear algebra, projected onto a 2d viewing surface. In particular, we include an illustration of a projection of a 3d vector onto a 2d hyperplane in a 3d ambient space, as well as onto the hyperplane's orthogonal complement.