### PR TITLE
refactor: `numsOf` for evaluating autodiff numbers

### DIFF
--- a/packages/core/src/contrib/Minkowski.ts
+++ b/packages/core/src/contrib/Minkowski.ts
@@ -1,5 +1,5 @@
 import { outwardUnitNormal } from "contrib/Queries";
-import { genCode, ops, secondaryGraph } from "engine/Autodiff";
+import { ops } from "engine/Autodiff";
 import {
   absVal,
   add,
@@ -33,6 +33,7 @@ import {
   implicitHalfPlaneFunc,
   implicitIntersectionOfEllipsesFunc,
 } from "./ImplicitShapes";
+import { numsOf } from "./Utils";
 
 /**
  * Compute coordinates of Minkowski sum of AABBs representing the first rectangle `box1` and the negative of the second rectangle `box2`.
@@ -148,14 +149,7 @@ export const convexPartitions = (p: ad.Num[][]): ad.Num[][][] => {
   // the input values embedded in the children of the `ad.Num`s we were passed,
   // run a convex partitioning algorithm on those vertex positions, and cross
   // our fingers that this remains a valid convex partition as we optimize
-  const g = secondaryGraph(p.flat());
-  const inputs = [];
-  for (const v of g.nodes.keys()) {
-    if (typeof v !== "number" && v.tag === "Input") {
-      inputs[v.key] = v.val;
-    }
-  }
-  const coords = genCode(g)(inputs).secondary;
+  const coords = numsOf(p.flat());
 
   // map each point back to its original VecAD object; note, this depends on the
   // fact that two points with the same contents are considered different as

--- a/packages/core/src/contrib/Utils.ts
+++ b/packages/core/src/contrib/Utils.ts
@@ -189,12 +189,24 @@ export const closestPt_PtSeg = (
   return ops.vadd(start, ops.vmul(t1, dir));
 };
 
-export const numsOf = (xs: ad.Num[]) => {
+/**
+ * Get numerical values of nodes in the computation graph. This function calls `secondaryGraph` to construct a partial computation graph and run `genCode` to generate code to evaluate the values.
+ *
+ * @param xs nodes in the computation graph
+ * @returns a list of `number`s corresponding to nodes in `xs`
+ */
+export const numsOf = (xs: ad.Num[]): number[] => {
   const g = secondaryGraph(xs);
+  const inputs = [];
+  for (const v of g.nodes.keys()) {
+    if (typeof v !== "number" && v.tag === "Input") {
+      inputs[v.key] = v.val;
+    }
+  }
   const f = genCode(g);
-  return f([]).secondary;
+  return f(inputs).secondary;
 };
 
-export const numOf = (x: ad.Num) => {
+export const numOf = (x: ad.Num): number => {
   return numsOf([x])[0];
 };

--- a/packages/core/src/contrib/Utils.ts
+++ b/packages/core/src/contrib/Utils.ts
@@ -190,7 +190,7 @@ export const closestPt_PtSeg = (
 };
 
 /**
- * Get numerical values of nodes in the computation graph. This function calls `secondaryGraph` to construct a partial computation graph and run `genCode` to generate code to evaluate the values.
+ * Get numerical values of nodes in the computation graph. This function calls `secondaryGraph` to construct a partial computation graph and runs `genCode` to generate code to evaluate the values.
  *
  * @param xs nodes in the computation graph
  * @returns a list of `number`s corresponding to nodes in `xs`


### PR DESCRIPTION
# Description

Related issue/PR: #907 

Aside from the main optimizer, other parts of the system sometimes need to get the numerical values of autodiff nodes. Notably, `convexPartitions` needs to evaluate points in a polygon before the optimizer runs. Similarly, any computation in `Function.ts` that needs JS `number` from `ad.Num` will need to run such evaluation. Currently, we go through these steps to achieve this:

1. Construct a `secondaryGraph` with `inputs` that are sources of the output nodes of interest
2. Run `genCode` on the graph, and evaluate the generated code with the input values.  

This PR modifies `numsOf` and `numOf` in `contrib/Util.ts` to perform 1 so we can just call `numsOf(xs)` or `numOf(x)` without doing the steps manually.

# Checklist

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new ESLint warnings
- [x] I have reviewed any generated changes to the `diagrams/` folder
