### PR TITLE
build: Replace monaco-editor with monaco-editor-core

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -8,9 +8,9 @@
   "scripts": {
     "dev": "vite",
     "watch": "vite build --watch",
-    "build": "vite build && yarn replace-monaco && yarn replace-shift",
-    "replace-monaco": "sed -i '' 's%^import require$$0 from \"monaco-editor\";$%import { editor as require$$0 } from \"monaco-editor-core\";%' dist/index.es.js",
-    "replace-shift": "sed -i '' 's%^import require$$1 from \"monaco-editor/esm/vs/editor/common/commands/shiftCommand\";$%import * as require$$1 from \"monaco-editor-core/esm/vs/editor/common/commands/shiftCommand\";%' dist/index.es.js",
+    "build": "vite build && yarn replace-monaco && yarn replace-shift && shx rm -f dist/index.es.js.bak",
+    "replace-monaco": "sed -i.bak 's%^import require$$0 from \"monaco-editor\";$%import { editor as require$$0 } from \"monaco-editor-core\";%' dist/index.es.js",
+    "replace-shift": "sed -i.bak 's%^import require$$1 from \"monaco-editor/esm/vs/editor/common/commands/shiftCommand\";$%import * as require$$1 from \"monaco-editor-core/esm/vs/editor/common/commands/shiftCommand\";%' dist/index.es.js",
     "typecheck": "tsc",
     "preview": "vite preview",
     "storybook": "start-storybook -p 6006",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -8,7 +8,9 @@
   "scripts": {
     "dev": "vite",
     "watch": "vite build --watch",
-    "build": "vite build",
+    "build": "vite build && yarn replace-monaco && yarn replace-shift",
+    "replace-monaco": "sed -i '' 's%^import require$$0 from \"monaco-editor\";$%import { editor as require$$0 } from \"monaco-editor-core\";%' dist/index.es.js",
+    "replace-shift": "sed -i '' 's%^import require$$1 from \"monaco-editor/esm/vs/editor/common/commands/shiftCommand\";$%import * as require$$1 from \"monaco-editor-core/esm/vs/editor/common/commands/shiftCommand\";%' dist/index.es.js",
     "typecheck": "tsc",
     "preview": "vite preview",
     "storybook": "start-storybook -p 6006",
@@ -22,7 +24,7 @@
   },
   "dependencies": {
     "@monaco-editor/react": "^4.0.11",
-    "monaco-editor": "^0.31.0",
+    "monaco-editor-core": "^0.31.0",
     "monaco-vim": "^0.3.4"
   },
   "devDependencies": {

--- a/packages/components/src/Listing.tsx
+++ b/packages/components/src/Listing.tsx
@@ -1,6 +1,6 @@
 import MonacoEditor, { useMonaco } from "@monaco-editor/react";
 import { compileDomain } from "@penrose/core";
-import { editor } from "monaco-editor";
+import { editor } from "monaco-editor-core";
 import { useEffect } from "react";
 import { SetupSubstanceMonaco } from "./editing/languages/SubstanceConfig";
 

--- a/packages/components/src/editing/EditorPane.tsx
+++ b/packages/components/src/editing/EditorPane.tsx
@@ -1,6 +1,6 @@
 import MonacoEditor, { useMonaco } from "@monaco-editor/react";
 import { Env } from "@penrose/core";
-import { editor } from "monaco-editor";
+import { editor } from "monaco-editor-core";
 import { initVimMode } from "monaco-vim";
 import { useEffect, useRef } from "react";
 import { SetupDomainMonaco } from "./languages/DomainConfig";

--- a/packages/components/src/editing/languages/DomainConfig.ts
+++ b/packages/components/src/editing/languages/DomainConfig.ts
@@ -1,5 +1,5 @@
 import { Monaco } from "@monaco-editor/react";
-import { IRange, languages } from "monaco-editor";
+import { IRange, languages } from "monaco-editor-core";
 import { CommentCommon, CommonTokens } from "./common";
 
 export const DomainConfig: languages.LanguageConfiguration = {
@@ -66,7 +66,7 @@ export const SetupDomainMonaco = (monaco: Monaco) => {
   monaco.languages.setLanguageConfiguration("domain", DomainConfig);
   monaco.languages.setMonarchTokensProvider("domain", DomainLanguageTokens());
   const dispose = monaco.languages.registerCompletionItemProvider("domain", {
-    provideCompletionItems: (model, position) => {
+    provideCompletionItems: (model: any, position: any) => {
       const word = model.getWordUntilPosition(position);
       const range: IRange = {
         startLineNumber: position.lineNumber,

--- a/packages/components/src/editing/languages/StyleConfig.ts
+++ b/packages/components/src/editing/languages/StyleConfig.ts
@@ -1,6 +1,6 @@
 import { Monaco } from "@monaco-editor/react";
 import { compDict, constrDict, objDict, shapedefs } from "@penrose/core";
-import { IRange, languages } from "monaco-editor";
+import { IRange, languages } from "monaco-editor-core";
 import { CommentCommon, CommonTokens } from "./common";
 
 export const StyleConfig: languages.LanguageConfiguration = {
@@ -164,7 +164,7 @@ export const SetupStyleMonaco = (monaco: Monaco) => {
   monaco.languages.setLanguageConfiguration("style", StyleConfig);
   monaco.languages.setMonarchTokensProvider("style", StyleLanguageTokens);
   const dispose = monaco.languages.registerCompletionItemProvider("style", {
-    provideCompletionItems: (model, position) => {
+    provideCompletionItems: (model: any, position: any) => {
       const word = model.getWordUntilPosition(position);
       const range: IRange = {
         startLineNumber: position.lineNumber,

--- a/packages/components/src/editing/languages/SubstanceConfig.ts
+++ b/packages/components/src/editing/languages/SubstanceConfig.ts
@@ -1,6 +1,6 @@
 import { Monaco } from "@monaco-editor/react";
 import { Env } from "@penrose/core";
-import { editor, IRange, languages, Position } from "monaco-editor";
+import { editor, IRange, languages, Position } from "monaco-editor-core";
 import { CommentCommon, CommonTokens } from "./common";
 
 export const SubstanceConfig: languages.LanguageConfiguration = {

--- a/packages/components/src/editing/languages/common.ts
+++ b/packages/components/src/editing/languages/common.ts
@@ -1,4 +1,4 @@
-import { languages } from "monaco-editor";
+import { languages } from "monaco-editor-core";
 
 export const CommentCommon: any = {
   comment: [

--- a/yarn.lock
+++ b/yarn.lock
@@ -16650,10 +16650,10 @@ modify-values@^1.0.0:
   resolved "https://registry.yarnpkg.com/modify-values/-/modify-values-1.0.1.tgz#b3939fa605546474e3e3e3c63d64bd43b4ee6022"
   integrity sha512-xV2bxeN6F7oYjZWTe/YPAy6MN2M+sL4u/Rlm2AHCIVGfo2p1yGmBHQ6vHehl4bRTZBdHu3TSkWdYgkwpYzAGSw==
 
-monaco-editor@^0.31.0:
+monaco-editor-core@^0.31.0:
   version "0.31.1"
-  resolved "https://registry.yarnpkg.com/monaco-editor/-/monaco-editor-0.31.1.tgz#67f597b3e45679d1f551237e12a3a42c4438b97b"
-  integrity sha512-FYPwxGZAeP6mRRyrr5XTGHD9gRXVjy7GUzF4IPChnyt3fS5WrNxIkS8DNujWf6EQy0Zlzpxw8oTVE+mWI2/D1Q==
+  resolved "https://registry.yarnpkg.com/monaco-editor-core/-/monaco-editor-core-0.31.1.tgz#7dfde54f00a3894e87db6151b7c1333944727455"
+  integrity sha512-JdwqSmTJP10bhb7qc94ehWX0C1D2R2rwCHfm+5Vd2Oh0dwjfeCAWHDelnTZ+BVbGPCb+7ZGHZvG+oYZHdmuemg==
 
 monaco-vim@^0.3.4:
   version "0.3.4"


### PR DESCRIPTION
# Description

This PR replaces our dependency on [monaco-editor](https://www.npmjs.com/package/monaco-editor) with [monaco-editor-core](https://www.npmjs.com/package/monaco-editor-core). Compare the output of `yarn build` in `@penrose/components` _after_ this PR...

```
$ vite build && yarn replace-monaco && yarn replace-shift && shx rm -f dist/index.es.js.bak
vite v2.8.3 building for production...
transforming (1) src/index.tsBrowserslist: caniuse-lite is outdated. Please run:
  npx browserslist@latest --update-db
  Why you should do it regularly: https://github.com/browserslist/browserslist#browsers-data-updating
transforming (489) ../../node_modules/monaco-editor-core/esm/vs/editor/contrib/unicodeHighlighter/bannerController.css'monaco-editor' is imported by monaco-editor?commonjs-external, but could not be resolved – treating it as an external dependency
'monaco-editor/esm/vs/editor/common/commands/shiftCommand' is imported by monaco-editor/esm/vs/editor/common/commands/shiftCommand?commonjs-external, but could not be resolved – treating it as an external dependency
✓ 694 modules transformed.
dist/style.css     165.83 KiB / gzip: 63.68 KiB
dist/index.es.js   8582.39 KiB / gzip: 1768.48 KiB
dist/index.es.js.map 16729.27 KiB
$ sed -i.bak 's%^import require$$0 from "monaco-editor";$%import { editor as require$$0 } from "monaco-editor-core";%' dist/index.es.js
$ sed -i.bak 's%^import require$$1 from "monaco-editor/esm/vs/editor/common/commands/shiftCommand";$%import * as require$$1 from "monaco-editor-core/esm/vs/editor/common/commands/shiftCommand";%' dist/index.es.js
✨  Done in 7.56s.
```

... with _before_:

```
yarn run v1.22.19
$ vite build
vite v2.8.3 building for production...
transforming (1) src/index.tsBrowserslist: caniuse-lite is outdated. Please run:
  npx browserslist@latest --update-db
  Why you should do it regularly: https://github.com/browserslist/browserslist#browsers-data-updating
✓ 857 modules transformed.
dist/index.es.js           0.20 KiB / gzip: 0.16 KiB
dist/index.es.js.map       0.09 KiB
dist/abap.js               20.67 KiB / gzip: 5.64 KiB
dist/abap.js.map           37.99 KiB
dist/tsMode.js             46.60 KiB / gzip: 9.13 KiB
dist/tsMode.js.map         72.10 KiB
dist/apex.js               5.89 KiB / gzip: 2.03 KiB
dist/apex.js.map           10.96 KiB
dist/azcli.js              1.64 KiB / gzip: 0.50 KiB
dist/azcli.js.map          2.85 KiB
dist/bat.js                2.68 KiB / gzip: 1.06 KiB
dist/bat.js.map            4.70 KiB
dist/bicep.js              3.72 KiB / gzip: 1.22 KiB
dist/bicep.js.map          6.65 KiB
dist/cameligo.js           3.40 KiB / gzip: 1.16 KiB
dist/cameligo.js.map       6.52 KiB
dist/clojure.js            13.46 KiB / gzip: 3.86 KiB
dist/clojure.js.map        23.83 KiB
dist/coffee.js             5.46 KiB / gzip: 1.55 KiB
dist/coffee.js.map         9.86 KiB
dist/cpp.js                7.92 KiB / gzip: 2.36 KiB
dist/cpp.js.map            14.18 KiB
dist/htmlMode.js           62.29 KiB / gzip: 10.83 KiB
dist/htmlMode.js.map       100.20 KiB
dist/csp.js                1.94 KiB / gzip: 0.68 KiB
dist/csp.js.map            3.15 KiB
dist/cssMode.js            64.82 KiB / gzip: 11.48 KiB
dist/cssMode.js.map        104.50 KiB
dist/css.js                6.04 KiB / gzip: 1.60 KiB
dist/css.js.map            10.63 KiB
dist/csharp.js             6.79 KiB / gzip: 1.97 KiB
dist/csharp.js.map         12.48 KiB
dist/dockerfile.js         3.12 KiB / gzip: 0.87 KiB
dist/dockerfile.js.map     5.69 KiB
dist/dart.js               6.09 KiB / gzip: 1.89 KiB
dist/dart.js.map           10.98 KiB
dist/ecl.js                7.89 KiB / gzip: 2.51 KiB
dist/ecl.js.map            14.78 KiB
dist/fsharp.js             4.38 KiB / gzip: 1.52 KiB
dist/fsharp.js.map         8.02 KiB
dist/elixir.js             13.53 KiB / gzip: 2.78 KiB
dist/elixir.js.map         22.23 KiB
dist/flow9.js              2.85 KiB / gzip: 1.05 KiB
dist/flow9.js.map          5.36 KiB
dist/go.js                 4.07 KiB / gzip: 1.35 KiB
dist/go.js.map             7.69 KiB
dist/graphql.js            3.37 KiB / gzip: 1.23 KiB
dist/graphql.js.map        6.08 KiB
dist/html.js               7.50 KiB / gzip: 1.73 KiB
dist/html.js.map           12.96 KiB
dist/hcl.js                4.97 KiB / gzip: 1.71 KiB
dist/hcl.js.map            8.21 KiB
dist/ini.js                1.73 KiB / gzip: 0.72 KiB
dist/ini.js.map            3.17 KiB
dist/handlebars.js         10.50 KiB / gzip: 2.01 KiB
dist/handlebars.js.map     17.59 KiB
dist/javascript.js         1.56 KiB / gzip: 0.64 KiB
dist/javascript.js.map     2.75 KiB
dist/jsonMode.js           79.58 KiB / gzip: 14.65 KiB
dist/jsonMode.js.map       128.35 KiB
dist/julia.js              10.29 KiB / gzip: 2.86 KiB
dist/julia.js.map          18.67 KiB
dist/java.js               4.68 KiB / gzip: 1.61 KiB
dist/java.js.map           8.52 KiB
dist/less.js               5.25 KiB / gzip: 1.62 KiB
dist/less.js.map           9.12 KiB
dist/lua.js                3.35 KiB / gzip: 1.13 KiB
dist/lua.js.map            6.19 KiB
dist/lexon.js              3.66 KiB / gzip: 1.17 KiB
dist/lexon.js.map          6.61 KiB
dist/m3.js                 4.24 KiB / gzip: 1.51 KiB
dist/m3.js.map             7.92 KiB
dist/liquid.js             6.12 KiB / gzip: 2.04 KiB
dist/liquid.js.map         10.73 KiB
dist/mips.js               4.12 KiB / gzip: 1.32 KiB
dist/mips.js.map           7.38 KiB
dist/markdown.js           5.60 KiB / gzip: 1.64 KiB
dist/markdown.js.map       9.66 KiB
dist/msdax.js              7.08 KiB / gzip: 2.18 KiB
dist/msdax.js.map          12.89 KiB
dist/objective-c.js        3.68 KiB / gzip: 1.26 KiB
dist/objective-c.js.map    6.90 KiB
dist/typescript.js         8.10 KiB / gzip: 2.53 KiB
dist/typescript.js.map     14.16 KiB
dist/kotlin.js             5.02 KiB / gzip: 1.69 KiB
dist/kotlin.js.map         9.21 KiB
dist/pascaligo.js          3.14 KiB / gzip: 1.11 KiB
dist/pascaligo.js.map      6.00 KiB
dist/mysql.js              15.72 KiB / gzip: 4.30 KiB
dist/mysql.js.map          27.83 KiB
dist/pla.js                2.92 KiB / gzip: 0.86 KiB
dist/pla.js.map            5.25 KiB
dist/pascal.js             4.54 KiB / gzip: 1.61 KiB
dist/pascal.js.map         8.57 KiB
dist/php.js                11.64 KiB / gzip: 2.35 KiB
dist/php.js.map            19.76 KiB
dist/perl.js               11.96 KiB / gzip: 3.39 KiB
dist/perl.js.map           21.65 KiB
dist/powershell.js         5.29 KiB / gzip: 1.61 KiB
dist/powershell.js.map     9.26 KiB
dist/postiats.js           11.59 KiB / gzip: 2.72 KiB
dist/postiats.js.map       20.62 KiB
dist/protobuf.js           12.63 KiB / gzip: 2.33 KiB
dist/protobuf.js.map       21.82 KiB
dist/pgsql.js              17.68 KiB / gzip: 4.71 KiB
dist/pgsql.js.map          29.31 KiB
dist/python.js             5.69 KiB / gzip: 1.91 KiB
dist/python.js.map         10.39 KiB
dist/pug.js                8.05 KiB / gzip: 1.94 KiB
dist/pug.js.map            14.51 KiB
dist/qsharp.js             4.64 KiB / gzip: 1.59 KiB
dist/qsharp.js.map         8.95 KiB
dist/r.js                  4.85 KiB / gzip: 1.50 KiB
dist/r.js.map              8.83 KiB
dist/redis.js              5.38 KiB / gzip: 1.69 KiB
dist/redis.js.map          9.94 KiB
dist/razor.js              13.17 KiB / gzip: 2.74 KiB
dist/razor.js.map          22.44 KiB
dist/restructuredtext.js   5.15 KiB / gzip: 1.58 KiB
dist/restructuredtext.js.map 8.95 KiB
dist/rust.js               6.26 KiB / gzip: 2.05 KiB
dist/rust.js.map           11.66 KiB
dist/redshift.js           15.94 KiB / gzip: 4.56 KiB
dist/redshift.js.map       27.11 KiB
dist/sb.js                 2.77 KiB / gzip: 1.03 KiB
dist/sb.js.map             4.99 KiB
dist/ruby.js               12.20 KiB / gzip: 2.90 KiB
dist/ruby.js.map           20.83 KiB
dist/scheme.js             2.67 KiB / gzip: 1.02 KiB
dist/scheme.js.map         4.91 KiB
dist/shell.js              4.44 KiB / gzip: 1.37 KiB
dist/shell.js.map          8.27 KiB
dist/scss.js               8.41 KiB / gzip: 1.98 KiB
dist/scss.js.map           14.82 KiB
dist/scala.js              10.13 KiB / gzip: 2.37 KiB
dist/scala.js.map          17.54 KiB
dist/sparql.js             3.81 KiB / gzip: 1.36 KiB
dist/sparql.js.map         7.08 KiB
dist/sophia.js             4.07 KiB / gzip: 1.40 KiB
dist/sophia.js.map         7.46 KiB
dist/st.js                 10.05 KiB / gzip: 2.50 KiB
dist/st.js.map             18.26 KiB
dist/sql.js                14.61 KiB / gzip: 4.11 KiB
dist/sql.js.map            26.23 KiB
dist/swift.js              6.07 KiB / gzip: 1.93 KiB
dist/swift.js.map          10.55 KiB
dist/solidity.js           25.20 KiB / gzip: 4.80 KiB
dist/solidity.js.map       43.34 KiB
dist/tcl.js                5.16 KiB / gzip: 1.58 KiB
dist/tcl.js.map            9.46 KiB
dist/twig.js               8.53 KiB / gzip: 1.77 KiB
dist/twig.js.map           14.71 KiB
dist/systemverilog.js      11.02 KiB / gzip: 3.03 KiB
dist/systemverilog.js.map  19.78 KiB
dist/xml.js                3.76 KiB / gzip: 1.30 KiB
dist/xml.js.map            6.42 KiB
dist/vb.js                 8.04 KiB / gzip: 2.29 KiB
dist/vb.js.map             14.46 KiB
dist/yaml.js               4.95 KiB / gzip: 1.43 KiB
dist/yaml.js.map           8.48 KiB
dist/powerquery.js         21.37 KiB / gzip: 5.13 KiB
dist/powerquery.js.map     33.62 KiB
dist/style.css             165.83 KiB / gzip: 63.26 KiB
dist/index.js              8651.61 KiB / gzip: 1775.38 KiB
dist/index.js.map          16862.38 KiB
✨  Done in 7.98s.
```

# Checklist

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new ESLint warnings
- [x] I have reviewed any generated changes to the `diagrams/` folder

# Open questions

- Where exactly are those two `import`s in `dist/index.es.js` (which this PR modifies via `sed`) coming from? Is there a better way to replace them, before `vite build` rather than after?
- Why do the `provideCompletionItems` parameters need to be explicitly typed as `any` after this PR?