### PR TITLE
fix: resize behaviors of diagram panel components

### DIFF
--- a/packages/editor/src/components/DiagramPanel.tsx
+++ b/packages/editor/src/components/DiagramPanel.tsx
@@ -224,56 +224,68 @@ export default function DiagramPanel() {
   };
 
   return (
-    <div>
-      {state === null && (
-        <span onClick={() => setShowEasterEgg((s) => !s)}>
-          press compile to see diagram
-        </span>
-      )}
+    <div style={{ display: "flex", flexDirection: "row", height: "100%" }}>
       <div
         style={{
+          display: "flex",
+          flexDirection: "column",
+          maxHeight: "100%",
           width: "100%",
-          height: "100%",
-          overflow: "auto",
-          backgroundColor: "#FFFFFF",
-          border: "1px solid gray",
         }}
-        ref={canvasRef}
-      />
-      {state && (
-        <div>
-          <BlueButton onClick={downloadSvg}>SVG</BlueButton>
-          <BlueButton onClick={downloadPdf}>PDF</BlueButton>
-        </div>
-      )}
-      {error && (
+      >
+        {state === null && (
+          <span onClick={() => setShowEasterEgg((s) => !s)}>
+            press compile to see diagram
+          </span>
+        )}
+        {state && (
+          <div style={{ display: "flex" }}>
+            <BlueButton onClick={downloadSvg}>SVG</BlueButton>
+            <BlueButton onClick={downloadPdf}>PDF</BlueButton>
+          </div>
+        )}
+        {error && (
+          <div
+            style={{
+              bottom: 0,
+              backgroundColor: "#ffdada",
+              maxHeight: "100%",
+              maxWidth: "100%",
+              minHeight: "100px",
+              overflow: "auto",
+              padding: "10px",
+              boxSizing: "border-box",
+            }}
+          >
+            <span
+              style={{ fontWeight: "bold", color: "#ee4e4e", fontSize: 14 }}
+            >
+              error ({error.errorType})
+            </span>
+            <pre>{showError(error).toString()}</pre>
+          </div>
+        )}
         <div
           style={{
-            bottom: 0,
-            backgroundColor: "#ffdada",
+            display: "flex",
+            minHeight: "60%",
             maxHeight: "100%",
-            maxWidth: "100%",
-            overflow: "auto",
-            padding: "10px",
-            boxSizing: "border-box",
+            justifyContent: "center",
           }}
-        >
-          <span style={{ fontWeight: "bold", color: "#ee4e4e", fontSize: 14 }}>
-            error ({error.errorType})
-          </span>
-          <pre>{showError(error).toString()}</pre>
-        </div>
-      )}
-      {showEasterEgg && (
-        <iframe
-          width="100%"
-          height="600"
-          src="https://www.youtube.com/embed/ofFLYfUEPVE?start=9&amp;autoplay=1"
-          title="YouTube video player"
-          frameBorder="0"
-          allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
-        ></iframe>
-      )}
+          ref={canvasRef}
+        />
+
+        {showEasterEgg && (
+          <iframe
+            width="100%"
+            height="600"
+            src="https://www.youtube.com/embed/ofFLYfUEPVE?start=9&amp;autoplay=1"
+            title="YouTube video player"
+            frameBorder="0"
+            allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+          ></iframe>
+        )}
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
# Description

Resolves #1051 

This PR ensures the diagram always appears entirely in the diagram panel of `editor`. 

# Implementation strategy and design decisions

* Added some flexboxes and width/height settings so all elements in `DiagramPanel` can be as visible as possible.
* Rearranged these elements so errors and buttons are on the top of the div. Somehow this fixes a lot of the layout issues. CSS is dark magic.

# Examples with steps to reproduce them

![Kapture 2022-09-20 at 16 07 15](https://user-images.githubusercontent.com/11740102/191356569-c01638d3-446d-418f-9920-6b63ef6fe3c3.gif)


# Checklist

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new ESLint warnings
- [x] I have reviewed any generated changes to the `diagrams/` folder

# Open questions

Perhaps I overused flexboxes here? Can't really figure out a minimal solution. This one behaves okay, but it's a bit tedious to specify.
