### PR TITLE
chore: allow user to export mutation metadata in `synthesizer-ui`

### DIFF
--- a/packages/synthesizer-ui/src/components/Content.tsx
+++ b/packages/synthesizer-ui/src/components/Content.tsx
@@ -10,8 +10,10 @@ import {
   compileDomain,
   compileSubstance,
   PenroseState,
+  prettySubstance,
   RenderStatic,
   showError,
+  showMutations,
   SubProg,
   SynthesizedSubstance,
   Synthesizer,
@@ -144,8 +146,11 @@ export class Content extends React.Component<ContentProps, ContentState> {
 
   exportDiagrams = async (indices: number[]) => {
     const zip = JSZip();
+    zip.file(`domain.dsl`, this.state.domain);
+    zip.file(`style.sty`, this.state.style);
     for (const idx of indices) {
       const state = this.state.states[idx];
+      const { prog, ops } = this.state.progs[idx];
       const svg = await RenderStatic(state, async (path: string) => {
         const response = await fetch(path);
         if (!response.ok) {
@@ -155,6 +160,8 @@ export class Content extends React.Component<ContentProps, ContentState> {
         return await response.text();
       });
       zip.file(`diagram_${idx}.svg`, svg.outerHTML.toString());
+      zip.file(`substance_${idx}.sub`, prettySubstance(prog));
+      zip.file(`mutations_${idx}.txt`, showMutations(ops));
     }
     zip.generateAsync({ type: "blob" }).then(function (content) {
       saveAs(content, "diagrams.zip");


### PR DESCRIPTION
# Description

This PR allow `synthesizer-ui` to export both the Substance files and mutation record upon "Export All."

# Implementation strategy and design decisions

The implementation basically uses existing data stored in the state and serialize them using standard pretty-print functions.

# Examples with steps to reproduce them

# Checklist

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new ESLint warnings
- [x] I have reviewed any generated changes to the `diagrams/` folder
