### PR TITLE
feat: requires `forall` declarations

### DIFF
--- a/packages/core/src/compiler/Style.test.ts
+++ b/packages/core/src/compiler/Style.test.ts
@@ -280,30 +280,30 @@ describe("Compiler", () => {
       // vectors or accesspaths, but the ability to override accesspaths was
       // removed in the compiler rewrite (see the comment in the "first Style
       // compiler pass" section of `types/styleSemantics`)
-      `Object o {
+      `forall Object o {
     shape o.shape = Line {}
     -- o.shape.start[0] = 0.
 }
 `,
-      `Object o {
+      `forall Object o {
     shape o.shape = Line {
         start: (0., ?)
     }
 }`,
-      `Object o {
+      `forall Object o {
     shape o.shape = Line {
           start: (?, ?)
     }
     -- o.shape.start[0] = 0.
 }`,
-      `Object o {
+      `forall Object o {
     o.y = ?
     shape o.shape = Line {
         start: (0., o.y)
     }
 }`,
       // Set field
-      `Object o {
+      `forall Object o {
        o.f = (?, ?)
        -- o.f[0] = 0.
        o.shape = Circle {}

--- a/packages/core/src/parser/Style.ne
+++ b/packages/core/src/parser/Style.ne
@@ -142,15 +142,15 @@ header
   |  namespace {% id %}
 
 selector -> 
-    forall:? decl_patterns _ml  
+    forall decl_patterns _ml  
     {% (d) => selector(d[1], undefined, undefined) %}
-  | forall:? decl_patterns _ml select_where 
+  | forall decl_patterns _ml select_where 
     {% (d) => selector(d[1], undefined, d[3]) %} 
-  | forall:? decl_patterns _ml select_with 
+  | forall decl_patterns _ml select_with 
     {% (d) => selector(d[1], d[3], undefined)%}   
-  | forall:? decl_patterns _ml select_where select_with 
+  | forall decl_patterns _ml select_where select_with 
     {% (d) => selector(d[1], d[4], d[3]) %} 
-  | forall:? decl_patterns _ml select_with select_where 
+  | forall decl_patterns _ml select_with select_where 
     {% (d) => selector(d[1], d[3], d[4]) %} 
 
 forall -> "forall" __ {% nth(0) %}

--- a/packages/core/src/parser/StyleParser.test.ts
+++ b/packages/core/src/parser/StyleParser.test.ts
@@ -86,7 +86,7 @@ describe("Selector Grammar", () => {
     const prog = `
   -- this is a comment
 
-  Set A with Set B { 
+  forall Set A with Set B { 
 
   }
   
@@ -99,15 +99,15 @@ describe("Selector Grammar", () => {
 
   test("forall keyword", () => {
     const prog = `
-  Set B { }
+  forall Set B { }
 
   forall Set A, B { }
 
-  Set \`C\` { }
+  forall Set \`C\` { }
 
-  Set A, B { }
+  forall Set A, B { }
 
-  Set A, \`B\`; Map f
+  forall Set A, \`B\`; Map f
   {
 
   }`;
@@ -203,7 +203,7 @@ where C := intersect ( A, B, Not(f) ) ;\
     expect(parseStyle(prog).isErr()).toEqual(true);
   });
   test("cannot set subVars as aliases", () => {
-    const prog = "Set x; Set y where IsSubset(x,y) as `A` {}";
+    const prog = "forall Set x; Set y where IsSubset(x,y) as `A` {}";
     expect(parseStyle(prog).isErr()).toEqual(true);
   });
 
@@ -290,7 +290,7 @@ forall Set A, B; Map f {
 
   test("path assign with expressions", () => {
     const prog = `
-Set B {
+forall Set B {
   -- property paths
   A.circle.boolProp = true
   A.circle.boolProp1 = false

--- a/packages/examples/src/full-moon/full-moon.sty
+++ b/packages/examples/src/full-moon/full-moon.sty
@@ -59,7 +59,7 @@ forall Crater c1; Crater c2 {
     ensure disjoint(c1.icon, c2.icon, 5.0)
 }
 
-Moon m; Crater c
+forall Moon m; Crater c
 where HasCrater(m, c) {
     c.icon above m.icon
     ensure contains(m.icon, c.icon, 5.0)
@@ -128,7 +128,7 @@ forall Branch b; Moon m {
     ensure disjoint(b.icon, m.icon, 20.0)
 }
 
-Branch left; Branch right; Branch base
+forall Branch left; Branch right; Branch base
 where AreSubbranches(left, right, base) {
 
     override left.baseX = base.tipX

--- a/packages/examples/src/geometry-domain/euclidean-teaser.sty
+++ b/packages/examples/src/geometry-domain/euclidean-teaser.sty
@@ -61,7 +61,7 @@ const {
 }
 
 --Plane
-Plane p {
+forall Plane p {
   dim = 700.0
   p.text = Equation {
     center : ((dim / 2.0) - const.textPadding2, (dim / 2.0) - const.textPadding2)
@@ -84,7 +84,7 @@ Plane p {
 }
 
 --Point
-Point p {
+forall Point p {
   p.x = ?
   p.y = ?
   p.vec = (p.x, p.y)
@@ -106,7 +106,7 @@ Point p {
   ensure atDist(p.icon, p.text, const.textPadding)
 }
 
-Point p
+forall Point p
 with Plane P
 where In(p, P) {
   -- TODO: the problem is that this ensures the padding is const? Or is > padding okay?
@@ -117,7 +117,7 @@ where In(p, P) {
   p.text above P.icon
 }
 
-Point p, q, r
+forall Point p, q, r
 where Collinear(p, q, r) {
   ensure collinear(p.icon.center, q.icon.center, r.icon.center)
   encourage repel(p.icon, q.icon, const.repelWeight)
@@ -137,7 +137,7 @@ Linelike l {
   }
 }
 
-Ray r
+forall Ray r
 where r := MkRay(base, direction)
 with Point base; Point direction {
   r.start = base.vec
@@ -157,7 +157,7 @@ with Point base; Point direction {
   }
 }
 
-Line l
+forall Line l
 where l := MkLine(p, q)
 with Point p; Point q {
   l.start = p.vec
@@ -176,7 +176,7 @@ with Point p; Point q {
   }
 }
 
-Linelike l1, l2 -- should this work with rays and lines?
+forall Linelike l1, l2 -- should this work with rays and lines?
 where ParallelMarker1(l1, l2) {
   l1.tick1 = Path {
     pathData : pathFromPoints("open", chevron(l1.icon, 20., 6))
@@ -192,7 +192,7 @@ where ParallelMarker1(l1, l2) {
   }
 }
 
-Linelike l1, l2
+forall Linelike l1, l2
 where Parallel(l1, l2) {
   -- make slopes 
   l1s = (l1.icon.end[1]-l1.icon.start[1])/(l1.icon.end[0]-l1.icon.start[0]) * 10000
@@ -201,7 +201,7 @@ where Parallel(l1, l2) {
   ensure equal(l1s, l2s)
 }
 --Segment
-Segment e
+forall Segment e
 where e := MkSegment(p, q)
 with Point p; Point q {
   override e.vec = [q.x - p.x, q.y - p.y]
@@ -223,17 +223,17 @@ with Point p; Point q {
   encourage pointLineDist(q.text.center, e.icon, 30.)
 }
 
-Segment e; Plane p {
+forall Segment e; Plane p {
   e.icon above p.icon
 }
 
-Linelike s, t
+forall Linelike s, t
 where EqualLength(s, t) {
   encourage equal(vdist(s.icon.start, s.icon.end), vdist(t.icon.start, t.icon.end))
 }
 
 --TODO eventually this should also provide an equal length marker since it is bisecting the segment
-Segment s
+forall Segment s
 where s := PerpendicularBisector(s2, p)
 with Segment s2; Point p {
   override s.icon = Line {
@@ -259,7 +259,7 @@ with Segment s2; Point p {
   ensure equal(norm(s.icon.end - s.icon.start), const.rayLength)
 }
 
-Segment s
+forall Segment s
 where s := PerpendicularBisectorLabelPts(s2, p1, p2)
 with Segment s2; Point p1, p2 {
   override p2.vec = midpoint(s2.icon.start, s2.icon.end)
@@ -285,7 +285,7 @@ with Segment s2; Point p1, p2 {
 }
 
 -- NOTE: Get rid of repetition
-Linelike s, t 
+forall Linelike s, t 
 where EqualLengthMarker1(s, t) {
   override s.tick = Path {
     pathData : ticksOnLine(s.icon.start, s.icon.end, 15., 1, 10.)
@@ -304,7 +304,7 @@ where EqualLengthMarker1(s, t) {
 }
 
 -- NOTE: Get rid of repetition
-Linelike s, t 
+forall Linelike s, t 
 where EqualLengthMarker2(s, t) {
   --need slope of line, then need to equally distribute the tick marks
   override s.tick = Path {
@@ -324,7 +324,7 @@ where EqualLengthMarker2(s, t) {
 }
 
 -- NOTE: Get rid of repetition
-Linelike s, t 
+forall Linelike s, t 
 where EqualLengthMarker3(s, t) {
   --need slope of line, then need to equally distribute the tick marks
   override s.tick = Path {
@@ -344,7 +344,7 @@ where EqualLengthMarker3(s, t) {
 }
 
 --Angle
-Angle theta
+forall Angle theta
 where theta := InteriorAngle(p, q, r)
 with Point p; Point q; Point r {
   theta.p = p.vec
@@ -379,7 +379,7 @@ with Point p; Point q; Point r {
 }
 
 -- NOTE: Get rid of repetition
-Angle a, b
+forall Angle a, b
 where EqualAngleMarker1(a, b) {
   --find points from p->q, then q->r for each vector. draw vectors for each
   startA = ptOnLine(a.q, a.p, a.radius)
@@ -405,7 +405,7 @@ where EqualAngleMarker1(a, b) {
 }
 
 -- NOTE: Get rid of repetition
-Angle a, b
+forall Angle a, b
 where EqualAngleMarker2(a, b) {
   startA = ptOnLine(a.q, a.p, a.radius)
   endA = ptOnLine(a.q, a.r, a.radius)
@@ -450,7 +450,7 @@ where EqualAngleMarker2(a, b) {
 }
 
 -- NOTE: Get rid of repetition
-Angle a, b
+forall Angle a, b
 where EqualAngleMarker3(a, b) {
   startA = ptOnLine(a.q, a.p, a.radius)
   endA = ptOnLine(a.q, a.r, a.radius)
@@ -514,7 +514,7 @@ where EqualAngleMarker3(a, b) {
  }
 }
 
-Angle a, b
+forall Angle a, b
 where EqualAngle(a, b) {
   -- make sure angle a is equal to angle b
   dotA = dot(normalize(a.p - a.q), normalize(a.r - a.q))
@@ -522,12 +522,12 @@ where EqualAngle(a, b) {
   ensure equal(dotA, dotB)
 }
 
-Angle a
+forall Angle a
 where RightUnmarked(a) {
   ensure perpendicular(a.p, a.q, a.r)
 }
 
-Angle a
+forall Angle a
 where RightMarked(a) {
   --render half square path of size a.radius
   override a.mark = Path {
@@ -540,12 +540,12 @@ where RightMarked(a) {
 }
 
 -- TODO inRange NaN's
-Angle a
+forall Angle a
 where Supplementary(a) {
   ensure inRange(dot(a.p - a.q, a.r - a.q), 0, 1)
 }
 
-Triangle t; Plane P 
+forall Triangle t; Plane P 
 where t := MkTriangle(p, q, r)
 with Point p; Point q; Point r {
   t.PQ above P.icon
@@ -554,7 +554,7 @@ with Point p; Point q; Point r {
   t.icon above P.icon
 }
 
-Triangle t
+forall Triangle t
 where t := MkTriangle(p, q, r)
 with Point p; Point q; Point r {
   t.strokeWidth = 0.0
@@ -586,7 +586,7 @@ with Point p; Point q; Point r {
   ensure disjoint(r.text, t.icon)
 }
 
-Point p
+forall Point p
 where Incenter(p, T)
 with Triangle T {
   s1 = T.PQ.start
@@ -612,7 +612,7 @@ with Triangle T {
   }
 }
 
-Point p
+forall Point p
 where Circumcenter(p, T)
 with Triangle T {
   clr = setOpacity(Colors.darkpurple, 0.6)
@@ -637,7 +637,7 @@ with Triangle T {
   encourage repelPt(const.repelWeight, T.QR.start, T.RP.start)
 }
 
-Point p
+forall Point p
 where Centroid(p, T)
 with Triangle T {
   clr = setOpacity(Colors.darkpurple, 0.6)
@@ -672,7 +672,7 @@ with Triangle T {
   }
 }
 
-Point p
+forall Point p
 where Orthocenter(p, T)
 with Triangle T {
   clr = setOpacity(Colors.darkpurple, 0.6)
@@ -720,7 +720,7 @@ with Triangle T {
 
 --Rectangle
 -- -- Should the rectangle be constructed from the points, or vice versa?
-Rectangle R
+forall Rectangle R
 where R := MkRectangle(p, q, r, s)
 with Point p; Point q; Point r; Point s {
   override R.color = Colors.none
@@ -739,7 +739,7 @@ with Point p; Point q; Point r; Point s {
   -- R.icon above P.icon
 }
 
-Quadrilateral Q
+forall Quadrilateral Q
 where Q := MkQuadrilateral(p, q, r, s)
 with Point p; Point q; Point r; Point s {
   Q.p = p.icon.center
@@ -779,7 +779,7 @@ with Point p; Point q; Point r; Point s {
 }
 
 --TODO corner case shoves points far off canvas
-Quadrilateral Q
+forall Quadrilateral Q
 where Parallelogram(Q) {
   pq = (Q.q[1]-Q.p[1])/(Q.q[0]-Q.p[0]) * 10000
   rs = (Q.r[1]-Q.s[1])/(Q.r[0]-Q.s[0]) * 10000
@@ -802,7 +802,7 @@ where Parallelogram(Q) {
 }
 
 --FUNCTIONS
-Segment s
+forall Segment s
 where s := MidSegment(T, p, q)
 with Triangle T; Point p; Point q {
   override p.vec = midpoint(T.PQ.start, T.PQ.end)
@@ -816,7 +816,7 @@ with Triangle T; Point p; Point q {
   }
 }
 
-Point p
+forall Point p
 where p := MkMidpoint(l)
 with Linelike l {
   override p.vec = midpoint(l.icon.start, l.icon.end)
@@ -827,14 +827,14 @@ with Linelike l {
   ensure disjoint(l.icon, p.text)
 }
 
-Point p
+forall Point p
 where Midpoint(l, p)
 with Linelike l {
   override p.vec = midpoint(l.icon.start, l.icon.end)
 }
 
 -- TODO sometimes bisector becomes a scaled version of either side length PQ or QR of angle PQR
-Linelike s
+forall Linelike s
 where AngleBisector(a, s)
 with Angle a; Point p {
   -- first angle = p, q, end
@@ -844,7 +844,7 @@ with Angle a; Point p {
   ensure equal(dotA, dotB)
 }
 
-Circle c {
+forall Circle c {
   c.radius = const.circleRadius
   c.vec = (?, ?)
 
@@ -857,7 +857,7 @@ Circle c {
   }
 }
 
-Circle c
+forall Circle c
 where c := MkCircleR(p, q)
 with Point p, q {
   override c.radius = vdist(p.vec, q.vec)
@@ -878,7 +878,7 @@ with Point p, q {
 --   override c.radius = vdist(p.vec, q.vec) / 2
 -- }
 
-Segment s
+forall Segment s
 where s := Chord(c, p, q)
 with Circle c; Point p, q {
   override s.vec = q.vec - p.vec
@@ -896,7 +896,7 @@ with Circle c; Point p, q {
   ensure ptCircleIntersect(q.vec, c.icon)
 }
 
-Segment s
+forall Segment s
 where s := Radius(c, p)
 with Circle c; Point p {
   override s.vec = p.vec - c.vec
@@ -911,7 +911,7 @@ with Circle c; Point p {
   ensure ptCircleIntersect(p.vec, c.icon)
 }
 
-Segment s
+forall Segment s
 where s := Diameter(c, p, q)
 with Circle c; Point p, q {
   override s.vec = q.vec - p.vec
@@ -930,23 +930,23 @@ with Circle c; Point p, q {
   ensure ptCircleIntersect(q.vec, c.icon)
 }
 
-Point p
+forall Point p
 where OnCircle(c, p)
 with Circle c {
   ensure ptCircleIntersect(p.vec, c.icon)
 }
 
-Point p
+forall Point p
 where CircleCenter(c, p)
 with Circle c {
   override p.vec = c.vec
 }
 
-Ray r {
+forall Ray r {
     r.length = const.rayLength
 }
 
-Ray r
+forall Ray r
 with Angle theta; Point x; Point y; Point z
 where r := Bisector(theta); theta := InteriorAngle(y, x, z) {
   -- find the vector for the bisector ray

--- a/packages/examples/src/geometry-domain/euclidean-teaser.sty
+++ b/packages/examples/src/geometry-domain/euclidean-teaser.sty
@@ -125,7 +125,7 @@ where Collinear(p, q, r) {
 }
 
 --Linelike
-Linelike l {
+forall Linelike l {
   l.color = Colors.black
 
   l.icon = Line {

--- a/packages/examples/src/geometry-domain/euclidean.sty
+++ b/packages/examples/src/geometry-domain/euclidean.sty
@@ -58,7 +58,7 @@ const {
 }
 
 --Plane
-Plane p {
+forall Plane p {
   dim = 700.0
   p.text = Equation {
     center : ((dim / 2.0) - const.textPadding2, (dim / 2.0) - const.textPadding2)
@@ -82,7 +82,7 @@ Plane p {
 }
 
 --Point
-Point p {
+forall Point p {
   p.x = ?
   p.y = ?
   p.vec = (p.x, p.y)
@@ -105,7 +105,7 @@ Point p {
     ensure atDist(p.icon, p.text, const.textPadding)
 }
 
-Point p
+forall Point p
 with Plane P
 where In(p, P) {
   -- TODO: the problem is that this ensures the padding is const? Or is > padding okay?
@@ -117,7 +117,7 @@ where In(p, P) {
   p.text above P.icon
 }
 
-Point p, q, r
+forall Point p, q, r
 where Collinear(p, q, r) {
   ensure collinear(p.icon.center, q.icon.center, r.icon.center)
   encourage repel(p.icon, q.icon, const.repelWeight)
@@ -125,7 +125,7 @@ where Collinear(p, q, r) {
 }
 
 --Linelike
-Linelike l {
+forall Linelike l {
   l.color = Colors.black
 
   l.icon = Line {
@@ -137,7 +137,7 @@ Linelike l {
   }
 }
 
-Ray r
+forall Ray r
 where r := MkRay(base, direction)
 with Point base; Point direction {
   r.start = base.vec
@@ -158,7 +158,7 @@ with Point base; Point direction {
 
 }
 
-Line l
+forall Line l
 where l := MkLine(p, q)
 with Point p; Point q {
   l.start = p.vec
@@ -177,7 +177,7 @@ with Point p; Point q {
   }
 }
 
-Linelike l1, l2 -- should this work with rays and lines?
+forall Linelike l1, l2 -- should this work with rays and lines?
 where ParallelMarker1(l1, l2) {
   l1.tick1 = Path {
     d : pathFromPoints("open", chevron(l1.icon, 20., 6))
@@ -193,7 +193,7 @@ where ParallelMarker1(l1, l2) {
   }
 }
 
-Linelike l1, l2
+forall Linelike l1, l2
 where Parallel(l1, l2) {
   -- make slopes 
   l1s = (l1.icon.end[1]-l1.icon.start[1])/(l1.icon.end[0]-l1.icon.start[0]) * 10000
@@ -202,7 +202,7 @@ where Parallel(l1, l2) {
   ensure equal(l1s, l2s)
 }
 --Segment
-Segment e
+forall Segment e
 where e := MkSegment(p, q)
 with Point p; Point q {
   override e.vec = [q.x - p.x, q.y - p.y]
@@ -224,17 +224,17 @@ with Point p; Point q {
   encourage pointLineDist(q.text.center, e.icon, 30.)
 }
 
-Segment e; Plane p {
+forall Segment e; Plane p {
   e.icon above p.icon
 }
 
-Linelike s, t
+forall Linelike s, t
 where EqualLength(s, t) {
   encourage equal(vdist(s.icon.start, s.icon.end), vdist(t.icon.start, t.icon.end))
 }
 
 --TODO eventually this should also provide an equal length marker since it is bisecting the segment
-Segment s
+forall Segment s
 where s := PerpendicularBisector(s2, p)
 with Segment s2; Point p {
   override s.icon = Line {
@@ -258,7 +258,7 @@ with Segment s2; Point p {
   ensure perpendicular(s.icon.start, s.icon.end, s2.icon.end)
 }
 
-Segment s
+forall Segment s
 where s := PerpendicularBisectorLabelPts(s2, p1, p2)
 with Segment s2; Point p1, p2 {
   override p2.vec = midpoint(s2.icon.start, s2.icon.end)
@@ -284,7 +284,7 @@ with Segment s2; Point p1, p2 {
 }
 
 -- NOTE: Get rid of repetition
-Linelike s, t 
+forall Linelike s, t 
 where EqualLengthMarker1(s, t) {
   override s.tick = Path {
     d : ticksOnLine(s.icon.start, s.icon.end, 15., 1, 10.)
@@ -303,7 +303,7 @@ where EqualLengthMarker1(s, t) {
 }
 
 -- NOTE: Get rid of repetition
-Linelike s, t 
+forall Linelike s, t 
 where EqualLengthMarker2(s, t) {
   --need slope of line, then need to equally distribute the tick marks
   override s.tick = Path {
@@ -323,7 +323,7 @@ where EqualLengthMarker2(s, t) {
 }
 
 -- NOTE: Get rid of repetition
-Linelike s, t 
+forall Linelike s, t 
 where EqualLengthMarker3(s, t) {
   --need slope of line, then need to equally distribute the tick marks
   override s.tick = Path {
@@ -343,7 +343,7 @@ where EqualLengthMarker3(s, t) {
 }
 
 --Angle
-Angle theta
+forall Angle theta
 where theta := InteriorAngle(p, q, r)
 with Point p; Point q; Point r {
   theta.p = p.vec
@@ -369,7 +369,7 @@ with Point p; Point q; Point r {
 }
 
 -- NOTE: Get rid of repetition
-Angle a, b
+forall Angle a, b
 where EqualAngleMarker1(a, b) {
   --find points from p->q, then q->r for each vector. draw vectors for each
   startA = ptOnLine(a.q, a.p, a.radius)
@@ -395,7 +395,7 @@ where EqualAngleMarker1(a, b) {
 }
 
 -- NOTE: Get rid of repetition
-Angle a, b
+forall Angle a, b
 where EqualAngleMarker2(a, b) {
   startA = ptOnLine(a.q, a.p, a.radius)
   endA = ptOnLine(a.q, a.r, a.radius)
@@ -410,13 +410,13 @@ where EqualAngleMarker2(a, b) {
     strokeWidth : 2.0
     strokeColor : Colors.black
     fillColor: Colors.none
- }
+  }
   override b.mark = Path {
     d : arc("open", startB, endB, (b.radius, b.radius), 0, 0, sweepB)
     strokeWidth : 2.0
     strokeColor : Colors.black
     fillColor: Colors.none
- }
+  }
 
   bigR = const.bigThetaRadius
   startAbig = ptOnLine(a.q, a.p, bigR)
@@ -430,17 +430,17 @@ where EqualAngleMarker2(a, b) {
     strokeWidth : 2.0
     strokeColor : Colors.black
     fillColor: Colors.none
- }
+  }
   override b.mark2 = Path {
     d : arc("open", startBbig, endBbig, (bigR, bigR), 0, 0, sweepB)
     strokeWidth : 2.0
     strokeColor : Colors.black
     fillColor: Colors.none
- }
+  }
 }
 
 -- NOTE: Get rid of repetition
-Angle a, b
+forall Angle a, b
 where EqualAngleMarker3(a, b) {
   startA = ptOnLine(a.q, a.p, a.radius)
   endA = ptOnLine(a.q, a.r, a.radius)
@@ -495,16 +495,16 @@ where EqualAngleMarker3(a, b) {
     strokeWidth : 2.0
     strokeColor : Colors.black
     fillColor: Colors.none
- }
+  }
   override b.mark3 = Path {
     d : arc("open", startBbig, endBbig, (bigR, bigR), 0, 0, sweepB)
     strokeWidth : 2.0
     strokeColor : Colors.black
     fillColor: Colors.none
- }
+  }
 }
 
-Angle a, b
+forall Angle a, b
 where EqualAngle(a, b) {
   -- make sure angle a is equal to angle b
   dotA = dot(normalize(a.p - a.q), normalize(a.r - a.q))
@@ -512,12 +512,12 @@ where EqualAngle(a, b) {
   ensure equal(dotA, dotB)
 }
 
-Angle a
+forall Angle a
 where RightUnmarked(a) {
   ensure perpendicular(a.p, a.q, a.r)
 }
 
-Angle a
+forall Angle a
 where RightMarked(a) {
   --render half square path of size a.radius
   override a.mark = Path {
@@ -530,12 +530,12 @@ where RightMarked(a) {
 }
 
 -- TODO inRange NaN's
-Angle a
+forall Angle a
 where Supplementary(a) {
   ensure inRange(dot(a.p - a.q, a.r - a.q), 0, 1)
 }
 
-Triangle t; Plane P 
+forall Triangle t; Plane P 
 where t := MkTriangle(p, q, r)
 with Point p; Point q; Point r {
   t.PQ above P.icon
@@ -543,7 +543,7 @@ with Point p; Point q; Point r {
   t.RP above P.icon
 }
 
-Triangle t
+forall Triangle t
 where t := MkTriangle(p, q, r)
 with Point p; Point q; Point r {
   t.color = Colors.black
@@ -570,7 +570,7 @@ with Point p; Point q; Point r {
   }
 }
 
-Point p
+forall Point p
 where Incenter(p, T)
 with Triangle T {
   s1 = T.PQ.start
@@ -596,7 +596,7 @@ with Triangle T {
   }
 }
 
-Point p
+forall Point p
 where Circumcenter(p, T)
 with Triangle T {
   clr = setOpacity(Colors.darkpurple, 0.6)
@@ -621,7 +621,7 @@ with Triangle T {
   encourage repelPt(const.repelWeight, T.QR.start, T.RP.start)
 }
 
-Point p
+forall Point p
 where Centroid(p, T)
 with Triangle T {
   clr = setOpacity(Colors.darkpurple, 0.6)
@@ -656,7 +656,7 @@ with Triangle T {
   }
 }
 
-Point p
+forall Point p
 where Orthocenter(p, T)
 with Triangle T {
   clr = setOpacity(Colors.darkpurple, 0.6)
@@ -704,7 +704,7 @@ with Triangle T {
 
 --Rectangle
 -- -- Should the rectangle be constructed from the points, or vice versa?
-Rectangle R
+forall Rectangle R
 where R := MkRectangle(p, q, r, s)
 with Point p; Point q; Point r; Point s {
   override R.color = Colors.none
@@ -723,7 +723,7 @@ with Point p; Point q; Point r; Point s {
   -- R.icon above P.icon
 }
 
-Quadrilateral Q
+forall Quadrilateral Q
 where Q := MkQuadrilateral(p, q, r, s)
 with Point p; Point q; Point r; Point s {
   Q.p = p.icon.center
@@ -763,7 +763,7 @@ with Point p; Point q; Point r; Point s {
 }
 
 --TODO corner case shoves points far off canvas
-Quadrilateral Q
+forall Quadrilateral Q
 where Parallelogram(Q) {
   pq = (Q.q[1]-Q.p[1])/(Q.q[0]-Q.p[0]) * 10000
   rs = (Q.r[1]-Q.s[1])/(Q.r[0]-Q.s[0]) * 10000
@@ -786,7 +786,7 @@ where Parallelogram(Q) {
 }
 
 --FUNCTIONS
-Segment s
+forall Segment s
 where s := MidSegment(T, p, q)
 with Triangle T; Point p; Point q {
   override p.vec = midpoint(T.PQ.start, T.PQ.end)
@@ -800,20 +800,20 @@ with Triangle T; Point p; Point q {
   }
 }
 
-Point p
+forall Point p
 where p := MkMidpoint(l)
 with Linelike l {
   override p.vec = midpoint(l.icon.start, l.icon.end)
 }
 
-Point p
+forall Point p
 where Midpoint(l, p)
 with Linelike l {
   override p.vec = midpoint(l.icon.start, l.icon.end)
 }
 
 -- TODO sometimes bisector becomes a scaled version of either side length PQ or QR of angle PQR
-Linelike s
+forall Linelike s
 where AngleBisector(a, s)
 with Angle a; Point p {
   -- first angle = p, q, end
@@ -823,7 +823,7 @@ with Angle a; Point p {
   ensure equal(dotA, dotB)
 }
 
-Circle c {
+forall Circle c {
   c.radius = const.circleRadius
   c.vec = (?, ?)
 
@@ -836,7 +836,7 @@ Circle c {
   }
 }
 
-Circle c
+forall Circle c
 where c := MkCircleR(p, q)
 with Point p, q {
   override c.radius = vdist(p.vec, q.vec)
@@ -857,7 +857,7 @@ with Point p, q {
 --   override c.radius = vdist(p.vec, q.vec) / 2
 -- }
 
-Segment s
+forall Segment s
 where s := Chord(c, p, q)
 with Circle c; Point p, q {
   override s.vec = q.vec - p.vec
@@ -875,7 +875,7 @@ with Circle c; Point p, q {
   ensure ptCircleIntersect(q.vec, c.icon)
 }
 
-Segment s
+forall Segment s
 where s := Radius(c, p)
 with Circle c; Point p {
   override s.vec = p.vec - c.vec
@@ -890,7 +890,7 @@ with Circle c; Point p {
   ensure ptCircleIntersect(p.vec, c.icon)
 }
 
-Segment s
+forall Segment s
 where s := Diameter(c, p, q)
 with Circle c; Point p, q {
   override s.vec = q.vec - p.vec
@@ -909,13 +909,13 @@ with Circle c; Point p, q {
   ensure ptCircleIntersect(q.vec, c.icon)
 }
 
-Point p
+forall Point p
 where OnCircle(c, p)
 with Circle c {
   ensure ptCircleIntersect(p.vec, c.icon)
 }
 
-Point p
+forall Point p
 where CircleCenter(c, p)
 with Circle c {
   override p.vec = c.vec

--- a/packages/examples/src/graph-domain/disjoint-1d-intervals.sty
+++ b/packages/examples/src/graph-domain/disjoint-1d-intervals.sty
@@ -24,7 +24,7 @@ Colors {
 global {
 }
 
-Vertex V {
+forall Vertex V {
        len = 200.
        V.center = ?
 
@@ -74,7 +74,7 @@ Vertex V {
 --         ensure disjointIntervals(`v1`.shape, `v2`.shape)
 -- }
 
-Vertex v1; Vertex v2 {
+forall Vertex v1; Vertex v2 {
 -- Note this generates the constraints twice
         ensure disjointIntervals(v1.shape, v2.shape)
 }

--- a/packages/examples/src/graph-domain/disjoint-1d-point.sty
+++ b/packages/examples/src/graph-domain/disjoint-1d-point.sty
@@ -24,11 +24,11 @@ Colors {
 global {
 }
 
-Vertex V {
+forall Vertex V {
 }
 
 -- Point with DOF or not
-Vertex `v1` {
+forall Vertex `v1` {
        `v1`.val = ?
        -- `v1`.val = 0.
        `v1`.shape = Circle {
@@ -38,7 +38,7 @@ Vertex `v1` {
        }
 }
 
-Vertex `v2` {
+forall Vertex `v2` {
        len = 300.
        -- With an additional DOF, tends to repel both
        `v2`.center = ?
@@ -55,6 +55,6 @@ Vertex `v2` {
 }
 
 -- Point-line
-Vertex `v1`; Vertex `v2` {
+forall Vertex `v1`; Vertex `v2` {
        ensure disjointScalar(`v1`.val, `v2`.left, `v2`.right)
 }

--- a/packages/examples/src/graph-domain/disjoint-rect-line-horiz.sty
+++ b/packages/examples/src/graph-domain/disjoint-rect-line-horiz.sty
@@ -34,7 +34,7 @@ global {
     vertexWidth = 100.
 }
 
-Vertex V {
+forall Vertex V {
        V.x = ?
        V.y = ?
 
@@ -62,7 +62,7 @@ Vertex V {
        V.shape above global.box
 }
 
-Edge e {
+forall Edge e {
        e.len = 200.
        e.center = ?
        e.y = ?
@@ -85,19 +85,18 @@ Edge e {
        ensure contains(global.box, e.shape)
 }
 
-Edge `e2` {
+forall Edge `e2` {
      override `e2`.len = 100.
 }
 
-Vertex `v1` {
+forall Vertex `v1` {
        override `v1`.shape.width = 500.
 }
 
--- This is applied to each pair twice (as (a,b) then (b,a))
-Vertex v1; Vertex v2 {
+forall Vertex v1; Vertex v2 {
        ensure disjoint(v1.shape, v2.shape, 0.)
 }
 
-Vertex v; Edge e {
+forall Vertex v; Edge e {
        ensure disjoint(v.shape, e.shape)
 }

--- a/packages/examples/src/graph-domain/disjoint-rect-line-vert.sty
+++ b/packages/examples/src/graph-domain/disjoint-rect-line-vert.sty
@@ -35,7 +35,7 @@ global {
     global.vertexWidth = 100.
 }
 
-Vertex V {
+forall Vertex V {
        V.x = ?
        V.y = ?
 
@@ -63,7 +63,7 @@ Vertex V {
        V.shape above global.box
 }
 
-Edge e {
+forall Edge e {
        e.len = 200.
        e.center = ?
        e.x = ?
@@ -86,19 +86,18 @@ Edge e {
        ensure contains(global.box, e.shape)
 }
 
-Edge `e2` {
+forall Edge `e2` {
      override `e2`.len = 100.
 }
 
-Vertex `v1` {
+forall Vertex `v1` {
        override `v1`.shape.width = 500.
 }
 
--- This is applied to each pair twice (as (a,b) then (b,a))
-Vertex v1; Vertex v2 {
+forall Vertex v1; Vertex v2 {
        ensure disjoint(v1.shape, v2.shape, 0.)
 }
 
-Vertex v; Edge e {
+forall Vertex v; Edge e {
        ensure disjointRectLineAA(v.shape, e.shape)
 }

--- a/packages/examples/src/graph-domain/disjoint-rects-large-canvas.sty
+++ b/packages/examples/src/graph-domain/disjoint-rects-large-canvas.sty
@@ -34,7 +34,7 @@ global {
     vertexWidth = 100.
 }
 
-Vertex V {
+forall Vertex V {
        V.x = ?
        V.y = ?
 
@@ -62,11 +62,10 @@ Vertex V {
        V.shape above global.box
 }
 
-Vertex `v1` {
+forall Vertex `v1` {
        override `v1`.shape.width = 300.
 }
 
--- This is applied to each pair twice (as (a,b) then (b,a))
-Vertex v1; Vertex v2 {
+forall Vertex v1; Vertex v2 {
        ensure disjoint(v1.shape, v2.shape, 0.)
 }

--- a/packages/examples/src/graph-domain/disjoint-rects-small-canvas.sty
+++ b/packages/examples/src/graph-domain/disjoint-rects-small-canvas.sty
@@ -34,7 +34,7 @@ global {
     vertexWidth = 100.
 }
 
-Vertex V {
+forall Vertex V {
        V.x = ?
        V.y = ?
 
@@ -62,11 +62,10 @@ Vertex V {
        V.shape above global.box
 }
 
-Vertex `v1` {
+forall Vertex `v1` {
        override `v1`.shape.width = 300.
 }
 
--- This is applied to each pair twice (as (a,b) then (b,a))
-Vertex v1; Vertex v2 {
+forall Vertex v1; Vertex v2 {
        ensure disjoint(v1.shape, v2.shape, 0.)
 }

--- a/packages/examples/src/graph-domain/disjoint-rects.sty
+++ b/packages/examples/src/graph-domain/disjoint-rects.sty
@@ -35,7 +35,7 @@ global {
     vertexWidth = 100.
 }
 
-Vertex V {
+forall Vertex V {
        V.x = ?
        V.y = ?
 
@@ -63,11 +63,10 @@ Vertex V {
        V.shape above global.box
 }
 
-Vertex `v1` {
+forall Vertex `v1` {
        override `v1`.shape.width = 500.
 }
 
--- This is applied to each pair twice (as (a,b) then (b,a))
-Vertex v1; Vertex v2 {
+forall Vertex v1; Vertex v2 {
        ensure disjoint(v1.shape, v2.shape, 0.)
 }

--- a/packages/examples/src/graph-domain/graph-theory-simple.sty
+++ b/packages/examples/src/graph-domain/graph-theory-simple.sty
@@ -38,7 +38,7 @@ global {
     }
 }
 
-Vertex V {
+forall Vertex V {
        V.shape = Rectangle { 
          width: V.text.width + global.padding
          height: V.text.height + global.padding
@@ -60,7 +60,7 @@ Vertex V {
        V.shape above global.box
 }
 
-Edge E
+forall Edge E
 where E := MkEdge(v1, v2)
 with Vertex v1; Vertex v2 {
 
@@ -112,19 +112,19 @@ with Vertex v1; Vertex v2 {
      E.shape above global.box
 }
 
-Vertex v1; Vertex v2 {
+forall Vertex v1; Vertex v2 {
 -- DEBUG: These two together appear to cause a horrible slowdown, but not individually??
 -- Maybe because there are constraints and objectives??
        -- ensure disjoint(v1.shape, v2.shape, 10.)
        -- encourage repel(v1.shape, v2.shape)
 }
 
-Edge e1; Edge e2 {
+forall Edge e1; Edge e2 {
    -- ensure disjoint(e1.text, e2.text)
    -- ensure notCrossing(e1.shape, e2.shape)
 }
 
-Vertex v; Edge e {
+forall Vertex v; Edge e {
 -- DEBUG: These two also appear to cause a big slowdown?
        -- ensure disjoint(v.shape, e.shape)
        -- ensure disjoint(v.shape, e.text)

--- a/packages/examples/src/graph-domain/graph-theory.sty
+++ b/packages/examples/src/graph-domain/graph-theory.sty
@@ -38,7 +38,7 @@ global {
 -- TODO: Can we have a "below everything" directive? or something broader than pairwise
 }
 
-Vertex V {
+forall Vertex V {
        -- TODO: Can we have boxes with rounded corners
        V.shape = Rectangle { 
          width: V.text.width + global.padding
@@ -63,7 +63,7 @@ Vertex V {
        V.shape above global.box
 }
 
-Edge E
+forall Edge E
 where E := MkEdge(v1, v2)
 with Vertex v1; Vertex v2 {
 
@@ -116,20 +116,20 @@ with Vertex v1; Vertex v2 {
      E.shape above global.box
 }
 
-Vertex v1; Vertex v2 {
+forall Vertex v1; Vertex v2 {
        -- TODO: Make this work WRT rectangle dimensions
        ensure disjoint(v1.shape, v2.shape, 10.)
        encourage repel(v1.shape, v2.shape)
 }
 
-Edge e1; Edge e2 {
+forall Edge e1; Edge e2 {
      -- TODO: Minimize edge crossings
      -- I guess an alternative is that no line intersects a box
    ensure disjoint(e1.text, e2.text)
    ensure disjoint(e1.shape, e2.shape)
 }
 
-Vertex v; Edge e {
+forall Vertex v; Edge e {
        ensure disjoint(v.shape, e.shape)
        ensure disjoint(v.shape, e.text)
 }

--- a/packages/examples/src/hypergraph/hypergraph-3d.sty
+++ b/packages/examples/src/hypergraph/hypergraph-3d.sty
@@ -198,38 +198,38 @@ forall Edge e {
   ensure equal(e.rectx, e.x)
 }
 
-Layer1 l; Edge e
+forall Layer1 l; Edge e
 where Layer1HasEdge(l, e) {
   override e.x = l.x
   ensure lessThan(l.yb, e.yb)
   ensure lessThan(e.yt, l.yt)
 }
 
-Layer2 l; Edge e
+forall Layer2 l; Edge e
 where Layer2HasEdge(l, e) {
   override e.x = l.x
   ensure lessThan(l.yb, e.yb)
   ensure lessThan(e.yt, l.yt)
 }
 
-Layer3 l; Edge e
+forall Layer3 l; Edge e
 where Layer3HasEdge(l, e) {
   override e.x = l.x
   ensure lessThan(l.yb, e.yb)
   ensure lessThan(e.yt, l.yt)
 }
 
-Edge e; Node n
+forall Edge e; Node n
 where EdgeHasNodeInLayer1(e, n) {
   ensure contains(e.rect, n.dot1, 4)
 }
 
-Edge e; Node n
+forall Edge e; Node n
 where EdgeHasNodeInLayer2(e, n) {
   ensure contains(e.rect, n.dot2, 4)
 }
 
-Edge e; Node n
+forall Edge e; Node n
 where EdgeHasNodeInLayer3(e, n) {
   ensure contains(e.rect, n.dot3, 4)
 }

--- a/packages/examples/src/hypergraph/hypergraph.sty
+++ b/packages/examples/src/hypergraph/hypergraph.sty
@@ -128,28 +128,28 @@ forall Layer3 l {
   l.yt = ?
 }
 
-Graph g; Layer1 l
+forall Graph g; Layer1 l
 where GraphHasLayer1(g, l) {
   override l.x = g.x1
   override l.yb = g.yb
   override l.yt = g.yt
 }
 
-Graph g; Layer2 l
+forall Graph g; Layer2 l
 where GraphHasLayer2(g, l) {
   override l.x = g.x2
   override l.yb = g.yb
   override l.yt = g.yt
 }
 
-Graph g; Layer3 l
+forall Graph g; Layer3 l
 where GraphHasLayer3(g, l) {
   override l.x = g.x3
   override l.yb = g.yb
   override l.yt = g.yt
 }
 
-Graph g; Node n
+forall Graph g; Node n
 where GraphHasNode(g, n) {
   override n.xl = g.xl
   override n.x1 = g.x1
@@ -191,38 +191,38 @@ forall Edge e {
   ensure equal(e.rectx, e.x)
 }
 
-Layer1 l; Edge e
+forall Layer1 l; Edge e
 where Layer1HasEdge(l, e) {
   override e.x = l.x
   ensure lessThan(l.yb, e.yb)
   ensure lessThan(e.yt, l.yt)
 }
 
-Layer2 l; Edge e
+forall Layer2 l; Edge e
 where Layer2HasEdge(l, e) {
   override e.x = l.x
   ensure lessThan(l.yb, e.yb)
   ensure lessThan(e.yt, l.yt)
 }
 
-Layer3 l; Edge e
+forall Layer3 l; Edge e
 where Layer3HasEdge(l, e) {
   override e.x = l.x
   ensure lessThan(l.yb, e.yb)
   ensure lessThan(e.yt, l.yt)
 }
 
-Edge e; Node n
+forall Edge e; Node n
 where EdgeHasNodeInLayer1(e, n) {
   ensure contains(e.rect, n.dot1, 4)
 }
 
-Edge e; Node n
+forall Edge e; Node n
 where EdgeHasNodeInLayer2(e, n) {
   ensure contains(e.rect, n.dot2, 4)
 }
 
-Edge e; Node n
+forall Edge e; Node n
 where EdgeHasNodeInLayer3(e, n) {
   ensure contains(e.rect, n.dot3, 4)
 }

--- a/packages/examples/src/logic-circuit-domain/distinctive-shape.sty
+++ b/packages/examples/src/logic-circuit-domain/distinctive-shape.sty
@@ -50,7 +50,7 @@ forall OutputNode A; OutputNode B {
 
 -- Gates
 
-XORGate G
+forall XORGate G
 where G := MakeXORGate(IN1, IN2, OUT)
 with Node IN1; Node IN2; Node OUT {
     G.center = (?, ?)
@@ -123,7 +123,7 @@ with Node IN1; Node IN2; Node OUT {
     ensure equal(vdist(OUT.center, (G.part1.center[0] + 45.0, G.part1.center[1])), 0.0)
 }
 
-ANDGate G
+forall ANDGate G
 where G := MakeANDGate(IN1, IN2, OUT)
 with Node IN1; Node IN2; Node OUT {
     G.center = (?, ?)
@@ -160,7 +160,7 @@ with Node IN1; Node IN2; Node OUT {
     ensure equal(vdist(OUT.center, (G.part1.center[0] + 45.0, G.part1.center[1])), 0.0)
 }
 
-SplitComponent x
+forall SplitComponent x
 where x := MakeSplitComponent(IN, OUT1, OUT2)
 with Node IN; Node OUT1; Node OUT2 {
     x.center = IN.center
@@ -196,7 +196,7 @@ forall Connection x; XORGate y {
 
 -- Connections
 
-Connection C
+forall Connection C
 where C := MakeConnection(A, B)
 with Node A; Node B {
     C.pivot = ?

--- a/packages/examples/src/mesh-set-domain/DomainInterop.sty
+++ b/packages/examples/src/mesh-set-domain/DomainInterop.sty
@@ -13,7 +13,7 @@ const {
       repelWeight = 0.0
 }
 
-Set x {
+forall Set x {
     x.icon = Circle {
         strokeWidth : 0.0
     }
@@ -30,7 +30,7 @@ Set x {
     x.icon below x.text
 }
 
-Set x; Set y
+forall Set x; Set y
 where IsSubset(x, y) {
     ensure contains(y.icon, x.icon, 5.0)
     ensure smallerThan(x.icon, y.icon)
@@ -39,19 +39,19 @@ where IsSubset(x, y) {
     -- layering1  = y.text below x.icon
 }
 
-Set x; Set y
+forall Set x; Set y
 where NotIntersecting(x, y) {
     ensure disjoint(x.icon, y.icon)
 }
 
-Set x; Set y
+forall Set x; Set y
 where Intersect(x, y) {
     ensure overlapping(x.icon, y.icon)
     ensure disjoint(y.text, x.icon)
     ensure disjoint(x.text, y.icon)
 }
 
-Point p {
+forall Point p {
     p.offset = 10.0
     p.icon = Circle {
         strokeWidth : 0.0
@@ -65,7 +65,7 @@ Point p {
     }
 }
 
-Point p
+forall Point p
 with Set A
 where PointIn(A, p) {
     ensure contains(A.icon, p.icon, 0.3 * A.icon.r)
@@ -73,7 +73,7 @@ where PointIn(A, p) {
     p.text above A.icon
 }
 
-Point p
+forall Point p
 with Set A
 where PointNotIn(A, p) {
 -- where Not(PointIn(A, p)) {
@@ -81,17 +81,17 @@ where PointNotIn(A, p) {
 }
 
 -- Put all the text on top of everything
-Set x; Set y {
+forall Set x; Set y {
     encourage repel(x.text, y.text, const.repelWeight)
     x.icon below y.text
 }
 
-Point p; Point q {
+forall Point p; Point q {
      -- encourage repel(p.icon, q.icon, G.repelWeight2)
      encourage repel(p.text, q.text, const.repelWeight)
 }
 
-Set x; Point p {
+forall Set x; Point p {
     p.icon above x.icon
     p.text above x.icon
 
@@ -174,7 +174,7 @@ Colors {
 }
 
 -- TODO: this is going to match Subcomplex too... how to fix that?
-SimplicialComplex K {
+forall SimplicialComplex K {
        -- No longer necessary, as box size is being computed
        -- K.x_offset = ?
        -- K.y_offset = ?
@@ -228,7 +228,7 @@ SimplicialComplex K {
 }
 
 -- TODO: this generates a (K1, K2) and (K2, K1) match
-SimplicialComplex K1; SimplicialComplex K2 {
+forall SimplicialComplex K1; SimplicialComplex K2 {
 	 padding = 30.0
 
 	 -- TODO: improve this for rectangles by not just using the x size
@@ -239,7 +239,7 @@ SimplicialComplex K1; SimplicialComplex K2 {
 	 -- distFn = ensure distBetween(K1.icon, K2.icon, padding)
 }
 
-Vertex v 
+forall Vertex v 
 where InVS(v, K)
 with SimplicialComplex K {
      v.xpos = ?
@@ -274,7 +274,7 @@ with SimplicialComplex K {
 }
 
 -- Style a distinguished vertex (only if it's a result)
-Vertex v
+forall Vertex v
 where DeclaredV(v); InVS(v, K); Result(v)
 with SimplicialComplex K {
       -- Don't label the vertex because then we need to position it...
@@ -303,7 +303,7 @@ with SimplicialComplex K {
      ensure inRange(v.padding_y, v.icon.y - v.padding_range, v.icon.y + v.padding_range) */
 }
 
-Vertex v; Edge e
+forall Vertex v; Edge e
 where InVS(v, K); InES(e, K)
 with SimplicialComplex K {
      offset = 5.0
@@ -312,7 +312,7 @@ with SimplicialComplex K {
      ensure disjoint(v.text, e.icon, offset)
 }
 
-Vertex v; Edge e
+forall Vertex v; Edge e
 where DeclaredV(v); InVS(v, K); InES(e, K)
 with SimplicialComplex K {
      offset = 5.0
@@ -321,7 +321,7 @@ with SimplicialComplex K {
      ensure disjoint(v.text, e.icon, offset)
 }
 
-Edge e
+forall Edge e
 where e := MkEdge(v1, v2); InES(e, K)
 with Vertex v1; Vertex v2; SimplicialComplex K {
      e.icon = Line { 
@@ -347,7 +347,7 @@ with Vertex v1; Vertex v2; SimplicialComplex K {
 }
 
 -- Style a distinguished edge (only if it's declared to be a result)
-Edge e
+forall Edge e
 where DeclaredE(e); e := MkEdge(v1, v2); InES(e, K); Result(e)
 with Vertex v1; Vertex v2; SimplicialComplex K {
      override e.icon.strokeWidth = global.selectedEdgeStroke
@@ -365,7 +365,7 @@ with Vertex v1; Vertex v2; SimplicialComplex K {
      e.text above K.icon
 }
 
-Face f -- 255,552 substitutions = 22 e * 22 e * 22 e * 12 f * 2 sc
+forall Face f -- 255,552 substitutions = 22 e * 22 e * 22 e * 12 f * 2 sc
 where f := MkFace(e1, e2, e3); InFS(f, K)
 with Edge e1; Edge e2; Edge e3; SimplicialComplex K {
      f.color = Colors.silver
@@ -393,7 +393,7 @@ with Edge e1; Edge e2; Edge e3; SimplicialComplex K {
 }
 
 -- Style and label a distinguished face
-Face f
+forall Face f
 where DeclaredF(f); InFS(f, K)
 with SimplicialComplex K {
      -- Need to pick a color that doesn't "override" the selected edges and vertices!
@@ -402,7 +402,7 @@ with SimplicialComplex K {
 }
 
 -- Relative layerings within a simplicial complex
-Vertex v; Edge e; Face f
+forall Vertex v; Edge e; Face f
 where InVS(v, K); InES(e, K); InFS(f, K)
 with SimplicialComplex K {
       v.text above f.icon 
@@ -410,18 +410,18 @@ with SimplicialComplex K {
 }
 
 -- Only label the (last) result of an operation
-Object e
+forall Object e
 with SimplicialComplex K
 where Result(e) {
       override K.const_text.string = e.label
 }
 
-Edge e; Face f {
+forall Edge e; Face f {
      e.icon above f.icon
      e.text above f.icon
 }
 
-Vertex v; Vertex w {
+forall Vertex v; Vertex w {
      encourage repel(v.icon, w.icon, 1.0)
 }
 
@@ -452,14 +452,14 @@ where Identified(p, v) {
    -- lenFn = encourage equal(norm_(p.icon.x - v.icon.x, p.icon.y - v.icon.y), 100.0)
 }
 
-Set s; Edge e
+forall Set s; Edge e
 where Identified(e, s) {
       -- Make all edge subsets the same random color
       s.icon.fillColor = setOpacity(Colors.purple, 0.2) -- const.subsetColor
 }
 
 -- TODO: hack for position; assuming there's only one face
-Set s; Face f
+forall Set s; Face f
 where Identified(f, s) {
     s.icon.center = (200.0, 0.0)
 }

--- a/packages/examples/src/minkowski-tests/maze/ellipse-maze.sty
+++ b/packages/examples/src/minkowski-tests/maze/ellipse-maze.sty
@@ -29,6 +29,6 @@ forall Triangle x {
     encourage lessThan(-400.0, x.y)
 }
 
-Triangle x; Maze y {
+forall Triangle x; Maze y {
     ensure disjoint(x.icon, y.icon)
 }

--- a/packages/examples/src/minkowski-tests/maze/maze.sty
+++ b/packages/examples/src/minkowski-tests/maze/maze.sty
@@ -46,10 +46,10 @@ forall Triangle x {
     encourage equal(0.0, x.a[1])
 }
 
-Triangle x; Triangle y {
+forall Triangle x; Triangle y {
    ensure disjoint(x.icon, y.icon)
 }
 
-Triangle x; Maze y {
+forall Triangle x; Maze y {
     ensure disjoint(x.icon, y.icon)
 }

--- a/packages/examples/src/molecules/molecules-basic.sty
+++ b/packages/examples/src/molecules/molecules-basic.sty
@@ -38,7 +38,7 @@ forall Nitrogen x {
 
 -- Bonds
 
-SingleBond b
+forall SingleBond b
 where b := MakeSingleBond(x, y)
 with Atom x; Atom y {
     b.line = Line {
@@ -50,7 +50,7 @@ with Atom x; Atom y {
     ensure equal(vdist(x.icon.center, y.icon.center), 60.0)
 }
 
-DoubleBond b
+forall DoubleBond b
 where b := MakeDoubleBond(x, y)
 with Atom x; Atom y {
     b.line1 = Line {
@@ -69,7 +69,7 @@ with Atom x; Atom y {
     ensure equal(vdist(x.icon.center, y.icon.center), 60.0)
 }
 
-TripleBond b
+forall TripleBond b
 where b := MakeTripleBond(x, y)
 with Atom x; Atom y {
     b.line1 = Line {

--- a/packages/examples/src/molecules/molecules-elegant.sty
+++ b/packages/examples/src/molecules/molecules-elegant.sty
@@ -39,19 +39,19 @@ forall Nitrogen x {
 
 -- Bonds
 
-SingleBond b
+forall SingleBond b
 where b := MakeSingleBond(x, y)
 with Atom x; Atom y {
     ensure equal(vdist(x.icon.center, y.icon.center), 60.0)
 }
 
-DoubleBond b
+forall DoubleBond b
 where b := MakeDoubleBond(x, y)
 with Atom x; Atom y {
     ensure equal(vdist(x.icon.center, y.icon.center), 60.0)
 }
 
-TripleBond b
+forall TripleBond b
 where b := MakeTripleBond(x, y)
 with Atom x; Atom y {
     ensure equal(vdist(x.icon.center, y.icon.center), 60.0)

--- a/packages/examples/src/molecules/molecules.sty
+++ b/packages/examples/src/molecules/molecules.sty
@@ -39,7 +39,7 @@ forall Nitrogen x {
 
 -- Bonds
 
-SingleBond b
+forall SingleBond b
 where b := MakeSingleBond(x, y)
 with Atom x; Atom y {
     b.line = Line {
@@ -51,7 +51,7 @@ with Atom x; Atom y {
     ensure equal(vdist(x.icon.center, y.icon.center), 60.0)
 }
 
-DoubleBond b
+forall DoubleBond b
 where b := MakeDoubleBond(x, y)
 with Atom x; Atom y {
     b.line1 = Line {
@@ -70,7 +70,7 @@ with Atom x; Atom y {
     ensure equal(vdist(x.icon.center, y.icon.center), 60.0)
 }
 
-TripleBond b
+forall TripleBond b
 where b := MakeTripleBond(x, y)
 with Atom x; Atom y {
     b.line1 = Line {

--- a/packages/examples/src/monoidal-category-domain/monoidal-test.sty
+++ b/packages/examples/src/monoidal-category-domain/monoidal-test.sty
@@ -39,7 +39,7 @@ canvas {
          bot = canvas.box.center[1] - canvas.box.height/2.
 }
 
-Object o {
+forall Object o {
        scalar o.minY = canvas.bot
        scalar o.maxY = canvas.top
 
@@ -73,7 +73,7 @@ Object o {
     o.shape above canvas.box
 }
 
-Morphism m {
+forall Morphism m {
          -- The floating vars are the rect centers
          shape m.shape = Rectangle { 
                   center: (?, ?)
@@ -101,7 +101,7 @@ Morphism m {
          m.text above m.shape
 }
 
-Object p
+forall Object p
 with Object a, b
 where p := tensor(a, b) {
       override p.shape.strokeColor = rgba(1.0, 0.0, 0.0, 0.1)
@@ -129,7 +129,7 @@ where p := tensor(a, b) {
 
 Morphism m
 with Object a, b
-where m := join(a, b) {
+forall where m := join(a, b) {
       -- override m.shape.fillColor = Colors.green
 
       -- TODO: overriding nonexistent fields should throw an error. like `override a.sdjfsadfjhks = 0`
@@ -157,12 +157,12 @@ where m := join(a, b) {
       b.shape above m.shape
 }
 
-Object o; Morphism m
+forall Object o; Morphism m
 where NotChildOf(o, m) {
        ensure disjointRectLineAA(m.shape, o.shape)
 }
 
-Morphism m1; Morphism m2 {
+forall Morphism m1; Morphism m2 {
          ensure disjoint(m1.shape, m2.shape)
 }
 

--- a/packages/examples/src/set-theory-domain/continuousmap.sty
+++ b/packages/examples/src/set-theory-domain/continuousmap.sty
@@ -14,7 +14,7 @@ Colors {
   lightYellow = rgba(0.95, 0.96, 0.92, 0.5)
 }
 
-Set x {
+forall Set x {
     x.icon = Circle {
         fillColor : Colors.lightBlue
         strokeColor : Colors.black
@@ -33,7 +33,7 @@ Set x {
 }
 
 -- Selector ordering matters!
-Set x; Set y
+forall Set x; Set y
 where IsSubset(x, y) {
   ensure contains(y.icon, x.icon, 10.0)
   -- y.sizeFn    = ensure smallerThan(x.icon, y.icon)
@@ -41,7 +41,7 @@ where IsSubset(x, y) {
   x.icon above y.icon
 }
 
-Map f
+forall Map f
 where From(f, X, Y); IsSubset(X, R1); IsSubset(Y, R2)
 with Set X; Set Y; Set R1; Set R2 {
   f.padding = 20.0
@@ -69,18 +69,18 @@ with Set X; Set Y; Set R1; Set R2 {
     -- f.centerFn = encourage centerArrow(f.icon, R1.icon, R2.icon)
 }
 
-Set `U` {
+forall Set `U` {
     override `U`.icon.strokeStyle = "dashed"
     override `U`.icon.strokeWidth = Const.strokeWidth
 }
 
-Set `V` {
+forall Set `V` {
     override `V`.icon.strokeStyle = "dashed"
     override `V`.icon.strokeWidth = Const.strokeWidth
 }
 
 -- TODO: use subtyping for reals?
-Set `Rn` {
+forall Set `Rn` {
     `Rn`.iconSize = canvas.height / 3
 
     override `Rn`.icon = Rectangle {
@@ -102,7 +102,7 @@ Set `Rn` {
 
 }
 
-Set `Rm`
+forall Set `Rm`
 with Set `Rn` {
     -- TODO: factor this block out
     override `Rm`.icon = Rectangle {

--- a/packages/examples/src/set-theory-domain/tree.sty
+++ b/packages/examples/src/set-theory-domain/tree.sty
@@ -26,7 +26,7 @@ Global {
    scalar setRadius = 18.
 }
 
-Set x {
+forall Set x {
 
    vec2 x.center = (?,?)
 
@@ -46,13 +46,13 @@ Set x {
    }
 }
 
-Set x; Set y {
+forall Set x; Set y {
    -- Try to make sure no labels overlap
    encourage repel(x.bounds, y.bounds, 5.0)
 }
 
 
-Set x; Set y
+forall Set x; Set y
 where IsSubset(x, y) {
 
    vec2 p = x.center

--- a/packages/examples/src/set-theory-domain/venn-3d.sty
+++ b/packages/examples/src/set-theory-domain/venn-3d.sty
@@ -3,7 +3,7 @@ canvas {
   height = 700
 }
 
-Set x {
+forall Set x {
     x.shape = Circle {
         strokeWidth : 0.
     }
@@ -48,12 +48,12 @@ where IsSubset(x, y) {
     x.shadow above y.shape
 }
 
-Set x; Set y
+forall Set x; Set y
 where Not(Intersecting(x, y)) {
     ensure disjoint(x.shape, y.shape)
 }
 
-Set x; Set y
+forall Set x; Set y
 where Intersecting(x, y) {
     ensure overlapping(x.shape, y.shape)
     ensure disjoint(y.text, x.shape)

--- a/packages/examples/src/set-theory-domain/venn-polygon.sty
+++ b/packages/examples/src/set-theory-domain/venn-polygon.sty
@@ -63,14 +63,14 @@ forall Point p {
     p.textLayering = p.text above p.icon
 }
 
-Point p
+forall Point p
 with Set A
 where PointIn(A, p) {
     ensure contains(A.icon, p.icon, 0.3 * A.icon.r)
     p.layering = p.icon above A.icon
 }
 
-Point p
+forall Point p
 with Set A
 where Not(PointIn(A, p)) {
     ensure disjoint(A.icon, p.icon)

--- a/packages/examples/src/shape-spec/shape-spec-dashes.sty
+++ b/packages/examples/src/shape-spec/shape-spec-dashes.sty
@@ -3,7 +3,7 @@ canvas {
   height = 700
 }
 
-Path A {
+forall Path A {
     A.icon = Path {
         d : pathFromPoints("open", [(0,0), (0,100), (100,100)])
         strokeWidth : 5
@@ -11,7 +11,7 @@ Path A {
     }
 }
 
-Circle E {
+forall Circle E {
     E.icon = Circle { 
         strokeColor : rgba(0.,0.,0.,1.)
         strokeWidth : 5
@@ -19,7 +19,7 @@ Circle E {
     }
 }
 
-Rectangle F {
+forall Rectangle F {
     F.icon = Rectangle { 
         strokeColor : rgba(0.,0.,0.,1.)
         strokeDasharray : "30 30"
@@ -27,28 +27,28 @@ Rectangle F {
     }
 }
 
-Line G {
+forall Line G {
     G.icon = Line {
         strokeDasharray : "5 5 20 2"
     }
 }
 
-Equation H {
+forall Equation H {
     H.icon = Equation { }
 }
 
-Image I {
+forall Image I {
     I.icon = Image { }
 }
 
-DashedArrow J {
+forall DashedArrow J {
     J.icon = Line {
         style : "dashed"
         endArrowhead : true
     }
 }
 
-DashArrayArrow K {
+forall DashArrayArrow K {
     K.icon = Line {
         strokeDasharray : "30 10 1 10"
         endArrowhead : true

--- a/packages/examples/src/spec-shape-callout/shape.sty
+++ b/packages/examples/src/spec-shape-callout/shape.sty
@@ -24,7 +24,7 @@ colors {
        none = none()
 }
 
-Node n {
+forall Node n {
      n.shape = Circle { 
              r: global.nodeR
              strokeWidth: 0.

--- a/packages/examples/src/spec-shape-callout/shape2.sty
+++ b/packages/examples/src/spec-shape-callout/shape2.sty
@@ -16,7 +16,7 @@ colors {
        none = none()
 }
 
-Node n {
+forall Node n {
      n.shape = Circle { 
              r: global.nodeR
              strokeWidth: 0.


### PR DESCRIPTION
# Description

Related issue/PR: #1006 

Style selectors are now required to start with keyword `forall`.

# Implementation strategy and design decisions

We modified the Style parser to mandate `forall` keyword, and changed all the examples and test cases to reflect this.

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new ESLint warnings
- [x] I have reviewed any generated changes to the `diagrams/` folder

