### PR TITLE
docs: Add instructions to delete Nx cache

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -249,6 +249,12 @@ To delete all build artifacts (but no `node_modules/`):
 git clean -dfxe node_modules/
 ```
 
+To delete the Nx build artifact cache:
+
+```sh
+npx rimraf node_modules/.cache/
+```
+
 To delete `node_modules/` (but not build artifacts) in all `packages/`:
 
 ```sh


### PR DESCRIPTION
# Description

Currently `CONTRIBUTING.md` includes instructions to delete build artifacts, but if you do that, Nx will just restore them from cache. This PR adds instructions to delete the Nx cache.

# Checklist

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new ESLint warnings
- [x] I have reviewed any generated changes to the `diagrams/` folder