### PR TITLE
chore: return instead of logging cyclic layering warning

### DIFF
--- a/packages/core/src/types/errors.ts
+++ b/packages/core/src/types/errors.ts
@@ -188,7 +188,10 @@ export type StyleError =
   | RuntimeValueTypeError;
 
 // Compilation warnings
-export type StyleWarning = ImplicitOverrideWarning | NoopDeleteWarning;
+export type StyleWarning =
+  | ImplicitOverrideWarning
+  | NoopDeleteWarning
+  | LayerCycleWarning;
 
 export interface StyleDiagnostics {
   errors: im.List<StyleError>;
@@ -205,6 +208,11 @@ export interface ImplicitOverrideWarning {
 export interface NoopDeleteWarning {
   tag: "NoopDeleteWarning";
   path: ResolvedPath<C>;
+}
+export interface LayerCycleWarning {
+  tag: "LayerCycleWarning";
+  cycles: string[][];
+  approxOrdering: string[];
 }
 
 //#endregion

--- a/packages/core/src/utils/Error.ts
+++ b/packages/core/src/utils/Error.ts
@@ -408,6 +408,16 @@ canvas {
       )} (at ${locc("Style", error.path)}).`;
     }
 
+    case "LayerCycleWarning": {
+      return `Cycles detected in layering order: ${error.cycles
+        .map((c) => c.join(", "))
+        .join(
+          "; "
+        )}. The system approximated a global layering order instead: ${error.approxOrdering.join(
+        ", "
+      )}`;
+    }
+
     // ----- END STYLE WARNINGS
 
     case "Fatal": {


### PR DESCRIPTION
# Description

Related issue/PR: #1086, #730 

#730 approximates a global ordering of shapes when `layer` statements lead to cycles. We decided to give a warning when that happens, but only in the form of `log.warn`. This PR returns the warning as Style compiler diagnostics and remove the `log.warn` message so it won't print it out during testing.

NOTE: this PR doesn't fully resolve #1086. Still needs to investigate another case of an unwanted console message.

# Implementation strategy and design decisions

Include a high-level summary of the implementation strategy and list important design decisions made, if any.

# Examples with steps to reproduce them

* Simplify layering code to use `{ below, above }` thought
* `computeShapeLayering` returns an optional warning

# Checklist

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new ESLint warnings
- [x] I have reviewed any generated changes to the `diagrams/` folder

