### PR TITLE
build: don't use `tsc-alias`

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -17,7 +17,7 @@
     "watch": "yarn build --watch",
     "test": "cross-env NODE_OPTIONS='--no-warnings --experimental-vm-modules' jest",
     "test-watch": "yarn test --watchAll",
-    "build-decls": "tsc --emitDeclarationOnly --outDir build/dist && tsc-alias -p tsconfig.json",
+    "build-decls": "tsc --emitDeclarationOnly",
     "typecheck": ":",
     "docs": "typedoc --plugin none --out docs",
     "docs:md": "typedoc --plugin typedoc-plugin-markdown --out docs/md",
@@ -125,7 +125,6 @@
     "jest-junit": "^12.0.0",
     "jscodeshift": "^0.11.0",
     "ts-jest": "^27.1.3",
-    "tsc-alias": "^1.6.7",
     "tslib": "^2.1.0",
     "typedoc": "^0.22.11",
     "typedoc-plugin-markdown": "^3.11.13"

--- a/packages/core/src/analysis/SubstanceAnalysis.test.ts
+++ b/packages/core/src/analysis/SubstanceAnalysis.test.ts
@@ -1,15 +1,15 @@
-import { compileDomain } from "compiler/Domain";
+import _ from "lodash";
+import { compileDomain } from "../compiler/Domain";
 import {
   compileSubstance,
   prettyStmt,
   prettySubstance,
-} from "compiler/Substance";
-import { dummyIdentifier } from "engine/EngineUtils";
-import _ from "lodash";
-import { similarMappings, similarNodes, SubNode } from "synthesis/Search";
-import { A } from "types/ast";
-import { Env } from "types/domain";
-import { SubProg, SubStmt } from "types/substance";
+} from "../compiler/Substance";
+import { dummyIdentifier } from "../engine/EngineUtils";
+import { similarMappings, similarNodes, SubNode } from "../synthesis/Search";
+import { A } from "../types/ast";
+import { Env } from "../types/domain";
+import { SubProg, SubStmt } from "../types/substance";
 import {
   appendStmt,
   intersection,

--- a/packages/core/src/analysis/SubstanceAnalysis.ts
+++ b/packages/core/src/analysis/SubstanceAnalysis.ts
@@ -1,7 +1,7 @@
-import { prettyStmt } from "compiler/Substance";
 import im from "immutable";
 import _ from "lodash";
-import { A, AbstractNode, C, Identifier, metaProps } from "types/ast";
+import { prettyStmt } from "../compiler/Substance";
+import { A, AbstractNode, C, Identifier, metaProps } from "../types/ast";
 import {
   ConstructorDecl,
   DomainStmt,
@@ -9,7 +9,7 @@ import {
   FunctionDecl,
   PredicateDecl,
   TypeDecl,
-} from "types/domain";
+} from "../types/domain";
 import {
   ApplyConstructor,
   ApplyFunction,
@@ -23,7 +23,7 @@ import {
   SubProg,
   SubStmt,
   TypeConsApp,
-} from "types/substance";
+} from "../types/substance";
 
 export interface Signature {
   args: string[];

--- a/packages/core/src/compiler/Domain.test.ts
+++ b/packages/core/src/compiler/Domain.test.ts
@@ -1,12 +1,12 @@
 import { examples } from "@penrose/examples";
-import { compileDomain, isSubtype } from "compiler/Domain";
 import * as fs from "fs";
 import nearley from "nearley";
-import grammar from "parser/DomainParser";
 import * as path from "path";
-import { Env } from "types/domain";
-import { PenroseError } from "types/errors";
-import { Result, showError } from "utils/Error";
+import grammar from "../parser/DomainParser";
+import { Env } from "../types/domain";
+import { PenroseError } from "../types/errors";
+import { Result, showError } from "../utils/Error";
+import { compileDomain, isSubtype } from "./Domain";
 
 const outputDir = "/tmp/contexts";
 const saveContexts = false;

--- a/packages/core/src/compiler/Domain.ts
+++ b/packages/core/src/compiler/Domain.ts
@@ -1,9 +1,9 @@
 import im from "immutable";
 import _ from "lodash";
 import nearley from "nearley";
-import domainGrammar from "parser/DomainParser";
-import { idOf, lastLocation, prettyParseError } from "parser/ParserUtil";
-import { A, C } from "types/ast";
+import domainGrammar from "../parser/DomainParser";
+import { idOf, lastLocation, prettyParseError } from "../parser/ParserUtil";
+import { A, C } from "../types/ast";
 import {
   Arg,
   ConstructorDecl,
@@ -16,15 +16,15 @@ import {
   TypeConstructor,
   TypeDecl,
   TypeVar,
-} from "types/domain";
+} from "../types/domain";
 import {
   DomainError,
   ParseError,
   PenroseError,
   TypeNotFound,
   TypeVarNotFound,
-} from "types/errors";
-import { ApplyConstructor, TypeConsApp } from "types/substance";
+} from "../types/errors";
+import { ApplyConstructor, TypeConsApp } from "../types/substance";
 import {
   and,
   andThen,
@@ -39,8 +39,8 @@ import {
   symmetricArgLengthMismatch,
   symmetricTypeMismatch,
   typeNotFound,
-} from "utils/Error";
-import { Digraph } from "utils/Graph";
+} from "../utils/Error";
+import { Digraph } from "../utils/Graph";
 
 export const parseDomain = (
   prog: string

--- a/packages/core/src/compiler/Style.test.ts
+++ b/packages/core/src/compiler/Style.test.ts
@@ -2,19 +2,19 @@
 
 import { examples } from "@penrose/examples";
 import { ready } from "@penrose/optimizer";
-import * as S from "compiler/Style";
-import { compileSubstance } from "compiler/Substance";
 import im from "immutable";
-import { Either } from "types/common";
-import { Env } from "types/domain";
-import { PenroseError } from "types/errors";
-import { State } from "types/state";
-import { Assignment, Layer, Translation } from "types/styleSemantics";
-import { SubstanceEnv } from "types/substance";
-import { ColorV, RGBA } from "types/value";
-import { andThen, err, Result, showError } from "utils/Error";
-import { foldM, toLeft, ToRight, zip2 } from "utils/Util";
+import { Either } from "../types/common";
+import { Env } from "../types/domain";
+import { PenroseError } from "../types/errors";
+import { State } from "../types/state";
+import { Assignment, Layer, Translation } from "../types/styleSemantics";
+import { SubstanceEnv } from "../types/substance";
+import { ColorV, RGBA } from "../types/value";
+import { andThen, err, Result, showError } from "../utils/Error";
+import { foldM, toLeft, ToRight, zip2 } from "../utils/Util";
 import { compileDomain } from "./Domain";
+import * as S from "./Style";
+import { compileSubstance } from "./Substance";
 
 await ready;
 

--- a/packages/core/src/compiler/Style.ts
+++ b/packages/core/src/compiler/Style.ts
@@ -1,35 +1,34 @@
 import { CustomHeap } from "@datastructures-js/heap";
 import { genOptProblem } from "@penrose/optimizer";
-import { checkExpr, checkPredicate, checkVar } from "compiler/Substance";
 import consola from "consola";
-import { constrDict } from "contrib/Constraints";
-import { compDict } from "contrib/Functions";
-import { objDict } from "contrib/Objectives";
-import { input, ops } from "engine/Autodiff";
-import { add, div, mul, neg, pow, sub } from "engine/AutodiffFunctions";
-import {
-  compileCompGraph,
-  dummyIdentifier,
-  genGradient,
-} from "engine/EngineUtils";
 import graphlib from "graphlib";
 import im from "immutable";
 import _ from "lodash";
 import nearley from "nearley";
-import { lastLocation, prettyParseError } from "parser/ParserUtil";
-import styleGrammar from "parser/StyleParser";
 import seedrandom from "seedrandom";
+import { constrDict } from "../contrib/Constraints";
+import { compDict } from "../contrib/Functions";
+import { objDict } from "../contrib/Objectives";
+import { input, ops } from "../engine/Autodiff";
+import { add, div, mul, neg, pow, sub } from "../engine/AutodiffFunctions";
+import {
+  compileCompGraph,
+  dummyIdentifier,
+  genGradient,
+} from "../engine/EngineUtils";
+import { lastLocation, prettyParseError } from "../parser/ParserUtil";
+import styleGrammar from "../parser/StyleParser";
 import {
   Canvas,
   Context as MutableContext,
   InputMeta,
   makeCanvas,
   uniform,
-} from "shapes/Samplers";
-import { isShapeType, ShapeDef, shapedefs, ShapeType } from "shapes/Shapes";
-import * as ad from "types/ad";
-import { A, C, Identifier, SourceRange } from "types/ast";
-import { Env } from "types/domain";
+} from "../shapes/Samplers";
+import { isShapeType, ShapeDef, shapedefs, ShapeType } from "../shapes/Shapes";
+import * as ad from "../types/ad";
+import { A, C, Identifier, SourceRange } from "../types/ast";
+import { Env } from "../types/domain";
 import {
   BinOpTypeError,
   LayerCycleWarning,
@@ -39,9 +38,9 @@ import {
   StyleError,
   StyleWarning,
   SubstanceError,
-} from "types/errors";
-import { ShapeAD } from "types/shape";
-import { Fn, State } from "types/state";
+} from "../types/errors";
+import { ShapeAD } from "../types/shape";
+import { Fn, State } from "../types/state";
 import {
   BinaryOp,
   BindingForm,
@@ -65,7 +64,7 @@ import {
   StyT,
   UOp,
   Vector,
-} from "types/style";
+} from "../types/style";
 import {
   Assignment,
   BlockAssignment,
@@ -85,7 +84,7 @@ import {
   Subst,
   Translation,
   WithContext,
-} from "types/styleSemantics";
+} from "../types/styleSemantics";
 import {
   ApplyConstructor,
   ApplyFunction,
@@ -97,7 +96,7 @@ import {
   SubstanceEnv,
   SubStmt,
   TypeConsApp,
-} from "types/substance";
+} from "../types/substance";
 import {
   ArgVal,
   Field,
@@ -109,7 +108,7 @@ import {
   PropID,
   Value,
   VectorV,
-} from "types/value";
+} from "../types/value";
 import {
   all,
   andThen,
@@ -122,8 +121,8 @@ import {
   safeChain,
   selectorFieldNotSupported,
   toStyleErrors,
-} from "utils/Error";
-import { Digraph } from "utils/Graph";
+} from "../utils/Error";
+import { Digraph } from "../utils/Graph";
 import {
   boolV,
   colorV,
@@ -139,8 +138,9 @@ import {
   val,
   vectorV,
   zip2,
-} from "utils/Util";
+} from "../utils/Util";
 import { checkTypeConstructor, isDeclaredSubtype } from "./Domain";
+import { checkExpr, checkPredicate, checkVar } from "./Substance";
 
 const log = consola
   .create({ level: (consola as any).LogLevel.Warn })

--- a/packages/core/src/compiler/Substance.test.ts
+++ b/packages/core/src/compiler/Substance.test.ts
@@ -1,13 +1,13 @@
 import { examples } from "@penrose/examples";
 import * as fs from "fs";
 import nearley from "nearley";
-import grammar from "parser/SubstanceParser";
 import * as path from "path";
-import { A } from "types/ast";
-import { Env } from "types/domain";
-import { PenroseError } from "types/errors";
-import { ApplyPredicate, SubRes, SubstanceEnv } from "types/substance";
-import { Result, showError, showType } from "utils/Error";
+import grammar from "../parser/SubstanceParser";
+import { A } from "../types/ast";
+import { Env } from "../types/domain";
+import { PenroseError } from "../types/errors";
+import { ApplyPredicate, SubRes, SubstanceEnv } from "../types/substance";
+import { Result, showError, showType } from "../utils/Error";
 import { compileDomain } from "./Domain";
 import { compileSubstance, prettySubstance } from "./Substance";
 

--- a/packages/core/src/compiler/Substance.ts
+++ b/packages/core/src/compiler/Substance.ts
@@ -1,10 +1,10 @@
-import { dummyIdentifier } from "engine/EngineUtils";
 import im from "immutable";
 import _ from "lodash";
 import nearley from "nearley";
-import { idOf, lastLocation, prettyParseError } from "parser/ParserUtil";
-import substanceGrammar from "parser/SubstanceParser";
-import { A, ASTNode, C, Identifier } from "types/ast";
+import { dummyIdentifier } from "../engine/EngineUtils";
+import { idOf, lastLocation, prettyParseError } from "../parser/ParserUtil";
+import substanceGrammar from "../parser/SubstanceParser";
+import { A, ASTNode, C, Identifier } from "../types/ast";
 import {
   Arg,
   ConstructorDecl,
@@ -12,8 +12,8 @@ import {
   FunctionDecl,
   Type,
   TypeConstructor,
-} from "types/domain";
-import { ParseError, PenroseError, SubstanceError } from "types/errors";
+} from "../types/domain";
+import { ParseError, PenroseError, SubstanceError } from "../types/errors";
 import {
   ApplyConstructor,
   ApplyFunction,
@@ -32,7 +32,7 @@ import {
   SubstanceEnv,
   SubStmt,
   TypeConsApp,
-} from "types/substance";
+} from "../types/substance";
 import {
   and,
   andThen,
@@ -50,8 +50,8 @@ import {
   typeNotFound,
   unexpectedExprForNestedPred,
   varNotFound,
-} from "utils/Error";
-import { zip2 } from "utils/Util";
+} from "../utils/Error";
+import { zip2 } from "../utils/Util";
 import { bottomType, checkTypeConstructor, isSubtype, topType } from "./Domain";
 
 export const parseSubstance = (

--- a/packages/core/src/contrib/Constraints.ts
+++ b/packages/core/src/contrib/Constraints.ts
@@ -1,3 +1,20 @@
+import { ops } from "../engine/Autodiff";
+import {
+  absVal,
+  add,
+  ifCond,
+  lt,
+  max,
+  min,
+  minN,
+  mul,
+  neg,
+  squared,
+  sub,
+} from "../engine/AutodiffFunctions";
+import * as BBox from "../engine/BBox";
+import { shapedefs } from "../shapes/Shapes";
+import * as ad from "../types/ad";
 import {
   atDistLabel,
   containsAABBs,
@@ -16,26 +33,9 @@ import {
   overlappingPolygons,
   overlappingRectlikeCircle,
   overlappingTextLine,
-} from "contrib/ConstraintsUtils";
-import { bboxFromShape, shapeSize } from "contrib/Queries";
-import { inRange, overlap1D } from "contrib/Utils";
-import { ops } from "engine/Autodiff";
-import {
-  absVal,
-  add,
-  ifCond,
-  lt,
-  max,
-  min,
-  minN,
-  mul,
-  neg,
-  squared,
-  sub,
-} from "engine/AutodiffFunctions";
-import * as BBox from "engine/BBox";
-import { shapedefs } from "shapes/Shapes";
-import * as ad from "types/ad";
+} from "./ConstraintsUtils";
+import { bboxFromShape, shapeSize } from "./Queries";
+import { inRange, overlap1D } from "./Utils";
 
 // -------- Simple constraints
 // Do not require shape queries, operate directly with `ad.Num` parameters.

--- a/packages/core/src/contrib/ConstraintsUtils.ts
+++ b/packages/core/src/contrib/ConstraintsUtils.ts
@@ -1,15 +1,4 @@
-import {
-  containsPolygonPoints,
-  convexPartitions,
-  overlappingImplicitEllipses,
-  overlappingPolygonPoints,
-  overlappingPolygonPointsEllipse,
-  rectangleDifference,
-  rectangleSignedDistance,
-} from "contrib/Minkowski";
-import { bboxFromShape, polygonLikePoints, shapeCenter } from "contrib/Queries";
-import { atDistOutside, noIntersectCircles, pointInBox } from "contrib/Utils";
-import { ops } from "engine/Autodiff";
+import { ops } from "../engine/Autodiff";
 import {
   absVal,
   add,
@@ -26,19 +15,30 @@ import {
   sqrt,
   squared,
   sub,
-} from "engine/AutodiffFunctions";
-import * as BBox from "engine/BBox";
-import { Circle } from "shapes/Circle";
-import { Ellipse } from "shapes/Ellipse";
-import { Equation } from "shapes/Equation";
-import { Image } from "shapes/Image";
-import { Line } from "shapes/Line";
-import { Polygon } from "shapes/Polygon";
-import { Rectangle } from "shapes/Rectangle";
-import { shapedefs } from "shapes/Shapes";
-import { Text } from "shapes/Text";
-import * as ad from "types/ad";
+} from "../engine/AutodiffFunctions";
+import * as BBox from "../engine/BBox";
+import { Circle } from "../shapes/Circle";
+import { Ellipse } from "../shapes/Ellipse";
+import { Equation } from "../shapes/Equation";
+import { Image } from "../shapes/Image";
+import { Line } from "../shapes/Line";
+import { Polygon } from "../shapes/Polygon";
+import { Rectangle } from "../shapes/Rectangle";
+import { shapedefs } from "../shapes/Shapes";
+import { Text } from "../shapes/Text";
+import * as ad from "../types/ad";
 import { circleToImplicitEllipse, ellipseToImplicit } from "./ImplicitShapes";
+import {
+  containsPolygonPoints,
+  convexPartitions,
+  overlappingImplicitEllipses,
+  overlappingPolygonPoints,
+  overlappingPolygonPointsEllipse,
+  rectangleDifference,
+  rectangleSignedDistance,
+} from "./Minkowski";
+import { bboxFromShape, polygonLikePoints, shapeCenter } from "./Queries";
+import { atDistOutside, noIntersectCircles, pointInBox } from "./Utils";
 
 // -------- Ovelapping helpers
 

--- a/packages/core/src/contrib/Functions.ts
+++ b/packages/core/src/contrib/Functions.ts
@@ -1,6 +1,5 @@
-import { bboxFromShape } from "contrib/Queries";
-import { clamp, inRange, numOf } from "contrib/Utils";
-import { ops } from "engine/Autodiff";
+import _ from "lodash";
+import { ops } from "../engine/Autodiff";
 import {
   absVal,
   acos,
@@ -48,16 +47,15 @@ import {
   tan,
   tanh,
   trunc,
-} from "engine/AutodiffFunctions";
-import * as BBox from "engine/BBox";
-import _ from "lodash";
-import { PathBuilder } from "renderer/PathBuilder";
-import { Ellipse } from "shapes/Ellipse";
-import { Line } from "shapes/Line";
-import { Polyline } from "shapes/Polyline";
-import { Context, uniform } from "shapes/Samplers";
-import { shapedefs } from "shapes/Shapes";
-import * as ad from "types/ad";
+} from "../engine/AutodiffFunctions";
+import * as BBox from "../engine/BBox";
+import { PathBuilder } from "../renderer/PathBuilder";
+import { Ellipse } from "../shapes/Ellipse";
+import { Line } from "../shapes/Line";
+import { Polyline } from "../shapes/Polyline";
+import { Context, uniform } from "../shapes/Samplers";
+import { shapedefs } from "../shapes/Shapes";
+import * as ad from "../types/ad";
 import {
   ArgVal,
   Color,
@@ -69,8 +67,10 @@ import {
   TupV,
   Value,
   VectorV,
-} from "types/value";
-import { getStart, linePts } from "utils/Util";
+} from "../types/value";
+import { getStart, linePts } from "../utils/Util";
+import { bboxFromShape } from "./Queries";
+import { clamp, inRange, numOf } from "./Utils";
 
 /**
  * Static dictionary of computation functions

--- a/packages/core/src/contrib/ImplicitShapes.ts
+++ b/packages/core/src/contrib/ImplicitShapes.ts
@@ -1,5 +1,4 @@
-import { outwardUnitNormal } from "contrib/Queries";
-import { EPS_DENOM, ops } from "engine/Autodiff";
+import { EPS_DENOM, ops } from "../engine/Autodiff";
 import {
   absVal,
   add,
@@ -11,11 +10,12 @@ import {
   neg,
   squared,
   sub,
-} from "engine/AutodiffFunctions";
-import { Circle } from "shapes/Circle";
-import { Ellipse } from "shapes/Ellipse";
-import * as ad from "types/ad";
+} from "../engine/AutodiffFunctions";
+import { Circle } from "../shapes/Circle";
+import { Ellipse } from "../shapes/Ellipse";
+import * as ad from "../types/ad";
 import { msign } from "./Functions";
+import { outwardUnitNormal } from "./Queries";
 
 /**
  * Parameters of implicitly defined ellipse:

--- a/packages/core/src/contrib/Minkowski.ts
+++ b/packages/core/src/contrib/Minkowski.ts
@@ -1,5 +1,5 @@
-import { outwardUnitNormal } from "contrib/Queries";
-import { ops } from "engine/Autodiff";
+import { convexPartition, isClockwise } from "poly-partition";
+import { ops } from "../engine/Autodiff";
 import {
   absVal,
   add,
@@ -17,12 +17,11 @@ import {
   sqrt,
   squared,
   sub,
-} from "engine/AutodiffFunctions";
-import * as BBox from "engine/BBox";
-import { convexPartition, isClockwise } from "poly-partition";
-import { Ellipse } from "shapes/Ellipse";
-import * as ad from "types/ad";
-import { safe } from "utils/Util";
+} from "../engine/AutodiffFunctions";
+import * as BBox from "../engine/BBox";
+import { Ellipse } from "../shapes/Ellipse";
+import * as ad from "../types/ad";
+import { safe } from "../utils/Util";
 import {
   ellipsePolynomial,
   ellipseToImplicit,
@@ -33,6 +32,7 @@ import {
   implicitHalfPlaneFunc,
   implicitIntersectionOfEllipsesFunc,
 } from "./ImplicitShapes";
+import { outwardUnitNormal } from "./Queries";
 import { numsOf } from "./Utils";
 
 /**

--- a/packages/core/src/contrib/Objectives.ts
+++ b/packages/core/src/contrib/Objectives.ts
@@ -1,7 +1,4 @@
-import { inDirection } from "contrib/ObjectivesUtils";
-import { bboxFromShape, shapeCenter } from "contrib/Queries";
-import { closestPt_PtSeg, repelPoint, sampleSeg } from "contrib/Utils";
-import { ops } from "engine/Autodiff";
+import { ops } from "../engine/Autodiff";
 import {
   absVal,
   add,
@@ -15,10 +12,13 @@ import {
   neg,
   squared,
   sub,
-} from "engine/AutodiffFunctions";
-import { shapedefs } from "shapes/Shapes";
-import * as ad from "types/ad";
-import { linePts } from "utils/Util";
+} from "../engine/AutodiffFunctions";
+import { shapedefs } from "../shapes/Shapes";
+import * as ad from "../types/ad";
+import { linePts } from "../utils/Util";
+import { inDirection } from "./ObjectivesUtils";
+import { bboxFromShape, shapeCenter } from "./Queries";
+import { closestPt_PtSeg, repelPoint, sampleSeg } from "./Utils";
 
 // -------- Simple objective functions
 // Do not require shape queries, operate directly with `ad.Num` parameters.

--- a/packages/core/src/contrib/ObjectivesUtils.ts
+++ b/packages/core/src/contrib/ObjectivesUtils.ts
@@ -1,7 +1,7 @@
-import { shapeCenter } from "contrib/Queries";
-import { ops } from "engine/Autodiff";
-import { squared, sub } from "engine/AutodiffFunctions";
-import * as ad from "types/ad";
+import { ops } from "../engine/Autodiff";
+import { squared, sub } from "../engine/AutodiffFunctions";
+import * as ad from "../types/ad";
+import { shapeCenter } from "./Queries";
 
 /**
  * Encourage the center of the shape `shape` to be in the direction `direction` with respect to shape `shapeRef`.

--- a/packages/core/src/contrib/Queries.ts
+++ b/packages/core/src/contrib/Queries.ts
@@ -1,8 +1,8 @@
-import { ops } from "engine/Autodiff";
-import { mul, neg, sqrt } from "engine/AutodiffFunctions";
-import * as BBox from "engine/BBox";
-import { shapedefs } from "shapes/Shapes";
-import * as ad from "types/ad";
+import { ops } from "../engine/Autodiff";
+import { mul, neg, sqrt } from "../engine/AutodiffFunctions";
+import * as BBox from "../engine/BBox";
+import { shapedefs } from "../shapes/Shapes";
+import * as ad from "../types/ad";
 import { msign } from "./Functions";
 
 /**

--- a/packages/core/src/contrib/SDF.test.ts
+++ b/packages/core/src/contrib/SDF.test.ts
@@ -1,16 +1,16 @@
 import { ready } from "@penrose/optimizer";
-import { genCodeSync, input, primaryGraph } from "engine/Autodiff";
 import seedrandom from "seedrandom";
-import { makeCircle } from "shapes/Circle";
-import { makeEllipse } from "shapes/Ellipse";
-import { makeLine } from "shapes/Line";
-import { makePolygon } from "shapes/Polygon";
-import { makeRectangle } from "shapes/Rectangle";
-import { Context, InputFactory, makeCanvas } from "shapes/Samplers";
-import * as ad from "types/ad";
-import { Shape } from "types/shapes";
-import { FloatV } from "types/value";
-import { black, floatV, ptListV, vectorV } from "utils/Util";
+import { genCodeSync, input, primaryGraph } from "../engine/Autodiff";
+import { makeCircle } from "../shapes/Circle";
+import { makeEllipse } from "../shapes/Ellipse";
+import { makeLine } from "../shapes/Line";
+import { makePolygon } from "../shapes/Polygon";
+import { makeRectangle } from "../shapes/Rectangle";
+import { Context, InputFactory, makeCanvas } from "../shapes/Samplers";
+import * as ad from "../types/ad";
+import { Shape } from "../types/shapes";
+import { FloatV } from "../types/value";
+import { black, floatV, ptListV, vectorV } from "../utils/Util";
 import { compDict, sdEllipse } from "./Functions";
 
 await ready;

--- a/packages/core/src/contrib/Utils.ts
+++ b/packages/core/src/contrib/Utils.ts
@@ -1,4 +1,10 @@
-import { EPS_DENOM, genCodeSync, ops, secondaryGraph } from "engine/Autodiff";
+import _ from "lodash";
+import {
+  EPS_DENOM,
+  genCodeSync,
+  ops,
+  secondaryGraph,
+} from "../engine/Autodiff";
 import {
   absVal,
   add,
@@ -13,10 +19,9 @@ import {
   or,
   squared,
   sub,
-} from "engine/AutodiffFunctions";
-import * as BBox from "engine/BBox";
-import _ from "lodash";
-import * as ad from "types/ad";
+} from "../engine/AutodiffFunctions";
+import * as BBox from "../engine/BBox";
+import * as ad from "../types/ad";
 
 /**
  * Require that a shape at `center1` with radius `r1` not intersect a shape at `center2` with radius `r2` with optional padding `padding`. (For a non-circle shape, its radius should be half of the shape's general "width")

--- a/packages/core/src/contrib/__testfixtures__/TestShapes.input.ts
+++ b/packages/core/src/contrib/__testfixtures__/TestShapes.input.ts
@@ -1,10 +1,10 @@
-import { makeCircle } from "shapes/Circle";
-import { makeLine } from "shapes/Line";
-import { makePolygon } from "shapes/Polygon";
-import { makeRectangle } from "shapes/Rectangle";
-import { makeCanvas, simpleContext } from "shapes/Samplers";
-import { black, floatV, ptListV, vectorV } from "utils/Util";
+import { makeCircle } from "../../shapes/Circle";
 import { makeEllipse } from "../../shapes/Ellipse";
+import { makeLine } from "../../shapes/Line";
+import { makePolygon } from "../../shapes/Polygon";
+import { makeRectangle } from "../../shapes/Rectangle";
+import { makeCanvas, simpleContext } from "../../shapes/Samplers";
+import { black, floatV, ptListV, vectorV } from "../../utils/Util";
 
 const context = simpleContext("TestShapes.input");
 const canvas = makeCanvas(800, 700);

--- a/packages/core/src/contrib/__tests__/Constraints.test.ts
+++ b/packages/core/src/contrib/__tests__/Constraints.test.ts
@@ -1,14 +1,14 @@
 import { ready } from "@penrose/optimizer";
-import { constrDict } from "contrib/Constraints";
-import { numOf } from "contrib/Utils";
+import * as ad from "../../types/ad";
+import { constrDict } from "../Constraints";
+import { numOf } from "../Utils";
 import {
   _circles,
   _ellipses,
   _lines,
   _polygons,
   _rectangles,
-} from "contrib/__testfixtures__/TestShapes.input";
-import * as ad from "types/ad";
+} from "../__testfixtures__/TestShapes.input";
 
 await ready;
 

--- a/packages/core/src/contrib/__tests__/ConstraintsUtils.test.ts
+++ b/packages/core/src/contrib/__tests__/ConstraintsUtils.test.ts
@@ -1,10 +1,7 @@
 import { ready } from "@penrose/optimizer";
-import {
-  overlappingAABBs,
-  overlappingPolygons,
-} from "contrib/ConstraintsUtils";
-import { _rectangles } from "contrib/__testfixtures__/TestShapes.input";
-import { genCodeSync, secondaryGraph } from "engine/Autodiff";
+import { genCodeSync, secondaryGraph } from "../../engine/Autodiff";
+import { overlappingAABBs, overlappingPolygons } from "../ConstraintsUtils";
+import { _rectangles } from "../__testfixtures__/TestShapes.input";
 
 await ready;
 

--- a/packages/core/src/contrib/__tests__/ImplicitShapes.test.ts
+++ b/packages/core/src/contrib/__tests__/ImplicitShapes.test.ts
@@ -1,19 +1,19 @@
 import { ready } from "@penrose/optimizer";
+import { addN, mul, polyRoots, sub } from "../../engine/AutodiffFunctions";
+import { makeCircle } from "../../shapes/Circle";
+import { makeEllipse } from "../../shapes/Ellipse";
+import { makeCanvas, simpleContext } from "../../shapes/Samplers";
+import * as ad from "../../types/ad";
+import { black, floatV, vectorV, zip2 } from "../../utils/Util";
 import {
   circleToImplicitEllipse,
   ellipsePolynomial,
   ellipseToImplicit,
   halfPlaneToImplicit,
   implicitEllipseFunc,
-} from "contrib/ImplicitShapes";
-import { pointCandidatesEllipse } from "contrib/Minkowski";
-import { numOf, numsOf } from "contrib/Utils";
-import { addN, mul, polyRoots, sub } from "engine/AutodiffFunctions";
-import { makeCircle } from "shapes/Circle";
-import { makeEllipse } from "shapes/Ellipse";
-import { makeCanvas, simpleContext } from "shapes/Samplers";
-import * as ad from "types/ad";
-import { black, floatV, vectorV, zip2 } from "utils/Util";
+} from "../ImplicitShapes";
+import { pointCandidatesEllipse } from "../Minkowski";
+import { numOf, numsOf } from "../Utils";
 
 await ready;
 

--- a/packages/core/src/contrib/__tests__/Minkowski.test.ts
+++ b/packages/core/src/contrib/__tests__/Minkowski.test.ts
@@ -1,12 +1,12 @@
 import { ready } from "@penrose/optimizer";
+import * as BBox from "../../engine/BBox";
+import * as ad from "../../types/ad";
 import {
   convexPartitions,
   halfPlaneSDF,
   rectangleDifference,
-} from "contrib/Minkowski";
-import { numsOf } from "contrib/Utils";
-import * as BBox from "engine/BBox";
-import * as ad from "types/ad";
+} from "../Minkowski";
+import { numsOf } from "../Utils";
 
 await ready;
 

--- a/packages/core/src/contrib/__tests__/Objectives.test.ts
+++ b/packages/core/src/contrib/__tests__/Objectives.test.ts
@@ -1,6 +1,6 @@
 import { ready } from "@penrose/optimizer";
-import { objDict } from "contrib/Objectives";
-import { numOf } from "contrib/Utils";
+import { objDict } from "../Objectives";
+import { numOf } from "../Utils";
 
 await ready;
 

--- a/packages/core/src/contrib/__tests__/ObjectivesUtils.test.ts
+++ b/packages/core/src/contrib/__tests__/ObjectivesUtils.test.ts
@@ -1,6 +1,6 @@
 import { ready } from "@penrose/optimizer";
-import { inDirection } from "contrib/ObjectivesUtils";
-import { numOf } from "contrib/Utils";
+import { inDirection } from "../ObjectivesUtils";
+import { numOf } from "../Utils";
 
 await ready;
 

--- a/packages/core/src/contrib/__tests__/Queries.test.ts
+++ b/packages/core/src/contrib/__tests__/Queries.test.ts
@@ -1,23 +1,23 @@
 import { ready } from "@penrose/optimizer";
-import { compDict } from "contrib/Functions";
+import { genCodeSync, ops, secondaryGraph } from "../../engine/Autodiff";
+import { sub } from "../../engine/AutodiffFunctions";
+import { makeCircle } from "../../shapes/Circle";
+import { makeEllipse } from "../../shapes/Ellipse";
+import { makeLine } from "../../shapes/Line";
+import { makePath } from "../../shapes/Path";
+import { makePolygon } from "../../shapes/Polygon";
+import { makeRectangle } from "../../shapes/Rectangle";
+import { makeCanvas, simpleContext } from "../../shapes/Samplers";
+import { Pt2 } from "../../types/ad";
+import { black, floatV, ptListV, vectorV } from "../../utils/Util";
+import { compDict } from "../Functions";
 import {
   bboxFromShape,
   outwardUnitNormal,
   polygonLikePoints,
   shapeCenter,
   shapeSize,
-} from "contrib/Queries";
-import { genCodeSync, ops, secondaryGraph } from "engine/Autodiff";
-import { sub } from "engine/AutodiffFunctions";
-import { makeCircle } from "shapes/Circle";
-import { makeEllipse } from "shapes/Ellipse";
-import { makeLine } from "shapes/Line";
-import { makePath } from "shapes/Path";
-import { makePolygon } from "shapes/Polygon";
-import { makeRectangle } from "shapes/Rectangle";
-import { makeCanvas, simpleContext } from "shapes/Samplers";
-import { Pt2 } from "types/ad";
-import { black, floatV, ptListV, vectorV } from "utils/Util";
+} from "../Queries";
 
 await ready;
 

--- a/packages/core/src/engine/Autodiff.test.ts
+++ b/packages/core/src/engine/Autodiff.test.ts
@@ -1,4 +1,8 @@
 import { ready } from "@penrose/optimizer";
+import _ from "lodash";
+import seedrandom from "seedrandom";
+import * as ad from "../types/ad";
+import { eqList, randList } from "../utils/Util";
 import {
   fns,
   genCode,
@@ -8,11 +12,7 @@ import {
   makeGraph,
   primaryGraph,
   secondaryGraph,
-} from "engine/Autodiff";
-import _ from "lodash";
-import seedrandom from "seedrandom";
-import * as ad from "types/ad";
-import { eqList, randList } from "utils/Util";
+} from "./Autodiff";
 import {
   add,
   addN,

--- a/packages/core/src/engine/Autodiff.ts
+++ b/packages/core/src/engine/Autodiff.ts
@@ -11,10 +11,10 @@ import {
 } from "@penrose/optimizer";
 import consola from "consola";
 import _ from "lodash";
-import * as ad from "types/ad";
-import { Multidigraph } from "utils/Graph";
-import { safe, zip2 } from "utils/Util";
-import * as wasm from "utils/Wasm";
+import * as ad from "../types/ad";
+import { Multidigraph } from "../utils/Graph";
+import { safe, zip2 } from "../utils/Util";
+import * as wasm from "../utils/Wasm";
 import {
   absVal,
   acos,

--- a/packages/core/src/engine/AutodiffFunctions.ts
+++ b/packages/core/src/engine/AutodiffFunctions.ts
@@ -1,4 +1,4 @@
-import * as ad from "types/ad";
+import * as ad from "../types/ad";
 
 const binary = (binop: ad.Binary["binop"]) => (
   v: ad.Num,

--- a/packages/core/src/engine/BBox.test.ts
+++ b/packages/core/src/engine/BBox.test.ts
@@ -1,16 +1,16 @@
 import { ready } from "@penrose/optimizer";
-import { compDict } from "contrib/Functions";
-import { makeCircle } from "shapes/Circle";
-import { makeEllipse } from "shapes/Ellipse";
-import { makeImage } from "shapes/Image";
-import { makeLine } from "shapes/Line";
-import { makePath } from "shapes/Path";
-import { makePolygon } from "shapes/Polygon";
-import { makePolyline } from "shapes/Polyline";
-import { makeRectangle } from "shapes/Rectangle";
-import { makeCanvas, simpleContext } from "shapes/Samplers";
-import { Poly, Scale } from "types/shapes";
-import { black, floatV, ptListV, vectorV } from "utils/Util";
+import { compDict } from "../contrib/Functions";
+import { makeCircle } from "../shapes/Circle";
+import { makeEllipse } from "../shapes/Ellipse";
+import { makeImage } from "../shapes/Image";
+import { makeLine } from "../shapes/Line";
+import { makePath } from "../shapes/Path";
+import { makePolygon } from "../shapes/Polygon";
+import { makePolyline } from "../shapes/Polyline";
+import { makeRectangle } from "../shapes/Rectangle";
+import { makeCanvas, simpleContext } from "../shapes/Samplers";
+import { Poly, Scale } from "../types/shapes";
+import { black, floatV, ptListV, vectorV } from "../utils/Util";
 import { genCodeSync, secondaryGraph } from "./Autodiff";
 import {
   BBox,

--- a/packages/core/src/engine/BBox.ts
+++ b/packages/core/src/engine/BBox.ts
@@ -1,10 +1,10 @@
-import { CircleProps } from "shapes/Circle";
-import { EllipseProps } from "shapes/Ellipse";
-import { LineProps } from "shapes/Line";
-import { PathProps } from "shapes/Path";
-import { RectangleProps } from "shapes/Rectangle";
-import * as ad from "types/ad";
-import { Center, Poly, Rect, Rotate, Scale } from "types/shapes";
+import { CircleProps } from "../shapes/Circle";
+import { EllipseProps } from "../shapes/Ellipse";
+import { LineProps } from "../shapes/Line";
+import { PathProps } from "../shapes/Path";
+import { RectangleProps } from "../shapes/Rectangle";
+import * as ad from "../types/ad";
+import { Center, Poly, Rect, Rotate, Scale } from "../types/shapes";
 import { ops } from "./Autodiff";
 import {
   absVal,

--- a/packages/core/src/engine/EngineUtils.ts
+++ b/packages/core/src/engine/EngineUtils.ts
@@ -2,9 +2,9 @@
 
 import { getInitConstraintWeight, Gradient } from "@penrose/optimizer";
 import _ from "lodash";
-import { InputMeta } from "shapes/Samplers";
-import { ShapeDef, shapedefs } from "shapes/Shapes";
-import * as ad from "types/ad";
+import { InputMeta } from "../shapes/Samplers";
+import { ShapeDef, shapedefs } from "../shapes/Shapes";
+import * as ad from "../types/ad";
 import {
   A,
   ASTNode,
@@ -12,11 +12,11 @@ import {
   Identifier,
   NodeType,
   SourceLoc,
-} from "types/ast";
-import { StyleError } from "types/errors";
-import { Shape, ShapeAD } from "types/shape";
-import { ShapeFn } from "types/state";
-import { Expr, Path } from "types/style";
+} from "../types/ast";
+import { StyleError } from "../types/errors";
+import { Shape, ShapeAD } from "../types/shape";
+import { ShapeFn } from "../types/state";
+import { Expr, Path } from "../types/style";
 import {
   Color,
   ColorV,
@@ -33,8 +33,8 @@ import {
   TupV,
   Value,
   VectorV,
-} from "types/value";
-import { safe } from "utils/Util";
+} from "../types/value";
+import { safe } from "../utils/Util";
 import { fns, genCode, input, makeGraph, secondaryGraph } from "./Autodiff";
 import { mul } from "./AutodiffFunctions";
 

--- a/packages/core/src/parser/Domain.ne
+++ b/packages/core/src/parser/Domain.ne
@@ -6,9 +6,9 @@
 /* eslint-disable */
 import moo from "moo";
 import _ from 'lodash'
-import { optional, tokensIn, basicSymbols, rangeOf, rangeBetween, rangeFrom, nth, convertTokenId } from 'parser/ParserUtil'
-import { C, ConcreteNode, StringLit } from "types/ast";
-import { DomainProg, TypeDecl, PredicateDecl, FunctionDecl, ConstructorDecl, PreludeDecl, NotationDecl, SubTypeDecl, TypeConstructor, Type, Arg, Prop } from "types/domain";
+import { optional, tokensIn, basicSymbols, rangeOf, rangeBetween, rangeFrom, nth, convertTokenId } from './ParserUtil'
+import { C, ConcreteNode, StringLit } from "../types/ast";
+import { DomainProg, TypeDecl, PredicateDecl, FunctionDecl, ConstructorDecl, PreludeDecl, NotationDecl, SubTypeDecl, TypeConstructor, Type, Arg, Prop } from "../types/domain";
 
 // NOTE: ordering matters here. Top patterns get matched __first__
 const lexer = moo.compile({

--- a/packages/core/src/parser/DomainParser.test.ts
+++ b/packages/core/src/parser/DomainParser.test.ts
@@ -2,8 +2,8 @@ import { examples } from "@penrose/examples";
 import * as fs from "fs";
 import nearley from "nearley";
 import * as path from "path";
-import { SourceRange } from "types/ast";
-import { DomainProg, PredicateDecl } from "types/domain";
+import { SourceRange } from "../types/ast";
+import { DomainProg, PredicateDecl } from "../types/domain";
 import grammar from "./DomainParser";
 
 const outputDir = "/tmp/asts";

--- a/packages/core/src/parser/ParserUtil.test.ts
+++ b/packages/core/src/parser/ParserUtil.test.ts
@@ -1,5 +1,5 @@
 import moo from "moo";
-import * as ParserUtil from "parser/ParserUtil";
+import * as ParserUtil from "./ParserUtil";
 
 describe("ParserUtil", () => {
   test("rangeOf", () => {

--- a/packages/core/src/parser/ParserUtil.ts
+++ b/packages/core/src/parser/ParserUtil.ts
@@ -1,6 +1,6 @@
 import _ from "lodash";
 import moo from "moo";
-import { C, Identifier, NodeType, SourceLoc, SourceRange } from "types/ast";
+import { C, Identifier, NodeType, SourceLoc, SourceRange } from "../types/ast";
 
 export const basicSymbols: moo.Rules = {
   ws: /[ \t]+/,

--- a/packages/core/src/parser/Style.ne
+++ b/packages/core/src/parser/Style.ne
@@ -6,10 +6,10 @@
 /* eslint-disable */
 import moo from "moo";
 import _ from 'lodash'
-import { basicSymbols, rangeOf, rangeBetween, rangeFrom, nth, convertTokenId } from 'parser/ParserUtil'
-import { C, ConcreteNode, Identifier, StringLit  } from "types/ast";
+import { basicSymbols, rangeOf, rangeBetween, rangeFrom, nth, convertTokenId } from './ParserUtil'
+import { C, ConcreteNode, Identifier, StringLit  } from "../types/ast";
 import { StyT, DeclPattern, DeclPatterns, RelationPatterns, Namespace, Selector, StyProg, HeaderBlock, RelBind, RelField, RelPred, SEFuncOrValCons, SEBind, Block, AnonAssign, Delete, Override, PathAssign, StyType, BindingForm, Path, Layering, BinaryOp, Expr, BinOp, SubVar, StyVar, UOp, List, Tuple, Vector, BoolLit, Vary, Fix, CompApp, ObjFn, ConstrFn, GPIDecl, PropertyDecl, ColorLit
-} from "types/style";
+} from "../types/style";
 
 const styleTypes: string[] =
   [ "scalar"

--- a/packages/core/src/parser/StyleParser.test.ts
+++ b/packages/core/src/parser/StyleParser.test.ts
@@ -1,10 +1,10 @@
 import { examples } from "@penrose/examples";
-import { parseStyle } from "compiler/Style";
 import * as fs from "fs";
 import nearley from "nearley";
 import * as path from "path";
-import { C } from "types/ast";
-import { StyProg } from "types/style";
+import { parseStyle } from "../compiler/Style";
+import { C } from "../types/ast";
+import { StyProg } from "../types/style";
 import grammar from "./StyleParser";
 
 const outputDir = "/tmp/asts";

--- a/packages/core/src/parser/Substance.ne
+++ b/packages/core/src/parser/Substance.ne
@@ -7,9 +7,9 @@
 /* eslint-disable */
 import moo from "moo";
 import _ from 'lodash'
-import { optional, basicSymbols, rangeOf, rangeBetween, rangeFrom, nth, convertTokenId } from 'parser/ParserUtil'
-import { C, ConcreteNode, Identifier, StringLit } from "types/ast";
-import { SubProg, SubStmt, Decl, Bind, ApplyPredicate, Deconstructor, Func, EqualExprs, EqualPredicates, LabelDecl, NoLabel, AutoLabel, LabelOption, TypeConsApp } from "types/substance";
+import { optional, basicSymbols, rangeOf, rangeBetween, rangeFrom, nth, convertTokenId } from './ParserUtil'
+import { C, ConcreteNode, Identifier, StringLit } from "../types/ast";
+import { SubProg, SubStmt, Decl, Bind, ApplyPredicate, Deconstructor, Func, EqualExprs, EqualPredicates, LabelDecl, NoLabel, AutoLabel, LabelOption, TypeConsApp } from "../types/substance";
 
 
 // NOTE: ordering matters here. Top patterns get matched __first__

--- a/packages/core/src/renderer/AttrHelper.ts
+++ b/packages/core/src/renderer/AttrHelper.ts
@@ -3,10 +3,14 @@
  * output SVG properties using the optimized shape properties as input.
  */
 
-import { Shape } from "types/shape";
-import { ColorV, FloatV, PtListV, StrV, VectorV } from "types/value";
-import { toFontRule } from "utils/CollectLabels";
-import { toScreen, toSvgOpacityProperty, toSvgPaintProperty } from "utils/Util";
+import { Shape } from "../types/shape";
+import { ColorV, FloatV, PtListV, StrV, VectorV } from "../types/value";
+import { toFontRule } from "../utils/CollectLabels";
+import {
+  toScreen,
+  toSvgOpacityProperty,
+  toSvgPaintProperty,
+} from "../utils/Util";
 import { attrMapSvg } from "./AttrMapSvg";
 
 /**

--- a/packages/core/src/renderer/Equation.ts
+++ b/packages/core/src/renderer/Equation.ts
@@ -1,4 +1,4 @@
-import { getAdValueAsString } from "utils/Util";
+import { getAdValueAsString } from "../utils/Util";
 import {
   attrAutoFillSvg,
   attrFill,

--- a/packages/core/src/renderer/Image.ts
+++ b/packages/core/src/renderer/Image.ts
@@ -1,4 +1,4 @@
-import { StrV } from "types/value";
+import { StrV } from "../types/value";
 import {
   attrAutoFillSvg,
   attrRotation,

--- a/packages/core/src/renderer/Line.ts
+++ b/packages/core/src/renderer/Line.ts
@@ -1,5 +1,5 @@
-import { Shape } from "types/shape";
-import { BoolV, ColorV, FloatV, StrV, VectorV } from "types/value";
+import { Shape } from "../types/shape";
+import { BoolV, ColorV, FloatV, StrV, VectorV } from "../types/value";
 import {
   ArrowheadSpec,
   getArrowhead,
@@ -7,7 +7,7 @@ import {
   toScreen,
   toSvgOpacityProperty,
   toSvgPaintProperty,
-} from "utils/Util";
+} from "../utils/Util";
 import { attrAutoFillSvg, attrTitle, DASH_ARRAY } from "./AttrHelper";
 import { ShapeProps } from "./Renderer";
 

--- a/packages/core/src/renderer/Path.ts
+++ b/packages/core/src/renderer/Path.ts
@@ -1,11 +1,11 @@
 import _ from "lodash";
-import { BoolV, ColorV, FloatV, PathCmd, StrV, SubPath } from "types/value";
+import { BoolV, ColorV, FloatV, PathCmd, StrV, SubPath } from "../types/value";
 import {
   getArrowhead,
   toScreen,
   toSvgOpacityProperty,
   toSvgPaintProperty,
-} from "utils/Util";
+} from "../utils/Util";
 import { attrAutoFillSvg, attrTitle, DASH_ARRAY } from "./AttrHelper";
 import { arrowHead } from "./Line";
 import { ShapeProps } from "./Renderer";

--- a/packages/core/src/renderer/PathBuilder.ts
+++ b/packages/core/src/renderer/PathBuilder.ts
@@ -1,5 +1,5 @@
-import * as ad from "types/ad";
-import { PathDataV, SubPath } from "types/value";
+import * as ad from "../types/ad";
+import { PathDataV, SubPath } from "../types/value";
 
 /**
  * Class for building SVG paths

--- a/packages/core/src/renderer/Renderer.ts
+++ b/packages/core/src/renderer/Renderer.ts
@@ -4,10 +4,10 @@
  *
  */
 
-import { shapedefs } from "shapes/Shapes";
-import { Shape } from "types/shape";
-import { LabelCache, State } from "types/state";
-import { StrV } from "types/value";
+import { shapedefs } from "../shapes/Shapes";
+import { Shape } from "../types/shape";
+import { LabelCache, State } from "../types/state";
+import { StrV } from "../types/value";
 import { dragUpdate } from "./dragUtils";
 import shapeMap from "./shapeMap";
 

--- a/packages/core/src/renderer/Text.ts
+++ b/packages/core/src/renderer/Text.ts
@@ -1,5 +1,5 @@
-import { StrV, VectorV } from "types/value";
-import { toScreen } from "utils/Util";
+import { StrV, VectorV } from "../types/value";
+import { toScreen } from "../utils/Util";
 import {
   attrAutoFillSvg,
   attrFill,

--- a/packages/core/src/renderer/dragUtils.ts
+++ b/packages/core/src/renderer/dragUtils.ts
@@ -1,6 +1,6 @@
-import * as ad from "types/ad";
-import { Properties, ShapeAD } from "types/shape";
-import { State } from "types/state";
+import * as ad from "../types/ad";
+import { Properties, ShapeAD } from "../types/shape";
+import { State } from "../types/state";
 
 /**
  * Retrieve data from drag events and update varying state accordingly

--- a/packages/core/src/shapes/Circle.ts
+++ b/packages/core/src/shapes/Circle.ts
@@ -1,7 +1,7 @@
-import * as ad from "types/ad";
-import { Center, Fill, Named, Shape, Stroke } from "types/shapes";
-import { FloatV } from "types/value";
-import { boolV, floatV, noPaint, strV } from "utils/Util";
+import * as ad from "../types/ad";
+import { Center, Fill, Named, Shape, Stroke } from "../types/shapes";
+import { FloatV } from "../types/value";
+import { boolV, floatV, noPaint, strV } from "../utils/Util";
 import {
   Canvas,
   Context,

--- a/packages/core/src/shapes/Ellipse.ts
+++ b/packages/core/src/shapes/Ellipse.ts
@@ -1,7 +1,7 @@
-import * as ad from "types/ad";
-import { Center, Fill, Named, Shape, Stroke } from "types/shapes";
-import { FloatV } from "types/value";
-import { boolV, floatV, noPaint, strV } from "utils/Util";
+import * as ad from "../types/ad";
+import { Center, Fill, Named, Shape, Stroke } from "../types/shapes";
+import { FloatV } from "../types/value";
+import { boolV, floatV, noPaint, strV } from "../utils/Util";
 import {
   Canvas,
   Context,

--- a/packages/core/src/shapes/Equation.ts
+++ b/packages/core/src/shapes/Equation.ts
@@ -7,8 +7,8 @@ import {
   Shape,
   String,
   Stroke,
-} from "types/shapes";
-import { black, boolV, floatV, noPaint, strV, vectorV } from "utils/Util";
+} from "../types/shapes";
+import { black, boolV, floatV, noPaint, strV, vectorV } from "../utils/Util";
 import { Canvas, Context, uniform } from "./Samplers";
 
 export interface EquationProps

--- a/packages/core/src/shapes/Image.ts
+++ b/packages/core/src/shapes/Image.ts
@@ -1,6 +1,6 @@
-import { Center, Named, Rect, Rotate, Shape } from "types/shapes";
-import { StrV } from "types/value";
-import { boolV, floatV, strV } from "utils/Util";
+import { Center, Named, Rect, Rotate, Shape } from "../types/shapes";
+import { StrV } from "../types/value";
+import { boolV, floatV, strV } from "../utils/Util";
 import {
   Canvas,
   Context,

--- a/packages/core/src/shapes/Line.ts
+++ b/packages/core/src/shapes/Line.ts
@@ -1,7 +1,7 @@
-import * as ad from "types/ad";
-import { Arrow, Named, Shape, Stroke } from "types/shapes";
-import { StrV, VectorV } from "types/value";
-import { boolV, floatV, strV } from "utils/Util";
+import * as ad from "../types/ad";
+import { Arrow, Named, Shape, Stroke } from "../types/shapes";
+import { StrV, VectorV } from "../types/value";
+import { boolV, floatV, strV } from "../utils/Util";
 import { Canvas, Context, sampleColor, sampleVector } from "./Samplers";
 
 export interface LineProps extends Named, Stroke, Arrow {

--- a/packages/core/src/shapes/Path.ts
+++ b/packages/core/src/shapes/Path.ts
@@ -1,7 +1,7 @@
-import * as ad from "types/ad";
-import { Arrow, Fill, Named, Shape, Stroke } from "types/shapes";
-import { PathDataV } from "types/value";
-import { boolV, floatV, noPaint, pathDataV, strV } from "utils/Util";
+import * as ad from "../types/ad";
+import { Arrow, Fill, Named, Shape, Stroke } from "../types/shapes";
+import { PathDataV } from "../types/value";
+import { boolV, floatV, noPaint, pathDataV, strV } from "../utils/Util";
 import { Canvas, Context, sampleColor } from "./Samplers";
 
 export interface PathProps extends Named, Stroke, Fill, Arrow {

--- a/packages/core/src/shapes/Polygon.ts
+++ b/packages/core/src/shapes/Polygon.ts
@@ -1,5 +1,5 @@
-import { Fill, Named, Poly, Scale, Shape, Stroke } from "types/shapes";
-import { boolV, floatV, noPaint, ptListV, strV } from "utils/Util";
+import { Fill, Named, Poly, Scale, Shape, Stroke } from "../types/shapes";
+import { boolV, floatV, noPaint, ptListV, strV } from "../utils/Util";
 import { Canvas, Context, sampleColor } from "./Samplers";
 
 export interface PolygonProps extends Named, Stroke, Fill, Scale, Poly {}

--- a/packages/core/src/shapes/Polyline.ts
+++ b/packages/core/src/shapes/Polyline.ts
@@ -1,5 +1,5 @@
-import { Fill, Named, Poly, Scale, Shape, Stroke } from "types/shapes";
-import { black, boolV, floatV, noPaint, ptListV, strV } from "utils/Util";
+import { Fill, Named, Poly, Scale, Shape, Stroke } from "../types/shapes";
+import { black, boolV, floatV, noPaint, ptListV, strV } from "../utils/Util";
 import { Canvas, Context } from "./Samplers";
 
 export interface PolylineProps extends Named, Stroke, Fill, Scale, Poly {}

--- a/packages/core/src/shapes/Rectangle.ts
+++ b/packages/core/src/shapes/Rectangle.ts
@@ -7,8 +7,8 @@ import {
   Rotate,
   Shape,
   Stroke,
-} from "types/shapes";
-import { boolV, floatV, noPaint, strV } from "utils/Util";
+} from "../types/shapes";
+import { boolV, floatV, noPaint, strV } from "../utils/Util";
 import {
   Canvas,
   Context,

--- a/packages/core/src/shapes/Samplers.ts
+++ b/packages/core/src/shapes/Samplers.ts
@@ -1,8 +1,8 @@
-import { input } from "engine/Autodiff";
 import seedrandom from "seedrandom";
-import * as ad from "types/ad";
-import { ColorV, FloatV, VectorV } from "types/value";
-import { colorV, floatV, randFloat, vectorV } from "utils/Util";
+import { input } from "../engine/Autodiff";
+import * as ad from "../types/ad";
+import { ColorV, FloatV, VectorV } from "../types/value";
+import { colorV, floatV, randFloat, vectorV } from "../utils/Util";
 
 type Range = [number, number];
 

--- a/packages/core/src/shapes/Shapes.ts
+++ b/packages/core/src/shapes/Shapes.ts
@@ -1,7 +1,7 @@
-import { input } from "engine/Autodiff";
-import * as BBox from "engine/BBox";
-import * as ad from "types/ad";
-import { Value } from "types/value";
+import { input } from "../engine/Autodiff";
+import * as BBox from "../engine/BBox";
+import * as ad from "../types/ad";
+import { Value } from "../types/value";
 import { Circle, makeCircle, sampleCircle } from "./Circle";
 import { Ellipse, makeEllipse, sampleEllipse } from "./Ellipse";
 import { Equation, makeEquation, sampleEquation } from "./Equation";

--- a/packages/core/src/shapes/Text.ts
+++ b/packages/core/src/shapes/Text.ts
@@ -1,4 +1,4 @@
-import * as ad from "types/ad";
+import * as ad from "../types/ad";
 import {
   Center,
   Fill,
@@ -8,9 +8,9 @@ import {
   Shape,
   String,
   Stroke,
-} from "types/shapes";
-import { FloatV, StrV } from "types/value";
-import { boolV, floatV, noPaint, strV, vectorV } from "utils/Util";
+} from "../types/shapes";
+import { FloatV, StrV } from "../types/value";
+import { boolV, floatV, noPaint, strV, vectorV } from "../utils/Util";
 import { Canvas, Context, sampleColor, uniform } from "./Samplers";
 
 export interface TextProps

--- a/packages/core/src/synthesis/Mutation.test.ts
+++ b/packages/core/src/synthesis/Mutation.test.ts
@@ -1,7 +1,7 @@
-import { compileDomain } from "compiler/Domain";
-import { compileSubstance, prettyStmt } from "compiler/Substance";
-import { SubRes } from "types/substance";
-import { showError } from "utils/Error";
+import { compileDomain } from "../compiler/Domain";
+import { compileSubstance, prettyStmt } from "../compiler/Substance";
+import { SubRes } from "../types/substance";
+import { showError } from "../utils/Error";
 import { enumerateStmtMutations } from "./Mutation";
 import { initContext } from "./Synthesizer";
 

--- a/packages/core/src/synthesis/Mutation.ts
+++ b/packages/core/src/synthesis/Mutation.ts
@@ -1,3 +1,4 @@
+import _ from "lodash";
 import {
   appendStmt,
   ArgExpr,
@@ -9,11 +10,10 @@ import {
   removeStmt,
   replaceStmt,
   stmtExists,
-} from "analysis/SubstanceAnalysis";
-import { prettyStmt, prettySubNode } from "compiler/Substance";
-import { dummyIdentifier } from "engine/EngineUtils";
-import _ from "lodash";
-import { A, Identifier } from "types/ast";
+} from "../analysis/SubstanceAnalysis";
+import { prettyStmt, prettySubNode } from "../compiler/Substance";
+import { dummyIdentifier } from "../engine/EngineUtils";
+import { A, Identifier } from "../types/ast";
 import {
   ApplyConstructor,
   ApplyFunction,
@@ -22,7 +22,7 @@ import {
   Func,
   SubProg,
   SubStmt,
-} from "types/substance";
+} from "../types/substance";
 import {
   addID,
   generateArgStmt,

--- a/packages/core/src/synthesis/Search.test.ts
+++ b/packages/core/src/synthesis/Search.test.ts
@@ -1,17 +1,17 @@
-import { sortStmts, typeOf } from "analysis/SubstanceAnalysis";
-import { prettyStmt } from "compiler/Substance";
 import _ from "lodash";
 import pc from "pandemonium/choice";
 import rdiff from "recursive-diff";
 import seedrandom from "seedrandom";
-import { A } from "types/ast";
-import { SubProg, SubRes } from "types/substance";
+import { sortStmts, typeOf } from "../analysis/SubstanceAnalysis";
+import { prettyStmt } from "../compiler/Substance";
 import {
   compileDomain,
   compileSubstance,
   prettySubstance,
   showError,
 } from "../index";
+import { A } from "../types/ast";
+import { SubProg, SubRes } from "../types/substance";
 import {
   enumerateStmtMutations,
   executeMutation,

--- a/packages/core/src/synthesis/Search.ts
+++ b/packages/core/src/synthesis/Search.ts
@@ -1,3 +1,5 @@
+import _ from "lodash";
+import rdiff from "recursive-diff";
 import {
   cleanNode,
   findTypes,
@@ -7,10 +9,11 @@ import {
   nodesEqual,
   sortStmts,
   subProg,
-} from "analysis/SubstanceAnalysis";
-import { prettyStmt, prettySubstance } from "compiler/Substance";
-import _ from "lodash";
-import rdiff from "recursive-diff";
+} from "../analysis/SubstanceAnalysis";
+import { prettyStmt, prettySubstance } from "../compiler/Substance";
+import { A, AbstractNode, Identifier, metaProps } from "../types/ast";
+import { Env, Type } from "../types/domain";
+import { LabelOption, SubExpr, SubProg, SubStmt } from "../types/substance";
 import {
   Add,
   addMutation,
@@ -21,10 +24,7 @@ import {
   executeMutation,
   Mutation,
   MutationGroup,
-} from "synthesis/Mutation";
-import { A, AbstractNode, Identifier, metaProps } from "types/ast";
-import { Env, Type } from "types/domain";
-import { LabelOption, SubExpr, SubProg, SubStmt } from "types/substance";
+} from "./Mutation";
 import {
   filterContext,
   initContext,

--- a/packages/core/src/synthesis/Synthesizer.test.ts
+++ b/packages/core/src/synthesis/Synthesizer.test.ts
@@ -1,13 +1,13 @@
-import { cascadingDelete } from "analysis/SubstanceAnalysis";
-import { compileDomain } from "compiler/Domain";
+import { cascadingDelete } from "../analysis/SubstanceAnalysis";
+import { compileDomain } from "../compiler/Domain";
 import {
   compileSubstance,
   prettyStmt,
   prettySubstance,
-} from "compiler/Substance";
-import { A } from "types/ast";
-import { Env } from "types/domain";
-import { Decl, SubStmt } from "types/substance";
+} from "../compiler/Substance";
+import { A } from "../types/ast";
+import { Env } from "../types/domain";
+import { Decl, SubStmt } from "../types/substance";
 import { Delete, executeMutations, removeStmtCtx } from "./Mutation";
 import { initContext, Synthesizer, SynthesizerSetting } from "./Synthesizer";
 

--- a/packages/core/src/synthesis/Synthesizer.ts
+++ b/packages/core/src/synthesis/Synthesizer.ts
@@ -1,3 +1,9 @@
+import consola from "consola";
+import im from "immutable";
+import _ from "lodash";
+import pc from "pandemonium/choice";
+import pr from "pandemonium/random";
+import seedrandom from "seedrandom";
 import {
   appendStmt,
   applyBind,
@@ -14,16 +20,36 @@ import {
   matchSignatures,
   nullaryTypeCons,
   SubStmtKind,
-} from "analysis/SubstanceAnalysis";
-import { subTypesOf } from "compiler/Domain";
-import { prettyStmt, prettySubstance } from "compiler/Substance";
-import consola from "consola";
-import { dummyIdentifier } from "engine/EngineUtils";
-import im from "immutable";
-import _ from "lodash";
-import pc from "pandemonium/choice";
-import pr from "pandemonium/random";
-import seedrandom from "seedrandom";
+} from "../analysis/SubstanceAnalysis";
+import { subTypesOf } from "../compiler/Domain";
+import { prettyStmt, prettySubstance } from "../compiler/Substance";
+import { dummyIdentifier } from "../engine/EngineUtils";
+import { A, Identifier } from "../types/ast";
+import {
+  Arg,
+  ConstructorDecl,
+  DomainStmt,
+  Env,
+  FunctionDecl,
+  PredicateDecl,
+  Type,
+  TypeConstructor,
+  TypeDecl,
+} from "../types/domain";
+import {
+  ApplyConstructor,
+  ApplyFunction,
+  ApplyPredicate,
+  Bind,
+  Decl,
+  Func,
+  SubExpr,
+  SubPredArg,
+  SubProg,
+  SubRes,
+  SubStmt,
+  TypeConsApp,
+} from "../types/substance";
 import {
   Add,
   addMutation,
@@ -44,33 +70,7 @@ import {
   Mutation,
   MutationGroup,
   showMutations,
-} from "synthesis/Mutation";
-import { A, Identifier } from "types/ast";
-import {
-  Arg,
-  ConstructorDecl,
-  DomainStmt,
-  Env,
-  FunctionDecl,
-  PredicateDecl,
-  Type,
-  TypeConstructor,
-  TypeDecl,
-} from "types/domain";
-import {
-  ApplyConstructor,
-  ApplyFunction,
-  ApplyPredicate,
-  Bind,
-  Decl,
-  Func,
-  SubExpr,
-  SubPredArg,
-  SubProg,
-  SubRes,
-  SubStmt,
-  TypeConsApp,
-} from "types/substance";
+} from "./Mutation";
 
 type RandomFunction = (min: number, max: number) => number;
 

--- a/packages/core/src/types/ad.ts
+++ b/packages/core/src/types/ad.ts
@@ -1,5 +1,5 @@
 import { Outputs } from "@penrose/optimizer";
-import { Multidigraph } from "utils/Graph";
+import { Multidigraph } from "../utils/Graph";
 
 // The following three regions define the core types for our symbolic
 // differentiation engine. Note that, despite the name, this is not actually

--- a/packages/core/src/types/errors.ts
+++ b/packages/core/src/types/errors.ts
@@ -1,5 +1,5 @@
 import im from "immutable";
-import * as ad from "types/ad";
+import * as ad from "./ad";
 import { A, AbstractNode, C, Identifier, SourceLoc, SourceRange } from "./ast";
 import { Arg, TypeConstructor, TypeVar } from "./domain";
 import { State } from "./state";

--- a/packages/core/src/types/shapes.ts
+++ b/packages/core/src/types/shapes.ts
@@ -1,4 +1,4 @@
-import * as ad from "types/ad";
+import * as ad from "./ad";
 import { BoolV, ColorV, FloatV, PtListV, StrV, VectorV } from "./value";
 
 //#region shape hierarchy interfaces

--- a/packages/core/src/types/state.ts
+++ b/packages/core/src/types/state.ts
@@ -1,6 +1,6 @@
 import { Gradient, OptState } from "@penrose/optimizer";
-import { Canvas, InputMeta } from "shapes/Samplers";
-import * as ad from "types/ad";
+import { Canvas, InputMeta } from "../shapes/Samplers";
+import * as ad from "./ad";
 import { A } from "./ast";
 import { StyleWarning } from "./errors";
 import { Shape, ShapeAD } from "./shape";

--- a/packages/core/src/types/styleSemantics.ts
+++ b/packages/core/src/types/styleSemantics.ts
@@ -1,6 +1,6 @@
 import im from "immutable";
-import { ShapeType } from "shapes/Shapes";
-import { Digraph } from "utils/Graph";
+import { ShapeType } from "../shapes/Shapes";
+import { Digraph } from "../utils/Graph";
 import * as ad from "./ad";
 import { A, C, Identifier } from "./ast";
 import { StyleDiagnostics, StyleError } from "./errors";

--- a/packages/core/src/utils/CollectLabels.ts
+++ b/packages/core/src/utils/CollectLabels.ts
@@ -4,16 +4,16 @@ import { TeX } from "mathjax-full/js/input/tex.js";
 import { AllPackages } from "mathjax-full/js/input/tex/AllPackages.js";
 import { mathjax } from "mathjax-full/js/mathjax.js";
 import { SVG } from "mathjax-full/js/output/svg.js";
-import { InputMeta } from "shapes/Samplers";
-import { ShapeDef, shapedefs } from "shapes/Shapes";
+import { InputMeta } from "../shapes/Samplers";
+import { ShapeDef, shapedefs } from "../shapes/Shapes";
 // @ts-expect-error missing types
 import svgflatten from "svg-flatten";
 import svgpath from "svgpath";
-import * as ad from "types/ad";
-import { PenroseError } from "types/errors";
-import { Properties, ShapeAD } from "types/shape";
-import { EquationData, LabelCache, State, TextData } from "types/state";
-import { FloatV } from "types/value";
+import * as ad from "../types/ad";
+import { PenroseError } from "../types/errors";
+import { Properties, ShapeAD } from "../types/shape";
+import { EquationData, LabelCache, State, TextData } from "../types/state";
+import { FloatV } from "../types/value";
 import { err, ok, Result } from "./Error";
 import {
   getAdValueAsColor,

--- a/packages/core/src/utils/Error.ts
+++ b/packages/core/src/utils/Error.ts
@@ -1,6 +1,6 @@
-import { isConcrete } from "engine/EngineUtils";
-import { shapedefs } from "shapes/Shapes";
 import { Result } from "true-myth";
+import { isConcrete } from "../engine/EngineUtils";
+import { shapedefs } from "../shapes/Shapes";
 import {
   A,
   AbstractNode,
@@ -9,8 +9,8 @@ import {
   NodeType,
   SourceLoc,
   SourceRange,
-} from "types/ast";
-import { Arg, Type, TypeConstructor } from "types/domain";
+} from "../types/ast";
+import { Arg, Type, TypeConstructor } from "../types/domain";
 import {
   ArgLengthMismatch,
   CyclicSubtypes,
@@ -34,11 +34,11 @@ import {
   TypeNotFound,
   UnexpectedExprForNestedPred,
   VarNotFound,
-} from "types/errors";
-import { State } from "types/state";
-import { BindingForm, ColorLit } from "types/style";
-import { Deconstructor, SubExpr } from "types/substance";
-import { prettyPrintPath, prettyPrintResolvedPath } from "utils/Util";
+} from "../types/errors";
+import { State } from "../types/state";
+import { BindingForm, ColorLit } from "../types/style";
+import { Deconstructor, SubExpr } from "../types/substance";
+import { prettyPrintPath, prettyPrintResolvedPath } from "./Util";
 const {
   or,
   and,

--- a/packages/core/src/utils/Util.ts
+++ b/packages/core/src/utils/Util.ts
@@ -1,20 +1,20 @@
 import _ from "lodash";
 import seedrandom from "seedrandom";
-import { LineProps } from "shapes/Line";
-import { ShapeType } from "shapes/Shapes";
-import * as ad from "types/ad";
-import { A } from "types/ast";
-import { Either, Left, Right } from "types/common";
-import { Properties } from "types/shape";
-import { Fn, State } from "types/state";
-import { BindingForm, Expr, Path } from "types/style";
+import { LineProps } from "../shapes/Line";
+import { ShapeType } from "../shapes/Shapes";
+import * as ad from "../types/ad";
+import { A } from "../types/ast";
+import { Either, Left, Right } from "../types/common";
+import { Properties } from "../types/shape";
+import { Fn, State } from "../types/state";
+import { BindingForm, Expr, Path } from "../types/style";
 import {
   Context,
   LocalVarSubst,
   ResolvedName,
   ResolvedPath,
   WithContext,
-} from "types/styleSemantics";
+} from "../types/styleSemantics";
 import {
   BoolV,
   Color,
@@ -31,7 +31,7 @@ import {
   Val,
   Value,
   VectorV,
-} from "types/value";
+} from "../types/value";
 
 //#region general
 

--- a/packages/core/tsconfig.json
+++ b/packages/core/tsconfig.json
@@ -1,6 +1,5 @@
 {
   "compilerOptions": {
-    "baseUrl": "./",
     "outDir": "build/dist",
     "module": "es2022",
     "target": "es2017",
@@ -8,7 +7,6 @@
     "sourceMap": true,
     "allowJs": true,
     "moduleResolution": "node",
-    "rootDir": "src",
     "forceConsistentCasingInFileNames": true,
     "noImplicitThis": true,
     "noImplicitAny": true,
@@ -25,19 +23,7 @@
     "isolatedModules": true,
     "strict": true,
     "declaration": true,
-    "declarationMap": true,
-    "paths": {
-      "analysis/*": ["./src/analysis/*"],
-      "compiler/*": ["./src/compiler/*"],
-      "contrib/*": ["./src/contrib/*"],
-      "engine/*": ["./src/engine/*"],
-      "parser/*": ["./src/parser/*"],
-      "renderer/*": ["./src/renderer/*"],
-      "shapes/*": ["./src/shapes/*"],
-      "synthesis/*": ["./src/synthesis/*"],
-      "types/*": ["./src/types/*"],
-      "utils/*": ["./src/utils/*"]
-    }
+    "declarationMap": true
   },
   "formatCodeOptions": {
     "baseIndentSize": 0,

--- a/yarn.lock
+++ b/yarn.lock
@@ -7694,7 +7694,7 @@ commander@7.1.0:
   resolved "https://registry.yarnpkg.com/commander/-/commander-7.1.0.tgz#f2eaecf131f10e36e07d894698226e36ae0eb5ff"
   integrity sha512-pRxBna3MJe6HKnBGsDyMv8ETbptw3axEdYHoqNh7gu5oDcew8fs0xnivZGm06Ogk8zGAJ9VX+OPEr2GXEQK4dg==
 
-commander@>=7.0.0, commander@^9.0.0:
+commander@>=7.0.0:
   version "9.2.0"
   resolved "https://registry.yarnpkg.com/commander/-/commander-9.2.0.tgz#6e21014b2ed90d8b7c9647230d8b7a94a4a419a9"
   integrity sha512-e2i4wANQiSXgnrBlIatyHtP1odfUp0BbV5Y5nEGbxtIrStkEOAAzCUirvLBNXHLr7kwLvJl6V+4V3XV9x7Wd9w==
@@ -11034,7 +11034,7 @@ globby@^10.0.1:
     merge2 "^1.2.3"
     slash "^3.0.0"
 
-globby@^11, globby@^11.0.1, globby@^11.0.2, globby@^11.0.3, globby@^11.0.4, globby@^11.1.0:
+globby@^11, globby@^11.0.1, globby@^11.0.2, globby@^11.0.3, globby@^11.1.0:
   version "11.1.0"
   resolved "https://registry.yarnpkg.com/globby/-/globby-11.1.0.tgz#bd4be98bb042f83d796f7e3811991fbe82a0d34b"
   integrity sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g==
@@ -14555,11 +14555,6 @@ mute-stream@0.0.8, mute-stream@~0.0.4:
   resolved "https://registry.yarnpkg.com/mute-stream/-/mute-stream-0.0.8.tgz#1630c42b2251ff81e2a283de96a5497ea92e5e0d"
   integrity sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA==
 
-mylas@^2.1.9:
-  version "2.1.9"
-  resolved "https://registry.yarnpkg.com/mylas/-/mylas-2.1.9.tgz#8329626f95c0ce522ca7d3c192eca6221d172cdc"
-  integrity sha512-pa+cQvmhoM8zzgitPYZErmDt9EdTNVnXsH1XFjMeM4TyG4FFcgxrvK1+jwabVFwUOEDaSWuXBMjg43kqt/Ydlg==
-
 mz@^2.5.0:
   version "2.7.0"
   resolved "https://registry.yarnpkg.com/mz/-/mz-2.7.0.tgz#95008057a56cafadc2bc63dde7f9ff6955948e32"
@@ -15832,13 +15827,6 @@ pkg-dir@^5.0.0:
   dependencies:
     find-up "^5.0.0"
 
-plimit-lit@^1.2.6:
-  version "1.2.6"
-  resolved "https://registry.yarnpkg.com/plimit-lit/-/plimit-lit-1.2.6.tgz#8c1336f26a042b6e9f1acc665be5eee4c2a55fb3"
-  integrity sha512-EuVnKyDeFgr58aidKf2G7DI41r23bxphlvBKAZ8e8dT9of0Ez2g9w6JbJGUP1YBNC2yG9+ZCCbjLj4yS1P5Gzw==
-  dependencies:
-    queue-lit "^1.2.7"
-
 pluralize@^8.0.0:
   version "8.0.0"
   resolved "https://registry.yarnpkg.com/pluralize/-/pluralize-8.0.0.tgz#1a6fa16a38d12a1901e0320fa017051c539ce3b1"
@@ -16486,11 +16474,6 @@ querystring@^0.2.0:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/querystring/-/querystring-0.2.1.tgz#40d77615bb09d16902a85c3e38aa8b5ed761c2dd"
   integrity sha512-wkvS7mL/JMugcup3/rMitHmd9ecIGd2lhFhK9N3UUQ450h66d1r3Y9nvXzQAW1Lq+wyx61k/1pfKS5KuKiyEbg==
-
-queue-lit@^1.2.7:
-  version "1.2.7"
-  resolved "https://registry.yarnpkg.com/queue-lit/-/queue-lit-1.2.7.tgz#69081656c9e7b81f09770bb2de6aa007f1a90763"
-  integrity sha512-K/rTdggORRcmf3+c89ijPlgJ/ldGP4oBj6Sm7VcTup4B2clf03Jo8QaXTnMst4EEQwkUbOZFN4frKocq2I85gw==
 
 queue-microtask@^1.2.2:
   version "1.2.3"
@@ -19087,18 +19070,6 @@ ts-pnp@^1.1.6:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/ts-pnp/-/ts-pnp-1.2.0.tgz#a500ad084b0798f1c3071af391e65912c86bca92"
   integrity sha512-csd+vJOb/gkzvcCHgTGSChYpy5f1/XKNsmvBGO4JXS+z1v2HobugDz4s1IeFXM3wZB44uczs+eazB5Q/ccdhQw==
-
-tsc-alias@^1.6.7:
-  version "1.6.7"
-  resolved "https://registry.yarnpkg.com/tsc-alias/-/tsc-alias-1.6.7.tgz#354840d6444db79dd13fcc4f9ec37574ff9d5120"
-  integrity sha512-GRbZx/zTee01JtrHB7hkddgxn+aQqYDmRaFv/MTYIqBbk/L8Zf0nA/T60wXOr/Q7002YXppUFXsqsu5ViWB4vQ==
-  dependencies:
-    chokidar "^3.5.3"
-    commander "^9.0.0"
-    globby "^11.0.4"
-    mylas "^2.1.9"
-    normalize-path "^3.0.0"
-    plimit-lit "^1.2.6"
 
 tsconfig-paths@^3.12.0:
   version "3.12.0"


### PR DESCRIPTION
# Description

This PR goes back on #941 by replacing all our `import` paths with relative paths. I don't actually think we should do this: it's pretty gross.

# Checklist

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new ESLint warnings
- [x] I have reviewed any generated registry diagram changes