### PR TITLE
ci: build and deploy edgeworth on feature branches

### DIFF
--- a/.github/workflows/edgeworth.yml
+++ b/.github/workflows/edgeworth.yml
@@ -14,9 +14,7 @@ jobs:
       - name: Install packages
         uses: ./.github/actions/packages
       - name: Build edgeworth
-        # run: npx nx run synthesizer-ui:build
-        run: |
-          mkdir packages/synthesizer-ui/dist
+        run: npx nx run synthesizer-ui:build
       - name: Deploy edgeworth under the current commit SHA
         uses: JamesIves/github-pages-deploy-action@4.1.4
         with:

--- a/.github/workflows/edgeworth.yml
+++ b/.github/workflows/edgeworth.yml
@@ -1,4 +1,4 @@
-name: Build
+name: Edgeworth
 on:
   pull_request:
   push:

--- a/.github/workflows/edgeworth.yml
+++ b/.github/workflows/edgeworth.yml
@@ -1,6 +1,5 @@
 name: Edgeworth
 on:
-  pull_request:
   push:
     branches:
       - main

--- a/.github/workflows/edgeworth.yml
+++ b/.github/workflows/edgeworth.yml
@@ -13,14 +13,14 @@ jobs:
         uses: actions/checkout@v2
       - name: Install packages
         uses: ./.github/actions/packages
-      - name: Build edgeworth
-        run: npx nx run synthesizer-ui:build
+      # - name: Build edgeworth
+      #   run: npx nx run synthesizer-ui:build
       - name: Deploy edgeworth under the current commit SHA
         uses: JamesIves/github-pages-deploy-action@4.1.4
         with:
           branch: gh-pages
           folder: packages/synthesizer-ui/dist
-          target-folder: /edgeworth/${ github.sha }/
+          target-folder: edgeworth/${ github.sha }/
       - name: Add .nojekyll
         run: |
           mkdir extra/

--- a/.github/workflows/edgeworth.yml
+++ b/.github/workflows/edgeworth.yml
@@ -13,14 +13,16 @@ jobs:
         uses: actions/checkout@v2
       - name: Install packages
         uses: ./.github/actions/packages
-      # - name: Build edgeworth
-      #   run: npx nx run synthesizer-ui:build
+      - name: Build edgeworth
+        # run: npx nx run synthesizer-ui:build
+        run: |
+          mkdir packages/synthesizer-ui/dist
       - name: Deploy edgeworth under the current commit SHA
         uses: JamesIves/github-pages-deploy-action@4.1.4
         with:
           branch: gh-pages
           folder: packages/synthesizer-ui/dist
-          target-folder: edgeworth/${ github.sha }/
+          target-folder: edgeworth/${{ github.sha }}/
       - name: Add .nojekyll
         run: |
           mkdir extra/

--- a/.github/workflows/edgeworth.yml
+++ b/.github/workflows/edgeworth.yml
@@ -1,0 +1,34 @@
+name: Build
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+      - "edgeworth/**"
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Install packages
+        uses: ./.github/actions/packages
+      - name: Build edgeworth
+        run: npx nx run synthesizer-ui:build
+      - name: Deploy docs
+        uses: JamesIves/github-pages-deploy-action@4.1.4
+        with:
+          branch: gh-pages
+          folder: packages/synthesizer-ui/dist
+          target-folder: ${GITHUB_SHA::6}/storybook/
+      - name: Add .nojekyll
+        run: |
+          mkdir extra/
+          touch extra/.nojekyll
+        working-directory: packages/synthesizer-ui/
+      - name: Deploy .nojekyll
+        uses: JamesIves/github-pages-deploy-action@4.1.4
+        with:
+          branch: gh-pages
+          folder: packages/synthesizer-ui/extra/
+          clean: false

--- a/.github/workflows/edgeworth.yml
+++ b/.github/workflows/edgeworth.yml
@@ -15,12 +15,12 @@ jobs:
         uses: ./.github/actions/packages
       - name: Build edgeworth
         run: npx nx run synthesizer-ui:build
-      - name: Deploy docs
+      - name: Deploy edgeworth under the current commit SHA
         uses: JamesIves/github-pages-deploy-action@4.1.4
         with:
           branch: gh-pages
           folder: packages/synthesizer-ui/dist
-          target-folder: ${GITHUB_SHA::6}/storybook/
+          target-folder: /edgeworth/${ github.sha }/
       - name: Add .nojekyll
         run: |
           mkdir extra/

--- a/packages/synthesizer-ui/src/App.tsx
+++ b/packages/synthesizer-ui/src/App.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import { Content } from "./components/Content";
 function App() {
   return (

--- a/packages/synthesizer-ui/vite.config.ts
+++ b/packages/synthesizer-ui/vite.config.ts
@@ -8,14 +8,4 @@ export default defineConfig({
   optimizeDeps: {
     exclude: ["@penrose/core", "@penrose/components"],
   },
-  build: {
-    rollupOptions: {
-      external: ["react", "react-dom"],
-      output: {
-        globals: {
-          react: "React",
-        },
-      },
-    },
-  },
 });

--- a/packages/synthesizer-ui/vite.config.ts
+++ b/packages/synthesizer-ui/vite.config.ts
@@ -3,6 +3,7 @@ import { defineConfig } from "vite";
 
 // https://vitejs.dev/config/
 export default defineConfig({
+  base: "./",
   plugins: [react()],
   optimizeDeps: {
     exclude: ["@penrose/core", "@penrose/components"],


### PR DESCRIPTION
# Description

Related issue/PR: N/A

For running experiments and standardize deployment, this PR adds a workflow for Edgeworth (`synthesizer-ui`) to deploy each commit in `edgeworth/*` branches to `gh-pages`. Edgeworth is not yet ready for public use yet, so I'm only deploying to GH Pages as nightly releases.

# Implementation strategy and design decisions

* Added a separate workflow configuration.
* Fixed some vite issues with `synthesizer-ui`: relative base path, unnecessary react config
