### PR TITLE
chore: add optional diagram interactivity to `editor`

### DIFF
--- a/packages/editor/src/components/DiagramOptions.tsx
+++ b/packages/editor/src/components/DiagramOptions.tsx
@@ -54,6 +54,21 @@ export default function DiagramOptions() {
           </label>
         </div>
       </div>
+      <div>
+        <label>
+          interactive mode{" "}
+          <input
+            type="checkbox"
+            checked={diagramMetadata.interactive}
+            onChange={(e) =>
+              setDiagramMetadata((metadata) => ({
+                ...metadata,
+                interactive: e.target.checked,
+              }))
+            }
+          />
+        </label>
+      </div>
     </div>
   );
 }

--- a/packages/editor/src/components/DiagramPanel.tsx
+++ b/packages/editor/src/components/DiagramPanel.tsx
@@ -1,4 +1,6 @@
 import {
+  PenroseState,
+  RenderInteractive,
   RenderStatic,
   showError,
   stateConverged,
@@ -11,6 +13,7 @@ import { useRecoilCallback, useRecoilState, useRecoilValue } from "recoil";
 import { v4 as uuid } from "uuid";
 import {
   currentRogerState,
+  diagramMetadataSelector,
   diagramState,
   WorkspaceMetadata,
   workspaceMetadataSelector,
@@ -45,6 +48,7 @@ export default function DiagramPanel() {
   const [showEasterEgg, setShowEasterEgg] = useState(false);
   const { location, id } = useRecoilValue(workspaceMetadataSelector);
   const rogerState = useRecoilValue(currentRogerState);
+  const { interactive } = useRecoilValue(diagramMetadataSelector);
 
   const requestRef = useRef<number>();
 
@@ -53,7 +57,19 @@ export default function DiagramPanel() {
     if (state !== null && cur !== null) {
       (async () => {
         // render the current frame
-        const rendered = await RenderStatic(state, pathResolver);
+        const rendered = interactive
+          ? await RenderInteractive(
+              state,
+              (newState: PenroseState) => {
+                setDiagram({
+                  ...diagram,
+                  state: newState,
+                });
+                step();
+              },
+              pathResolver
+            )
+          : await RenderStatic(state, pathResolver);
         if (cur.firstElementChild) {
           cur.replaceChild(rendered, cur.firstElementChild);
         } else {

--- a/packages/editor/src/state/atoms.ts
+++ b/packages/editor/src/state/atoms.ts
@@ -278,6 +278,7 @@ export const diagramState = atom<Diagram>({
       variation: generateVariation(),
       stepSize: 10000,
       autostep: true,
+      interactive: false,
     },
   },
 

--- a/packages/editor/src/state/atoms.ts
+++ b/packages/editor/src/state/atoms.ts
@@ -260,6 +260,7 @@ export type DiagramMetadata = {
   variation: string;
   stepSize: number;
   autostep: boolean;
+  interactive: boolean;
 };
 
 export type Diagram = {


### PR DESCRIPTION
# Description

Related issue/PR: #644 

Although we want to disable dragging for end-users until there's a good technical solution to interactivity, the default interactive mode is still useful for debugging. This PR adds interactivity as an optional debug feature.


# Implementation strategy and design decisions

Conditionally call `RenderStatic` or `RenderInteractive` depending on the value 

# Examples with steps to reproduce them

* In "settings": check debug mode
* in "options": check interactive mode
* Re-compile or resample go get a draggable diagram.

# Checklist

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new ESLint warnings
- [x] I have reviewed any generated changes to the `diagrams/` folder
