### PR TITLE
chore: Migrate to official VS Code MDX extension

### DIFF
--- a/penrose.code-workspace
+++ b/penrose.code-workspace
@@ -6,7 +6,7 @@
       "folke.vscode-monorepo-workspace",
       "karyfoundation.nearley",
       "penrose.penrose-vs",
-      "silvenon.mdx"
+      "unifiedjs.vscode-mdx"
     ]
   },
   "folders": [


### PR DESCRIPTION
# Description

This PR migrates our VS Code MDX extension recommendation from [silvenon.mdx](https://marketplace.visualstudio.com/items?itemName=silvenon.mdx) to [unifiedjs.vscode-mdx](https://marketplace.visualstudio.com/items?itemName=unifiedjs.vscode-mdx). From the former's README:

> _**Note**: This extension has been deprecated in favor of the [official MDX extension](https://marketplace.visualstudio.com/items?itemName=unifiedjs.vscode-mdx)._

# Checklist

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new ESLint warnings
- [x] I have reviewed any generated changes to the `diagrams/` folder