### PR TITLE
fix: canvas disappears on mobile browsers

### DIFF
--- a/packages/editor/src/components/DiagramPanel.tsx
+++ b/packages/editor/src/components/DiagramPanel.tsx
@@ -70,6 +70,8 @@ export default function DiagramPanel() {
               pathResolver
             )
           : await RenderStatic(state, pathResolver);
+        rendered.setAttribute("width", "100%");
+        rendered.setAttribute("height", "100%");
         if (cur.firstElementChild) {
           cur.replaceChild(rendered, cur.firstElementChild);
         } else {
@@ -282,13 +284,12 @@ export default function DiagramPanel() {
           </div>
         )}
         <div
-          style={
-            {
-              // display: "flex",
-              // minHeight: "60%",
-              // maxHeight: "100%",
-            }
-          }
+          style={{
+            display: "flex",
+            minHeight: "60%",
+            maxHeight: "100%",
+            justifyContent: "center",
+          }}
           ref={canvasRef}
         />
 

--- a/packages/editor/src/components/DiagramPanel.tsx
+++ b/packages/editor/src/components/DiagramPanel.tsx
@@ -282,11 +282,13 @@ export default function DiagramPanel() {
           </div>
         )}
         <div
-          style={{
-            display: "flex",
-            minHeight: "60%",
-            maxHeight: "100%",
-          }}
+          style={
+            {
+              // display: "flex",
+              // minHeight: "60%",
+              // maxHeight: "100%",
+            }
+          }
           ref={canvasRef}
         />
 

--- a/packages/editor/src/components/DiagramPanel.tsx
+++ b/packages/editor/src/components/DiagramPanel.tsx
@@ -286,7 +286,6 @@ export default function DiagramPanel() {
             display: "flex",
             minHeight: "60%",
             maxHeight: "100%",
-            justifyContent: "center",
           }}
           ref={canvasRef}
         />


### PR DESCRIPTION
# Description

Fixes: #1135 

# Implementation strategy and design decisions

By default, `<svg>` has `auto` width and height, which is supposed to [be treated at 100%](https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/width#svg), but somehow the mobile browsers don't seem to respect that. This PR manually set them to `100%`. 


# Checklist

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new ESLint warnings
- [x] I have reviewed any generated changes to the `diagrams/` folder

