### PR TITLE
docs: Diversify our homepage demo

### DIFF
--- a/packages/components/src/Demo.tsx
+++ b/packages/components/src/Demo.tsx
@@ -41,7 +41,6 @@ const Demo = (props: {
         height={props.width}
         monacoOptions={{
           theme: props.darkMode ? "vs-dark" : "vs",
-          wordWrap: "on",
           wrappingIndent: "indent",
         }}
       />

--- a/packages/components/src/Demo.tsx
+++ b/packages/components/src/Demo.tsx
@@ -31,7 +31,7 @@ const Demo = (props: {
         display: "flex",
         flexDirection: "row",
         height: "100%",
-        flex: 1,
+        flexWrap: "wrap",
       }}
     >
       <Listing
@@ -39,7 +39,11 @@ const Demo = (props: {
         substance={example.sub}
         width={props.width}
         height={props.width}
-        monacoOptions={{ theme: props.darkMode ? "vs-dark" : "vs" }}
+        monacoOptions={{
+          theme: props.darkMode ? "vs-dark" : "vs",
+          wordWrap: "on",
+          wrappingIndent: "indent",
+        }}
       />
       <div style={{ width: props.width, height: props.width }}>
         <Simple

--- a/packages/components/src/Listing.tsx
+++ b/packages/components/src/Listing.tsx
@@ -8,6 +8,7 @@ export const defaultMonacoOptions: editor.IStandaloneEditorConstructionOptions =
   automaticLayout: true,
   readOnly: true,
   minimap: { enabled: false },
+  wordWrap: "on",
   lineNumbers: "off",
   fontSize: 16,
   scrollbar: {

--- a/packages/components/src/Listing.tsx
+++ b/packages/components/src/Listing.tsx
@@ -8,7 +8,6 @@ export const defaultMonacoOptions: editor.IStandaloneEditorConstructionOptions =
   automaticLayout: true,
   readOnly: true,
   minimap: { enabled: false },
-  wordWrap: "on",
   lineNumbers: "off",
   fontSize: 16,
   scrollbar: {

--- a/packages/docs-site/src/pages/index.js
+++ b/packages/docs-site/src/pages/index.js
@@ -101,7 +101,13 @@ export default function Home() {
 
         <h1>Example</h1>
         <p>Here's Penrose running in your browser:</p>
-        <DemoWrapper style={{ margin: "auto" }} examples={demo} width="400px" />
+        <div style={{ display: "flex", justifyContent: "center" }}>
+          <DemoWrapper
+            style={{ margin: "auto" }}
+            examples={demo}
+            width="400px"
+          />
+        </div>
       </main>
     </Layout>
   );

--- a/packages/docs-site/src/pages/index.js
+++ b/packages/docs-site/src/pages/index.js
@@ -36,15 +36,31 @@ function HomepageHeader() {
 export default function Home() {
   const { siteConfig } = useDocusaurusContext();
 
-  const trio = {
-    dsl: examples["set-theory-domain"]["setTheory.dsl"],
-    sub: examples["set-theory-domain"]["tree.sub"],
-    sty: examples["set-theory-domain"]["venn.sty"],
-  };
   const demo = [
-    { variation: "foo", ...trio },
-    { variation: "bar", ...trio },
-    { variation: "baz", ...trio },
+    {
+      dsl: examples["geometry-domain"]["geometry.dsl"],
+      sub: examples["geometry-domain"]["teaser.sub"],
+      sty: examples["geometry-domain"]["euclidean-teaser.sty"],
+      variation: "WhisperPeafowl34044",
+    },
+    {
+      dsl: examples["set-theory-domain"]["functions.dsl"],
+      sub: examples["set-theory-domain"]["continuousmap.sub"],
+      sty: examples["set-theory-domain"]["continuousmap.sty"],
+      variation: "",
+    },
+    {
+      dsl: examples["set-theory-domain"]["setTheory.dsl"],
+      sub: examples["set-theory-domain"]["tree.sub"],
+      sty: examples["set-theory-domain"]["venn.sty"],
+      variation: "PlumvilleCapybara104",
+    },
+    {
+      dsl: examples["lagrange-bases"]["lagrange-bases.dsl"],
+      sub: examples["lagrange-bases"]["example.sub"],
+      sty: examples["lagrange-bases"]["lagrange-bases.sty"],
+      variation: "RainmakerMarten88256",
+    },
   ];
 
   return (

--- a/packages/docs-site/src/pages/index.js
+++ b/packages/docs-site/src/pages/index.js
@@ -51,8 +51,8 @@ const findTrio = (sub, sty) => {
   const [{ substance, style, domain, variation }] = matching;
   return {
     dsl: exampleFromURI(registry.domains[domain].URI),
-    sub: exampleFromURI(registry.domains[substance].URI),
-    sty: exampleFromURI(registry.domains[style].URI),
+    sub: exampleFromURI(registry.substances[substance].URI),
+    sty: exampleFromURI(registry.styles[style].URI),
     variation,
   };
 };

--- a/packages/docs-site/src/pages/index.js
+++ b/packages/docs-site/src/pages/index.js
@@ -1,6 +1,6 @@
 import Link from "@docusaurus/Link";
 import useDocusaurusContext from "@docusaurus/useDocusaurusContext";
-import { examples } from "@penrose/examples";
+import { examples, registry } from "@penrose/examples";
 import Layout from "@theme/Layout";
 import clsx from "clsx";
 import * as React from "react";
@@ -33,34 +33,38 @@ function HomepageHeader() {
   );
 }
 
+const exampleFromURI = (uri) => {
+  let x = examples;
+  for (const part of uri.split("/")) {
+    x = x[part];
+  }
+  return x;
+};
+
+const findTrio = (sub, sty) => {
+  const matching = registry.trios.filter(
+    ({ substance, style }) => substance === sub && style === sty
+  );
+  if (matching.length !== 1) {
+    throw Error(`expected exactly one matching trio, got ${matching.length}`);
+  }
+  const [{ substance, style, domain, variation }] = matching;
+  return {
+    dsl: exampleFromURI(registry.domains[domain].URI),
+    sub: exampleFromURI(registry.domains[substance].URI),
+    sty: exampleFromURI(registry.domains[style].URI),
+    variation,
+  };
+};
+
 export default function Home() {
   const { siteConfig } = useDocusaurusContext();
 
   const demo = [
-    {
-      dsl: examples["geometry-domain"]["geometry.dsl"],
-      sub: examples["geometry-domain"]["teaser.sub"],
-      sty: examples["geometry-domain"]["euclidean-teaser.sty"],
-      variation: "WhisperPeafowl34044",
-    },
-    {
-      dsl: examples["set-theory-domain"]["functions.dsl"],
-      sub: examples["set-theory-domain"]["continuousmap.sub"],
-      sty: examples["set-theory-domain"]["continuousmap.sty"],
-      variation: "",
-    },
-    {
-      dsl: examples["set-theory-domain"]["setTheory.dsl"],
-      sub: examples["set-theory-domain"]["tree.sub"],
-      sty: examples["set-theory-domain"]["venn.sty"],
-      variation: "PlumvilleCapybara104",
-    },
-    {
-      dsl: examples["lagrange-bases"]["lagrange-bases.dsl"],
-      sub: examples["lagrange-bases"]["example.sub"],
-      sty: examples["lagrange-bases"]["lagrange-bases.sty"],
-      variation: "RainmakerMarten88256",
-    },
+    findTrio("siggraph-teaser", "euclidean-teaser"),
+    findTrio("continuousmap", "continuousmap"),
+    findTrio("tree", "venn"),
+    findTrio("lagrange-bases", "lagrange-bases"),
   ];
 
   return (

--- a/packages/examples/src/lagrange-bases/example.sub
+++ b/packages/examples/src/lagrange-bases/example.sub
@@ -1,9 +1,7 @@
 Node a, b, c, d
 Node u, v, x, y, z
---Element t1 := LinearTriangle( a, b, c )
 Element t2 := QuadraticTriangle( a, b, c, x, y, z )
 Element e := QuadraticTriangle( b, a, d, x, u, v )
---Element q1 := LinearQuad( a, b, c, d )
 
 Label a $p_i$
 Label b $p_j$


### PR DESCRIPTION
# Description

This PR replaces our current demo set of diagrams (just venn diagram with three different seeds) with four nice diagrams chosen from our registry.

One of those is the `lagrange-bases` example, from which this PR also removes a couple lines that were previously commented out, for nicer presentation.

# Checklist

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new ESLint warnings
- [x] I have reviewed any generated changes to the `diagrams/` folder