### PR TITLE
build: Skip missing package.json in turboConfig.js

### DIFF
--- a/turboConfig.js
+++ b/turboConfig.js
@@ -15,22 +15,21 @@ const turboJSON = {
 };
 const packagesDir = "packages";
 for (const package of fs.readdirSync(packagesDir)) {
-  const { name, turbo } = JSON.parse(
-    fs.readFileSync(path.join(packagesDir, package, "package.json")).toString()
-  );
-  if (turbo) {
-    for (const [script, unparsed] of Object.entries(turbo)) {
-      const config = yaml.load(`{${unparsed}}`);
-      const entry = {
-        dependsOn: [
-          ...(basePipeline[script]?.dependsOn ?? []),
-          ...(config.deps ?? []),
-        ],
-        outputs: config.out ?? [],
-      };
-      if ("cache" in config) entry.cache = config.cache;
-      turboJSON.pipeline[`${name}#${script}`] = entry;
-    }
+  const p = path.join(packagesDir, package, "package.json");
+  if (!fs.existsSync(p)) continue;
+  const { name, turbo } = JSON.parse(fs.readFileSync(p).toString());
+  if (!turbo) continue;
+  for (const [script, unparsed] of Object.entries(turbo)) {
+    const config = yaml.load(`{${unparsed}}`);
+    const entry = {
+      dependsOn: [
+        ...(basePipeline[script]?.dependsOn ?? []),
+        ...(config.deps ?? []),
+      ],
+      outputs: config.out ?? [],
+    };
+    if ("cache" in config) entry.cache = config.cache;
+    turboJSON.pipeline[`${name}#${script}`] = entry;
   }
 }
 fs.writeFileSync("turbo.json", JSON.stringify(turboJSON, null, 2));


### PR DESCRIPTION
# Description

This PR makes the `turboConfig.js` script added in #1081 not crash if there exists a `packages/*/` directory not containing a `package.json` file. This came up in the meeting on Friday, because I had been working on #1092, but when I switched from that branch to a different branch without `packages/optimizer/`, any `turbo` command would crash.

# Examples with steps to reproduce them

```sh
mkdir packages/foo/
yarn typecheck
```

# Checklist

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new ESLint warnings
- [x] I have reviewed any generated changes to the `diagrams/` folder