### PR TITLE
feat: add "Duplicate Workspace" button to `editor`

### DIFF
--- a/packages/editor/src/components/SavedBrowser.tsx
+++ b/packages/editor/src/components/SavedBrowser.tsx
@@ -2,6 +2,7 @@ import { useRecoilValue } from "recoil";
 import { localFilesState, workspaceMetadataSelector } from "../state/atoms";
 import {
   useDeleteLocalFile,
+  useDuplicate,
   useLoadLocalWorkspace,
   useSaveLocally,
 } from "../state/callbacks";
@@ -14,6 +15,7 @@ export default function SavedFilesBrowser() {
   const loadWorkspace = useLoadLocalWorkspace();
   const workspaceMetadata = useRecoilValue(workspaceMetadataSelector);
   const saveLocally = useSaveLocally();
+  const duplicate = useDuplicate();
   const onDelete = useDeleteLocalFile();
   return (
     <div>
@@ -32,6 +34,10 @@ export default function SavedFilesBrowser() {
           !workspaceMetadata.location.saved) && (
           <BlueButton onClick={saveLocally}>save current workspace</BlueButton>
         )}
+        {workspaceMetadata.location.kind === "local" &&
+          workspaceMetadata.location.saved && (
+            <BlueButton onClick={duplicate}>duplicate workspace</BlueButton>
+          )}
       </div>
     </div>
   );

--- a/packages/editor/src/state/callbacks.ts
+++ b/packages/editor/src/state/callbacks.ts
@@ -117,16 +117,26 @@ export const useResampleDiagram = () =>
   });
 
 const _saveLocally = (set: any) => {
-  console.info("saving locally...");
+  const id = toast.loading("saving...");
   set(workspaceMetadataSelector, (state: WorkspaceMetadata) => ({
     ...state,
     location: { kind: "local", saved: true } as WorkspaceLocation,
   }));
+  toast.dismiss(id);
 };
 
 export const useSaveLocally = () =>
   useRecoilCallback(({ set }) => () => {
     _saveLocally(set);
+  });
+
+export const useDuplicate = () =>
+  useRecoilCallback(({ set }) => () => {
+    set(workspaceMetadataSelector, (state: WorkspaceMetadata) => ({
+      ...state,
+      location: { kind: "local", saved: true } as WorkspaceLocation,
+      id: uuid(),
+    }));
   });
 
 const _confirmDirtyWorkspace = (workspace: Workspace): boolean => {


### PR DESCRIPTION
# Description

When working with a trio in `editor`'s local storage, there's no good way to create a "fork" of the current workspace. For now, I added a "duplicate workspace" button to quickly fork the current workspace.  

# Implementation strategy and design decisions

Pretty much reused the code for `saveLocally`

# Checklist

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new ESLint warnings
- [x] I have reviewed any generated changes to the `diagrams/` folder

# Open questions

Perhaps longer term it's better to have an experience similar to [mermaid](https://mermaid.live/)
