### PR TITLE
perf: Time calls to makeGraph and genCode

### DIFF
--- a/packages/automator/index.tsx
+++ b/packages/automator/index.tsx
@@ -83,6 +83,14 @@ const singleProcess = async (
     fs.readFileSync(join(prefix, arg), "utf8").toString()
   );
 
+  const times = new Map<string, number>();
+  const makeStopwatch = (name: string) => {
+    const start = process.hrtime();
+    return () => {
+      times.set(name, toMs(process.hrtime(start)));
+    };
+  };
+
   // Compilation
   console.log(`Compiling for ${out}/${sub} ...`);
   const overallStart = process.hrtime();
@@ -92,6 +100,7 @@ const singleProcess = async (
     style: styIn,
     domain: dslIn,
     variation,
+    makeStopwatch,
   });
   const compileEnd = process.hrtime(compileStart);
   if (compilerOutput.isErr()) {
@@ -192,6 +201,7 @@ const singleProcess = async (
         labelling: convertHrtime(labelEnd).milliseconds,
         optimization: convertHrtime(convergeEnd).milliseconds,
         rendering: convertHrtime(reactRenderEnd).milliseconds,
+        ...Object.fromEntries(times),
       },
       // violatingConstraints: constrs,
       // nonzeroConstraints: constrs.length > 0,

--- a/packages/automator/subtime.js
+++ b/packages/automator/subtime.js
@@ -1,0 +1,48 @@
+#!/usr/bin/env node
+
+const fs = require("fs");
+
+const [, , filename, big, ...smalls] = process.argv;
+const aggregateData = JSON.parse(fs.readFileSync(filename, "utf8"));
+
+const data = [];
+const sums = Object.fromEntries(smalls.map((small) => [small, 0]));
+
+for (const [, { timeTaken }] of Object.entries(aggregateData)) {
+  const dataPoint = {};
+  for (const small of smalls) {
+    dataPoint[small] = timeTaken[small] / timeTaken[big];
+    sums[small] += dataPoint[small];
+  }
+  data.push(dataPoint);
+}
+
+const means = Object.fromEntries(
+  Object.entries(sums).map(([key, value]) => [key, value / data.length])
+);
+
+const sumsOfSquares = Object.fromEntries(smalls.map((small) => [small, 0]));
+
+for (const dataPoint of data) {
+  for (const small of smalls) {
+    sumsOfSquares[small] += (dataPoint[small] - means[small]) ** 2;
+  }
+}
+
+const stdevs = Object.fromEntries(
+  Object.entries(sumsOfSquares).map(([key, value]) => [
+    key,
+    Math.sqrt(value / data.length),
+  ])
+);
+
+console.log();
+console.log(`Percentages of ${big} time:`);
+console.log();
+const padSize = Math.max(...smalls.map((small) => small.length));
+for (const small of smalls) {
+  const name = small.padEnd(padSize);
+  const mean = (means[small] * 100).toFixed(2).padStart(5);
+  const stdev = (stdevs[small] * 100).toFixed(2).padStart(5);
+  console.log(`    ${name} ${mean}% ± ${stdev}%`);
+}

--- a/packages/automator/subtime.js
+++ b/packages/automator/subtime.js
@@ -42,7 +42,7 @@ console.log();
 const padSize = Math.max(...smalls.map((small) => small.length));
 for (const small of smalls) {
   const name = small.padEnd(padSize);
-  const mean = (means[small] * 100).toFixed(2).padStart(5);
-  const stdev = (stdevs[small] * 100).toFixed(2).padStart(5);
+  const mean = (means[small] * 100).toFixed(1).padStart(4);
+  const stdev = (stdevs[small] * 100).toFixed(1).padStart(4);
   console.log(`    ${name} ${mean}% ± ${stdev}%`);
 }

--- a/packages/core/src/compiler/Style.ts
+++ b/packages/core/src/compiler/Style.ts
@@ -93,6 +93,7 @@ import {
   SubStmt,
   TypeConsApp,
 } from "types/substance";
+import { StopwatchFactory } from "types/time";
 import {
   ArgVal,
   Field,
@@ -2999,7 +3000,8 @@ export const compileStyle = (
   variation: string,
   stySource: string,
   subEnv: SubstanceEnv,
-  varEnv: Env
+  varEnv: Env,
+  makeStopwatch?: StopwatchFactory
 ): Result<State, PenroseError> => {
   const astOk = parseStyle(stySource);
   let styProg;
@@ -3067,12 +3069,19 @@ export const compileStyle = (
     ...onCanvases(canvas.value, shapes),
   ];
 
-  const computeShapes = compileCompGraph(shapes);
+  if (makeStopwatch === undefined) {
+    makeStopwatch = () => () => {
+      return;
+    };
+  }
+
+  const computeShapes = compileCompGraph(shapes, makeStopwatch);
 
   const params = genOptProblem(
     inputs,
     objFns.map(({ output }) => output),
-    constrFns.map(({ output }) => output)
+    constrFns.map(({ output }) => output),
+    makeStopwatch
   );
 
   const initState: State = {

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,5 +1,6 @@
 import { initConstraintWeight } from "engine/EngineUtils";
 import seedrandom from "seedrandom";
+import { StopwatchFactory } from "types/time";
 import { checkDomain, compileDomain, parseDomain } from "./compiler/Domain";
 import { compileStyle } from "./compiler/Style";
 import {
@@ -201,6 +202,7 @@ export const compileTrio = (prog: {
   style: string;
   domain: string;
   variation: string;
+  makeStopwatch?: StopwatchFactory;
 }): Result<State, PenroseError> => {
   const domainRes: Result<Env, PenroseError> = compileDomain(prog.domain);
 
@@ -210,7 +212,8 @@ export const compileTrio = (prog: {
   );
 
   const styRes: Result<State, PenroseError> = andThen(
-    (res) => compileStyle(prog.variation, prog.style, ...res),
+    (res) =>
+      compileStyle(prog.variation, prog.style, ...res, prog.makeStopwatch),
     subRes
   );
 

--- a/packages/core/src/types/time.ts
+++ b/packages/core/src/types/time.ts
@@ -1,0 +1,2 @@
+export type Stopwatch = () => void;
+export type StopwatchFactory = (name: string) => Stopwatch;


### PR DESCRIPTION
# Description

This PR (just an experiment, not to be merged) measures the performance impact of all the (four) places we call `makeGraph` or `genCode`.

# Implementation strategy and design decisions

I used a `makeStopwatch` function as a global context around in the Style compiler, which is initialized by `@penrose/automator` to store time data in a map that later gets included in the timing metadata.

# Examples with steps to reproduce them

Check out this PR and run these commands:

```sh
yarn
cd packages/automator/
yarn start batch registry.json out/ --src-prefix=../examples/src/ --folders
./subtime.js out/aggregateData.json compilation 'compileCompGraph secondaryGraph' 'compileCompGraph genCode' 'genOptProblem makeGraph' 'genOptProblem genCode'
```

I got these results on my 2020 MacBook with M1 chip:

```
Percentages of compilation time:

    compileCompGraph secondaryGraph  1.1% ±  1.5%
    compileCompGraph genCode         1.3% ±  3.7%
    genOptProblem makeGraph         55.2% ±  8.4%
    genOptProblem genCode           23.9% ±  3.5%
```

In other words, `makeGraph` and `genCode` together make up about three-quarters of all compilation time.

# Checklist

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new ESLint warnings
- [x] I have reviewed any generated changes to the `diagrams/` folder

# Open questions

- Should we expand our profiling infrastructure to make it easier to answer questions like this in the future?