### PR TITLE
docs: Fix formatting of expected yarn start output

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -119,8 +119,8 @@ yarn start
 Once it finishes building, you should see this near the end of the output:
 
 ```
-@penrose/editor:   > Local: http://localhost:3000/try/
-@penrose/editor:   > Network: use `--host` to expose
+  > Local: http://localhost:3000/try/
+  > Network: use `--host` to expose
 ```
 
 Click [that link][]. The page may take some time to load, but once it does, you


### PR DESCRIPTION
# Description

This PR makes a documentation change I forgot to make in #1142.

# Checklist

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new ESLint warnings
- [x] I have reviewed any generated changes to the `diagrams/` folder