### PR TITLE
refactor: Only make gradient nodes from primary output

### DIFF
--- a/packages/core/src/engine/Autodiff.test.ts
+++ b/packages/core/src/engine/Autodiff.test.ts
@@ -44,7 +44,7 @@ describe("makeGraph tests", () => {
       difference,
     ]);
 
-    expect(gradient.length).toBe(2);
+    expect(gradient.length).toBe(0); // no inputs reachable from primary output
     expect(secondary.length).toBe(3);
 
     const nodes: ad.Node[] = secondary.map((id) => graph.node(id));
@@ -62,9 +62,8 @@ describe("makeGraph tests", () => {
 
     const { graph } = secondaryGraph([f]);
 
-    // x1, t1, t2, f, the constant primary node 1, and the derivative 0 of the
-    // primary node with respect to the input x1
-    expect(graph.nodeCount()).toBe(6);
+    // x1, t1, t2, f, and the constant primary node 1
+    expect(graph.nodeCount()).toBe(5);
     expect(graph.edgeCount()).toBe(6); // the in-edges of the three mul nodes
   });
 });

--- a/packages/core/src/engine/Autodiff.ts
+++ b/packages/core/src/engine/Autodiff.ts
@@ -554,25 +554,11 @@ export const makeGraph = (
     );
   }
 
-  // easiest case: final stage, just add all the nodes and edges for the
-  // secondary outputs
-  const secondary = outputs.secondary.map(addNode);
-  while (!queue.isEmpty()) {
-    addNode(queue.dequeue());
-  }
-  while (!edges.isEmpty()) {
-    const [{ child, name }, parent] = edges.dequeue();
-    addEdge(child, parent, name);
-  }
-
-  // we wait until after adding all the nodes before get the IDs for the input
-  // gradients, because some of the inputs may only be reachable from the
-  // secondary outputs instead of the primary output; this isn't really
-  // necessary, because the gradients for all those inputs are just zero, so the
-  // caller could just substitute zero whenever the gradient is missing a key,
-  // but it's probably a bit less surprising if we always include an array
-  // element for the gradient on any input that is reachable even from the
-  // secondary outputs
+  // we get the IDs for the input gradients before adding all the secondary
+  // nodes, because some of the inputs may only be reachable from the secondary
+  // outputs instead of the primary output; really, the gradients for all those
+  // inputs are just zero, so the caller needs to substitute zero whenever the
+  // gradient is missing a key
   const gradient: ad.Id[] = [];
   for (const {
     id,
@@ -585,7 +571,18 @@ export const makeGraph = (
     // contiguous, e.g. if some inputs end up not being used in any of the
     // computations in the graph; but even if that happens, it's actually OK
     // (see the comment in the implementation of genCode below)
-    gradient[key] = (gradNodes.get(id) ?? [addNode(0)])[0];
+    gradient[key] = safe(gradNodes.get(id), "missing gradient")[0];
+  }
+
+  // easiest case: final stage, just add all the nodes and edges for the
+  // secondary outputs
+  const secondary = outputs.secondary.map(addNode);
+  while (!queue.isEmpty()) {
+    addNode(queue.dequeue());
+  }
+  while (!edges.isEmpty()) {
+    const [{ child, name }, parent] = edges.dequeue();
+    addEdge(child, parent, name);
   }
 
   return { graph, nodes, gradient, primary, secondary };


### PR DESCRIPTION
# Description

Previously, in `makeGraph`, we would first add all the nodes reachable from the primary output, then make gradient nodes for each of those, then add all the nodes reachable from the secondary output, and finally make a gradient output array from all the inputs we've seen so far. This means that, for nodes reachable from the secondary outputs but not the primary output, we would still make entries in the `gradient` array, for no reason. Those entries are redundant with the check in our `objectiveAndGradient` wrapper function created by `genOptProblem`:

https://github.com/penrose/penrose/blob/94da0ffdce15a93bbd87379f08aafe4587c78625/packages/core/src/engine/Optimizer.ts#L824-L827

Thus, this PR rearranges the end of `makeGraph` to create the `gradient` array before processing the `secondary` outputs. This makes some resulting graphs a bit smaller, as shown by the autodiff tests I had to modify here.

# Checklist

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new ESLint warnings
- [x] I have reviewed any generated changes to the `diagrams/` folder