### PR TITLE
chore: Remove VS Code Monorepo Workspace extension

### DIFF
--- a/penrose.code-workspace
+++ b/penrose.code-workspace
@@ -3,7 +3,6 @@
     "recommendations": [
       "dbaeumer.vscode-eslint",
       "esbenp.prettier-vscode",
-      "folke.vscode-monorepo-workspace",
       "karyfoundation.nearley",
       "penrose.penrose-vs",
       "unifiedjs.vscode-mdx"


### PR DESCRIPTION
# Description

I don't think it provides value, as of #732. Obviously this only removes it from our workspace's recommendations, and doesn't actually delete it from anyone's local setup; people are free to keep it installed if they wish.

# Checklist

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new ESLint warnings
- [x] I have reviewed any generated changes to the `diagrams/` folder