### PR TITLE
feat: detect and report cyclic assignments in Style

### DIFF
--- a/packages/core/src/compiler/Style.test.ts
+++ b/packages/core/src/compiler/Style.test.ts
@@ -750,6 +750,16 @@ delete x.z.p }`,
 }`,
       ],
 
+      CyclicAssignmentError: [
+        `forall Set x {
+          x.icon = Circle { }
+        }
+
+        forall Set x; Set y where IsSubset(x, y) {
+          override y.r = x.r + y.r
+        }`,
+      ],
+
       // TODO(errors): check multiple errors
 
       // TODO(errors): This throws too early, gives InsertedPathWithoutOverrideError -- correctly throws error but may be misleading

--- a/packages/core/src/compiler/Style.ts
+++ b/packages/core/src/compiler/Style.ts
@@ -2881,7 +2881,6 @@ export const translate = (
     })
   );
   if (cycles.length > 0) {
-    // TODO: improve the error
     return {
       ...trans,
       diagnostics: oneErr({ tag: "CyclicAssignmentError", cycles }),

--- a/packages/core/src/compiler/Style.ts
+++ b/packages/core/src/compiler/Style.ts
@@ -2069,8 +2069,6 @@ export const buildAssignment = (
                 block: { tag: "NamespaceId", contents: "" }, // HACK
                 subst: {},
                 locals: im.Map(),
-                start: { line: -1, col: -1 },
-                end: { line: -1, col: -1 },
               },
               expr: {
                 ...range,

--- a/packages/core/src/compiler/Style.ts
+++ b/packages/core/src/compiler/Style.ts
@@ -2082,14 +2082,8 @@ export const buildAssignment = (
                 block: { tag: "NamespaceId", contents: "" }, // HACK
                 subst: {},
                 locals: im.Map(),
-                start: {
-                  line: -1,
-                  col: -1,
-                },
-                end: {
-                  line: -1,
-                  col: -1,
-                },
+                start: { line: -1, col: -1 },
+                end: { line: -1, col: -1 },
               },
               expr: {
                 ...range,
@@ -3072,14 +3066,8 @@ const onCanvases = (canvas: Canvas, shapes: ShapeAD[]): Fn[] => {
             block: { tag: "NamespaceId", contents: "canvas" }, // doesn't matter
             subst: {},
             locals: im.Map(),
-            start: {
-              line: -1,
-              col: -1,
-            },
-            end: {
-              line: -1,
-              col: -1,
-            },
+            start: { line: -1, col: -1 },
+            end: { line: -1, col: -1 },
           },
           expr: {
             tag: "ConstrFn",

--- a/packages/core/src/types/errors.ts
+++ b/packages/core/src/types/errors.ts
@@ -360,7 +360,7 @@ export interface CanvasNonexistentDimsError {
 export interface CyclicAssignmentError {
   tag: "CyclicAssignmentError";
   // TODO: improve types, currently the generated id and source location
-  cycles: [string, SourceRange][][];
+  cycles: { id: string; src: SourceRange | undefined }[][];
 }
 
 export interface DeleteGlobalError {

--- a/packages/core/src/types/errors.ts
+++ b/packages/core/src/types/errors.ts
@@ -1,6 +1,6 @@
 import im from "immutable";
 import * as ad from "types/ad";
-import { A, AbstractNode, C, Identifier, SourceLoc } from "./ast";
+import { A, AbstractNode, C, Identifier, SourceLoc, SourceRange } from "./ast";
 import { Arg, TypeConstructor, TypeVar } from "./domain";
 import { State } from "./state";
 import {
@@ -182,6 +182,7 @@ export type StyleError =
   | BadIndexError
   | BinOpTypeError
   | CanvasNonexistentDimsError
+  | CyclicAssignmentError
   | DeleteGlobalError
   | DeleteSubstanceError
   | MissingPathError
@@ -354,6 +355,12 @@ export interface CanvasNonexistentDimsError {
   attr: "width" | "height";
   kind: "missing" | "GPI" | "wrong type";
   type?: Expr<A>["tag"];
+}
+
+export interface CyclicAssignmentError {
+  tag: "CyclicAssignmentError";
+  // TODO: improve types, currently the generated id and source location
+  cycles: [string, SourceRange][][];
 }
 
 export interface DeleteGlobalError {

--- a/packages/core/src/types/styleSemantics.ts
+++ b/packages/core/src/types/styleSemantics.ts
@@ -2,7 +2,7 @@ import im from "immutable";
 import { ShapeType } from "shapes/Shapes";
 import { Digraph } from "utils/Graph";
 import * as ad from "./ad";
-import { A, C, Identifier } from "./ast";
+import { A, C, Identifier, SourceRange } from "./ast";
 import { StyleDiagnostics, StyleError } from "./errors";
 import { Fn } from "./state";
 import { BindingForm, Expr, GPIDecl, Header, StyT } from "./style";
@@ -129,7 +129,7 @@ export interface BlockInfo {
   subst: Subst;
 }
 
-export interface Context extends BlockInfo, Locals {}
+export interface Context extends BlockInfo, Locals, SourceRange {}
 
 export interface ResolvedName {
   tag: "Global" | "Local" | "Substance";

--- a/packages/core/src/types/styleSemantics.ts
+++ b/packages/core/src/types/styleSemantics.ts
@@ -2,7 +2,7 @@ import im from "immutable";
 import { ShapeType } from "shapes/Shapes";
 import { Digraph } from "utils/Graph";
 import * as ad from "./ad";
-import { A, C, Identifier, SourceRange } from "./ast";
+import { A, C, Identifier } from "./ast";
 import { StyleDiagnostics, StyleError } from "./errors";
 import { Fn } from "./state";
 import { BindingForm, Expr, GPIDecl, Header, StyT } from "./style";
@@ -129,7 +129,7 @@ export interface BlockInfo {
   subst: Subst;
 }
 
-export interface Context extends BlockInfo, Locals, SourceRange {}
+export interface Context extends BlockInfo, Locals {}
 
 export interface ResolvedName {
   tag: "Global" | "Local" | "Substance";

--- a/packages/core/src/utils/Error.ts
+++ b/packages/core/src/utils/Error.ts
@@ -320,6 +320,15 @@ canvas {
       break; // dead code to please ESLint
     }
 
+    case "CyclicAssignmentError": {
+      const cycleString = error.cycles.map((c) =>
+        c.map(([id, src]) => `${id} (${locc("Style", src)})`)
+      );
+      return `The Style program contains cyclic variable assignments, where the following variables are defined in cycles:\n${showCycles(
+        cycleString
+      )}`;
+    }
+
     case "DeleteGlobalError": {
       return `Cannot delete global ${prettyPrintResolvedPath(
         error.path
@@ -433,7 +442,8 @@ canvas {
 };
 
 const showCycles = (cycles: string[][]) => {
-  const pathString = (path: string[]) => path.join(" -> ");
+  // repeats the cycle start again
+  const pathString = (path: string[]) => [...path, path[0]].join(" <-> ");
   return cycles.map(pathString).join("\n");
 };
 

--- a/packages/core/src/utils/Error.ts
+++ b/packages/core/src/utils/Error.ts
@@ -322,7 +322,9 @@ canvas {
 
     case "CyclicAssignmentError": {
       const cycleString = error.cycles.map((c) =>
-        c.map(([id, src]) => `${id} (${locc("Style", src)})`)
+        c.map(({ id, src }) =>
+          src === undefined ? id : `${id} (${locc("Style", src)})`
+        )
       );
       return `The Style program contains cyclic variable assignments, where the following variables are defined in cycles:\n${showCycles(
         cycleString

--- a/packages/core/src/utils/Error.ts
+++ b/packages/core/src/utils/Error.ts
@@ -445,7 +445,7 @@ canvas {
 
 const showCycles = (cycles: string[][]) => {
   // repeats the cycle start again
-  const pathString = (path: string[]) => [...path, path[0]].join(" <-> ");
+  const pathString = (path: string[]) => [...path, path[0]].join(" -> ");
   return cycles.map(pathString).join("\n");
 };
 


### PR DESCRIPTION
# Description

Related issue/PR: #760 

Style doesn't allow the user to assign values cyclically. For instance, `a = a + 1` is not a valid Style expression. Currently, the system fails silently whenever that happens. This PR adds an explicit check and report such errors in a human-readable way.

# Implementation strategy and design decisions

* Accumulate source location when building up the dependency graph in the first compilation pass
* Retrieve the source location and pretty-print them in error reporting

# Examples with steps to reproduce them

TODO

# Checklist

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new ESLint warnings
- [x] I have reviewed any generated changes to the `diagrams/` folder

# Open questions

Generally the Style compiler doesn't keep source locations around for long. Is there a more principled way to keep track of them?