### PR TITLE
refactor: consistently use our graph wrappers

### DIFF
--- a/packages/core/src/compiler/Domain.ts
+++ b/packages/core/src/compiler/Domain.ts
@@ -345,7 +345,7 @@ const addSubtype = (
 const computeTypeGraph = (env: Env): CheckerResult => {
   const { subTypes, types, typeGraph } = env;
   const [...typeNames] = types.keys();
-  typeNames.forEach((t: string) => typeGraph.setNode(t, t));
+  typeNames.forEach((t: string) => typeGraph.setNode(t, undefined));
   // NOTE: since we search for super types upstream, subtyping arrow points to supertype
   subTypes.forEach(
     ([subType, superType]: [TypeConstructor<C>, TypeConstructor<C>]) =>

--- a/packages/core/src/compiler/Style.ts
+++ b/packages/core/src/compiler/Style.ts
@@ -12,7 +12,6 @@ import {
   dummyIdentifier,
   genGradient,
 } from "engine/EngineUtils";
-import graphlib from "graphlib";
 import im from "immutable";
 import _ from "lodash";
 import nearley from "nearley";
@@ -123,7 +122,7 @@ import {
   selectorFieldNotSupported,
   toStyleErrors,
 } from "utils/Error";
-import { Digraph } from "utils/Graph";
+import { Digraph, Edge } from "utils/Graph";
 import {
   boolV,
   colorV,
@@ -2916,19 +2915,19 @@ export const computeShapeOrdering = (
   shapeOrdering: string[];
   warning?: LayerCycleWarning;
 } => {
-  const layerGraph: graphlib.Graph = new graphlib.Graph();
-  allGPINames.forEach((name: string) => layerGraph.setNode(name));
+  const layerGraph = new Digraph<string, undefined>();
+  allGPINames.forEach((name: string) => layerGraph.setNode(name, undefined));
   // topsort will return the most upstream node first. Since `shapeOrdering` is consistent with the SVG drawing order, we assign edges as "below => above".
   partialOrderings.forEach(({ below, above }: Layer) =>
-    layerGraph.setEdge(below, above)
+    layerGraph.setEdge({ v: below, w: above })
   );
 
   // if there are no cycles, return a global ordering from the top sort result
-  if (graphlib.alg.isAcyclic(layerGraph)) {
-    const shapeOrdering: string[] = graphlib.alg.topsort(layerGraph);
+  if (layerGraph.isAcyclic()) {
+    const shapeOrdering: string[] = layerGraph.topsort();
     return { shapeOrdering };
   } else {
-    const cycles = graphlib.alg.findCycles(layerGraph);
+    const cycles = layerGraph.findCycles();
     const shapeOrdering = pseudoTopsort(layerGraph);
     return {
       shapeOrdering,
@@ -2941,12 +2940,12 @@ export const computeShapeOrdering = (
   }
 };
 
-const pseudoTopsort = (graph: graphlib.Graph): string[] => {
+const pseudoTopsort = (graph: Digraph<string, undefined>): string[] => {
   const toVisit: CustomHeap<string> = new CustomHeap((a: string, b: string) => {
     const aIn = graph.inEdges(a);
     const bIn = graph.inEdges(b);
-    if (!aIn) return 1;
-    else if (!bIn) return -1;
+    if (aIn.length < 1) return 1;
+    else if (bIn.length < 1) return -1;
     else return aIn.length - bIn.length;
   });
   const res: string[] = [];
@@ -2957,8 +2956,8 @@ const pseudoTopsort = (graph: graphlib.Graph): string[] => {
     res.push(node);
     // remove all edges with `node`
     const toRemove = graph.nodeEdges(node);
-    if (toRemove !== undefined) {
-      toRemove.forEach((e: graphlib.Edge) => graph.removeEdge(e));
+    if (toRemove.length > 0) {
+      toRemove.forEach((e: Edge<string>) => graph.removeEdge(e));
       toVisit.fix();
     }
   }

--- a/packages/core/src/compiler/Style.ts
+++ b/packages/core/src/compiler/Style.ts
@@ -2944,9 +2944,7 @@ const pseudoTopsort = (graph: Digraph<string, undefined>): string[] => {
   const toVisit: CustomHeap<string> = new CustomHeap((a: string, b: string) => {
     const aIn = graph.inEdges(a);
     const bIn = graph.inEdges(b);
-    if (aIn.length < 1) return 1;
-    else if (bIn.length < 1) return -1;
-    else return aIn.length - bIn.length;
+    return aIn.length - bIn.length;
   });
   const res: string[] = [];
   graph.nodes().forEach((n: string) => toVisit.insert(n));
@@ -2956,10 +2954,8 @@ const pseudoTopsort = (graph: Digraph<string, undefined>): string[] => {
     res.push(node);
     // remove all edges with `node`
     const toRemove = graph.nodeEdges(node);
-    if (toRemove.length > 0) {
-      toRemove.forEach((e: Edge<string>) => graph.removeEdge(e));
-      toVisit.fix();
-    }
+    toRemove.forEach((e: Edge<string>) => graph.removeEdge(e));
+    toVisit.fix();
   }
   return res;
 };

--- a/packages/core/src/types/domain.ts
+++ b/packages/core/src/types/domain.ts
@@ -106,6 +106,6 @@ export interface Env {
   typeVars: im.Map<string, TypeVar<C>>;
   preludeValues: im.Map<string, TypeConstructor<C>>; // TODO: store as Substance values?
   subTypes: [TypeConstructor<C>, TypeConstructor<C>][];
-  typeGraph: Digraph<string, string>;
+  typeGraph: Digraph<string, undefined>;
 }
 //#endregion


### PR DESCRIPTION
# Description

This PR rewrites all our remaining usages of [`graphlib`](https://github.com/dagrejs/graphlib/wiki/API-Reference) to instead use the better-typed wrappers we added in #984. Now our only `graphlib` import is inside `packages/core/src/utils/Graph.ts`.

# Checklist

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new ESLint warnings
- [x] I have reviewed any generated registry diagram changes