### PR TITLE
fix: Generate code using heap instead of stack

### DIFF
--- a/packages/core/src/engine/Autodiff.ts
+++ b/packages/core/src/engine/Autodiff.ts
@@ -1143,11 +1143,11 @@ export const genCode = ({
   for (let i = 0; i < numBools; i++) {
     bools.push(false);
   }
-  const nums: number[] = [];
+  const numsUntyped: number[] = [];
   for (let i = 0; i < numNums; i++) {
-    // we need to make sure the engine knows it's floating-point, not an integer
-    nums.push(-0);
+    numsUntyped.push(-0);
   }
+  const nums = Float64Array.from(numsUntyped);
 
   return (inputs) => f(polyRoots, bools, nums, inputs);
 };

--- a/packages/core/src/types/ad.ts
+++ b/packages/core/src/types/ad.ts
@@ -229,33 +229,23 @@ export interface DebugNode {
   info: string;
 }
 
-export type Edge =
-  | UnaryEdge
-  | BinaryEdge
-  | CompEdge
-  | LogicEdge
-  | TernaryEdge
-  | NaryEdge
-  | PolyRootsEdge
-  | IndexEdge
-  | DebugEdge
-  | NotEdge;
-
+export type Edge = UnaryEdge | BinaryEdge | TernaryEdge | NaryEdge;
 export type UnaryEdge = undefined;
 export type BinaryEdge = "left" | "right";
-export type CompEdge = BinaryEdge;
-export type LogicEdge = BinaryEdge;
 export type TernaryEdge = "cond" | "then" | "els";
 export type NaryEdge = `${number}`;
-export type PolyRootsEdge = NaryEdge;
-export type IndexEdge = UnaryEdge;
-export type DebugEdge = UnaryEdge;
-export type NotEdge = UnaryEdge;
 
-export type Id = `_${number}`; // subset of valid JavaScript identifiers
+export const boolsName = "bools";
+export const numsName = "nums";
+
+export type Id = BoolId | NumId;
+export type BoolId = `${typeof boolsName}[${number}]`;
+export type NumId = `${typeof numsName}[${number}]`;
 
 export interface Graph extends Outputs<Id> {
   graph: Multidigraph<Id, Node, Edge>; // edges point from children to parents
+  numBools: number;
+  numNums: number;
   nodes: Map<Expr, Id>;
 }
 


### PR DESCRIPTION
# Description

Fixes #1070 by eliminating all local variables in the function constructed by `genCode`, instead using a `bools` array and a `nums` array. Preliminary performance results suggest that this makes Penrose almost twice as slow.

Currently this fails all the tests that use `polyRoots`, because I have not yet handled `ad.Vec`.

# Implementation strategy and design decisions

To make this at least somewhat efficient, we need to separate `boolean`s from `number`s. There are two obvious approaches:

1. Keep `makeGraph` the same, then separate them out in `genCode`.
2. Separate them out in `makeGraph`, keeping `genCode` the same.

The first approach is what I used for [my experiment where I changed `genCode` to produce C instead of JS](https://github.com/penrose/experiments/blob/05d231a8f5d8faf6fb1dcf642fde1c6d78f08634/2022-optimizer-performance/penrose.patch#L306-L336). I ended up going with the second approach here because it means I don't have to make a mapping between IDs in the graph and indices in these `bools` and `nums` arrays. I'm really not sure which is better, though; the second approach makes some of the logic in `makeGraph` messier.

As an aside, since I was touching code nearby, I cleaned up our unnecessarily verbose definition for `ad.Edge`.

# Examples with steps to reproduce them

In one terminal:

```sh
yarn
cd packages/examples/src/shape-distance/
node -e 'for (let i = 100; i < 1000; i++) { console.log(`Point p${i}\nAround(p${i},g)`); }' \
  >> hundred-points-around-star.sub
roger watch
```

Then in a separate terminal:

```
yarn start
```

Open http://localhost:3000/try/ in your browser, select the following files, and click "compile":

- `hundred-points-around-star.sub`
- `shape-distance.sty`
- `shapes.dsl`

Before this PR, you should get this error:

```
Uncaught RangeError: Maximum call stack size exceeded
    at eval (eval at genCode (Autodiff.ts:1094:13), <anonymous>:3:12)
    at Autodiff.ts:1095:22
    at Optimizer.ts:812:46
    at minimize (Optimizer.ts:659:56)
    at step (Optimizer.ts:152:19)
    at stepStateSafe (index.ts:75:15)
    at step (DiagramPanel.tsx:78:28)
```

After this PR, it should just work:

![points-around-star](https://user-images.githubusercontent.com/8246041/189247895-30f1d354-b0b5-4998-853a-bf599b9bed04.svg)

# Checklist

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new ESLint warnings
- [x] I have reviewed any generated changes to the `diagrams/` folder