### PR TITLE
ci: use `codecov-action@v3` in the `test` action

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -168,7 +168,7 @@ jobs:
       - uses: actions/checkout@master
       - uses: codecov/codecov-action@v3
         with:
-          directory: packages/core/
+          directory: packages/core/reports/junit/
       # TODO: some equivalent of CircleCI's store_test_results
       # with path: packages/core/reports/junit/
       - uses: actions/upload-artifact@v2

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -165,10 +165,8 @@ jobs:
       - name: Move test report
         run: mv junit.xml reports/junit/
         working-directory: packages/core/
-      - uses: actions/checkout@master
-      - uses: codecov/codecov-action@v3
-        with:
-          directory: packages/core/reports/junit/
+      - name: Upload coverage report to codecov
+        uses: codecov/codecov-action@v3
       # TODO: some equivalent of CircleCI's store_test_results
       # with path: packages/core/reports/junit/
       - uses: actions/upload-artifact@v2

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -165,9 +165,10 @@ jobs:
       - name: Move test report
         run: mv junit.xml reports/junit/
         working-directory: packages/core/
-      - name: Upload test coverage to codecov
-        run: bash <(curl -s https://codecov.io/bash)
-        working-directory: packages/core/
+      - uses: actions/checkout@master
+      - uses: codecov/codecov-action@v3
+        with:
+          directory: packages/core/
       # TODO: some equivalent of CircleCI's store_test_results
       # with path: packages/core/reports/junit/
       - uses: actions/upload-artifact@v2


### PR DESCRIPTION
# Description

codecov deprecated `codecov.io/bash`, causing `test` to fail on `main`. Updating to the new `codecov-action@v3`.

