### PR TITLE
chore: Delete .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,0 @@
-diagrams/* linguist-generated=true
-src/front-end/snap.svg.js linguist-vendored=true
-src/front-end/w3.css linguist-vendored=true


### PR DESCRIPTION
# Description

This PR deletes the `.gitattributes` file. Two of its lines (added in 207f8e636338f8127c2e551a820ea3b2a014bf10 and updated in d41d3907bd89a5c0fda570664bf875a688e9e5e5) refer to files from Haskell Penrose that no longer exist. The other line was added in #864 to try to cut down on diff noise for PRs that touch `diagrams/`, as per [this GitHub Docs page](https://docs.github.com/en/repositories/working-with-files/managing-files/customizing-how-changed-files-appear-on-github). It doesn't seem to have any effect for `*.svg` files though, so this whole file seems to currently be effectively useless.

# Checklist

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new ESLint warnings
- [x] I have reviewed any generated changes to the `diagrams/` folder