### PR TITLE
fix: some symmetric predicates don't match

### DIFF
--- a/packages/core/src/compiler/Style.test.ts
+++ b/packages/core/src/compiler/Style.test.ts
@@ -411,7 +411,7 @@ describe("Compiler", () => {
       const { state } = loadProgs({ dsl, sub, sty });
       expect(state.shapes.length).toEqual(0);
     });
-    test("symmetric predicate should match", () => {
+    test("symmetric predicate should match 1", () => {
       const dsl = `type Atom
       type Hydrogen <: Atom
       type Oxygen <: Atom
@@ -425,6 +425,23 @@ describe("Compiler", () => {
       where Bond(o, h) {
         myShape = Text {
           string: "Bond!"
+        }
+      }`;
+      const { state } = loadProgs({ dsl, sub, sty });
+      expect(state.shapes.length).toBeGreaterThan(0);
+    });
+    test("symmetric predicate should match 2", () => {
+      const dsl = `type Set
+      symmetric predicate Equal(Set, Set)`;
+      const sub = `Set A, B, C
+      Equal(A, B)
+      Equal(A, C)`;
+      const sty =
+        canvasPreamble +
+        `forall Set x, y, z
+      where Equal(x, y); Equal(y, z) {
+        myShape = Text {
+          string: "Equality!"
         }
       }`;
       const { state } = loadProgs({ dsl, sub, sty });

--- a/packages/core/src/compiler/Style.ts
+++ b/packages/core/src/compiler/Style.ts
@@ -169,13 +169,13 @@ const cartesianProduct = <Tin, Tout>(
   merge: (t1: Tin, t2: Tin) => Tout
 ): Tout[] => {
   const product: Tout[] = [];
-  t1.map((t1: Tin) => {
-    t2.map((t2: Tin) => {
-      if (consistent(t1, t2)) {
-        product.push(merge(t1, t2));
+  for (const i in t1) {
+    for (const j in t2) {
+      if (consistent(t1[i], t2[j])) {
+        product.push(merge(t1[i], t2[j]));
       }
-    });
-  });
+    }
+  }
   return product;
 };
 

--- a/packages/core/src/compiler/Style.ts
+++ b/packages/core/src/compiler/Style.ts
@@ -1248,7 +1248,7 @@ const matchStyApplyToSubApply = (
     }
 
     // Consider the original version
-    const rSubst1 = matchStyArgsToSubArgs(
+    const rSubstOriginal = matchStyArgsToSubArgs(
       styTypeMap,
       subTypeMap,
       varEnv,
@@ -1257,12 +1257,12 @@ const matchStyApplyToSubApply = (
     );
 
     // Consider the symmetric, flipped-argument version
-    let rSubst2 = undefined;
+    let rSubstSymmetric = undefined;
     const predicateDecl = varEnv.predicates.get(subRel.name.value);
     if (predicateDecl && predicateDecl.symmetric) {
       // Flip arguments
       const flippedStyArgs = [styRel.args[1], styRel.args[0]];
-      rSubst2 = matchStyArgsToSubArgs(
+      rSubstSymmetric = matchStyArgsToSubArgs(
         styTypeMap,
         subTypeMap,
         varEnv,
@@ -1271,9 +1271,9 @@ const matchStyApplyToSubApply = (
       );
     }
 
-    const rSubsts: Subst[] = [...rSubst1];
-    if (rSubst2 !== undefined) {
-      rSubsts.push(...rSubst2);
+    const rSubsts: Subst[] = [...rSubstOriginal];
+    if (rSubstSymmetric !== undefined) {
+      rSubsts.push(...rSubstSymmetric);
     }
 
     if (styRel.alias === undefined) {


### PR DESCRIPTION
# Description

Resolves #1126

Some symmetric predicates do not match. For example,
```
forall Set x, y, z
where Equal(x, y); Equal(y, z) {
    Text {
        string: "Hello"
    }
}
```
should match against
```
Set A, B, C
Equal(B, A)
Equal(B, C)
```
where `Equal` is symmetric. Using mapping `x --> A, y --> B, z --> C`, the `where`-clause becomes `Equal(A, B)` and `Equal(B, C)`. `Equal(A, B)` should match against `Equal(B, A)` due to symmetry, and `Equal(B, C)` also successfully matches. But, this matching is not admitted.

The reason is that when we first consider `Equal(x, y)`, we will only consider the version that is present in the Substance program. If that does not exist, then we will consider the alternative, symmetric version. But sometimes we actively seek for the symmetric version that is _not_ present in the substance.

# Implementation strategy and design decisions

The fix involves always considering both versions of a symmetric predicate, regardless of whether the original version exists in the substance. Then, using Cartesian products, generate all possible matchings _under_ symmetry.


# Checklist

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new ESLint warnings
- [x] I have reviewed any generated changes to the `diagrams/` folder

# Open questions

The search space blows up exponentially with the number of symmetric predicates due to additional stages of cartesian product. This problem existed prior to this fix, but with consideration of _both_ versions of symmetric predicates, the problem exacerbates.