### PR TITLE
build(deps): remove Cytoscape dependency

### DIFF
--- a/packages/editor/package.json
+++ b/packages/editor/package.json
@@ -49,7 +49,6 @@
     "@penrose/core": "1.3.0",
     "animals": "^0.0.3",
     "color-name-list": "^8.38.0",
-    "cytoscape": "^3.19.0",
     "flexlayout-react": "^0.7.3",
     "localforage": "^1.10.0",
     "lodash": "^4.17.21",
@@ -67,7 +66,6 @@
     "uuid": "^8.3.2"
   },
   "devDependencies": {
-    "@types/cytoscape": "^3.14.12",
     "@types/lodash": "^4.14.182",
     "@types/react": "^18.0.0",
     "@types/react-dom": "^18.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5835,11 +5835,6 @@
   dependencies:
     "@types/node" "*"
 
-"@types/cytoscape@^3.14.12":
-  version "3.19.4"
-  resolved "https://registry.yarnpkg.com/@types/cytoscape/-/cytoscape-3.19.4.tgz#f41214103b80ff3d7d8741bacc32265ed90e45b5"
-  integrity sha512-0IozTg1vdZrA3nuAK5o9Pa8nl2INUnTaXwcGwoiALDcsD8/TiVnp0Zi+R1IiPRG6edoy0Ya61/3osFLtfkhhmw==
-
 "@types/eslint-scope@^3.7.3":
   version "3.7.3"
   resolved "https://registry.yarnpkg.com/@types/eslint-scope/-/eslint-scope-3.7.3.tgz#125b88504b61e3c8bc6f870882003253005c3224"
@@ -9962,14 +9957,6 @@ cyclist@^1.0.1:
   resolved "https://registry.yarnpkg.com/cyclist/-/cyclist-1.0.1.tgz#596e9698fd0c80e12038c2b82d6eb1b35b6224d9"
   integrity sha1-WW6WmP0MgOEgOMK4LW6xs1tiJNk=
 
-cytoscape@^3.19.0:
-  version "3.20.0"
-  resolved "https://registry.yarnpkg.com/cytoscape/-/cytoscape-3.20.0.tgz#c626c1074f3a8a6f1bc58e8fbee8fd798a6fcbf3"
-  integrity sha512-V2OUoav8ltY9UPgdjuhQOqkkWT28IbJODioWCjcnLqmjym9lMpnD0ie0vdQCdAiZapjbTGAv8aoKmmSuVcC1gA==
-  dependencies:
-    heap "^0.2.6"
-    lodash.debounce "^4.0.8"
-
 dargs@^4.0.1:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/dargs/-/dargs-4.1.0.tgz#03a9dbb4b5c2f139bf14ae53f0b8a2a6a86f4e17"
@@ -13429,11 +13416,6 @@ heap-js@^2.1.6:
   version "2.1.6"
   resolved "https://registry.yarnpkg.com/heap-js/-/heap-js-2.1.6.tgz#817021e6d252ad6ba9a11ea65988cc4e6207782d"
   integrity sha512-xQxyJg7VcgveAZtY0eAu7iCn+2VCqLBkQoz7G4RnOIEsmP82J/LnRdr0I2Mi/pThkP5tviL8yFq5utE3yOPYpQ==
-
-heap@^0.2.6:
-  version "0.2.7"
-  resolved "https://registry.yarnpkg.com/heap/-/heap-0.2.7.tgz#1e6adf711d3f27ce35a81fe3b7bd576c2260a8fc"
-  integrity sha512-2bsegYkkHO+h/9MGbn6KWcE45cHZgPANo5LXF7EvWdT0yT2EguSVO1nDgU5c8+ZOPwp2vMNa7YFsJhVcDR9Sdg==
 
 highlight.js@^10.4.1, highlight.js@~10.7.0:
   version "10.7.3"


### PR DESCRIPTION
# Description

This PR removes the unused [Cytoscape](https://www.npmjs.com/package/cytoscape) from `editor`'s dependencies. It was added in #1000 for `packages/editor/src/components/CompGraph.tsx`, which was deleted in #984.

# Checklist

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new ESLint warnings
- [x] I have reviewed any generated changes to the `diagrams/` folder