### PR TITLE
build: don't use Nx cache

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -244,12 +244,6 @@ To delete all build artifacts (but no `node_modules/`):
 git clean -dfxe node_modules/
 ```
 
-To delete the Nx build artifact cache:
-
-```sh
-npx rimraf node_modules/.cache/
-```
-
 To delete `node_modules/` (but not build artifacts) in all `packages/`:
 
 ```sh
@@ -322,14 +316,6 @@ metadata in all our `package/*/package.json` files. Specifically, below the
 `"scripts"` section we usually have a `"nx"` section defining metadata about
 each script. When you update a script, be sure to update its accompanying
 metadata!
-
-By default, Nx does not cache tasks; we collect the names of all tasks to cache
-in the `"cacheableOperations"` part of our `nx.json` file. If you create a new
-script that you would like to be cached, remember to add its name to that list.
-This also implies that two scripts with the same name in different packages
-should not have different caching behavior, so if you don't want your script to
-be cached, check in `nx.json` first to make sure you aren't using a name that is
-already considered cacheable.
 
 The `"targetDefaults"` part of `nx.json` defines default dependencies for some
 scripts for which we use the same semantics across all our packages:

--- a/nx.json
+++ b/nx.json
@@ -1,33 +1,9 @@
 {
   "npmScope": "penrose",
-  "tasksRunnerOptions": {
-    "default": {
-      "runner": "nx/tasks-runners/default",
-      "options": {
-        "cacheableOperations": [
-          "build",
-          "build-decls",
-          "build-examples",
-          "build-parsers",
-          "build-shapedefs",
-          "build-storybook",
-          "build-wasm",
-          "build-wasm-bindgen",
-          "docs",
-          "write-translations"
-        ]
-      }
-    }
-  },
+  "tasksRunnerOptions": { "default": { "runner": "nx/tasks-runners/default" } },
   "targetDefaults": {
-    "build": {
-      "dependsOn": ["^build"]
-    },
-    "build-decls": {
-      "dependsOn": ["^build-decls"]
-    },
-    "typecheck": {
-      "dependsOn": ["build-decls"]
-    }
+    "build": { "dependsOn": ["^build"] },
+    "build-decls": { "dependsOn": ["^build-decls"] },
+    "typecheck": { "dependsOn": ["build-decls"] }
   }
 }

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -18,28 +18,16 @@
       "build": {
         "dependsOn": [
           "^build"
-        ],
-        "outputs": [
-          "{projectRoot}/dist/*.css",
-          "{projectRoot}/dist/*.js",
-          "{projectRoot}/dist/*.js.map"
         ]
       },
       "build-decls": {
         "dependsOn": [
           "^build-decls"
-        ],
-        "outputs": [
-          "{projectRoot}/dist/*.ts",
-          "{projectRoot}/dist/*.ts.map"
         ]
       },
       "build-storybook": {
         "dependsOn": [
           "^build"
-        ],
-        "outputs": [
-          "{projectRoot}/storybook/static"
         ]
       },
       "watch": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -31,25 +31,12 @@
           "^build",
           "^build-decls",
           "build-parsers"
-        ],
-        "outputs": [
-          "{projectRoot}/build/dist/index.js",
-          "{projectRoot}/build/dist/index.js.map"
         ]
       },
       "build-decls": {
         "dependsOn": [
           "^build-decls",
           "build-parsers"
-        ],
-        "outputs": [
-          "{projectRoot}/build/dist/**/*.ts",
-          "{projectRoot}/build/dist/**/*.ts.map"
-        ]
-      },
-      "build-parsers": {
-        "outputs": [
-          "{projectRoot}/src/parser/*Parser.ts"
         ]
       },
       "coverage": {
@@ -57,11 +44,6 @@
           "^build",
           "^build-decls",
           "build-parsers"
-        ],
-        "outputs": [
-          "{projectRoot}/coverage",
-          "{projectRoot}/junit.xml",
-          "{projectRoot}/reports"
         ]
       },
       "docs": {
@@ -69,9 +51,6 @@
           "^build",
           "^build-decls",
           "build-parsers"
-        ],
-        "outputs": [
-          "{projectRoot}/docs"
         ]
       },
       "start": {

--- a/packages/docs-site/package.json
+++ b/packages/docs-site/package.json
@@ -16,18 +16,11 @@
         "dependsOn": [
           "^build",
           "build-shapedefs"
-        ],
-        "outputs": [
-          "{projectRoot}/build"
         ]
       },
       "build-shapedefs": {
         "dependsOn": [
           "^build"
-        ],
-        "outputs": [
-          "{projectRoot}/public/try",
-          "{projectRoot}/src/shapedefs.json"
         ]
       },
       "dev": {

--- a/packages/editor/package.json
+++ b/packages/editor/package.json
@@ -16,10 +16,6 @@
       "build": {
         "dependsOn": [
           "^build"
-        ],
-        "outputs": [
-          "{projectRoot}/dist",
-          "{projectRoot}/public"
         ]
       },
       "dev": {

--- a/packages/examples/package.json
+++ b/packages/examples/package.json
@@ -15,11 +15,6 @@
           "build-examples"
         ]
       },
-      "build-examples": {
-        "outputs": [
-          "{projectRoot}/dist"
-        ]
-      },
       "build": {
         "dependsOn": [
           "build-examples"

--- a/packages/optimizer/package.json
+++ b/packages/optimizer/package.json
@@ -17,31 +17,16 @@
       "build": {
         "dependsOn": [
           "build-wasm-bindgen"
-        ],
-        "outputs": [
-          "{projectRoot}/index.js",
-          "{projectRoot}/index.js.map"
         ]
       },
       "build-decls": {
         "dependsOn": [
           "build-wasm-bindgen"
-        ],
-        "outputs": [
-          "{projectRoot}/bindings"
-        ]
-      },
-      "build-wasm": {
-        "outputs": [
-          "{projectRoot}/target"
         ]
       },
       "build-wasm-bindgen": {
         "dependsOn": [
           "build-wasm"
-        ],
-        "outputs": [
-          "{projectRoot}/build"
         ]
       }
     }

--- a/packages/roger/package.json
+++ b/packages/roger/package.json
@@ -65,15 +65,6 @@
     "preinstall-global": "yarn build",
     "install-global": "yarn link"
   },
-  "nx": {
-    "targets": {
-      "build": {
-        "outputs": [
-          "{projectRoot}/dist"
-        ]
-      }
-    }
-  },
   "engines": {
     "node": ">=12.0.0"
   },

--- a/packages/synthesizer-ui/package.json
+++ b/packages/synthesizer-ui/package.json
@@ -16,9 +16,6 @@
       "build": {
         "dependsOn": [
           "^build"
-        ],
-        "outputs": [
-          "{projectRoot}/dist"
         ]
       },
       "dev": {


### PR DESCRIPTION
# Description

This PR removes the monorepo build artifact caching added by #1081 and #1142, also removing the need for #1175. In practice, my observation has been that most of our tasks are either very fast (e.g. esbuild) or already cache automatically (e.g. Cargo), and that for the ones that aren't super fast (e.g. Vite build in components or editor), Nx usually doesn't cache those anyway because their dependencies changed. Furthermore, it requires a lot of configuration to correctly identify cache hits; so far we've only been specifying the outputs of each task and not the inputs, so Nx usually reruns tasks unnecessarily because it sees changes in the output artifacts of downstream tasks and conservatively assumes that those might affect things. On the flipside, I've also often found myself running `rm -r node_modules/.cache/` just to be sure that Nx isn't caching things incorrectly. Specifically, some of our scripts (e.g. `wasm-bindgen`) don't delete the contents of their output directory before writing to it, so if they aren't writing as many files as they were before, Nx will still pick those up and put them in the cache even though they aren't outputs of the current task run. In theory we could deal with this by manually deleting these output directories before writing to them, but even that doesn't really seem feasible: for instance, if we were to always delete `target/` before running Cargo, that would get rid of its own caching abilities, which wouldn't be worth it.

# Checklist

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new ESLint warnings
- [x] I have reviewed any generated registry diagram changes