### PR TITLE
refactor: Delete ops.angleBetween2

### DIFF
--- a/packages/core/src/engine/Autodiff.ts
+++ b/packages/core/src/engine/Autodiff.ts
@@ -860,19 +860,6 @@ export const ops = {
       sub(mul(u[0], v[1]), mul(u[1], v[0])),
     ];
   },
-
-  /**
-   * Return the angle between two 2D vectors `v` and `w` in radians.
-   * From https://github.com/thi-ng/umbrella/blob/develop/packages/vectors/src/angle-between.ts#L11
-   * NOTE: This function has not been thoroughly tested
-   */
-  angleBetween2: (v: ad.Num[], w: ad.Num[]): ad.Num => {
-    if (v.length !== 2 || w.length !== 2) {
-      throw Error("expected two 2-vectors");
-    }
-    const t = atan2(ops.cross2(v, w), ops.vdot(v, w));
-    return t;
-  },
 };
 
 export const fns = {


### PR DESCRIPTION
# Description

This PR deletes the `ops.angleBetween2` function, because it is currently unused and is identical to `ops.angleFrom`.

# Checklist

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new ESLint warnings
- [x] I have reviewed any generated changes to the `diagrams/` folder