### PR TITLE
feat: hexadecimal color literals in Style

### DIFF
--- a/packages/components/src/editing/languages/StyleConfig.ts
+++ b/packages/components/src/editing/languages/StyleConfig.ts
@@ -198,7 +198,7 @@ export const SetupStyleMonaco = (monaco: Monaco) => {
         ) => {
           if (matches !== null) {
             const hexColor = hexToRgba(matches[1]);
-            if (hexColor !== null) {
+            if (hexColor) {
               const [red, green, blue, alpha] = hexColor;
               const color = {
                 color: {

--- a/packages/components/src/editing/languages/StyleConfig.ts
+++ b/packages/components/src/editing/languages/StyleConfig.ts
@@ -2,8 +2,9 @@ import { Monaco } from "@monaco-editor/react";
 import {
   compDict,
   constrDict,
-  hexToRGBA,
+  hexToRgba,
   objDict,
+  rgbaToHex,
   shapedefs,
 } from "@penrose/core";
 import { editor, IRange, languages } from "monaco-editor";
@@ -109,6 +110,7 @@ export const StyleLanguageTokens: languages.IMonarchLanguage = {
         /\b[+-]?(?:\d+(?:[.]\d*)?(?:[eE][+-]?\d+)?|[.]\d+(?:[eE][+-]?\d+)?)\b/,
         "number.float",
       ],
+      [/#([0-9A-Fa-f]{3,})/, "number.hex"],
       { include: "@whitespace" },
     ],
     ...CommentCommon,
@@ -174,7 +176,7 @@ export const SetupStyleMonaco = (monaco: Monaco) => {
       const { red, green, blue, alpha } = colorInfo.color;
       return [
         {
-          label: `rgba(${red}, ${green}, ${blue}, ${alpha})`,
+          label: rgbaToHex([red, green, blue, alpha]),
         },
       ];
     },
@@ -195,7 +197,7 @@ export const SetupStyleMonaco = (monaco: Monaco) => {
           { matches, range }: editor.FindMatch
         ) => {
           if (matches !== null) {
-            const [red, green, blue, alpha] = hexToRGBA(matches[1]);
+            const [red, green, blue, alpha] = hexToRgba(matches[1]);
             const color = {
               color: {
                 red,

--- a/packages/components/src/editing/languages/StyleConfig.ts
+++ b/packages/components/src/editing/languages/StyleConfig.ts
@@ -1,5 +1,11 @@
 import { Monaco } from "@monaco-editor/react";
-import { compDict, constrDict, objDict, shapedefs } from "@penrose/core";
+import {
+  compDict,
+  constrDict,
+  hexToRGBA,
+  objDict,
+  shapedefs,
+} from "@penrose/core";
 import { editor, IRange, languages } from "monaco-editor";
 import { CommentCommon, CommonTokens } from "./common";
 
@@ -174,7 +180,7 @@ export const SetupStyleMonaco = (monaco: Monaco) => {
     },
 
     provideDocumentColors: (model) => {
-      const colorRegex = /rgba\(\s*(.*)\s*,\s*(.*)\s*,\s*(.*)\s*,\s*(.*)\s*\)/;
+      const colorRegex = /#([0-9A-Fa-f]{3,})/;
       const colorMatches = model.findMatches(
         colorRegex.source,
         false,
@@ -189,12 +195,13 @@ export const SetupStyleMonaco = (monaco: Monaco) => {
           { matches, range }: editor.FindMatch
         ) => {
           if (matches !== null) {
+            const [red, green, blue, alpha] = hexToRGBA(matches[1]);
             const color = {
               color: {
-                red: +matches[1],
-                green: +matches[2],
-                blue: +matches[3],
-                alpha: +matches[4],
+                red,
+                green,
+                blue,
+                alpha,
               },
               range: range,
             };

--- a/packages/components/src/editing/languages/StyleConfig.ts
+++ b/packages/components/src/editing/languages/StyleConfig.ts
@@ -197,17 +197,22 @@ export const SetupStyleMonaco = (monaco: Monaco) => {
           { matches, range }: editor.FindMatch
         ) => {
           if (matches !== null) {
-            const [red, green, blue, alpha] = hexToRgba(matches[1]);
-            const color = {
-              color: {
-                red,
-                green,
-                blue,
-                alpha,
-              },
-              range: range,
-            };
-            return [...colors, color];
+            const hexColor = hexToRgba(matches[1]);
+            if (hexColor !== null) {
+              const [red, green, blue, alpha] = hexColor;
+              const color = {
+                color: {
+                  red,
+                  green,
+                  blue,
+                  alpha,
+                },
+                range: range,
+              };
+              return [...colors, color];
+            } else {
+              return colors;
+            }
           } else {
             return colors;
           }

--- a/packages/core/src/compiler/Style.test.ts
+++ b/packages/core/src/compiler/Style.test.ts
@@ -693,6 +693,12 @@ Bond(O, H2)`;
     };
 
     const errorStyProgs = {
+      // ------ Generic errors
+      InvalidColorLiteral: [
+        `forall Set x { 
+          x.color = #12777733aa
+       }`,
+      ],
       // ------ Selector errors (from Substance)
       SelectorVarMultipleDecl: [`forall Set x; Set x { }`],
       SelectorFieldNotSupported: [`forall Set x where x has randomfield { }`],

--- a/packages/core/src/compiler/Style.ts
+++ b/packages/core/src/compiler/Style.ts
@@ -2553,7 +2553,6 @@ const evalExpr = (
     case "ColorLit": {
       const hex = expr.contents;
       const rgba = hexToRGBA(hex);
-      console.log(hex, rgba);
       if (rgba !== null) {
         return ok(val(colorV({ tag: "RGBA", contents: rgba })));
       } else {

--- a/packages/core/src/compiler/Style.ts
+++ b/packages/core/src/compiler/Style.ts
@@ -2554,7 +2554,7 @@ const evalExpr = (
     case "ColorLit": {
       const hex = expr.contents;
       const rgba = hexToRgba(hex);
-      if (rgba !== null) {
+      if (rgba) {
         return ok(val(colorV({ tag: "RGBA", contents: rgba })));
       } else {
         return err(oneErr(invalidColorLiteral(expr)));

--- a/packages/core/src/compiler/Style.ts
+++ b/packages/core/src/compiler/Style.ts
@@ -110,6 +110,7 @@ import {
   all,
   andThen,
   err,
+  invalidColorLiteral,
   isErr,
   ok,
   parseError,
@@ -2556,8 +2557,7 @@ const evalExpr = (
       if (rgba !== null) {
         return ok(val(colorV({ tag: "RGBA", contents: rgba })));
       } else {
-        throw new Error(`invalid color literal ${hex}`);
-        // return err(oneErr(genericStyleError([`invalid color literal ${hex}`])));
+        return err(oneErr(invalidColorLiteral(expr)));
       }
     }
     case "CompApp": {

--- a/packages/core/src/compiler/Style.ts
+++ b/packages/core/src/compiler/Style.ts
@@ -123,7 +123,7 @@ import {
   boolV,
   colorV,
   floatV,
-  hexToRGBA,
+  hexToRgba,
   listV,
   llistV,
   matrixV,
@@ -2552,7 +2552,7 @@ const evalExpr = (
     }
     case "ColorLit": {
       const hex = expr.contents;
-      const rgba = hexToRGBA(hex);
+      const rgba = hexToRgba(hex);
       if (rgba !== null) {
         return ok(val(colorV({ tag: "RGBA", contents: rgba })));
       } else {

--- a/packages/core/src/compiler/Style.ts
+++ b/packages/core/src/compiler/Style.ts
@@ -3001,12 +3001,15 @@ const onCanvases = (canvas: Canvas, shapes: ShapeAD[]): Fn[] => {
   return fns;
 };
 
-export const compileStyle = (
+export const compileStyleHelper = (
   variation: string,
   stySource: string,
   subEnv: SubstanceEnv,
   varEnv: Env
-): Result<State, PenroseError> => {
+): Result<
+  { state: State; translation: Translation; assignment: Assignment },
+  PenroseError
+> => {
   const astOk = parseStyle(stySource);
   let styProg;
   if (astOk.isOk()) {
@@ -3099,7 +3102,21 @@ export const compileStyle = (
 
   log.info("init state from GenOptProblem", initState);
 
-  return ok(initState);
+  return ok({
+    state: initState,
+    translation,
+    assignment,
+  });
 };
+
+export const compileStyle = (
+  variation: string,
+  stySource: string,
+  subEnv: SubstanceEnv,
+  varEnv: Env
+): Result<State, PenroseError> =>
+  compileStyleHelper(variation, stySource, subEnv, varEnv).map(
+    ({ state }) => state
+  );
 
 //#endregion Main funcitons

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -334,6 +334,7 @@ export type { PenroseError } from "./types/errors";
 export type { Shape } from "./types/shape";
 export * as Value from "./types/value";
 export type { Result } from "./utils/Error";
+export { hexToRGBA } from "./utils/Util";
 export {
   compileDomain,
   compileSubstance,

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -334,7 +334,7 @@ export type { PenroseError } from "./types/errors";
 export type { Shape } from "./types/shape";
 export * as Value from "./types/value";
 export type { Result } from "./utils/Error";
-export { hexToRGBA } from "./utils/Util";
+export { hexToRgba, rgbaToHex } from "./utils/Util";
 export {
   compileDomain,
   compileSubstance,

--- a/packages/core/src/parser/ParserUtil.ts
+++ b/packages/core/src/parser/ParserUtil.ts
@@ -17,7 +17,7 @@ export const basicSymbols: moo.Rules = {
   rparen: ")",
   apos: "'",
   comma: ",",
-  hex_literal: /#(?:[0-9A-Fa-f]{3,})/,
+  hex_literal: /#[0-9A-Fa-f]{3,}/,
   string_literal: {
     // match: /"(?:[^\n\\"]|\\["\\ntbfr])*"/,
     // Not sure why we were disallowing backslashes in string literals;

--- a/packages/core/src/parser/ParserUtil.ts
+++ b/packages/core/src/parser/ParserUtil.ts
@@ -17,6 +17,7 @@ export const basicSymbols: moo.Rules = {
   rparen: ")",
   apos: "'",
   comma: ",",
+  hex_literal: /#(?:[0-9A-Fa-f]{3,})/,
   string_literal: {
     // match: /"(?:[^\n\\"]|\\["\\ntbfr])*"/,
     // Not sure why we were disallowing backslashes in string literals;

--- a/packages/core/src/parser/Style.ne
+++ b/packages/core/src/parser/Style.ne
@@ -497,13 +497,9 @@ bool_lit -> ("true" | "false") {%
 
 color_lit 
   -> %hex_literal
-  # -> "#" hexdigit:+
-  # -> "#" hexdigit hexdigit hexdigit 
-  # |  "#" hexdigit hexdigit hexdigit hexdigit hexdigit hexdigit 
-  # |  "#" hexdigit hexdigit hexdigit hexdigit hexdigit hexdigit hexdigit hexdigit 
   {% ([d]): ColorLit<C> => ({
     ...nodeData,
-    ...rangeOf(d), // TODO: fix range
+    ...rangeOf(d), 
     tag: "ColorLit",
     contents: d.text.slice(1, d.text.length)
   })

--- a/packages/core/src/parser/Style.ne
+++ b/packages/core/src/parser/Style.ne
@@ -446,6 +446,7 @@ arithmeticExpr
 # NOTE: all of the expr_literal can be operands of inline computation 
 expr_literal
   -> bool_lit {% id %}
+  |  color_lit {% id %}
   |  string_lit {% id %}
   |  annotated_float {% id %}
   |  computation_function {% id %}
@@ -493,6 +494,14 @@ bool_lit -> ("true" | "false") {%
     contents: d.text === 'true' // https://stackoverflow.com/questions/263965/how-can-i-convert-a-string-to-boolean-in-javascript
   })
 %}
+
+color_lit 
+  -> "#" hexdigit hexdigit hexdigit hexdigit hexdigit hexdigit hexdigit hexdigit 
+  |  "#" hexdigit hexdigit hexdigit hexdigit hexdigit hexdigit 
+  |  "#" hexdigit hexdigit hexdigit 
+  {% ([, ...d]) => d.join("") %}
+
+hexdigit -> [a-fA-F0-9] {% id %}
 
 string_lit -> %string_literal {%
   ([d]): StringLit<C> => ({

--- a/packages/core/src/parser/Style.ne
+++ b/packages/core/src/parser/Style.ne
@@ -8,7 +8,7 @@ import * as moo from "moo";
 import { concat, compact, flatten, last } from 'lodash'
 import { basicSymbols, rangeOf, rangeBetween, rangeFrom, nth, convertTokenId } from 'parser/ParserUtil'
 import { C, ConcreteNode, Identifier, StringLit  } from "types/ast";
-import { StyT, DeclPattern, DeclPatterns, RelationPatterns, Namespace, Selector, StyProg, HeaderBlock, RelBind, RelField, RelPred, SEFuncOrValCons, SEBind, Block, AnonAssign, Delete, Override, PathAssign, StyType, BindingForm, Path, Layering, BinaryOp, Expr, BinOp, SubVar, StyVar, UOp, List, Tuple, Vector, BoolLit, Vary, Fix, CompApp, ObjFn, ConstrFn, GPIDecl, PropertyDecl, 
+import { StyT, DeclPattern, DeclPatterns, RelationPatterns, Namespace, Selector, StyProg, HeaderBlock, RelBind, RelField, RelPred, SEFuncOrValCons, SEBind, Block, AnonAssign, Delete, Override, PathAssign, StyType, BindingForm, Path, Layering, BinaryOp, Expr, BinOp, SubVar, StyVar, UOp, List, Tuple, Vector, BoolLit, Vary, Fix, CompApp, ObjFn, ConstrFn, GPIDecl, PropertyDecl, ColorLit
 } from "types/style";
 
 const styleTypes: string[] =
@@ -496,12 +496,18 @@ bool_lit -> ("true" | "false") {%
 %}
 
 color_lit 
-  -> "#" hexdigit hexdigit hexdigit hexdigit hexdigit hexdigit hexdigit hexdigit 
-  |  "#" hexdigit hexdigit hexdigit hexdigit hexdigit hexdigit 
-  |  "#" hexdigit hexdigit hexdigit 
-  {% ([, ...d]) => d.join("") %}
-
-hexdigit -> [a-fA-F0-9] {% id %}
+  -> %hex_literal
+  # -> "#" hexdigit:+
+  # -> "#" hexdigit hexdigit hexdigit 
+  # |  "#" hexdigit hexdigit hexdigit hexdigit hexdigit hexdigit 
+  # |  "#" hexdigit hexdigit hexdigit hexdigit hexdigit hexdigit hexdigit hexdigit 
+  {% ([d]): ColorLit<C> => ({
+    ...nodeData,
+    ...rangeOf(d), // TODO: fix range
+    tag: "ColorLit",
+    contents: d.text.slice(1, d.text.length)
+  })
+ %}
 
 string_lit -> %string_literal {%
   ([d]): StringLit<C> => ({

--- a/packages/core/src/types/errors.ts
+++ b/packages/core/src/types/errors.ts
@@ -3,7 +3,15 @@ import * as ad from "types/ad";
 import { A, AbstractNode, C, Identifier, SourceLoc } from "./ast";
 import { Arg, TypeConstructor, TypeVar } from "./domain";
 import { State } from "./state";
-import { BindingForm, BinOp, Expr, GPIDecl, Path, UOp } from "./style";
+import {
+  BindingForm,
+  BinOp,
+  ColorLit,
+  Expr,
+  GPIDecl,
+  Path,
+  UOp,
+} from "./style";
 import { ResolvedPath } from "./styleSemantics";
 import { Deconstructor, SubExpr, TypeConsApp } from "./substance";
 import { Value } from "./value";
@@ -152,6 +160,7 @@ export type StyleError =
   | ParseError
   | GenericStyleError
   | StyleErrorList
+  | InvalidColorLiteral
   // Selector errors (from Substance)
   | SelectorVarMultipleDecl
   | SelectorDeclTypeMismatch
@@ -231,6 +240,11 @@ export interface ParseError {
   tag: "ParseError";
   message: string;
   location?: SourceLoc;
+}
+
+export interface InvalidColorLiteral {
+  tag: "InvalidColorLiteral";
+  color: ColorLit<C>;
 }
 
 export interface SelectorVarMultipleDecl {

--- a/packages/core/src/types/style.ts
+++ b/packages/core/src/types/style.ts
@@ -191,6 +191,7 @@ export type Expr<T> =
   | AnnoFloat<T>
   | StringLit<T>
   | BoolLit<T>
+  | ColorLit<T>
   | Path<T>
   | CompApp<T>
   | ObjFn<T>
@@ -211,6 +212,11 @@ export type IntLit<T> = ASTNode<T> & {
 export type BoolLit<T> = ASTNode<T> & {
   tag: "BoolLit";
   contents: boolean;
+};
+
+export type ColorLit<T> = ASTNode<T> & {
+  tag: "ColorLit";
+  contents: string;
 };
 
 export type CompApp<T> = ASTNode<T> & {

--- a/packages/core/src/utils/Error.ts
+++ b/packages/core/src/utils/Error.ts
@@ -4,6 +4,7 @@ import { Result } from "true-myth";
 import {
   A,
   AbstractNode,
+  C,
   Identifier,
   NodeType,
   SourceLoc,
@@ -17,6 +18,7 @@ import {
   DomainError,
   DuplicateName,
   FatalError,
+  InvalidColorLiteral,
   NaNError,
   ParseError,
   PenroseError,
@@ -34,7 +36,7 @@ import {
   VarNotFound,
 } from "types/errors";
 import { State } from "types/state";
-import { BindingForm } from "types/style";
+import { BindingForm, ColorLit } from "types/style";
 import { Deconstructor, SubExpr } from "types/substance";
 import { prettyPrintPath, prettyPrintResolvedPath } from "utils/Util";
 const {
@@ -90,6 +92,10 @@ export const showError = (
     }
     case "ParseError":
       return error.message;
+    case "InvalidColorLiteral":
+      return `${error.color.contents} (at ${loc(
+        error.color
+      )}) is not a valid color literal. Color literals must be one of the following formats: #RGB, #RGBA, #RRGGBB, #RRGGBBAA.`;
     case "TypeDeclared": {
       return `Type ${error.typeName.value} already exists.`;
     }
@@ -560,6 +566,13 @@ export const parseError = (
   tag: "ParseError",
   message,
   location,
+});
+
+export const invalidColorLiteral = (
+  color: ColorLit<C>
+): InvalidColorLiteral => ({
+  tag: "InvalidColorLiteral",
+  color,
 });
 
 export const nanError = (message: string, lastState: State): NaNError => ({

--- a/packages/core/src/utils/Util.ts
+++ b/packages/core/src/utils/Util.ts
@@ -179,7 +179,7 @@ export const toScreen = (
 
 export const hexToRgba = (
   hex: string
-): [number, number, number, number] | null => {
+): [number, number, number, number] | undefined => {
   const parseIntHex = (value: string) => {
     return parseInt(value, 16);
   };

--- a/packages/core/src/utils/Util.ts
+++ b/packages/core/src/utils/Util.ts
@@ -502,6 +502,8 @@ export const llistV = (contents: ad.Num[][]): LListV<ad.Num> => ({
 
 export const black = (): ColorV<ad.Num> =>
   colorV({ tag: "RGBA", contents: [0, 0, 0, 1] });
+export const white = (): ColorV<ad.Num> =>
+  colorV({ tag: "RGBA", contents: [1, 1, 1, 1] });
 
 export const noPaint = (): ColorV<ad.Num> => colorV({ tag: "NONE" });
 

--- a/packages/core/src/utils/Util.ts
+++ b/packages/core/src/utils/Util.ts
@@ -177,7 +177,7 @@ export const toScreen = (
 
 //#region color
 
-export const hexToRGBA = (
+export const hexToRgba = (
   hex: string
 ): [number, number, number, number] | null => {
   const parseIntHex = (value: string) => {
@@ -226,12 +226,24 @@ export const hexToRGBA = (
   return [r / 255, g / 255, b / 255, a / 255];
 };
 
-export const toHexRGB = (color: [number, number, number]): string => {
+export const rgbToHex = (color: [number, number, number]): string => {
   return color.reduce((prev: string, cur: number) => {
-    const hex = Math.round(255 * cur).toString(16);
+    const hex = toHexDigit(cur);
     const padded = hex.length === 1 ? "0" + hex : hex;
     return prev + padded;
   }, "#");
+};
+
+export const rgbaToHex = (color: [number, number, number, number]): string => {
+  return color.reduce((prev: string, cur: number) => {
+    const hex = toHexDigit(cur);
+    const padded = hex.length === 1 ? "0" + hex : hex;
+    return prev + padded;
+  }, "#");
+};
+
+const toHexDigit = (n: number): string => {
+  return Math.round(255 * n).toString(16);
 };
 
 // TODO nest this
@@ -274,13 +286,13 @@ export const hsvToRGB = (
 export const toSvgPaintProperty = (color: Color<number>): string => {
   switch (color.tag) {
     case "RGBA":
-      return toHexRGB([
+      return rgbToHex([
         color.contents[0],
         color.contents[1],
         color.contents[2],
       ]);
     case "HSVA":
-      return toHexRGB(
+      return rgbToHex(
         hsvToRGB([color.contents[0], color.contents[1], color.contents[2]])
       );
     case "NONE":

--- a/packages/core/src/utils/Util.ts
+++ b/packages/core/src/utils/Util.ts
@@ -188,7 +188,7 @@ export const hexToRgba = (
   const isSix = hex.length === 6;
   const isEight = hex.length === 8;
   if (!isThree && !isFour && !isSix && !isEight) {
-    return null;
+    return undefined;
   }
   let r = 0;
   let g = 0;

--- a/packages/core/src/utils/Util.ts
+++ b/packages/core/src/utils/Util.ts
@@ -177,6 +177,55 @@ export const toScreen = (
 
 //#region color
 
+export const hexToRGBA = (
+  hex: string
+): [number, number, number, number] | null => {
+  const parseIntHex = (value: string) => {
+    return parseInt(value, 16);
+  };
+  const isThree = hex.length === 3;
+  const isFour = hex.length === 4;
+  const isSix = hex.length === 6;
+  const isEight = hex.length === 8;
+  if (!isThree && !isFour && !isSix && !isEight) {
+    return null;
+  }
+  let r = 0;
+  let g = 0;
+  let b = 0;
+  let a = 255; // NOTE: alpha defaults to 255
+
+  switch (hex.length) {
+    case 3: {
+      r = parseIntHex(hex.slice(0, 1).repeat(2));
+      g = parseIntHex(hex.slice(1, 2).repeat(2));
+      b = parseIntHex(hex.slice(2, 3).repeat(2));
+      break;
+    }
+    case 4: {
+      r = parseIntHex(hex.slice(0, 1).repeat(2));
+      g = parseIntHex(hex.slice(1, 2).repeat(2));
+      b = parseIntHex(hex.slice(2, 3).repeat(2));
+      a = parseIntHex(hex.slice(3, 4).repeat(2));
+      break;
+    }
+    case 6: {
+      r = parseIntHex(hex.slice(0, 2));
+      g = parseIntHex(hex.slice(2, 4));
+      b = parseIntHex(hex.slice(4, 6));
+      break;
+    }
+    case 8: {
+      r = parseIntHex(hex.slice(0, 2));
+      g = parseIntHex(hex.slice(2, 4));
+      b = parseIntHex(hex.slice(4, 6));
+      a = parseIntHex(hex.slice(6, 8));
+      break;
+    }
+  }
+  return [r / 255, g / 255, b / 255, a / 255];
+};
+
 export const toHexRGB = (color: [number, number, number]): string => {
   return color.reduce((prev: string, cur: number) => {
     const hex = Math.round(255 * cur).toString(16);

--- a/packages/examples/src/set-theory-domain/continuousmap.sty
+++ b/packages/examples/src/set-theory-domain/continuousmap.sty
@@ -9,9 +9,9 @@ Const {
 }
 
 Colors {
-  black = rgba(0.0, 0.0, 0.0, 1.0)
-  lightBlue = rgba(0.1, 0.1, 0.9, 0.2)
-  lightYellow = rgba(0.95, 0.96, 0.92, 0.5)
+  black = #000000
+  lightBlue = #1a1ae633
+  lightYellow = #f2f5eb80
 }
 
 forall Set x {

--- a/packages/examples/src/set-theory-domain/continuousmap.sty
+++ b/packages/examples/src/set-theory-domain/continuousmap.sty
@@ -11,7 +11,7 @@ Const {
 Colors {
   black = #000000
   lightBlue = #1a1ae633
-  lightYellow = #f2f5eb80
+  lightYellow = setOpacity(#f2f5eb, 0.5)
 }
 
 forall Set x {


### PR DESCRIPTION
# Description

Related issue/PR: #1094 

The non-standard `rgba` format Style used had been a pain to work with. This PR adds native support for hexadecimal color literals as specified in [web standards](https://developer.mozilla.org/en-US/docs/Web/CSS/hex-color), i.e.:

```
#RGB        // The three-value syntax
#RGBA       // The four-value syntax
#RRGGBB     // The six-value syntax
#RRGGBBAA   // The eight-value syntax
```

Both upper- and lower-case hex digits are supported.

Style writers can use standard hex colors with highlighting and color picker support in the IDE. 

![image](https://user-images.githubusercontent.com/11740102/192578176-01b832d5-eb68-4a62-befe-7b58ec73bf84.png)

# Implementation strategy and design decisions

* `RGBA` is the ground-truth storage format in the Style compiler, and `#rrggbbaa` is the output format used by the color picker.
* Add tests to validate values of hex literals
* Updated `continousmap.sty` to use hex literals
* Side mission: found a bunch of very duplicated code in `Style.test.ts`. Pulled them into `loadProgs` to simplify things.

# Examples with steps to reproduce them

# Checklist

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new ESLint warnings
- [x] I have reviewed any generated changes to the `diagrams/` folder

# Open questions

Questions that require more discussion or to be addressed in future development:
