### PR TITLE
build: move `optimizer` into `devDependencies`

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -105,7 +105,6 @@
   "dependencies": {
     "@datastructures-js/heap": "^3.2.0",
     "@datastructures-js/queue": "^4.1.3",
-    "@penrose/optimizer": "1.3.0",
     "consola": "^2.15.2",
     "fast-memoize": "^2.5.2",
     "graphlib": "^2.1.8",
@@ -124,6 +123,7 @@
   },
   "devDependencies": {
     "@penrose/examples": "1.3.0",
+    "@penrose/optimizer": "1.3.0",
     "@types/graphlib": "^2.1.7",
     "@types/jest": "^27.4.1",
     "@types/jscodeshift": "^0.11.0",


### PR DESCRIPTION
# Description

#1092 added a new package, `@penrose/optimizer`, to the `dependencies` of `@penrose/core`. However, we avoid publishing it via `"private": true`, so currently people can't use `@penrose/core` from npm because `@penrose/optimizer` is missing. This PR attempts to fix that problem by changing `@penrose/optimizer` to be a dev dependency instead, since we currently just bundle it using esbuild. See also #1173.

# Checklist

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new ESLint warnings
- [x] I have reviewed any generated registry diagram changes