### PR TITLE
ci: Don't try to comment on PRs from forks

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -32,7 +32,7 @@ jobs:
           echo EOF >> $GITHUB_ENV
           rm stats.md
         working-directory: packages/automator/
-      - if: github.event_name == 'pull_request'
+      - if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == 'penrose/penrose'
         name: Comment on PR with stats
         uses: marocchino/sticky-pull-request-comment@v2
         with:


### PR DESCRIPTION
# Description

This PR attempts to fix the CI failure in #1102 by using the condition from [here](https://github.com/orgs/community/discussions/25217#discussioncomment-3246901) to make our `bench` job not try to comment on a PR unless it comes from a branch in this source repo (not a fork).

# Checklist

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new ESLint warnings
- [x] I have reviewed any generated changes to the `diagrams/` folder