### PR TITLE
fix: avoid 404 in homepage try link

### DIFF
--- a/packages/docs-site/index.md
+++ b/packages/docs-site/index.md
@@ -13,7 +13,7 @@ hero:
       link: /docs/tutorial/welcome
     - theme: sponsor
       text: Try
-      link: /try/index.html
+      link: pathname:///try/index.html
     - theme: alt
       text: Video
       link: https://vimeo.com/416822487


### PR DESCRIPTION
# Description

After #1172 was merged, @keenancrane noticed that one of our homepage "try" links was still giving a 404 error. This PR fixes that.

# Checklist

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new ESLint warnings
- [x] I have reviewed any generated registry diagram changes