### PR TITLE
ci: Put stats in a text chart on every CI run and PR

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,7 +28,7 @@ jobs:
           path: packages/automator/out/
       - name: Generate CI summary
         run: |
-          yarn start ascii out stats.md
+          yarn start textchart out stats.md
           cat stats.md >> $GITHUB_STEP_SUMMARY
           grep -L EOF stats.md
           echo 'REGISTRY_STATS<<EOF' >> $GITHUB_ENV

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,6 +26,17 @@ jobs:
         with:
           name: diagrams
           path: packages/automator/out/
+      - name: Generate CI summary
+        run: |
+          yarn start ascii out stats.md
+          cat stats.md >> $GITHUB_STEP_SUMMARY
+          rm stats.md
+        working-directory: packages/automator/
+      - if: github.event_name == 'pull_request'
+        name: Comment on PR with link to stats
+        uses: marocchino/sticky-pull-request-comment@v2
+        with:
+          message: 📊 [Click here to see stats!](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})
       - name: Check that the generated diagrams/ are all up to date
         run: |
           rm -r diagrams/

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,13 +30,20 @@ jobs:
         run: |
           yarn start ascii out stats.md
           cat stats.md >> $GITHUB_STEP_SUMMARY
+          grep -L EOF stats.md
+          echo 'REGISTRY_STATS<<EOF' >> $GITHUB_ENV
+          cat stats.md >> $GITHUB_ENV
+          echo EOF >> $GITHUB_ENV
           rm stats.md
         working-directory: packages/automator/
       - if: github.event_name == 'pull_request'
         name: Comment on PR with link to stats
         uses: marocchino/sticky-pull-request-comment@v2
         with:
-          message: 📊 [Click here to see stats!](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})
+          message: |
+            📊 [Stats](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})
+
+            ${{ env.REGISTRY_STATS }}
       - name: Check that the generated diagrams/ are all up to date
         run: |
           rm -r diagrams/

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -37,11 +37,11 @@ jobs:
           rm stats.md
         working-directory: packages/automator/
       - if: github.event_name == 'pull_request'
-        name: Comment on PR with link to stats
+        name: Comment on PR with stats
         uses: marocchino/sticky-pull-request-comment@v2
         with:
           message: |
-            📊 [Stats](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})
+            # 📊 [Performance](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})
 
             ${{ env.REGISTRY_STATS }}
       - name: Check that the generated diagrams/ are all up to date

--- a/packages/automator/README.md
+++ b/packages/automator/README.md
@@ -10,7 +10,7 @@ Penrose Automator.
 Usage:
   automator batch LIB OUTFOLDER [--folders] [--src-prefix=PREFIX] [--repeat=TIMES] [--render=OUTFOLDER] [--cross-energy]
   automator render ARTIFACTSFOLDER OUTFOLDER
-  automator ascii ARTIFACTSFOLDER OUTFILE
+  automator textchart ARTIFACTSFOLDER OUTFILE
   automator draw SUBSTANCE STYLE DOMAIN OUTFOLDER [--src-prefix=PREFIX] [--variation=VARIATION] [--folders] [--cross-energy]
   automator shapedefs [SHAPEFILE]
 

--- a/packages/automator/README.md
+++ b/packages/automator/README.md
@@ -10,10 +10,12 @@ Penrose Automator.
 Usage:
   automator batch LIB OUTFOLDER [--folders] [--src-prefix=PREFIX] [--repeat=TIMES] [--render=OUTFOLDER] [--cross-energy]
   automator render ARTIFACTSFOLDER OUTFOLDER
+  automator ascii ARTIFACTSFOLDER OUTFILE
   automator draw SUBSTANCE STYLE DOMAIN OUTFOLDER [--src-prefix=PREFIX] [--variation=VARIATION] [--folders] [--cross-energy]
+  automator shapedefs [SHAPEFILE]
 
 Options:
-  -o, --outFile PATH Path to either an SVG file or a folder, depending on the value of --folders. [default: output.svg]
+  -o, --outFile PATH Path to either a file or a folder, depending on the value of --folders. [default: output.svg]
   --folders Include metadata about each output diagram. If enabled, outFile has to be a path to a folder.
   --src-prefix PREFIX the prefix to SUBSTANCE, STYLE, and DOMAIN, or the library equivalent in batch mode. No trailing "/" required. [default: .]
   --repeat TIMES the number of instances

--- a/packages/automator/artifacts.ts
+++ b/packages/automator/artifacts.ts
@@ -1,8 +1,8 @@
-const pug = require("pug");
-const fs = require("fs");
-const neodoc = require("neodoc");
-const _ = require("lodash");
-const vis = require("./vis");
+import * as fs from "fs";
+import _ from "lodash";
+import pug from "pug";
+import { InstanceData } from "./types";
+import vis from "./vis";
 
 const PAGELEN = 5;
 const gridLink = "grid.html";
@@ -10,6 +10,39 @@ const statLink = "vis.html";
 
 const mainTemplate = pug.compileFile("template.pug");
 const statTemplate = pug.compileFile("stat.pug");
+
+interface Artifact {
+  substance: string;
+  style: string;
+  domain: string;
+  rendered: string;
+  metadata: InstanceData;
+}
+
+const getArtifacts = (artifactsDir: string): Map<string, Artifact> => {
+  const dirs = fs
+    .readdirSync(artifactsDir, { withFileTypes: true })
+    .filter((dirent) => dirent.isDirectory())
+    .map(({ name }) => name);
+
+  return new Map(
+    dirs.map((dir) => {
+      const prefixString = `${artifactsDir}/${dir}/`;
+      return [
+        dir,
+        {
+          substance: fs.readFileSync(`${prefixString}substance.sub`, "utf8"),
+          style: fs.readFileSync(`${prefixString}style.sty`, "utf8"),
+          domain: fs.readFileSync(`${prefixString}domain.dsl`, "utf8"),
+          rendered: fs.readFileSync(`${prefixString}output.svg`, "utf8"),
+          metadata: JSON.parse(
+            fs.readFileSync(`${prefixString}meta.json`, "utf8")
+          ),
+        },
+      ];
+    })
+  );
+};
 
 export const renderArtifacts = (artifactsDir: string, outDir: string) => {
   console.log(`Generating web pages for the artifacts from ${artifactsDir}...`);
@@ -22,30 +55,8 @@ export const renderArtifacts = (artifactsDir: string, outDir: string) => {
   const aggregateData = JSON.parse(
     fs.readFileSync(`${artifactsDir}/aggregateData.json`, "utf8")
   );
-  var nonzeroDiagrams = 0;
-  var totalTime = 0;
-  for (let d in aggregateData) {
-    if (aggregateData[d].nonzeroConstraints) {
-      nonzeroDiagrams++;
-    }
-    totalTime += aggregateData[d].timeTaken.overall;
-  }
-  // console.log("Diagrams with non-zero constraints", nonzeroDiagrams);
-  // console.log(
-  //   "Average time to compute diagram: ",
-  //   totalTime / Object.keys(aggregateData).length
-  // );
 
-  const artifacts = dirs.map((dir) => {
-    const prefixString = `${artifactsDir}/${dir}/`;
-    return {
-      substance: fs.readFileSync(`${prefixString}substance.sub`, "utf8"),
-      style: fs.readFileSync(`${prefixString}style.sty`, "utf8"),
-      domain: fs.readFileSync(`${prefixString}domain.dsl`, "utf8"),
-      rendered: fs.readFileSync(`${prefixString}output.svg`, "utf8"),
-      metadata: JSON.parse(fs.readFileSync(`${prefixString}meta.json`, "utf8")),
-    };
-  });
+  const artifacts = [...getArtifacts(artifactsDir).values()];
 
   if (!fs.existsSync(outDir)) {
     fs.mkdirSync(outDir);
@@ -118,4 +129,30 @@ export const renderArtifacts = (artifactsDir: string, outDir: string) => {
     })
   );
   console.log(`Artifact pages generated in ${outDir}`);
+};
+
+export const printAsciiStats = (artifactsDir: string, outFile: string) => {
+  const artifacts = getArtifacts(artifactsDir);
+
+  const lines = [
+    "# Key",
+    "",
+    "```",
+    "     0    1s   2s   3s   4s   5s   6s   7s   8s   9s",
+    "     |    |    |    |    |    |    |    |    |    |",
+    "name ▝▀▀▀▀▀▀▀▀▀▀▀▚▄▄▄▄▄▄▄▄▄▞▀▀▀▀▀▀▀▀▀▀▀▀▚▄▄▄▄▄▄▄▄▄▖",
+    "      compilation labelling optimization rendering",
+    "```",
+    "",
+    "# Stats",
+    "",
+    "```",
+  ];
+
+  for (const [key] of artifacts) {
+    lines.push(key);
+  }
+
+  lines.push("```", "");
+  fs.writeFileSync(outFile, lines.join("\n"));
 };

--- a/packages/automator/artifacts.ts
+++ b/packages/automator/artifacts.ts
@@ -188,8 +188,7 @@ export const printAsciiStats = (artifactsDir: string, outFile: string) => {
   const lines = [
     "# Key",
     "",
-    "Note that each bar component rounds up to the nearest 100ms, so each full",
-    "bar is an overestimate by up to 400ms.",
+    "Note that each bar component rounds up to the nearest 100ms, so each full bar is an overestimate by up to 400ms.",
     "",
     "```",
     "     0s   1s   2s   3s   4s   5s   6s   7s   8s   9s",

--- a/packages/automator/artifacts.ts
+++ b/packages/automator/artifacts.ts
@@ -186,7 +186,7 @@ export const printAsciiStats = (artifactsDir: string, outFile: string) => {
   }
 
   const lines = [
-    "# Key",
+    "## Key",
     "",
     "Note that each bar component rounds up to the nearest 100ms, so each full bar is an overestimate by up to 400ms.",
     "",
@@ -197,7 +197,7 @@ export const printAsciiStats = (artifactsDir: string, outFile: string) => {
     "      compilation labelling optimization rendering",
     "```",
     "",
-    "# Stats",
+    "## Data",
     "",
     "```",
   ];

--- a/packages/automator/artifacts.ts
+++ b/packages/automator/artifacts.ts
@@ -178,7 +178,7 @@ const makeContinuousBar = (xs: number[]): string => {
   return makeDiscreteBar(columns);
 };
 
-export const printAsciiStats = (artifactsDir: string, outFile: string) => {
+export const printTextChart = (artifactsDir: string, outFile: string) => {
   const artifacts = getArtifacts(artifactsDir);
   if (artifacts.size < 1) {
     fs.writeFileSync(outFile, "");

--- a/packages/automator/index.tsx
+++ b/packages/automator/index.tsx
@@ -20,7 +20,8 @@ import fetch from "node-fetch";
 import { dirname, join, parse, resolve } from "path";
 import * as prettier from "prettier";
 import uniqid from "uniqid";
-import { renderArtifacts } from "./artifacts";
+import { printAsciiStats, renderArtifacts } from "./artifacts";
+import { AggregateData, InstanceData } from "./types";
 
 const USAGE = `
 Penrose Automator.
@@ -28,6 +29,7 @@ Penrose Automator.
 Usage:
   automator batch LIB OUTFOLDER [--folders] [--src-prefix=PREFIX] [--repeat=TIMES] [--render=OUTFOLDER] [--cross-energy]
   automator render ARTIFACTSFOLDER OUTFOLDER
+  automator ascii ARTIFACTSFOLDER OUTFILE
   automator draw SUBSTANCE STYLE DOMAIN OUTFOLDER [--src-prefix=PREFIX] [--variation=VARIATION] [--folders] [--cross-energy]
   automator shapedefs [SHAPEFILE]
 
@@ -182,7 +184,7 @@ const singleProcess = async (
       );
     }
 
-    const metadata = {
+    const metadata: InstanceData = {
       ...meta,
       renderedOn: Date.now(),
       timeTaken: {
@@ -254,7 +256,7 @@ const batchProcess = async (
   let reference = trioLibrary[0];
   let referenceState = undefined;
 
-  const finalMetadata = {};
+  const finalMetadata: AggregateData = {};
   // NOTE: for parallelism, use forEach.
   // But beware the console gets messy and it's hard to track what failed
   for (const { domain, style, substance, variation, meta } of trioLibrary) {
@@ -395,6 +397,8 @@ const getShapeDefs = (outFile?: string): void => {
     }
   } else if (args.render) {
     renderArtifacts(args.ARTIFACTSFOLDER, args.OUTFOLDER);
+  } else if (args.ascii) {
+    printAsciiStats(args.ARTIFACTSFOLDER, args.OUTFILE);
   } else if (args.draw) {
     await singleProcess(
       variation,

--- a/packages/automator/index.tsx
+++ b/packages/automator/index.tsx
@@ -20,7 +20,7 @@ import fetch from "node-fetch";
 import { dirname, join, parse, resolve } from "path";
 import * as prettier from "prettier";
 import uniqid from "uniqid";
-import { printAsciiStats, renderArtifacts } from "./artifacts";
+import { printTextChart, renderArtifacts } from "./artifacts";
 import { AggregateData, InstanceData } from "./types";
 
 const USAGE = `
@@ -29,7 +29,7 @@ Penrose Automator.
 Usage:
   automator batch LIB OUTFOLDER [--folders] [--src-prefix=PREFIX] [--repeat=TIMES] [--render=OUTFOLDER] [--cross-energy]
   automator render ARTIFACTSFOLDER OUTFOLDER
-  automator ascii ARTIFACTSFOLDER OUTFILE
+  automator textchart ARTIFACTSFOLDER OUTFILE
   automator draw SUBSTANCE STYLE DOMAIN OUTFOLDER [--src-prefix=PREFIX] [--variation=VARIATION] [--folders] [--cross-energy]
   automator shapedefs [SHAPEFILE]
 
@@ -37,7 +37,7 @@ Options:
   -o, --outFile PATH Path to either a file or a folder, depending on the value of --folders. [default: output.svg]
   --folders Include metadata about each output diagram. If enabled, outFile has to be a path to a folder.
   --src-prefix PREFIX the prefix to SUBSTANCE, STYLE, and DOMAIN, or the library equivalent in batch mode. No trailing "/" required. [default: .]
-  --repeat TIMES the number of instances 
+  --repeat TIMES the number of instances
   --cross-energy Compute the cross-instance energy
   --variation The variation to use
 `;
@@ -397,8 +397,8 @@ const getShapeDefs = (outFile?: string): void => {
     }
   } else if (args.render) {
     renderArtifacts(args.ARTIFACTSFOLDER, args.OUTFOLDER);
-  } else if (args.ascii) {
-    printAsciiStats(args.ARTIFACTSFOLDER, args.OUTFILE);
+  } else if (args.textchart) {
+    printTextChart(args.ARTIFACTSFOLDER, args.OUTFILE);
   } else if (args.draw) {
     await singleProcess(
       variation,

--- a/packages/automator/types.ts
+++ b/packages/automator/types.ts
@@ -1,0 +1,37 @@
+export interface TimeTaken {
+  overall: number;
+  compilation: number;
+  labelling: number;
+  optimization: number;
+  rendering: number;
+}
+
+export interface OptProblem {
+  constraintCount: number;
+  objectiveCount: number;
+}
+
+export interface Reference {
+  substance: string;
+  style: string;
+  domain: string;
+  variation: string;
+}
+
+export interface InstanceData {
+  substanceName: string;
+  styleName: string;
+  domainName: string;
+  id: string;
+  renderedOn: number;
+  timeTaken: TimeTaken;
+  selectorMatches: [];
+  optProblem: OptProblem;
+  reference: Reference;
+  ciee: number | null; // JSON turns Infinity into null
+  extra?: unknown;
+}
+
+export interface AggregateData {
+  [key: string]: InstanceData;
+}


### PR DESCRIPTION
# Description

This PR adds a `textchart` mode to `@penrose/automator` which generates a simple Markdown file with performance stats, for use as a [GitHub Actions job summary](https://github.blog/2022-05-09-supercharging-github-actions-with-job-summaries/). It also uses [marocchino/sticky-pull-request-comment](https://github.com/marocchino/sticky-pull-request-comment) to generate a comment on the pull request containing those same stats (and also linking to the page containing that summary).

This will make it easier for people to glance at the performance characteristics of a pull request in their browser, without having to locally check out the PR and run the `.github/bench.sh` script as previously required by solutions like #972.

# Implementation strategy and design decisions

I added safety checks to ensure that really large numbers in the JSON don't result in this script trying to produce text lines that are extremely long. I also did a little minor refactoring in a couple parts of the `@penrose/automator` codebase.

# Examples with steps to reproduce them

Look at the autogenerated https://github.com/penrose/penrose/pull/1083#issuecomment-1240971831 below. Or, you could also run it locally if you want to:

```sh
yarn
cd packages/automator/
yarn start batch registry.json out/ --src-prefix=../examples/src/ --folders
yarn start textchart out /dev/stdout
```

# Checklist

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new ESLint warnings
- [x] I have reviewed any generated changes to the `diagrams/` folder

# Open questions

- These look great on Mac and fine on iPhone, but on Windows they look terrible: the characters don't line up with each other properly, and they're not even monospace! Any ideas on alternate characters to use?