### PR TITLE
build: Create a dedicated cloudflare.sh script

### DIFF
--- a/cloudflare.sh
+++ b/cloudflare.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+set -euxo pipefail
+yarn build:docs-site


### PR DESCRIPTION
# Description

This PR creates a `cloudflare.sh` script, with the intention that we set our Cloudflare Pages build command to `./cloudflare.sh`, so that, for instance, we can add extra things to this in pull requests (such as #1092, which needs to install Rust) without modifying the `yarn build:docs-site` script itself.

# Checklist

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new ESLint warnings
- [x] I have reviewed any generated changes to the `diagrams/` folder