### PR TITLE
feat: "follow the cursor" dragging mode

### DIFF
--- a/packages/core/src/compiler/Style.ts
+++ b/packages/core/src/compiler/Style.ts
@@ -3154,7 +3154,7 @@ export const compileStyleHelper = (
     canvas: canvas.value,
     computeShapes,
     params,
-    frozenValues: new Set<number>
+    frozenValues: new Set<number>(),
   };
 
   log.info("init state from GenOptProblem", initState);

--- a/packages/core/src/compiler/Style.ts
+++ b/packages/core/src/compiler/Style.ts
@@ -2708,7 +2708,15 @@ const evalExpr = (
     }
     case "Vary": {
       return ok(
-        val(floatV(mut.makeInput({ sampler: uniform(...canvas.xRange) })))
+        val(
+          floatV(
+            mut.makeInput({
+              tag: "Optimized",
+              stage: "ShapeLayout",
+              sampler: uniform(...canvas.xRange),
+            })
+          )
+        )
       );
     }
   }
@@ -3091,7 +3099,7 @@ export const compileStyleHelper = (
   const varyingValues: number[] = [];
   const inputs: InputMeta[] = [];
   const makeInput = (meta: InputMeta) => {
-    const val = "pending" in meta ? meta.pending : meta.sampler(rng);
+    const val = meta.tag === "Optimized" ? meta.sampler(rng) : meta.pending;
     const x = input({ key: varyingValues.length, val });
     varyingValues.push(val);
     inputs.push(meta);

--- a/packages/core/src/compiler/Style.ts
+++ b/packages/core/src/compiler/Style.ts
@@ -2712,7 +2712,6 @@ const evalExpr = (
           floatV(
             mut.makeInput({
               tag: "Optimized",
-              stage: "ShapeLayout",
               sampler: uniform(...canvas.xRange),
             })
           )
@@ -3155,6 +3154,7 @@ export const compileStyleHelper = (
     canvas: canvas.value,
     computeShapes,
     params,
+    frozenValues: [],
   };
 
   log.info("init state from GenOptProblem", initState);

--- a/packages/core/src/compiler/Style.ts
+++ b/packages/core/src/compiler/Style.ts
@@ -3154,7 +3154,7 @@ export const compileStyleHelper = (
     canvas: canvas.value,
     computeShapes,
     params,
-    frozenValues: [],
+    frozenValues: new Set<number>
   };
 
   log.info("init state from GenOptProblem", initState);

--- a/packages/core/src/contrib/Functions.ts
+++ b/packages/core/src/contrib/Functions.ts
@@ -1053,10 +1053,7 @@ export const compDict = {
   ): ColorV<ad.Num> => {
     if (colorType === "rgb") {
       const rgb = range(3).map(() =>
-        makeInput({
-          sampler: uniform(0.1, 0.9),
-          tag: "Optimized",
-        })
+        makeInput({ tag: "Optimized", sampler: uniform(0.1, 0.9) })
       );
 
       return {
@@ -1067,10 +1064,7 @@ export const compDict = {
         },
       };
     } else if (colorType === "hsv") {
-      const h = makeInput({
-        sampler: uniform(0, 360),
-        tag: "Optimized",
-      });
+      const h = makeInput({ tag: "Optimized", sampler: uniform(0, 360) });
       return {
         tag: "ColorV",
         contents: {

--- a/packages/core/src/contrib/Functions.ts
+++ b/packages/core/src/contrib/Functions.ts
@@ -1055,7 +1055,6 @@ export const compDict = {
       const rgb = range(3).map(() =>
         makeInput({
           sampler: uniform(0.1, 0.9),
-          stage: "ShapeLayout",
           tag: "Optimized",
         })
       );
@@ -1070,7 +1069,6 @@ export const compDict = {
     } else if (colorType === "hsv") {
       const h = makeInput({
         sampler: uniform(0, 360),
-        stage: "ShapeLayout",
         tag: "Optimized",
       });
       return {

--- a/packages/core/src/contrib/Functions.ts
+++ b/packages/core/src/contrib/Functions.ts
@@ -1052,7 +1052,13 @@ export const compDict = {
     colorType: string
   ): ColorV<ad.Num> => {
     if (colorType === "rgb") {
-      const rgb = range(3).map(() => makeInput({ sampler: uniform(0.1, 0.9) }));
+      const rgb = range(3).map(() =>
+        makeInput({
+          sampler: uniform(0.1, 0.9),
+          stage: "ShapeLayout",
+          tag: "Optimized",
+        })
+      );
 
       return {
         tag: "ColorV",
@@ -1062,7 +1068,11 @@ export const compDict = {
         },
       };
     } else if (colorType === "hsv") {
-      const h = makeInput({ sampler: uniform(0, 360) });
+      const h = makeInput({
+        sampler: uniform(0, 360),
+        stage: "ShapeLayout",
+        tag: "Optimized",
+      });
       return {
         tag: "ColorV",
         contents: {

--- a/packages/core/src/contrib/SDF.test.ts
+++ b/packages/core/src/contrib/SDF.test.ts
@@ -26,7 +26,7 @@ const makeContext = (pt: number[]): { context: Context; p: ad.Input[] } => {
     return x;
   };
   for (const coord of pt) {
-    makeInput({ tag: "Optimized", sampler: () => coord, stage: "" });
+    makeInput({ tag: "Optimized", sampler: () => coord });
   }
   return { context: { makeInput }, p: [...inputs] };
 };

--- a/packages/core/src/contrib/SDF.test.ts
+++ b/packages/core/src/contrib/SDF.test.ts
@@ -20,13 +20,13 @@ const makeContext = (pt: number[]): { context: Context; p: ad.Input[] } => {
   const makeInput: InputFactory = (meta) => {
     const x = input({
       key: inputs.length,
-      val: "pending" in meta ? meta.pending : meta.sampler(rng),
+      val: meta.tag === "Optimized" ? meta.sampler(rng) : meta.pending,
     });
     inputs.push(x);
     return x;
   };
   for (const coord of pt) {
-    makeInput({ sampler: () => coord });
+    makeInput({ tag: "Optimized", sampler: () => coord, stage: "" });
   }
   return { context: { makeInput }, p: [...inputs] };
 };

--- a/packages/core/src/engine/Optimizer.ts
+++ b/packages/core/src/engine/Optimizer.ts
@@ -109,6 +109,7 @@ const epConverged2 = (
  */
 export const step = (state: State, steps: number): State => {
   const optParams: Params = { ...state.params };
+  const { frozenValues } = state;
   const { optStatus, weight } = optParams;
   let xs: number[] = state.varyingValues;
 
@@ -135,7 +136,10 @@ export const step = (state: State, steps: number): State => {
         ...state,
         params: {
           ...state.params,
-          currObjectiveAndGradient: objectiveAndGradient(initConstraintWeight),
+          currObjectiveAndGradient: objectiveAndGradient(
+            initConstraintWeight,
+            frozenValues
+          ),
           weight: initConstraintWeight,
           UOround: 0,
           EPround: 0,
@@ -246,7 +250,8 @@ export const step = (state: State, steps: number): State => {
         optParams.UOround = 0;
 
         optParams.currObjectiveAndGradient = optParams.objectiveAndGradient(
-          optParams.weight
+          optParams.weight,
+          frozenValues
         );
 
         log.info(
@@ -809,7 +814,10 @@ export const genOptProblem = (
 
   const f = genCode(explicitGraph);
 
-  const objectiveAndGradient = (epWeight: number) => (xs: number[]) => {
+  const objectiveAndGradient = (
+    epWeight: number,
+    frozenValues: Set<number>
+  ) => (xs: number[]) => {
     const { primary, gradient, secondary } = f([...xs, epWeight]);
     return {
       f: primary,
@@ -820,7 +828,7 @@ export const genOptProblem = (
           return 0;
         } else {
           const meta = inputs[i];
-          return meta.tag === "Optimized" && !frozenVaryingValues.includes(i)
+          return meta.tag === "Optimized" && !frozenValues.has(i)
             ? gradient[i]
             : 0;
         }
@@ -833,11 +841,8 @@ export const genOptProblem = (
   const params: Params = {
     lastGradient: repeat(inputs.length, 0),
     lastGradientPreconditioned: repeat(inputs.length, 0),
-
     objectiveAndGradient,
-
-    currObjectiveAndGradient: objectiveAndGradient(weight),
-
+    currObjectiveAndGradient: objectiveAndGradient(weight, new Set()),
     energyGraph,
     weight,
     UOround: 0,

--- a/packages/core/src/engine/Optimizer.ts
+++ b/packages/core/src/engine/Optimizer.ts
@@ -815,7 +815,14 @@ export const genOptProblem = (
       gradf: xs.map((x, i) => {
         // fill in any holes in case some inputs weren't used in the graph, and
         // also treat pending values as constants rather than optimizing them
-        return i in gradient && !("pending" in inputs[i]) ? gradient[i] : 0;
+        if (!(i in gradient)) {
+          return 0;
+        } else {
+          const meta = inputs[i];
+          return meta.tag === "Optimized" && meta.stage === stage
+            ? gradient[i]
+            : 0;
+        }
       }),
       objEngs: secondary.slice(0, objEngs.length),
       constrEngs: secondary.slice(objEngs.length),

--- a/packages/core/src/engine/Optimizer.ts
+++ b/packages/core/src/engine/Optimizer.ts
@@ -783,7 +783,8 @@ export const evalEnergyOnCustom = (
 export const genOptProblem = (
   inputs: InputMeta[],
   objEngs: ad.Num[],
-  constrEngs: ad.Num[]
+  constrEngs: ad.Num[],
+  frozenVaryingValues: number[] = []
 ): Params => {
   // TODO: Doesn't reuse compiled function for now (since caching function in App currently does not work)
   // Compile objective and gradient
@@ -819,7 +820,7 @@ export const genOptProblem = (
           return 0;
         } else {
           const meta = inputs[i];
-          return meta.tag === "Optimized" && meta.stage === stage
+          return meta.tag === "Optimized" && !frozenVaryingValues.includes(i)
             ? gradient[i]
             : 0;
         }

--- a/packages/core/src/engine/Optimizer.ts
+++ b/packages/core/src/engine/Optimizer.ts
@@ -788,8 +788,7 @@ export const evalEnergyOnCustom = (
 export const genOptProblem = (
   inputs: InputMeta[],
   objEngs: ad.Num[],
-  constrEngs: ad.Num[],
-  frozenVaryingValues: number[] = []
+  constrEngs: ad.Num[]
 ): Params => {
   // TODO: Doesn't reuse compiled function for now (since caching function in App currently does not work)
   // Compile objective and gradient
@@ -816,7 +815,7 @@ export const genOptProblem = (
 
   const objectiveAndGradient = (
     epWeight: number,
-    frozenValues: Set<number>
+    frozenValues?: Set<number>
   ) => (xs: number[]) => {
     const { primary, gradient, secondary } = f([...xs, epWeight]);
     return {
@@ -828,7 +827,9 @@ export const genOptProblem = (
           return 0;
         } else {
           const meta = inputs[i];
-          return meta.tag === "Optimized" && !frozenValues.has(i)
+          return meta.tag === "Optimized" &&
+            frozenValues &&
+            !frozenValues.has(i)
             ? gradient[i]
             : 0;
         }

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -51,6 +51,7 @@ export const resample = (state: State): State => {
       weight: initConstraintWeight,
       optStatus: "NewIter",
     },
+    frozenValues: new Set(),
   };
 };
 

--- a/packages/core/src/renderer/Renderer.ts
+++ b/packages/core/src/renderer/Renderer.ts
@@ -96,12 +96,17 @@ export const DraggableShape = async (
   const onMouseDown = (e: MouseEvent) => {
     const { clientX, clientY } = e;
     const { x: tempX, y: tempY } = getPosition({ clientX, clientY }, parentSVG);
-    const { width: bboxW, height: bboxH } = (e.target as any).getBBox();
-    const bbox = elem.getBoundingClientRect();
-    const { x: bboxX, y: bboxY } = getPosition(
-      { clientX: bbox.x, clientY: bbox.y },
-      parentSVG
-    );
+    const {
+      width: bboxW,
+      height: bboxH,
+      x: bboxX,
+      y: bboxY,
+    } = (e.target as SVGSVGElement).getBBox({ stroke: true });
+    // const bbox = elem.getBoundingClientRect();
+    // const { x: bboxX, y: bboxY } = getPosition(
+    //   { clientX: bbox.x, clientY: bbox.y },
+    //   parentSVG
+    // );
     const minX = tempX - bboxX;
     const maxX = canvas[0] - bboxW + (tempX - bboxX);
     const minY = tempY - bboxY;

--- a/packages/core/src/renderer/Renderer.ts
+++ b/packages/core/src/renderer/Renderer.ts
@@ -102,11 +102,6 @@ export const DraggableShape = async (
       x: bboxX,
       y: bboxY,
     } = (e.target as SVGSVGElement).getBBox({ stroke: true });
-    // const bbox = elem.getBoundingClientRect();
-    // const { x: bboxX, y: bboxY } = getPosition(
-    //   { clientX: bbox.x, clientY: bbox.y },
-    //   parentSVG
-    // );
     const minX = tempX - bboxX;
     const maxX = canvas[0] - bboxW + (tempX - bboxX);
     const minY = tempY - bboxY;

--- a/packages/core/src/renderer/Renderer.ts
+++ b/packages/core/src/renderer/Renderer.ts
@@ -54,10 +54,13 @@ export const RenderShape = async ({
  * @param e
  * @param svg
  */
-const getPosition = (e: MouseEvent, svg: SVGSVGElement) => {
+const getPosition = (
+  { clientX, clientY }: { clientX: number; clientY: number },
+  svg: SVGSVGElement
+) => {
   const CTM = svg.getScreenCTM();
   if (CTM !== null) {
-    return { x: (e.clientX - CTM.e) / CTM.a, y: (e.clientY - CTM.f) / CTM.d };
+    return { x: (clientX - CTM.e) / CTM.a, y: (clientY - CTM.f) / CTM.d };
   }
   return { x: 0, y: 0 };
 };
@@ -74,9 +77,10 @@ export const DraggableShape = async (
   parentSVG: SVGSVGElement,
   canvasSizeCustom?: [number, number]
 ): Promise<SVGGElement> => {
+  const canvas = shapeProps.canvasSize;
   const elem = await RenderShape({
     ...shapeProps,
-    canvasSize: canvasSizeCustom ? canvasSizeCustom : shapeProps.canvasSize,
+    canvasSize: canvasSizeCustom ? canvasSizeCustom : canvas,
   });
   const g = document.createElementNS("http://www.w3.org/2000/svg", "g");
   const { shapeType } = shapeProps.shape;
@@ -90,15 +94,28 @@ export const DraggableShape = async (
   g.appendChild(elem);
 
   const onMouseDown = (e: MouseEvent) => {
-    const tempX = getPosition(e, parentSVG).x;
-    const tempY = getPosition(e, parentSVG).y;
+    const { clientX, clientY } = e;
+    const { x: tempX, y: tempY } = getPosition({ clientX, clientY }, parentSVG);
+    const { width: bboxW, height: bboxH } = (e.target as any).getBBox();
+    const bbox = elem.getBoundingClientRect();
+    const { x: bboxX, y: bboxY } = getPosition(
+      { clientX: bbox.x, clientY: bbox.y },
+      parentSVG
+    );
+    const minX = tempX - bboxX;
+    const maxX = canvas[0] - bboxW + (tempX - bboxX);
+    const minY = tempY - bboxY;
+    const maxY = canvas[1] - bboxH + (tempY - bboxY);
+
     g.setAttribute("opacity", "0.5");
     let dx = 0,
       dy = 0;
     const onMouseMove = (e: MouseEvent) => {
       const { x, y } = getPosition(e, parentSVG);
-      dx = x - tempX;
-      dy = tempY - y;
+      const constrainedX = clamp(x, minX, maxX);
+      const constrainedY = clamp(y, minY, maxY);
+      dx = constrainedX - tempX;
+      dy = tempY - constrainedY;
       g.setAttribute(`transform`, `translate(${dx},${-dy})`);
     };
     const onMouseUp = () => {
@@ -184,3 +201,6 @@ export const RenderStatic = async (
     return svg;
   });
 };
+
+const clamp = (x: number, min: number, max: number): number =>
+  Math.min(Math.max(x, min), max);

--- a/packages/core/src/renderer/dragUtils.ts
+++ b/packages/core/src/renderer/dragUtils.ts
@@ -1,4 +1,3 @@
-import { genOptProblem } from "engine/Optimizer";
 import * as ad from "types/ad";
 import { Properties, ShapeAD } from "types/shape";
 import { State } from "types/state";
@@ -13,24 +12,21 @@ export const dragUpdate = (
   dy: number
 ): State => {
   const xs = [...state.varyingValues];
-  const frozenVaryingValues = [];
+  const frozenValues = new Set<number>();
   for (const shape of state.shapes) {
     if (shape.properties.name.contents === id) {
       const ids = dragShape(shape, [dx, dy], xs);
-      frozenVaryingValues.push(...ids);
+      ids.forEach((i) => frozenValues.add(i));
     }
   }
-  const { inputs, constrFns, objFns } = state;
   const updated: State = {
     ...state,
-    params: genOptProblem(
-      inputs,
-      objFns.map(({ output }) => output),
-      constrFns.map(({ output }) => output),
-      frozenVaryingValues
-    ),
+    params: {
+      ...state.params,
+      optStatus: "NewIter",
+    },
     varyingValues: xs,
-    frozenValues: frozenVaryingValues,
+    frozenValues,
   };
   return updated;
 };

--- a/packages/core/src/renderer/dragUtils.ts
+++ b/packages/core/src/renderer/dragUtils.ts
@@ -1,3 +1,4 @@
+import { genOptProblem } from "engine/Optimizer";
 import * as ad from "types/ad";
 import { Properties, ShapeAD } from "types/shape";
 import { State } from "types/state";
@@ -12,42 +13,50 @@ export const dragUpdate = (
   dy: number
 ): State => {
   const xs = [...state.varyingValues];
+  const frozenVaryingValues = [];
   for (const shape of state.shapes) {
     if (shape.properties.name.contents === id) {
-      dragShape(shape, [dx, dy], xs);
+      const ids = dragShape(shape, [dx, dy], xs);
+      frozenVaryingValues.push(...ids);
     }
   }
+  const { inputs, constrFns, objFns } = state;
   const updated: State = {
     ...state,
-    params: { ...state.params, optStatus: "NewIter" },
+    params: genOptProblem(
+      inputs,
+      objFns.map(({ output }) => output),
+      constrFns.map(({ output }) => output),
+      frozenVaryingValues
+    ),
     varyingValues: xs,
+    frozenValues: frozenVaryingValues,
   };
   return updated;
 };
 
 // TODO: factor out position props in shapedef
+// return: a list of updated ids
 const dragShape = (
   shape: ShapeAD,
   offset: [number, number],
   xs: number[]
-): void => {
+): number[] => {
   const { shapeType, properties } = shape;
   switch (shapeType) {
     case "Path":
       console.log("Path drag unimplemented", shape); // Just to prevent crashing on accidental drag
-      return;
+      return [];
     case "Polygon":
       console.log("Polygon drag unimplemented", shape); // Just to prevent crashing on accidental drag
-      return;
+      return [];
     case "Polyline":
       console.log("Polyline drag unimplemented", shape); // Just to prevent crashing on accidental drag
-      return;
+      return [];
     case "Line":
-      moveProperties(properties, ["start", "end"], offset, xs);
-      return;
+      return moveProperties(properties, ["start", "end"], offset, xs);
     default:
-      moveProperties(properties, ["center"], offset, xs);
-      return;
+      return moveProperties(properties, ["center"], offset, xs);
   }
 };
 
@@ -59,17 +68,21 @@ const moveProperties = (
   propsToMove: string[],
   [dx, dy]: [number, number],
   xs: number[]
-): void => {
+): number[] => {
+  const ids: number[] = [];
   for (const propertyID of propsToMove) {
     const value = properties[propertyID];
     if (value.tag === "VectorV") {
       const [x, y] = value.contents;
       if (typeof x !== "number" && x.tag === "Input") {
         xs[x.key] += dx;
+        ids.push(x.key);
       }
       if (typeof y !== "number" && y.tag === "Input") {
         xs[y.key] += dy;
+        ids.push(y.key);
       }
     }
   }
+  return ids;
 };

--- a/packages/core/src/shapes/Equation.ts
+++ b/packages/core/src/shapes/Equation.ts
@@ -28,17 +28,11 @@ export const sampleEquation = (
   style: strV(""),
   fillColor: black(),
   center: vectorV([
-    context.makeInput({
-      sampler: uniform(...canvas.xRange),
-      tag: "Optimized",
-    }),
-    context.makeInput({
-      sampler: uniform(...canvas.yRange),
-      tag: "Optimized",
-    }),
+    context.makeInput({ tag: "Optimized", sampler: uniform(...canvas.xRange) }),
+    context.makeInput({ tag: "Optimized", sampler: uniform(...canvas.yRange) }),
   ]),
-  width: floatV(context.makeInput({ pending: 0, tag: "Unoptimized" })),
-  height: floatV(context.makeInput({ pending: 0, tag: "Unoptimized" })),
+  width: floatV(context.makeInput({ tag: "Unoptimized", pending: 0 })),
+  height: floatV(context.makeInput({ tag: "Unoptimized", pending: 0 })),
   rotation: floatV(0),
   string: strV("defaultLabelText"),
   strokeWidth: floatV(0),

--- a/packages/core/src/shapes/Equation.ts
+++ b/packages/core/src/shapes/Equation.ts
@@ -30,12 +30,10 @@ export const sampleEquation = (
   center: vectorV([
     context.makeInput({
       sampler: uniform(...canvas.xRange),
-      stage: "LabelLayout",
       tag: "Optimized",
     }),
     context.makeInput({
       sampler: uniform(...canvas.yRange),
-      stage: "LabelLayout",
       tag: "Optimized",
     }),
   ]),

--- a/packages/core/src/shapes/Equation.ts
+++ b/packages/core/src/shapes/Equation.ts
@@ -8,8 +8,8 @@ import {
   String,
   Stroke,
 } from "types/shapes";
-import { black, boolV, floatV, noPaint, strV } from "utils/Util";
-import { Canvas, Context, sampleVector } from "./Samplers";
+import { black, boolV, floatV, noPaint, strV, vectorV } from "utils/Util";
+import { Canvas, Context, uniform } from "./Samplers";
 
 export interface EquationProps
   extends Named,
@@ -27,9 +27,20 @@ export const sampleEquation = (
   name: strV("defaultEquation"),
   style: strV(""),
   fillColor: black(),
-  center: sampleVector(context, canvas),
-  width: floatV(context.makeInput({ pending: 0 })),
-  height: floatV(context.makeInput({ pending: 0 })),
+  center: vectorV([
+    context.makeInput({
+      sampler: uniform(...canvas.xRange),
+      stage: "LabelLayout",
+      tag: "Optimized",
+    }),
+    context.makeInput({
+      sampler: uniform(...canvas.yRange),
+      stage: "LabelLayout",
+      tag: "Optimized",
+    }),
+  ]),
+  width: floatV(context.makeInput({ pending: 0, tag: "Unoptimized" })),
+  height: floatV(context.makeInput({ pending: 0, tag: "Unoptimized" })),
   rotation: floatV(0),
   string: strV("defaultLabelText"),
   strokeWidth: floatV(0),

--- a/packages/core/src/shapes/Samplers.ts
+++ b/packages/core/src/shapes/Samplers.ts
@@ -74,14 +74,8 @@ export const sampleVector = (
   canvas: Canvas
 ): VectorV<ad.Num> =>
   vectorV([
-    makeInput({
-      sampler: uniform(...canvas.xRange),
-      tag: "Optimized",
-    }),
-    makeInput({
-      sampler: uniform(...canvas.yRange),
-      tag: "Optimized",
-    }),
+    makeInput({ tag: "Optimized", sampler: uniform(...canvas.xRange) }),
+    makeInput({ tag: "Optimized", sampler: uniform(...canvas.yRange) }),
   ]);
 
 export const sampleWidth = (
@@ -89,10 +83,7 @@ export const sampleWidth = (
   canvas: Canvas
 ): FloatV<ad.Num> =>
   floatV(
-    makeInput({
-      sampler: uniform(3, canvas.width / 6),
-      tag: "Optimized",
-    })
+    makeInput({ tag: "Optimized", sampler: uniform(3, canvas.width / 6) })
   );
 
 export const sampleHeight = (
@@ -100,37 +91,20 @@ export const sampleHeight = (
   canvas: Canvas
 ): FloatV<ad.Num> =>
   floatV(
-    makeInput({
-      sampler: uniform(3, canvas.height / 6),
-      tag: "Optimized",
-    })
+    makeInput({ tag: "Optimized", sampler: uniform(3, canvas.height / 6) })
   );
 
 export const sampleStroke = ({ makeInput }: Context): FloatV<ad.Num> =>
-  floatV(
-    makeInput({
-      sampler: uniform(0.5, 3),
-      tag: "Optimized",
-    })
-  );
+  floatV(makeInput({ tag: "Optimized", sampler: uniform(0.5, 3) }));
 
 export const sampleColor = ({ makeInput }: Context): ColorV<ad.Num> => {
   const [min, max] = [0.1, 0.9];
   return colorV({
     tag: "RGBA",
     contents: [
-      makeInput({
-        sampler: uniform(min, max),
-        tag: "Optimized",
-      }),
-      makeInput({
-        sampler: uniform(min, max),
-        tag: "Optimized",
-      }),
-      makeInput({
-        sampler: uniform(min, max),
-        tag: "Optimized",
-      }),
+      makeInput({ tag: "Optimized", sampler: uniform(min, max) }),
+      makeInput({ tag: "Optimized", sampler: uniform(min, max) }),
+      makeInput({ tag: "Optimized", sampler: uniform(min, max) }),
       0.5,
     ],
   });

--- a/packages/core/src/shapes/Samplers.ts
+++ b/packages/core/src/shapes/Samplers.ts
@@ -32,7 +32,6 @@ export type Sampler = (rng: seedrandom.prng) => number;
 export interface OptimizedMeta {
   tag: "Optimized";
   sampler: Sampler;
-  stage: string;
 }
 
 export interface UnoptimizedMeta {
@@ -77,12 +76,10 @@ export const sampleVector = (
   vectorV([
     makeInput({
       sampler: uniform(...canvas.xRange),
-      stage: "ShapeLayout",
       tag: "Optimized",
     }),
     makeInput({
       sampler: uniform(...canvas.yRange),
-      stage: "ShapeLayout",
       tag: "Optimized",
     }),
   ]);
@@ -94,7 +91,6 @@ export const sampleWidth = (
   floatV(
     makeInput({
       sampler: uniform(3, canvas.width / 6),
-      stage: "ShapeLayout",
       tag: "Optimized",
     })
   );
@@ -106,7 +102,6 @@ export const sampleHeight = (
   floatV(
     makeInput({
       sampler: uniform(3, canvas.height / 6),
-      stage: "ShapeLayout",
       tag: "Optimized",
     })
   );
@@ -115,7 +110,6 @@ export const sampleStroke = ({ makeInput }: Context): FloatV<ad.Num> =>
   floatV(
     makeInput({
       sampler: uniform(0.5, 3),
-      stage: "ShapeLayout",
       tag: "Optimized",
     })
   );
@@ -127,17 +121,14 @@ export const sampleColor = ({ makeInput }: Context): ColorV<ad.Num> => {
     contents: [
       makeInput({
         sampler: uniform(min, max),
-        stage: "ShapeLayout",
         tag: "Optimized",
       }),
       makeInput({
         sampler: uniform(min, max),
-        stage: "ShapeLayout",
         tag: "Optimized",
       }),
       makeInput({
         sampler: uniform(min, max),
-        stage: "ShapeLayout",
         tag: "Optimized",
       }),
       0.5,

--- a/packages/core/src/shapes/Text.ts
+++ b/packages/core/src/shapes/Text.ts
@@ -48,12 +48,10 @@ export const sampleText = (context: Context, canvas: Canvas): TextProps => ({
   center: vectorV([
     context.makeInput({
       sampler: uniform(...canvas.xRange),
-      stage: "LabelLayout",
       tag: "Optimized",
     }),
     context.makeInput({
       sampler: uniform(...canvas.yRange),
-      stage: "LabelLayout",
       tag: "Optimized",
     }),
   ]),

--- a/packages/core/src/shapes/Text.ts
+++ b/packages/core/src/shapes/Text.ts
@@ -10,8 +10,8 @@ import {
   Stroke,
 } from "types/shapes";
 import { FloatV, StrV } from "types/value";
-import { boolV, floatV, noPaint, strV } from "utils/Util";
-import { Canvas, Context, sampleColor, sampleVector } from "./Samplers";
+import { boolV, floatV, noPaint, strV, vectorV } from "utils/Util";
+import { Canvas, Context, sampleColor, uniform } from "./Samplers";
 
 export interface TextProps
   extends Named,
@@ -45,11 +45,22 @@ export const sampleText = (context: Context, canvas: Canvas): TextProps => ({
   strokeColor: noPaint(),
   strokeDasharray: strV(""),
   fillColor: sampleColor(context),
-  center: sampleVector(context, canvas),
-  width: floatV(context.makeInput({ pending: 0 })),
-  height: floatV(context.makeInput({ pending: 0 })),
-  ascent: floatV(context.makeInput({ pending: 0 })),
-  descent: floatV(context.makeInput({ pending: 0 })),
+  center: vectorV([
+    context.makeInput({
+      sampler: uniform(...canvas.xRange),
+      stage: "LabelLayout",
+      tag: "Optimized",
+    }),
+    context.makeInput({
+      sampler: uniform(...canvas.yRange),
+      stage: "LabelLayout",
+      tag: "Optimized",
+    }),
+  ]),
+  width: floatV(context.makeInput({ tag: "Unoptimized", pending: 0 })),
+  height: floatV(context.makeInput({ tag: "Unoptimized", pending: 0 })),
+  ascent: floatV(context.makeInput({ tag: "Unoptimized", pending: 0 })),
+  descent: floatV(context.makeInput({ tag: "Unoptimized", pending: 0 })),
   rotation: floatV(0),
   string: strV("defaultText"),
   visibility: strV(""),

--- a/packages/core/src/shapes/Text.ts
+++ b/packages/core/src/shapes/Text.ts
@@ -46,14 +46,8 @@ export const sampleText = (context: Context, canvas: Canvas): TextProps => ({
   strokeDasharray: strV(""),
   fillColor: sampleColor(context),
   center: vectorV([
-    context.makeInput({
-      sampler: uniform(...canvas.xRange),
-      tag: "Optimized",
-    }),
-    context.makeInput({
-      sampler: uniform(...canvas.yRange),
-      tag: "Optimized",
-    }),
+    context.makeInput({ tag: "Optimized", sampler: uniform(...canvas.xRange) }),
+    context.makeInput({ tag: "Optimized", sampler: uniform(...canvas.yRange) }),
   ]),
   width: floatV(context.makeInput({ tag: "Unoptimized", pending: 0 })),
   height: floatV(context.makeInput({ tag: "Unoptimized", pending: 0 })),

--- a/packages/core/src/types/state.ts
+++ b/packages/core/src/types/state.ts
@@ -25,6 +25,7 @@ export interface State {
   canvas: Canvas;
   computeShapes: ShapeFn;
   params: Params;
+  frozenValues: number[];
 }
 
 /**

--- a/packages/core/src/types/state.ts
+++ b/packages/core/src/types/state.ts
@@ -25,7 +25,11 @@ export interface State {
   canvas: Canvas;
   computeShapes: ShapeFn;
   params: Params;
-  frozenValues: number[];
+  /**
+   * A set of indices of `varyingValues` that are treated as constant during optimization.
+   * Currently used for the drag interaction.
+   */
+  frozenValues: Set<number>;
 }
 
 /**
@@ -106,7 +110,10 @@ export interface Params {
   lbfgsInfo: LbfgsParams;
 
   // Higher-order functions (not yet applied with hyperparameters, in this case, just the EP weight)
-  objectiveAndGradient: (epWeight: number) => (xs: number[]) => FnEvaled;
+  objectiveAndGradient: (
+    epWeight: number,
+    frozenValues: Set<number>
+  ) => (xs: number[]) => FnEvaled;
 
   // Applied with weight (or hyperparameters in general) -- may change with the EP round
   currObjectiveAndGradient(xs: number[]): FnEvaled;

--- a/packages/core/src/types/state.ts
+++ b/packages/core/src/types/state.ts
@@ -112,7 +112,7 @@ export interface Params {
   // Higher-order functions (not yet applied with hyperparameters, in this case, just the EP weight)
   objectiveAndGradient: (
     epWeight: number,
-    frozenValues: Set<number>
+    frozenValues?: Set<number>
   ) => (xs: number[]) => FnEvaled;
 
   // Applied with weight (or hyperparameters in general) -- may change with the EP round

--- a/packages/core/src/utils/Util.ts
+++ b/packages/core/src/utils/Util.ts
@@ -2,6 +2,7 @@ import * as _ from "lodash";
 import { times } from "lodash";
 import seedrandom from "seedrandom";
 import { LineProps } from "shapes/Line";
+import { ShapeType } from "shapes/Shapes";
 import * as ad from "types/ad";
 import { A } from "types/ast";
 import { Either, Left, Right } from "types/common";
@@ -371,7 +372,7 @@ export const eqList = (xs: number[], ys: number[]): boolean => {
 // calculates bounding box dimensions of a shape - used in inspector views
 export const bBoxDims = (
   properties: Properties<number>,
-  shapeType: string
+  shapeType: ShapeType
 ): [number, number] => {
   let [w, h] = [0, 0];
   if (shapeType === "Circle") {


### PR DESCRIPTION
# Description

Related issue/PR: #644, #1115 

The current dragging behavior is counter-intuitive. After a user drags a shape in interactive mode, the optimizer steps all variable in the state, including the one the user interacted with. If a user drags a shape from point A to B, the shape might end up in point C. This PR allows the system to programmatically specify "frozen" variable during optimization, which gives zero gradient and therefore stays during optimization.

This feature was initially developed in #1115. Since it's an experimental PR, I'm separating this feature out, which is stable and ready to be merged.

Note: this mode of optimization requires the frozen variables to be in the feasible region. In the context of dragging, if the user drags a shape off screen and the system freezes the `x, y` of the shape, the optimizer won't find a solution. To remedy this, this PR also constrain the draggable area to the canvas. 

# Implementation strategy and design decisions

* Add annotation to input variables
* Freeze dragged inputs in subsequent optimization
* Constrain dragging so the shapes always stay entirely on canvas: uses `getBBox` with `stroke: true` to get shape bboxes and compute offsets after `mouseDown`. Reference: https://www.petercollingridge.co.uk/tutorials/svg/interactive/dragging/

# Examples with steps to reproduce them

See https://github.com/penrose/penrose/pull/1107 for instructions on how to enable interactive mode.

https://user-images.githubusercontent.com/11740102/201419814-162128aa-1030-4fd3-af65-5dede682e926.mov

# Checklist

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new ESLint warnings
- [x] I have reviewed any generated changes to the `diagrams/` folder

# Open questions

* More of a research question: 
