### PR TITLE
chore: add automator's `out/` to `.prettierignore`

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,4 +1,5 @@
 *.hbs
+/packages/automator/out/
 /packages/automator/progs/
 /packages/browser-ui/tsconfig.json
 /packages/components/storybook-static/


### PR DESCRIPTION
# Description

#939 added `out/` to `packages/automator/.gitignore` but forgot to add it to `.prettierignore`. This PR does the latter so that running `yarn format` after something like the following doesn't try to format all the `packages/automator/out/*/meta.json` files:

```sh
yarn start batch registry.json out/ --src-prefix=../examples/src/ --folders
```

# Checklist

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new ESLint warnings
- [x] I have reviewed any generated changes to the `diagrams/` folder