### PR TITLE
fix: Reaction example Style

### DIFF
--- a/packages/examples/src/structural-formula/pseudo-3d-reaction.sty
+++ b/packages/examples/src/structural-formula/pseudo-3d-reaction.sty
@@ -324,9 +324,9 @@ where SingleBond(o,h1); SingleBond(o,h2) { -- TODO make an issue about symmetry 
    vec2 c = h2.center
    encourage equal( angleBetween(b-a,c-a), toRadians(104.5) )
 }
-forall Carbon c; Oxygen o1; Oxygen o2 -- carbon dioxide (CO2)
-where DoubleBond(c,o1); DoubleBond(c,o2) {
-   vec2 a = c.center
+forall Carbon c0; Oxygen o1; Oxygen o2 -- carbon dioxide (CO2)
+where DoubleBond(c0,o1); DoubleBond(c0,o2) {
+   vec2 a = c0.center
    vec2 b = o1.center
    vec2 c = o2.center
    encourage equal( angleBetween(b-a,c-a), toRadians(180.) )


### PR DESCRIPTION
# Description

@keenancrane added a Style program for reactions in #734. Because it uses `Text`, we don't currently include it in the registry, so we did not catch that it broke when we merged #984. This PR fixes the issue, which was caused by reusing the variable name `c` in one of the Style blocks.

# Examples with steps to reproduce them

- `structural-formula/reactions/methane-combustion.sub`
- `structural-formula/pseudo-3d-reaction.sty`
- `src/structural-formula/structural-formula.dsl`

# Checklist

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new ESLint warnings
- [x] I have reviewed any generated changes to the `diagrams/` folder