### PR TITLE
chore: use block cursor in vim mode

### DIFF
--- a/packages/components/src/editing/EditorPane.tsx
+++ b/packages/components/src/editing/EditorPane.tsx
@@ -7,7 +7,9 @@ import { SetupDomainMonaco } from "./languages/DomainConfig";
 import { SetupStyleMonaco } from "./languages/StyleConfig";
 import { SetupSubstanceMonaco } from "./languages/SubstanceConfig";
 
-const monacoOptions: editor.IEditorConstructionOptions = {
+const monacoOptions = (
+  vimMode: boolean
+): editor.IEditorConstructionOptions => ({
   automaticLayout: true,
   minimap: { enabled: false },
   wordWrap: "on",
@@ -15,7 +17,8 @@ const monacoOptions: editor.IEditorConstructionOptions = {
   fontSize: 16,
   copyWithSyntaxHighlighting: true,
   glyphMargin: false,
-};
+  cursorStyle: vimMode ? "block" : "line",
+});
 
 export default function EditorPane({
   value,
@@ -65,7 +68,7 @@ export default function EditorPane({
         onChange={(v) => onChange(v ?? "")}
         defaultLanguage={languageType}
         // HACK
-        options={{ ...(monacoOptions as any), readOnly }}
+        options={{ ...(monacoOptions(vimMode) as any), readOnly }}
         onMount={onEditorMount as any}
       />
       <div


### PR DESCRIPTION
# Description

`editor` uses the default line cursor in both normal and vim modes. Block cursor seems to be a more conventional default for vim.

# Checklist

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new ESLint warnings
- [x] I have reviewed any generated changes to the `diagrams/` folder

