### PR TITLE
feat: allow autodiff addends to be masked

### DIFF
--- a/packages/core/src/__tests__/overall.test.ts
+++ b/packages/core/src/__tests__/overall.test.ts
@@ -172,9 +172,9 @@ describe("Energy API", () => {
           smallerThanFns.map(({ output }) => output)
         ),
         params: genOptProblem(
-          state.inputs.map((meta) => meta.tag),
-          state.objFns.length,
-          smallerThanFns.length
+          state.inputs.map((meta) => meta.tag === "Optimized"),
+          state.objFns.map(() => true),
+          smallerThanFns.map(() => true)
         ),
       };
       expect(evalEnergy(state)).toBeGreaterThan(evalEnergy(stateFiltered));
@@ -256,10 +256,10 @@ describe("Run individual functions", () => {
       ]);
       stateEvaled.params.lastObjEnergies = initialEnergies.secondary.slice(
         0,
-        stateEvaled.params.numObjEngs
+        stateEvaled.params.objMask.length
       );
       stateEvaled.params.lastConstrEnergies = initialEnergies.secondary.slice(
-        stateEvaled.params.numObjEngs
+        stateEvaled.params.objMask.length
       );
 
       // Test objectives

--- a/packages/core/src/compiler/Style.ts
+++ b/packages/core/src/compiler/Style.ts
@@ -3162,9 +3162,9 @@ export const compileStyleHelper = async (
   );
 
   const params = genOptProblem(
-    inputs.map((meta) => meta.tag),
-    objFns.length,
-    constrFns.length
+    inputs.map((meta) => meta.tag === "Optimized"),
+    objFns.map(() => true),
+    constrFns.map(() => true)
   );
 
   const initState: State = {
@@ -3182,7 +3182,6 @@ export const compileStyleHelper = async (
     gradient,
     computeShapes,
     params,
-    frozenValues: [],
   };
 
   log.info("init state from GenOptProblem", initState);

--- a/packages/core/src/engine/Autodiff.test.ts
+++ b/packages/core/src/engine/Autodiff.test.ts
@@ -105,6 +105,21 @@ describe("genCode tests", () => {
       "secondary output 0 is present in 2 graphs"
     );
   });
+
+  test("mask", () => {
+    const v1 = [5];
+    const v2 = [];
+    v2[1] = 8;
+    const f = genCodeSync(
+      makeGraph({ primary: input({ key: 0, val: 0 }), secondary: v2 }),
+      makeGraph({ primary: input({ key: 0, val: 0 }), secondary: v1 })
+    );
+    expect(f.call([13], [true, false])).toEqual({
+      gradient: [1],
+      primary: 13,
+      secondary: [0, 8],
+    });
+  });
 });
 
 // df/f[x] with finite differences about xi

--- a/packages/core/src/engine/Autodiff.ts
+++ b/packages/core/src/engine/Autodiff.ts
@@ -2,7 +2,6 @@ import { Queue } from "@datastructures-js/queue";
 import {
   alignStackPointer,
   builtins,
-  BuiltinType,
   exportFunctionName,
   Gradient,
   importMemoryName,
@@ -889,90 +888,71 @@ const logAlignI32 = Math.log2(bytesI32);
 const bytesF64 = Float64Array.BYTES_PER_ELEMENT;
 const logAlignF64 = Math.log2(bytesF64);
 
-const numFuncTypes = 5;
-const typeIndexGradient = 0;
-const typeIndexAddToStackPointer = 1;
-const typeIndexUnary = 2;
-const typeIndexBinary = 3;
-const typeIndexPolyRoots = 4;
+interface Signature {
+  param: { [name: string]: number };
+  result: number[];
+  local?: { [name: string]: number };
+}
 
-const numGradientParams = 4;
-const gradientParamInput = 0;
-const gradientParamMask = 1;
-const gradientParamGradient = 2;
-const gradientParamSecondary = 3;
+const funcTypes = {
+  addToStackPointer: {
+    param: { size: wasm.TYPE.i32 },
+    result: [wasm.TYPE.i32],
+  },
+  unary: { param: { x: wasm.TYPE.f64 }, result: [wasm.TYPE.f64] },
+  binary: {
+    param: { x: wasm.TYPE.f64, y: wasm.TYPE.f64 },
+    result: [wasm.TYPE.f64],
+  },
+  polyRoots: {
+    param: { pointer: wasm.TYPE.i32, size: wasm.TYPE.i32 },
+    result: [],
+  },
+  addend: {
+    param: {
+      input: wasm.TYPE.i32,
+      gradient: wasm.TYPE.i32,
+      secondary: wasm.TYPE.i32,
+    },
+    result: [wasm.TYPE.f64],
+    local: { stackPointer: wasm.TYPE.i32 },
+  },
+  sum: {
+    param: {
+      input: wasm.TYPE.i32,
+      mask: wasm.TYPE.i32,
+      gradient: wasm.TYPE.i32,
+      secondary: wasm.TYPE.i32,
+    },
+    result: [wasm.TYPE.f64],
+  },
+};
 
-const gradientLocalStackPointer = 4;
+const getTypeIndex = (kind: string): number =>
+  Object.keys(funcTypes).indexOf(kind);
+
+const getParamIndex = (sig: Signature, name: string): number =>
+  Object.keys(sig.param).indexOf(name);
+
+const getLocalIndex = (sig: Signature, name: string): number =>
+  Object.keys(sig.param).length +
+  Object.keys(safe(sig.local, "no locals")).indexOf(name);
 
 const builtindex = new Map([...builtins.keys()].map((name, i) => [name, i]));
 
 const getBuiltindex = (name: string): number =>
   safe(builtindex.get(name), "unknown builtin");
 
-const builtinTypeIndex = (kind: BuiltinType): number => {
-  switch (kind) {
-    case "addToStackPointer": {
-      return typeIndexAddToStackPointer;
-    }
-    case "unary": {
-      return typeIndexUnary;
-    }
-    case "binary": {
-      return typeIndexBinary;
-    }
-    case "polyRoots": {
-      return typeIndexPolyRoots;
-    }
-  }
-};
-
 const typeSection = (t: wasm.Target): void => {
-  t.int(numFuncTypes);
+  t.int(Object.keys(funcTypes).length);
 
-  // typeIndexGradient
-  const numGradientReturns = 1;
-  t.byte(wasm.TYPE.FUNCTION);
-  t.int(numGradientParams);
-  for (let i = 0; i < numGradientParams; i++) t.byte(wasm.TYPE.i32);
-  t.int(numGradientReturns);
-  t.byte(wasm.TYPE.f64);
-
-  // typeIndexAddToStackPointer
-  const numAddToStackPointerParams = 1;
-  const numAddToStackPointerReturns = 1;
-  t.byte(wasm.TYPE.FUNCTION);
-  t.int(numAddToStackPointerParams);
-  t.byte(wasm.TYPE.i32);
-  t.int(numAddToStackPointerReturns);
-  t.byte(wasm.TYPE.i32);
-
-  // typeIndexUnary
-  const numUnaryParams = 1;
-  const numUnaryReturns = 1;
-  t.byte(wasm.TYPE.FUNCTION);
-  t.int(numUnaryParams);
-  t.byte(wasm.TYPE.f64);
-  t.int(numUnaryReturns);
-  t.byte(wasm.TYPE.f64);
-
-  // typeIndexBinary
-  const numBinaryParams = 2;
-  const numBinaryReturns = 1;
-  t.byte(wasm.TYPE.FUNCTION);
-  t.int(numBinaryParams);
-  t.byte(wasm.TYPE.f64);
-  t.byte(wasm.TYPE.f64);
-  t.int(numBinaryReturns);
-  t.byte(wasm.TYPE.f64);
-
-  // typeIndexPolyRoots
-  const numPolyRootsParams = 2;
-  const numPolyRootsReturns = 0;
-  t.byte(wasm.TYPE.FUNCTION);
-  t.int(numPolyRootsParams);
-  t.byte(wasm.TYPE.i32);
-  t.byte(wasm.TYPE.i32);
-  t.int(numPolyRootsReturns);
+  for (const { param, result } of Object.values(funcTypes)) {
+    t.byte(wasm.TYPE.FUNCTION);
+    t.int(Object.keys(param).length);
+    for (const typ of Object.values(param)) t.byte(typ);
+    t.int(result.length);
+    for (const typ of result) t.byte(typ);
+  }
 };
 
 const importSection = (t: wasm.Target): void => {
@@ -990,20 +970,21 @@ const importSection = (t: wasm.Target): void => {
     t.ascii(importModule);
     t.ascii(i.toString(36));
     t.byte(wasm.IMPORT.FUNCTION);
-    t.int(builtinTypeIndex(kind));
+    t.int(getTypeIndex(kind));
   });
 };
 
-const functionSection = (t: wasm.Target, numFunctions: number): void => {
-  t.int(numFunctions);
-  for (let i = 0; i < numFunctions; i++) t.int(typeIndexGradient);
+const functionSection = (t: wasm.Target, numAddends: number): void => {
+  t.int(numAddends + 1);
+  for (let i = 0; i < numAddends; i++) t.int(getTypeIndex("addend"));
+  t.int(getTypeIndex("sum"));
 };
 
-const exportSection = (t: wasm.Target, numFunctions: number): void => {
+const exportSection = (t: wasm.Target, numAddends: number): void => {
   const numExports = 1;
   t.int(numExports);
 
-  const funcIndex = builtins.size + numFunctions - 1;
+  const funcIndex = builtins.size + numAddends;
   t.ascii(exportFunctionName);
   t.byte(wasm.EXPORT.FUNCTION);
   t.int(funcIndex);
@@ -1011,7 +992,7 @@ const exportSection = (t: wasm.Target, numFunctions: number): void => {
 
 const modulePrefix = (gradientFunctionSizes: number[]): wasm.Module => {
   const numSections = 5;
-  const numFunctions = gradientFunctionSizes.length;
+  const numAddends = gradientFunctionSizes.length - 1;
 
   const typeSectionCount = new wasm.Count();
   typeSection(typeSectionCount);
@@ -1022,16 +1003,16 @@ const modulePrefix = (gradientFunctionSizes: number[]): wasm.Module => {
   const importSectionSize = importSectionCount.size;
 
   const functionSectionCount = new wasm.Count();
-  functionSection(functionSectionCount, numFunctions);
+  functionSection(functionSectionCount, numAddends);
   const functionSectionSize = functionSectionCount.size;
 
   const exportSectionCount = new wasm.Count();
-  exportSection(exportSectionCount, numFunctions);
+  exportSection(exportSectionCount, numAddends);
   const exportSectionSize = exportSectionCount.size;
 
   const codeSectionSize = gradientFunctionSizes
     .map((n) => wasm.intSize(n) + n)
-    .reduce((a, b) => a + b, wasm.intSize(numFunctions));
+    .reduce((a, b) => a + b, wasm.intSize(gradientFunctionSizes.length));
 
   const sumSectionSizes =
     numSections +
@@ -1058,15 +1039,15 @@ const modulePrefix = (gradientFunctionSizes: number[]): wasm.Module => {
 
   mod.byte(wasm.SECTION.FUNCTION);
   mod.int(functionSectionSize);
-  functionSection(mod, numFunctions);
+  functionSection(mod, numAddends);
 
   mod.byte(wasm.SECTION.EXPORT);
   mod.int(exportSectionSize);
-  exportSection(mod, numFunctions);
+  exportSection(mod, numAddends);
 
   mod.byte(wasm.SECTION.CODE);
   mod.int(codeSectionSize);
-  mod.int(numFunctions);
+  mod.int(gradientFunctionSizes.length);
 
   return mod;
 };
@@ -1328,11 +1309,11 @@ const compileNode = (
       t.int(getBuiltindex("__wbindgen_add_to_stack_pointer"));
 
       t.byte(wasm.OP.local.tee);
-      t.int(gradientLocalStackPointer);
+      t.int(getLocalIndex(funcTypes.addend, "stackPointer"));
 
       naryParams(preds).forEach((index, i) => {
         t.byte(wasm.OP.local.get);
-        t.int(gradientLocalStackPointer);
+        t.int(getLocalIndex(funcTypes.addend, "stackPointer"));
 
         t.byte(wasm.OP.local.get);
         t.int(index);
@@ -1350,7 +1331,7 @@ const compileNode = (
 
       for (let i = 0; i < node.degree; i++) {
         t.byte(wasm.OP.local.get);
-        t.int(gradientLocalStackPointer);
+        t.int(getLocalIndex(funcTypes.addend, "stackPointer"));
 
         t.byte(wasm.OP.f64.load);
         t.int(logAlignF64);
@@ -1415,10 +1396,12 @@ interface Locals {
   indices: Map<ad.Id, Local>;
 }
 
+const numAddendParams = Object.keys(funcTypes.addend.param).length;
+
 const getIndex = (locals: Locals, id: ad.Id): number => {
   const local = safe(locals.indices.get(id), "missing local");
   return (
-    numGradientParams +
+    numAddendParams +
     (local.typename === "i32" ? 0 : locals.counts.i32) +
     local.index
   );
@@ -1428,7 +1411,7 @@ const compileGraph = (
   t: wasm.Target,
   { graph, gradient, primary, secondary }: ad.Graph
 ): void => {
-  const counts = { i32: 1, f64: 0 }; // `gradientLocalStackPointer`
+  const counts = { i32: 1, f64: 0 }; // `stackPointer`
   const indices = new Map<ad.Id, Local>();
   for (const id of graph.nodes()) {
     const node = graph.node(id);
@@ -1451,7 +1434,7 @@ const compileGraph = (
     label: { key },
   } of getInputs(graph)) {
     t.byte(wasm.OP.local.get);
-    t.int(gradientParamInput);
+    t.int(getParamIndex(funcTypes.addend, "input"));
 
     t.byte(wasm.OP.f64.load);
     t.int(logAlignF64);
@@ -1481,10 +1464,10 @@ const compileGraph = (
 
   gradient.forEach((id, i) => {
     t.byte(wasm.OP.local.get);
-    t.int(gradientParamGradient);
+    t.int(getParamIndex(funcTypes.addend, "gradient"));
 
     t.byte(wasm.OP.local.get);
-    t.int(gradientParamGradient);
+    t.int(getParamIndex(funcTypes.addend, "gradient"));
 
     t.byte(wasm.OP.f64.load);
     t.int(logAlignF64);
@@ -1502,7 +1485,7 @@ const compileGraph = (
 
   secondary.forEach((id, i) => {
     t.byte(wasm.OP.local.get);
-    t.int(gradientParamSecondary);
+    t.int(getParamIndex(funcTypes.addend, "secondary"));
 
     t.byte(wasm.OP.local.get);
     t.int(getIndex(locals, id));
@@ -1529,19 +1512,23 @@ const compileSum = (t: wasm.Target, numAddends: number): void => {
 
   for (let i = 0; i < numAddends; i++) {
     t.byte(wasm.OP.local.get);
-    t.int(gradientParamMask);
+    t.int(getParamIndex(funcTypes.sum, "mask"));
 
     t.byte(wasm.OP.i32.load);
     t.int(logAlignI32);
     t.int(i * bytesI32);
 
     t.byte(wasm.OP.if);
-    t.int(typeIndexUnary);
+    t.int(getTypeIndex("unary"));
 
-    for (let j = 0; j < numGradientParams; j++) {
-      t.byte(wasm.OP.local.get);
-      t.int(j);
-    }
+    t.byte(wasm.OP.local.get);
+    t.int(getParamIndex(funcTypes.sum, "input"));
+
+    t.byte(wasm.OP.local.get);
+    t.int(getParamIndex(funcTypes.sum, "gradient"));
+
+    t.byte(wasm.OP.local.get);
+    t.int(getParamIndex(funcTypes.sum, "secondary"));
 
     t.byte(wasm.OP.call);
     t.int(builtins.size + i);

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -47,10 +47,10 @@ export const resample = (state: State): State => {
     ),
     params: {
       ...state.params,
+      gradMask: state.inputs.map((meta) => meta.tag === "Optimized"),
       weight: getInitConstraintWeight(),
       optStatus: "NewIter",
     },
-    frozenValues: [],
   };
 };
 
@@ -306,8 +306,8 @@ export const evalFns = (
       ...s.varyingValues,
       s.params.weight,
     ]);
-    lastObjEnergies = secondary.slice(0, s.params.numObjEngs);
-    lastConstrEnergies = secondary.slice(s.params.numObjEngs);
+    lastObjEnergies = secondary.slice(0, s.params.objMask.length);
+    lastConstrEnergies = secondary.slice(s.params.objMask.length);
   }
   return {
     constrEngs: new Map(

--- a/packages/core/src/renderer/dragUtils.ts
+++ b/packages/core/src/renderer/dragUtils.ts
@@ -12,21 +12,22 @@ export const dragUpdate = (
   dy: number
 ): State => {
   const xs = [...state.varyingValues];
-  const frozenValues = [];
+  const gradMask = state.inputs.map((meta) => meta.tag === "Optimized");
   for (const shape of state.shapes) {
     if (shape.properties.name.contents === id) {
-      const ids = dragShape(shape, [dx, dy], xs);
-      frozenValues.push(...ids);
+      for (const id of dragShape(shape, [dx, dy], xs)) {
+        gradMask[id] = false;
+      }
     }
   }
   const updated: State = {
     ...state,
     params: {
       ...state.params,
+      gradMask,
       optStatus: "NewIter",
     },
     varyingValues: xs,
-    frozenValues,
   };
   return updated;
 };

--- a/packages/core/src/utils/Wasm.ts
+++ b/packages/core/src/utils/Wasm.ts
@@ -25,6 +25,7 @@ export const LIMITS = { NO_MAXIMUM: 0x00 };
 
 /** Instruction opcodes. */
 export const OP = {
+  if: 0x04,
   call: 0x10,
   drop: 0x1a,
   select: 0x1b,
@@ -52,7 +53,7 @@ export const OP = {
     min: 0xa4,
     max: 0xa5,
   },
-  i32: { const: 0x41, eqz: 0x45, add: 0x6a, and: 0x71, or: 0x72 },
+  i32: { load: 0x28, const: 0x41, eqz: 0x45, add: 0x6a, and: 0x71, or: 0x72 },
   local: { get: 0x20, set: 0x21, tee: 0x22 },
 };
 

--- a/packages/optimizer/source.ts
+++ b/packages/optimizer/source.ts
@@ -1,4 +1,3 @@
-import { InputKind } from "./bindings/InputKind";
 import { LbfgsParams } from "./bindings/LbfgsParams";
 import { OptState } from "./bindings/OptState";
 import { OptStatus } from "./bindings/OptStatus";
@@ -33,6 +32,8 @@ const getOptimizer = () => {
     throw Error("optimizer not initialized");
   return { optimizer: maybeOptimizer, index: maybeIndex };
 };
+
+const bools = (a: boolean[]) => new Int32Array(a.map((x) => (x ? 1 : 0)));
 
 /**
  * The module name of every import in a module used to construct a `Gradient`.
@@ -157,29 +158,38 @@ const makeImports = () => {
  *   - `"polyRoots"` takes two `i32`s and returns nothing.
  *
  * - The module must export a function whose name matches `exportFunctionName`,
- *   which takes three `i32`s and returns one `f64`.
+ *   which takes four `i32`s and returns one `f64`.
  */
 export class Gradient {
   private f: WebAssembly.ExportValue;
+  private numAddends: number;
   private numSecondary: number;
 
-  private constructor(instance: WebAssembly.Exports, numSecondary: number) {
+  private constructor(
+    instance: WebAssembly.Exports,
+    numAddends: number,
+    numSecondary: number
+  ) {
     this.f = instance[exportFunctionName];
+    this.numAddends = numAddends;
     this.numSecondary = numSecondary;
   }
 
   /**
    * `ready` must be resolved first.
    * @param mod a compiled Wasm module following the conventions of this class
+   * @param numSecondary the number of addends for primary output and gradient
    * @param numSecondary the number of secondary outputs
    * @returns a usable `Gradient` object initialized with all necessary builtins
    */
   static async make(
     mod: WebAssembly.Module,
+    numAddends: number,
     numSecondary: number
   ): Promise<Gradient> {
     return new Gradient(
       (await WebAssembly.instantiate(mod, makeImports())).exports,
+      numAddends,
       numSecondary
     );
   }
@@ -187,9 +197,14 @@ export class Gradient {
   /**
    * Synchronous version of `make`; everything from its docstring applies here.
    */
-  static makeSync(mod: WebAssembly.Module, numSecondary: number): Gradient {
+  static makeSync(
+    mod: WebAssembly.Module,
+    numAddends: number,
+    numSecondary: number
+  ): Gradient {
     return new Gradient(
       new WebAssembly.Instance(mod, makeImports()).exports,
+      numAddends,
       numSecondary
     );
   }
@@ -201,16 +216,21 @@ export class Gradient {
 
   /**
    * @param inputs to the function
+   * @param mask which addends to include
    * @returns the `primary` output, its `gradient`, and any `secondary` outputs
    */
-  call(inputs: number[]): Outputs<number> {
+  call(inputs: number[], mask?: boolean[]): Outputs<number> {
     const { index } = getOptimizer();
+    const maskNums = new Int32Array(this.numAddends);
+    for (let i = 0; i < this.numAddends; i++)
+      maskNums[i] = mask !== undefined && i in mask && !mask[i] ? 0 : 1;
     const gradient = new Float64Array(inputs.length);
     const secondary = new Float64Array(this.numSecondary);
     this.link();
     const primary = penrose_call(
       index,
       new Float64Array(inputs),
+      maskNums,
       gradient,
       secondary
     );
@@ -244,18 +264,22 @@ export const getInitConstraintWeight = () => {
 
 /**
  * `ready` must be resolved first.
- * @param inputKinds whether each varying value index should be optimized
- * @param numObjEngs the number of objectives in this optimization problem
- * @param numConstrEngs the number of constraints in this optimization problem
+ * @param gradMask whether each varying value index should be optimized
+ * @param objMask whether each objective should be optimized
+ * @param constrMask whether each constraint should be optimized
  * @returns initial optimization parameters
  */
 export const genOptProblem = (
-  inputKinds: InputKind[],
-  numObjEngs: number,
-  numConstrEngs: number
+  gradMask: boolean[],
+  objMask: boolean[],
+  constrMask: boolean[]
 ): Params => {
   getOptimizer();
-  return penrose_gen_opt_problem(inputKinds, numObjEngs, numConstrEngs);
+  return penrose_gen_opt_problem(
+    bools(gradMask),
+    bools(objMask),
+    bools(constrMask)
+  );
 };
 
-export type { InputKind, LbfgsParams, OptState, OptStatus, Params };
+export type { LbfgsParams, OptState, OptStatus, Params };

--- a/packages/optimizer/src/lib.rs
+++ b/packages/optimizer/src/lib.rs
@@ -2,25 +2,20 @@ pub mod builtins;
 
 use log::Level;
 use serde::{Deserialize, Serialize};
-use std::collections::HashSet;
 use ts_rs::TS;
 use wasm_bindgen::{prelude::wasm_bindgen, JsValue};
+
+type Bool = i32; // 0 or 1 (`wasm-bindgen` doesn't support `bool` well)
 
 type Vector = nalgebra::DVector<f64>;
 type Matrix = nalgebra::DMatrix<f64>;
 
-type Compiled = fn(inputs: *const f64, gradient: *mut f64, secondary: *mut f64) -> f64;
+type Compiled =
+    fn(inputs: *const f64, mask: *const Bool, gradient: *mut f64, secondary: *mut f64) -> f64;
 
 // the ts-rs crate defines a `TS` trait and `ts` macro which generate Rust tests that, when run,
 // generate TypeScript definitions in the `bindings/` directory of this package; that's why the
 // `build-decls` script for this package is `cargo test`
-
-#[derive(Clone, Deserialize, PartialEq, Serialize, TS)]
-#[ts(export)]
-enum InputKind {
-    Optimized,
-    Unoptimized,
-}
 
 #[derive(Clone, Deserialize, Serialize, TS)]
 #[ts(export)]
@@ -63,12 +58,12 @@ struct FnEvaled {
 #[derive(Clone, Deserialize, Serialize, TS)]
 #[ts(export)]
 struct Params {
-    #[serde(rename = "inputKinds")]
-    input_kinds: Vec<InputKind>,
-    #[serde(rename = "numObjEngs")]
-    num_obj_engs: usize,
-    #[serde(rename = "numConstrEngs")]
-    num_constr_engs: usize,
+    #[serde(rename = "gradMask")]
+    grad_mask: Vec<bool>,
+    #[serde(rename = "objMask")]
+    obj_mask: Vec<bool>,
+    #[serde(rename = "constrMask")]
+    constr_mask: Vec<bool>,
 
     #[serde(rename = "optStatus")]
     opt_status: OptStatus,
@@ -108,11 +103,10 @@ struct Params {
 // Just the compiled function and its grad, with no weights for EP/constraints/penalties, etc.
 #[derive(Clone)]
 struct FnCached<'a> {
-    inputs: &'a [InputKind], // same length as `varyingValues`
-    frozen_values: &'a HashSet<usize>,
-    num_obj_engs: usize,
-    num_constr_engs: usize,
     f: Compiled,
+    grad_mask: &'a [bool],
+    obj_mask: &'a [bool],
+    constr_mask: &'a [bool],
 }
 
 #[derive(Deserialize, Serialize, TS)]
@@ -121,10 +115,6 @@ struct OptState {
     #[serde(rename = "varyingValues")]
     varying_values: Vec<f64>,
     params: Params,
-    /// A set of indices of `varyingValues` that are treated as constant during optimization.
-    /// Currently used for the drag interaction.
-    #[serde(rename = "frozenValues")]
-    frozen_values: HashSet<usize>,
 }
 
 // Returned after a call to `minimize`
@@ -181,6 +171,10 @@ const DEBUG_LINE_SEARCH: bool = false;
 
 ////////////////////////////////////////////////////////////////////////////////
 
+fn bools(v: Vec<Bool>) -> Vec<bool> {
+    v.into_iter().map(|n| n > 0).collect()
+}
+
 fn norm_list(xs: &[f64]) -> f64 {
     let sum_squares: f64 = xs.iter().map(|e| e * e).sum();
     sum_squares.sqrt()
@@ -216,33 +210,38 @@ fn unconstrained_converged(norm_grad: f64) -> bool {
 fn objective_and_gradient(f: FnCached, weight: f64, xs: &[f64]) -> FnEvaled {
     let len_inputs = xs.len();
     let len_gradient = len_inputs + 1;
-    let len_secondary = f.num_obj_engs + f.num_constr_engs;
+    let len_secondary = f.obj_mask.len() + f.constr_mask.len();
 
     let mut inputs = vec![0.; len_gradient];
     inputs[..len_inputs].copy_from_slice(xs);
     inputs[len_inputs] = weight;
+    let mask: Vec<i32> = f
+        .obj_mask
+        .iter()
+        .chain(f.constr_mask)
+        .map(|&b| if b { 1 } else { 0 })
+        .collect();
     let mut gradient = vec![0.; len_gradient];
     let mut secondary = vec![0.; len_secondary];
 
     let energy = (f.f)(
         inputs.as_ptr(),
+        mask.as_ptr(),
         gradient.as_mut_ptr(),
         secondary.as_mut_ptr(),
     );
 
     gradient.pop();
-    for i in 0..len_inputs {
-        let kind = &f.inputs[i];
-        if *kind != InputKind::Optimized || f.frozen_values.contains(&i) {
-            gradient[i] = 0.;
-        }
-    }
 
     FnEvaled {
         f: energy,
-        gradf: gradient,
-        obj_engs: secondary[..f.num_obj_engs].to_vec(),
-        constr_engs: secondary[f.num_obj_engs..].to_vec(),
+        gradf: gradient
+            .into_iter()
+            .zip(f.grad_mask)
+            .map(|(x, &b)| if b { x } else { 0. })
+            .collect(),
+        obj_engs: secondary[..f.obj_mask.len()].to_vec(),
+        constr_engs: secondary[f.obj_mask.len()..].to_vec(),
     }
 }
 
@@ -300,11 +299,10 @@ fn step(state: OptState, f: Compiled, steps: i32) -> OptState {
             let res = minimize(
                 &xs,
                 FnCached {
-                    inputs: &state.params.input_kinds,
-                    frozen_values: &state.frozen_values,
-                    num_obj_engs: state.params.num_obj_engs,
-                    num_constr_engs: state.params.num_constr_engs,
                     f,
+                    grad_mask: &state.params.grad_mask,
+                    obj_mask: &state.params.obj_mask,
+                    constr_mask: &state.params.constr_mask,
                 },
                 state.params.weight,
                 state.params.lbfgs_info,
@@ -873,17 +871,13 @@ fn minimize(
     };
 }
 
-fn gen_opt_problem(
-    input_kinds: Vec<InputKind>,
-    num_obj_engs: usize,
-    num_constr_engs: usize,
-) -> Params {
-    let last_gradient = vec![0.; input_kinds.len()];
-    let last_gradient_preconditioned = vec![0.; input_kinds.len()];
+fn gen_opt_problem(grad_mask: Vec<bool>, obj_mask: Vec<bool>, constr_mask: Vec<bool>) -> Params {
+    let last_gradient = vec![0.; grad_mask.len()];
+    let last_gradient_preconditioned = vec![0.; grad_mask.len()];
     Params {
-        input_kinds,
-        num_obj_engs,
-        num_constr_engs,
+        grad_mask,
+        obj_mask,
+        constr_mask,
 
         last_gradient,
         last_gradient_preconditioned,
@@ -924,10 +918,17 @@ pub fn penrose_init() {
 }
 
 #[wasm_bindgen]
-pub fn penrose_call(p: usize, inputs: &[f64], gradient: &mut [f64], secondary: &mut [f64]) -> f64 {
+pub fn penrose_call(
+    p: usize,
+    inputs: &[f64],
+    mask: &[Bool],
+    gradient: &mut [f64],
+    secondary: &mut [f64],
+) -> f64 {
     let f = unsafe { std::mem::transmute::<usize, Compiled>(p) };
     f(
         inputs.as_ptr(),
+        mask.as_ptr(),
         gradient.as_mut_ptr(),
         secondary.as_mut_ptr(),
     )
@@ -941,12 +942,11 @@ pub fn penrose_get_init_constraint_weight() -> f64 {
 
 #[wasm_bindgen]
 pub fn penrose_gen_opt_problem(
-    inputs: JsValue,
-    num_obj_engs: usize,
-    num_constr_engs: usize,
+    grad_mask: Vec<Bool>,
+    obj_mask: Vec<Bool>,
+    constr_mask: Vec<Bool>,
 ) -> JsValue {
-    let input_kinds: Vec<InputKind> = serde_wasm_bindgen::from_value(inputs).unwrap();
-    let params: Params = gen_opt_problem(input_kinds, num_obj_engs, num_constr_engs);
+    let params: Params = gen_opt_problem(bools(grad_mask), bools(obj_mask), bools(constr_mask));
     to_js_value(&params).unwrap()
 }
 


### PR DESCRIPTION
# Description

Prerequisite for #1115. This PR replaces our current heterogeneous system of `frozenValues`, `inputKinds`, `numObjEngs`, and `numConstrEngs` with a more homogeneous system of three masks: `gradMask`, `objMask`, and `constrMask`, each of which is a `boolean[]`. The codegen is also modified to generate an extra parameter as a mask for its addend subgraphs.

# Checklist

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new ESLint warnings
- [x] I have reviewed any generated registry diagram changes