### PR TITLE
feat: Make parse errors more readable

### DIFF
--- a/packages/core/src/compiler/Domain.ts
+++ b/packages/core/src/compiler/Domain.ts
@@ -3,7 +3,7 @@ import im from "immutable";
 import { every, keyBy, zipWith } from "lodash";
 import nearley from "nearley";
 import domainGrammar from "parser/DomainParser";
-import { idOf, lastLocation } from "parser/ParserUtil";
+import { idOf, lastLocation, prettyParseError } from "parser/ParserUtil";
 import { A, C } from "types/ast";
 import {
   Arg,
@@ -57,7 +57,7 @@ export const parseDomain = (
       return err(parseError(`Unexpected end of input`, lastLocation(parser)));
     }
   } catch (e) {
-    return err(parseError(<string>e, lastLocation(parser)));
+    return err(parseError(prettyParseError(e), lastLocation(parser)));
   }
 };
 

--- a/packages/core/src/compiler/Style.ts
+++ b/packages/core/src/compiler/Style.ts
@@ -12,7 +12,7 @@ import { alg, Edge, Graph } from "graphlib";
 import im from "immutable";
 import _, { range } from "lodash";
 import nearley from "nearley";
-import { lastLocation } from "parser/ParserUtil";
+import { lastLocation, prettyParseError } from "parser/ParserUtil";
 import styleGrammar from "parser/StyleParser";
 import seedrandom from "seedrandom";
 import {
@@ -2912,8 +2912,8 @@ export const parseStyle = (p: string): Result<StyProg<C>, ParseError> => {
     } else {
       return err(parseError(`Unexpected end of input`, lastLocation(parser)));
     }
-  } catch (e: unknown) {
-    return err(parseError(<string>e, lastLocation(parser)));
+  } catch (e) {
+    return err(parseError(prettyParseError(e), lastLocation(parser)));
   }
 };
 

--- a/packages/core/src/compiler/Substance.ts
+++ b/packages/core/src/compiler/Substance.ts
@@ -2,7 +2,7 @@ import { dummyIdentifier } from "engine/EngineUtils";
 import im from "immutable";
 import { findIndex } from "lodash";
 import nearley from "nearley";
-import { idOf, lastLocation } from "parser/ParserUtil";
+import { idOf, lastLocation, prettyParseError } from "parser/ParserUtil";
 import substanceGrammar from "parser/SubstanceParser";
 import { A, ASTNode, C, Identifier } from "types/ast";
 import {
@@ -69,7 +69,7 @@ export const parseSubstance = (
       return err(parseError(`Unexpected end of input`, lastLocation(parser)));
     }
   } catch (e) {
-    return err(parseError(<string>e, lastLocation(parser)));
+    return err(parseError(prettyParseError(e), lastLocation(parser)));
   }
 };
 

--- a/packages/core/src/parser/ParserUtil.ts
+++ b/packages/core/src/parser/ParserUtil.ts
@@ -191,3 +191,26 @@ export const lastLocation = (parser: nearley.Parser): SourceLoc | undefined => {
     return undefined;
   }
 };
+
+export const prettyParseError = (e: unknown): string => {
+  const lines: string[] = [];
+
+  let inStart = true;
+  const alreadySeen = new Set<string>();
+  for (const line of `${e}`.split("\n")) {
+    const match = line.match(/^A (.*) based on:$/);
+    if (match !== null) {
+      inStart = false;
+      const option = match[1];
+      if (!alreadySeen.has(option)) {
+        alreadySeen.add(option);
+        lines.push(`    ${option}`);
+      }
+    } else if (inStart) {
+      lines.push(line);
+    }
+  }
+
+  lines.push("");
+  return lines.join("\n");
+};

--- a/packages/core/src/parser/StyleParser.test.ts
+++ b/packages/core/src/parser/StyleParser.test.ts
@@ -200,11 +200,44 @@ where C := intersect ( A, B, Not(f) ) ;\
     const prog = `
     forall Set x; Set y where y := Baz(x) as foo {}
     `;
-    expect(parseStyle(prog).isErr()).toEqual(true);
+    const parsed = parseStyle(prog);
+    if (parsed.isErr()) {
+      expect(parsed.error.message)
+        .toEqual(`Error: Syntax error at line 2 col 43:
+
+      forall Set x; Set y where y := Baz(x) as
+                                            ^
+Unexpected as token: "as". Instead, I was expecting to see one of the following:
+
+    ws token
+    nl token
+    ";"
+    comment token
+    multiline_comment token
+    "with"
+    "{"
+`);
+    } else {
+      throw Error("expected parse error");
+    }
   });
   test("cannot set subVars as aliases", () => {
     const prog = "forall Set x; Set y where IsSubset(x,y) as `A` {}";
-    expect(parseStyle(prog).isErr()).toEqual(true);
+    const parsed = parseStyle(prog);
+    if (parsed.isErr()) {
+      expect(parsed.error.message)
+        .toEqual(`Error: Syntax error at line 1 col 44:
+
+  forall Set x; Set y where IsSubset(x,y) as \`
+                                             ^
+Unexpected tick token: "\`". Instead, I was expecting to see one of the following:
+
+    ws token
+    identifier token
+`);
+    } else {
+      throw Error("expected parse error");
+    }
   });
 
   test("label field check", () => {


### PR DESCRIPTION
# Description

Resolves #1052.

# Implementation strategy and design decisions

[The `reportError` function](https://github.com/kach/nearley/blob/6e24450f2b19b5b71557adf72ccd580f4e452b09/lib/nearley.js#L382-L386) @wodeni mentioned makes use not just of the `Parser`, but also of the specific `token` that caused the error. I didn't know how to access that token from the error we `catch`, although after looking more closely at [the Nearley code](https://github.com/kach/nearley/blob/6e24450f2b19b5b71557adf72ccd580f4e452b09/lib/nearley.js#L343-L346), it seems to be available via the `token` field. Thus, to me it seemed that we would need to do some textual processing of the error message regardless, just to get the line and column number.

In any case, the `prettyParseError` function I've written here is fairly small and easy to read, and (because of the way it is written) should degrade gracefully to the identity function if Nearley's error message formatting changes.

# Examples with steps to reproduce them

Replace one of the `=` tokens with `==` in `packages/examples/src/set-theory-domain/venn.sty`, then run this command from within the `packages/automator/` directory:

```sh
yarn start draw tree.sub venn.sty setTheory.dsl out --src-prefix=../examples/src/set-theory-domain --variation=PlumvilleCapybara104
```

## Before

See the first example in #1052.

## After

```
Error: Syntax error at line 7 col 10:

    x.icon ==
           ^
Unexpected token: "==". Instead, I was expecting to see one of the following:

    ws token
    "below"
    "above"
    "="
    "["
```

# Checklist

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new ESLint warnings
- [x] I have reviewed any generated changes to the `diagrams/` folder