### PR TITLE
ci: Don't grep for EOF in summary

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,7 +26,6 @@ jobs:
         run: |
           yarn start textchart out stats.md
           cat stats.md >> $GITHUB_STEP_SUMMARY
-          grep -L EOF stats.md
           echo 'REGISTRY_STATS<<EOF' >> $GITHUB_ENV
           cat stats.md >> $GITHUB_ENV
           echo EOF >> $GITHUB_ENV


### PR DESCRIPTION
# Description

CI has been failing today because of the `grep -L` we use to ensure the CI stats summary doesn't contain the substring `EOF`. I guess GitHub Actions upgraded their `grep` version and now `grep -L` doesn't work? In any case, I'm just removing this check for now.

# Checklist

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new ESLint warnings
- [x] I have reviewed any generated changes to the `diagrams/` folder