### PR TITLE
feat: Style inline color widgets

### DIFF
--- a/packages/components/src/editing/languages/StyleConfig.ts
+++ b/packages/components/src/editing/languages/StyleConfig.ts
@@ -1,6 +1,6 @@
 import { Monaco } from "@monaco-editor/react";
 import { compDict, constrDict, objDict, shapedefs } from "@penrose/core";
-import { IRange, languages } from "monaco-editor";
+import { editor, IRange, languages } from "monaco-editor";
 import { CommentCommon, CommonTokens } from "./common";
 
 export const StyleConfig: languages.LanguageConfiguration = {
@@ -183,17 +183,28 @@ export const SetupStyleMonaco = (monaco: Monaco) => {
         null,
         true
       );
-      console.log(colorMatches);
-
-      return colorMatches.map(({ matches, range }) => ({
-        color: {
-          red: +matches![1],
-          green: +matches![2],
-          blue: +matches![3],
-          alpha: +matches![4],
+      return colorMatches.reduce(
+        (
+          colors: languages.IColorInformation[],
+          { matches, range }: editor.FindMatch
+        ) => {
+          if (matches !== null) {
+            const color = {
+              color: {
+                red: +matches[1],
+                green: +matches[2],
+                blue: +matches[3],
+                alpha: +matches[4],
+              },
+              range: range,
+            };
+            return [...colors, color];
+          } else {
+            return colors;
+          }
         },
-        range: range,
-      }));
+        []
+      );
     },
   });
   const disposeCompletion = monaco.languages.registerCompletionItemProvider(

--- a/packages/components/src/editing/languages/StyleConfig.ts
+++ b/packages/components/src/editing/languages/StyleConfig.ts
@@ -163,20 +163,56 @@ export const SetupStyleMonaco = (monaco: Monaco) => {
   monaco.languages.register({ id: "style" });
   monaco.languages.setLanguageConfiguration("style", StyleConfig);
   monaco.languages.setMonarchTokensProvider("style", StyleLanguageTokens);
-  const dispose = monaco.languages.registerCompletionItemProvider("style", {
-    provideCompletionItems: (model, position) => {
-      const word = model.getWordUntilPosition(position);
-      const range: IRange = {
-        startLineNumber: position.lineNumber,
-        endLineNumber: position.lineNumber,
-        startColumn: word.startColumn,
-        endColumn: word.endColumn,
-      };
-      return { suggestions: StyleCompletions(range) } as any;
+  const disposeColor = monaco.languages.registerColorProvider("style", {
+    provideColorPresentations: (model, colorInfo) => {
+      const { red, green, blue, alpha } = colorInfo.color;
+      return [
+        {
+          label: `rgba(${red}, ${green}, ${blue}, ${alpha})`,
+        },
+      ];
     },
-    // HACK
+
+    provideDocumentColors: (model) => {
+      const colorRegex = /rgba\(\s*(.*)\s*,\s*(.*)\s*,\s*(.*)\s*,\s*(.*)\s*\)/;
+      const colorMatches = model.findMatches(
+        colorRegex.source,
+        false,
+        true,
+        false,
+        null,
+        true
+      );
+      console.log(colorMatches);
+
+      return colorMatches.map(({ matches, range }) => ({
+        color: {
+          red: +matches![1],
+          green: +matches![2],
+          blue: +matches![3],
+          alpha: +matches![4],
+        },
+        range: range,
+      }));
+    },
   });
+  const disposeCompletion = monaco.languages.registerCompletionItemProvider(
+    "style",
+    {
+      provideCompletionItems: (model, position) => {
+        const word = model.getWordUntilPosition(position);
+        const range: IRange = {
+          startLineNumber: position.lineNumber,
+          endLineNumber: position.lineNumber,
+          startColumn: word.startColumn,
+          endColumn: word.endColumn,
+        };
+        return { suggestions: StyleCompletions(range) } as any;
+      },
+    }
+  );
   return () => {
-    dispose.dispose();
+    disposeColor.dispose();
+    disposeCompletion.dispose();
   };
 };


### PR DESCRIPTION
# Description

Related issue/PR: N/A

@keenancrane asked:

> Is a pop-up color picker something that could be easily integrated into the framework you're using for the IDE?

This PR adds support for `ColorProvider` in our monaco editor for Style, which displays a color icon and on-hover color picker for all `rgba` function calls.

# Implementation strategy and design decisions

Since we do not have a language server, this PR is implemented in the simplest way: parsing the document with a regex for valid `rgba` function calls. Currently, this feature does not support `hsva` or any other functions that return colors. In addition, the arguments to `rgba` have to be floating-point literals; inline expression are not supported yet.

# Examples with steps to reproduce them

![image](https://user-images.githubusercontent.com/11740102/190260058-f7172be5-f2b9-44ae-a376-38edcd0b87f4.png)

# Checklist

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new ESLint warnings
- [x] I have reviewed any generated changes to the `diagrams/` folder

# Open questions

Ideally, we should have a language server that supports [Color decorators](https://code.visualstudio.com/api/language-extensions/programmatic-language-features#show-color-decorators). The server should tokenize and parse the Style program, and the color provider reasons over tokens and the AST instead of matching on text to find source ranges for the decorators.
