### PR TITLE
chore: Make Prettier ignore shapedefs.json

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -10,6 +10,7 @@
 /packages/core/src/renderer/not_found.json
 /packages/docs-site/.docusaurus/
 /packages/docs-site/static/try/
+/packages/docs-site/static/shapedefs.json
 /packages/roger/oclif.manifest.json
 /README.md
 /turbo.json


### PR DESCRIPTION
# Checklist

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new ESLint warnings
- [x] I have reviewed any generated changes to the `diagrams/` folder