### PR TITLE
feat(experimental): shape property auto-completion in `editor`

### DIFF
--- a/packages/components/src/editing/languages/StyleConfig.ts
+++ b/packages/components/src/editing/languages/StyleConfig.ts
@@ -2,6 +2,7 @@ import { Monaco } from "@monaco-editor/react";
 import {
   compDict,
   constrDict,
+  hexToRgba,
   objDict,
   rgbaToHex,
   shapedefs,

--- a/packages/components/src/editing/languages/StyleConfig.ts
+++ b/packages/components/src/editing/languages/StyleConfig.ts
@@ -2,13 +2,60 @@ import { Monaco } from "@monaco-editor/react";
 import {
   compDict,
   constrDict,
-  hexToRgba,
   objDict,
   rgbaToHex,
   shapedefs,
 } from "@penrose/core";
+import { ShapeType } from "@penrose/core/build/dist/shapes/Shapes";
 import { editor, IRange, languages } from "monaco-editor";
 import { CommentCommon, CommonTokens } from "./common";
+
+interface Global {
+  tag: "Global";
+}
+interface Block {
+  tag: "Block";
+}
+interface ShapeConstructor {
+  tag: "ShapeConstructor";
+  shapeName: string;
+}
+
+type StyleScope = Global | Block | ShapeConstructor;
+
+const guessScope = (prefixText: String): StyleScope => {
+  // HACK: count braces and capture shape name
+  const stack = [];
+  for (const c of prefixText) {
+    if (c === "{") {
+      const shapeRegexStr = `(${Object.keys(shapedefs).join(
+        "|"
+      )})[\\n\\r\\s]*\\{`;
+      const shapeRegex = new RegExp(shapeRegexStr, "g");
+      const matches = prefixText.matchAll(shapeRegex);
+      if (matches === null) {
+        stack.push(c);
+      } else {
+        let shapeName;
+        for (const match of matches) {
+          shapeName = match[1];
+        }
+        stack.push(shapeName);
+      }
+    } else if (c === "}") {
+      stack.pop();
+    }
+  }
+  // figure out scope
+  if (stack.length === 0) {
+    return { tag: "Global" };
+  } else if (stack.length === 1) {
+    return { tag: "Block" };
+  } else {
+    // 2 levels
+    return { tag: "ShapeConstructor", shapeName: stack.at(-1)! };
+  }
+};
 
 export const StyleConfig: languages.LanguageConfiguration = {
   comments: {
@@ -117,7 +164,39 @@ export const StyleLanguageTokens: languages.IMonarchLanguage = {
   },
 };
 
-export const StyleCompletions = (range: IRange): languages.CompletionItem[] => [
+export const StyleCompletions = (
+  range: IRange,
+  scope: StyleScope,
+  context: languages.CompletionContext
+): languages.CompletionItem[] => {
+  switch (scope.tag) {
+    case "Global":
+    case "Block":
+      if (
+        context.triggerKind !== languages.CompletionTriggerKind.TriggerCharacter
+      ) {
+        return defaultCompletions(range);
+      } else {
+        return [];
+      }
+    case "ShapeConstructor": {
+      const { shapeName } = scope;
+      // HACK: need to validate shapeName first
+      const def = shapedefs[shapeName as ShapeType];
+      return [
+        ...Object.entries(def.propTags).map(([prop, type]) => ({
+          label: prop,
+          detail: type,
+          insertText: prop,
+          kind: languages.CompletionItemKind.Property,
+          range,
+        })),
+      ];
+    }
+  }
+};
+
+const defaultCompletions = (range: IRange): languages.CompletionItem[] => [
   ...styleCustoms.keywords.map((keyword: string) => ({
     label: keyword,
     insertText: keyword,
@@ -126,9 +205,7 @@ export const StyleCompletions = (range: IRange): languages.CompletionItem[] => [
   })),
   ...styleCustoms.shapes.map((keyword: string) => ({
     label: keyword,
-    insertText: `${keyword} {
-  $0
-}`,
+    insertText: `${keyword} {$0}`,
     insertTextRules: languages.CompletionItemInsertTextRule.InsertAsSnippet,
     kind: languages.CompletionItemKind.Class,
     detail: "shape constructor",
@@ -221,10 +298,12 @@ export const SetupStyleMonaco = (monaco: Monaco) => {
       );
     },
   });
+
   const disposeCompletion = monaco.languages.registerCompletionItemProvider(
     "style",
     {
-      provideCompletionItems: (model, position) => {
+      triggerCharacters: ["\n"],
+      provideCompletionItems: (model, position, context) => {
         const word = model.getWordUntilPosition(position);
         const range: IRange = {
           startLineNumber: position.lineNumber,
@@ -232,7 +311,14 @@ export const SetupStyleMonaco = (monaco: Monaco) => {
           startColumn: word.startColumn,
           endColumn: word.endColumn,
         };
-        return { suggestions: StyleCompletions(range) } as any;
+        const prefix = model.getValueInRange({
+          startLineNumber: 1,
+          endLineNumber: position.lineNumber,
+          startColumn: 1,
+          endColumn: position.column,
+        });
+        const scope = guessScope(prefix);
+        return { suggestions: StyleCompletions(range, scope, context) };
       },
     }
   );


### PR DESCRIPTION
# Description

Related issue/PR: #353, #1099 

This PR is an experiment on providing context-sensitive autocompletion in Style using the VSCode completion provider. It only adds suggestion items when the cursor is in a shape constructor. 

# Implementation strategy and design decisions

* Manually detect the current scope by regex, which is not likely to be the actual implementation

# Examples with steps to reproduce them

# Checklist

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new ESLint warnings
- [ ] I have reviewed any generated changes to the `diagrams/` folder

# Open questions

Ideally, the completion provider should have AST-level information on the cursor location relative to the syntax tree. Should we run the Style parser as the user types? 