### PR TITLE
fix: clone rendered SVG node for `Equation` at render-time 

### DIFF
--- a/packages/core/src/renderer/Equation.ts
+++ b/packages/core/src/renderer/Equation.ts
@@ -28,7 +28,9 @@ const Equation = ({ shape, canvasSize, labels }: ShapeProps): SVGGElement => {
   const retrievedLabel = labels.get(getAdValueAsString(shape.properties.name));
 
   if (retrievedLabel && retrievedLabel.tag === "EquationData") {
-    const renderedLabel = retrievedLabel.rendered;
+    const renderedLabel = retrievedLabel.rendered.cloneNode(
+      true
+    ) as HTMLElement;
     const paths = renderedLabel.getElementsByTagName("path");
 
     // Map Width/Height, clear style

--- a/packages/core/src/renderer/Equation.ts
+++ b/packages/core/src/renderer/Equation.ts
@@ -28,6 +28,7 @@ const Equation = ({ shape, canvasSize, labels }: ShapeProps): SVGGElement => {
   const retrievedLabel = labels.get(getAdValueAsString(shape.properties.name));
 
   if (retrievedLabel && retrievedLabel.tag === "EquationData") {
+    // Clone the retrieved node first to avoid mutating existing labels
     const renderedLabel = retrievedLabel.rendered.cloneNode(
       true
     ) as HTMLElement;


### PR DESCRIPTION
# Description

Closes: #535 

Currently, we cache the rendered SVG node in `LabelCache` and `appendChild` in `renderer/Equation.ts`. However, `appendChild` doesn't clone the node and therefore remove the existing node from the DOM tree, causing the labels to disappear.

# Implementation strategy and design decisions

`cloneDeep` the SVG node after retrieving it from the label cache.

# Checklist

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new ESLint warnings
- [x] I have reviewed any generated changes to the `diagrams/` folder

# Open questions

Questions that require more discussion or to be addressed in future development:
