### PR TITLE
chore: rename `len` to `length` for readability

### DIFF
--- a/packages/components/src/stories/PenrosePrograms.tsx
+++ b/packages/components/src/stories/PenrosePrograms.tsx
@@ -564,7 +564,7 @@ where In(u,U) {
    ensure contains(U.background, u.arrow)
    ensure contains(U.background, u.text)
    ensure atDist(u.arrow, u.text, 15.0)
-   ensure lessThan(20, len(u.arrow))
+   ensure lessThan(20, length(u.arrow))
 
   layer u.text above U.xAxis
   layer u.text above U.yAxis

--- a/packages/core/src/contrib/Functions.ts
+++ b/packages/core/src/contrib/Functions.ts
@@ -470,12 +470,16 @@ export const compDict = {
   /**
    * Return the length of the line or arrow shape `[type, props]`.
    */
-  len: (_context: Context, [, props]: [string, any]): FloatV<ad.Num> => {
-    const [p1, p2] = linePts(props);
-    return {
-      tag: "FloatV",
-      contents: ops.vdist(p1, p2),
-    };
+  length: (_context: Context, [t, props]: [string, any]): FloatV<ad.Num> => {
+    if (!shapedefs[t].isLinelike) {
+      throw Error("length expects a line-like shape");
+    } else {
+      const [p1, p2] = linePts(props);
+      return {
+        tag: "FloatV",
+        contents: ops.vdist(p1, p2),
+      };
+    }
   },
 
   /**

--- a/packages/docs-site/docs/ref/style/functions.mdx
+++ b/packages/docs-site/docs/ref/style/functions.mdx
@@ -2042,9 +2042,9 @@ Figure out which side of the rectangle `[t1, s1]` the `start->end` line is hitti
 
 ---
 
-### len
+### length
 
-▸ `Static` **len**(`_context`, `__namedParameters`): `IFloatV`<`IVarAD`\>
+▸ `Static` **length**(`_context`, `__namedParameters`): `IFloatV`<`IVarAD`\>
 
 Return the length of the line or arrow shape `[type, props]`.
 

--- a/packages/examples/src/linear-algebra-domain/linearalgebra-paper-dashes.sty
+++ b/packages/examples/src/linear-algebra-domain/linearalgebra-paper-dashes.sty
@@ -122,7 +122,7 @@ where In(u,U) {
    ensure contains(U.background, u.arrow)
    ensure contains(U.background, u.text)
    ensure atDist(u.arrow, u.text, 15.0)
-   ensure lessThan(20, len(u.arrow))
+   ensure lessThan(20, length(u.arrow))
 
   layer u.text above U.xAxis
   layer u.text above U.yAxis

--- a/packages/examples/src/shape-distance/box-arrow.sty
+++ b/packages/examples/src/shape-distance/box-arrow.sty
@@ -22,7 +22,7 @@ forall Node from; Node to; Edge e1 where e1 := MkEdge(from, to) {
     ensure disjoint(to.icon, e1.icon)
     ensure disjoint(to.icon, from.icon, 400)
 
-    encourage minimal(len(e1.icon))
+    encourage minimal(length(e1.icon))
 }
 
 forall Edge e1; Edge e2 {


### PR DESCRIPTION
# Description

@keenancrane suggests to rename `len` to something more readable. The function takes in a line-like shape and return its length, which is distinct from `norm`. 

# Open questions

Without static type-checking of Style functions, the semantics of `length` is still not immediately clear to a Style writer. One could always do `norm(A.icon.start, A.icon.end)`, but I think it's still useful to keep `length` around. 
