### PR TITLE
feat: put the demo in the VitePress site

### DIFF
--- a/packages/components/src/Demo.tsx
+++ b/packages/components/src/Demo.tsx
@@ -8,8 +8,7 @@ const Demo = (props: {
     dsl: string;
     variation: string;
   }[];
-  width: string; // the width of each half; total width is twice this
-  // height must be equal to width (including in the passed Style canvas!)
+  width: string;
   darkMode: boolean;
 }) => {
   const [index, setIndex] = useState(0);
@@ -25,14 +24,16 @@ const Demo = (props: {
   const example = props.examples[index];
 
   return (
-    <Simple
-      substance={example.sub}
-      style={example.sty}
-      domain={example.dsl}
-      variation={example.variation}
-      interactive={false}
-      animate={true}
-    />
+    <div style={{ width: props.width, height: props.width }}>
+      <Simple
+        substance={example.sub}
+        style={example.sty}
+        domain={example.dsl}
+        variation={example.variation}
+        interactive={false}
+        animate={true}
+      />
+    </div>
   );
 };
 

--- a/packages/components/src/Demo.tsx
+++ b/packages/components/src/Demo.tsx
@@ -1,5 +1,4 @@
 import { useEffect, useState } from "react";
-import Listing from "./Listing";
 import { Simple } from "./Simple";
 
 const Demo = (props: {
@@ -26,35 +25,14 @@ const Demo = (props: {
   const example = props.examples[index];
 
   return (
-    <div
-      style={{
-        display: "flex",
-        flexDirection: "row",
-        height: "100%",
-        flexWrap: "wrap",
-      }}
-    >
-      <Listing
-        domain={example.dsl}
-        substance={example.sub}
-        width={props.width}
-        height={props.width}
-        monacoOptions={{
-          theme: props.darkMode ? "vs-dark" : "vs",
-          wrappingIndent: "indent",
-        }}
-      />
-      <div style={{ width: props.width, height: props.width }}>
-        <Simple
-          substance={example.sub}
-          style={example.sty}
-          domain={example.dsl}
-          variation={example.variation}
-          interactive={false}
-          animate={true}
-        />
-      </div>
-    </div>
+    <Simple
+      substance={example.sub}
+      style={example.sty}
+      domain={example.dsl}
+      variation={example.variation}
+      interactive={false}
+      animate={true}
+    />
   );
 };
 

--- a/packages/docs-site/.vitepress/theme/index.ts
+++ b/packages/docs-site/.vitepress/theme/index.ts
@@ -1,4 +1,5 @@
 import DefaultTheme from "vitepress/theme";
+import Layout from "../../src/components/Layout.vue";
 import "./custom.css";
 
-export default DefaultTheme;
+export default { ...DefaultTheme, Layout };

--- a/packages/docs-site/index.md
+++ b/packages/docs-site/index.md
@@ -4,9 +4,6 @@ hero:
   name: Penrose
   text: Create beautiful diagrams
   tagline: just by typing math notation in plain text.
-  image:
-    src: /img/logo.svg
-    alt: Penrose
   actions:
     - theme: brand
       text: Tutorial
@@ -27,9 +24,3 @@ features:
   - title: WIP
     details: "Penrose is an early-stage system that is actively in development. Feel free to get in touch: penrose-team@cs.cmu.edu"
 ---
-
-<script setup>
-import DemoWrapper from "./src/components/DemoWrapper.vue";
-</script>
-
-<DemoWrapper />

--- a/packages/docs-site/index.md
+++ b/packages/docs-site/index.md
@@ -27,3 +27,9 @@ features:
   - title: WIP
     details: "Penrose is an early-stage system that is actively in development. Feel free to get in touch: penrose-team@cs.cmu.edu"
 ---
+
+<script setup>
+import DemoWrapper from "./src/components/DemoWrapper.vue";
+</script>
+
+<DemoWrapper />

--- a/packages/docs-site/package.json
+++ b/packages/docs-site/package.json
@@ -46,6 +46,6 @@
     "@penrose/editor": "1.3.0",
     "markdown-it-katex": "^2.0.3",
     "shx": "^0.3.3",
-    "vitepress": "^1.0.0-alpha.33"
+    "vitepress": "^1.0.0-alpha.35"
   }
 }

--- a/packages/docs-site/package.json
+++ b/packages/docs-site/package.json
@@ -36,6 +36,11 @@
       }
     }
   },
+  "dependencies": {
+    "@penrose/components": "1.3.0",
+    "@penrose/examples": "1.3.0",
+    "veaury": "^2.3.11"
+  },
   "devDependencies": {
     "@penrose/automator": "1.3.0",
     "@penrose/editor": "1.3.0",

--- a/packages/docs-site/src/components/DemoWrapper.vue
+++ b/packages/docs-site/src/components/DemoWrapper.vue
@@ -1,0 +1,49 @@
+<script setup lang="ts">
+import { examples, registry } from "@penrose/examples";
+import { useData } from "vitepress";
+import { defineAsyncComponent } from "vue";
+
+const exampleFromURI = (uri) => {
+  let x = examples;
+  for (const part of uri.split("/")) {
+    x = x[part];
+  }
+  return x;
+};
+
+const findTrio = (sub, sty) => {
+  const matching = registry.trios.filter(
+    ({ substance, style }) => substance === sub && style === sty
+  );
+  if (matching.length !== 1) {
+    throw Error(`expected exactly one matching trio, got ${matching.length}`);
+  }
+  const [{ substance, style, domain, variation }] = matching;
+  return {
+    dsl: exampleFromURI(registry.domains[domain].URI),
+    sub: exampleFromURI(registry.substances[substance].URI),
+    sty: exampleFromURI(registry.styles[style].URI),
+    variation,
+  };
+};
+
+const demo = [
+  findTrio("siggraph-teaser", "euclidean-teaser"),
+  findTrio("continuousmap", "continuousmap"),
+  findTrio("tree", "venn"),
+  findTrio("lagrange-bases", "lagrange-bases"),
+];
+
+const Demo = defineAsyncComponent(async () => {
+  const { applyPureReactInVue } = await import("veaury");
+  window.global = window; // shim global for svg-flatten
+  const { Demo } = await import("@penrose/components");
+  return applyPureReactInVue(Demo);
+});
+
+const { isDark } = useData();
+</script>
+
+<template>
+  <Demo :examples="demo" width="400px" :darkMode="isDark" />
+</template>

--- a/packages/docs-site/src/components/DemoWrapper.vue
+++ b/packages/docs-site/src/components/DemoWrapper.vue
@@ -42,5 +42,8 @@ const Demo = defineAsyncComponent(async () => {
 </script>
 
 <template>
-  <Demo :examples="demo" width="400px" />
+  <div style="position: absolute; top: 50%; left: 50%; transform: translate(-50%, -50%); overflow: hidden;">
+    <!-- TODO: bad hardcoded width -->
+  <Demo :examples="demo" width="280px" />
+  </div>
 </template>

--- a/packages/docs-site/src/components/DemoWrapper.vue
+++ b/packages/docs-site/src/components/DemoWrapper.vue
@@ -28,9 +28,7 @@ const findTrio = (sub, sty) => {
 
 const demo = [
   findTrio("siggraph-teaser", "euclidean-teaser"),
-  findTrio("continuousmap", "continuousmap"),
   findTrio("tree", "venn"),
-  findTrio("lagrange-bases", "lagrange-bases"),
 ];
 
 const Demo = defineAsyncComponent(async () => {

--- a/packages/docs-site/src/components/DemoWrapper.vue
+++ b/packages/docs-site/src/components/DemoWrapper.vue
@@ -1,6 +1,5 @@
 <script setup lang="ts">
 import { examples, registry } from "@penrose/examples";
-import { useData } from "vitepress";
 import { defineAsyncComponent } from "vue";
 
 const exampleFromURI = (uri) => {
@@ -40,10 +39,8 @@ const Demo = defineAsyncComponent(async () => {
   const { Demo } = await import("@penrose/components");
   return applyPureReactInVue(Demo);
 });
-
-const { isDark } = useData();
 </script>
 
 <template>
-  <Demo :examples="demo" width="400px" :darkMode="isDark" />
+  <Demo :examples="demo" width="400px" />
 </template>

--- a/packages/docs-site/src/components/DemoWrapper.vue
+++ b/packages/docs-site/src/components/DemoWrapper.vue
@@ -42,8 +42,16 @@ const Demo = defineAsyncComponent(async () => {
 </script>
 
 <template>
-  <div style="position: absolute; top: 50%; left: 50%; transform: translate(-50%, -50%); overflow: hidden;">
+  <div
+    style="
+      position: absolute;
+      top: 50%;
+      left: 50%;
+      transform: translate(-50%, -50%);
+      overflow: hidden;
+    "
+  >
     <!-- TODO: bad hardcoded width -->
-  <Demo :examples="demo" width="280px" />
+    <Demo :examples="demo" width="280px" />
   </div>
 </template>

--- a/packages/docs-site/src/components/Layout.vue
+++ b/packages/docs-site/src/components/Layout.vue
@@ -1,0 +1,12 @@
+<script setup>
+import DefaultTheme from "vitepress/theme";
+import DemoWrapper from "./DemoWrapper.vue";
+
+const { Layout } = DefaultTheme;
+</script>
+
+<template>
+  <Layout>
+    <template #home-hero-image><DemoWrapper /></template>
+  </Layout>
+</template>

--- a/yarn.lock
+++ b/yarn.lock
@@ -19635,6 +19635,11 @@ vary@~1.1.2:
   resolved "https://registry.yarnpkg.com/vary/-/vary-1.1.2.tgz#2299f02c6ded30d4a5961b0b9f74524a18f634fc"
   integrity sha1-IpnwLG3tMNSllhsLn3RSShj2NPw=
 
+veaury@^2.3.11:
+  version "2.3.11"
+  resolved "https://registry.yarnpkg.com/veaury/-/veaury-2.3.11.tgz#53cf778fdf1ed9e35c3ea322c348eaee2b7dd7d7"
+  integrity sha512-Ok0tG8FmHbEqituLxRx0E4YnbcXUcEc4kIeWZv+sXKtD5RkmLoZLlU9EyViY4r43MF7cJDS9MGMMD5eISCUspA==
+
 vega-event-selector@~2.0.6:
   version "2.0.6"
   resolved "https://registry.yarnpkg.com/vega-event-selector/-/vega-event-selector-2.0.6.tgz#6beb00e066b78371dde1a0f40cb5e0bbaecfd8bc"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1713,27 +1713,27 @@
   resolved "https://registry.yarnpkg.com/@discoveryjs/json-ext/-/json-ext-0.5.6.tgz#d5e0706cf8c6acd8c6032f8d54070af261bbbb2f"
   integrity sha512-ws57AidsDvREKrZKYffXddNkyaF14iHNHm8VQnZH6t99E8gczjNN0GpvcGny0imC80yQ0tHz1xVUKk/KFQSUyA==
 
-"@docsearch/css@3.3.0", "@docsearch/css@^3.3.0":
-  version "3.3.0"
-  resolved "https://registry.yarnpkg.com/@docsearch/css/-/css-3.3.0.tgz#d698e48302d12240d7c2f7452ccb2d2239a8cd80"
-  integrity sha512-rODCdDtGyudLj+Va8b6w6Y85KE85bXRsps/R4Yjwt5vueXKXZQKYw0aA9knxLBT6a/bI/GMrAcmCR75KYOM6hg==
+"@docsearch/css@3.3.1", "@docsearch/css@^3.3.1":
+  version "3.3.1"
+  resolved "https://registry.yarnpkg.com/@docsearch/css/-/css-3.3.1.tgz#32041581bffb1a834072fd21ca66d1dd9f016098"
+  integrity sha512-nznHXeFHpAYjyaSNFNFpU+IJPjQA7AINM8ONjDx/Zx4O/pGAvqwgmcLNc7zR8qXRutqnzLo06yN63xFn36KFBw==
 
-"@docsearch/js@^3.3.0":
-  version "3.3.0"
-  resolved "https://registry.yarnpkg.com/@docsearch/js/-/js-3.3.0.tgz#c8f614b722cc8a6375e83f9c27557e9398d6a4d4"
-  integrity sha512-oFXWRPNvPxAzBhnFJ9UCFIYZiQNc3Yrv6912nZHw/UIGxsyzKpNRZgHq8HDk1niYmOSoLKtVFcxkccpQmYGFyg==
+"@docsearch/js@^3.3.1":
+  version "3.3.1"
+  resolved "https://registry.yarnpkg.com/@docsearch/js/-/js-3.3.1.tgz#61256bfb0cb17840e6259b9c86f409aa98f02438"
+  integrity sha512-BCVu7njUFJSUXDNvgK65xNYU1L7U3CKFJlawDXql17nQwfpBrNZHqp+eb8z9qu0SzauQKss9tsf/qwlFJ9BOGw==
   dependencies:
-    "@docsearch/react" "3.3.0"
+    "@docsearch/react" "3.3.1"
     preact "^10.0.0"
 
-"@docsearch/react@3.3.0":
-  version "3.3.0"
-  resolved "https://registry.yarnpkg.com/@docsearch/react/-/react-3.3.0.tgz#b8ac8e7f49b9bf2f96d34c24bc1cfd097ec0eead"
-  integrity sha512-fhS5adZkae2SSdMYEMVg6pxI5a/cE+tW16ki1V0/ur4Fdok3hBRkmN/H8VvlXnxzggkQIIRIVvYPn00JPjen3A==
+"@docsearch/react@3.3.1":
+  version "3.3.1"
+  resolved "https://registry.yarnpkg.com/@docsearch/react/-/react-3.3.1.tgz#47ce4a267a9daf1b5d913b979284b4f624088003"
+  integrity sha512-wdeQBODPkue6yVEEg4ntt+TiGJ6iXMBUNjBQJ0s1WVoc1OdcCnks/lkQ5LEfXETYR/q9QSbCCBnMjvnSoILaag==
   dependencies:
     "@algolia/autocomplete-core" "1.7.2"
     "@algolia/autocomplete-preset-algolia" "1.7.2"
-    "@docsearch/css" "3.3.0"
+    "@docsearch/css" "3.3.1"
     algoliasearch "^4.0.0"
 
 "@emotion/babel-plugin@^11.7.1":
@@ -5374,25 +5374,25 @@
   resolved "https://registry.yarnpkg.com/@vue/shared/-/shared-3.2.45.tgz#a3fffa7489eafff38d984e23d0236e230c818bc2"
   integrity sha512-Ewzq5Yhimg7pSztDV+RH1UDKBzmtqieXQlpTVm2AwraoRL/Rks96mvd8Vgi7Lj+h+TH8dv7mXD3FRZR3TUvbSg==
 
-"@vueuse/core@^9.8.2":
-  version "9.8.2"
-  resolved "https://registry.yarnpkg.com/@vueuse/core/-/core-9.8.2.tgz#a142281bb33368c74668a180a813c7c8d91f89d8"
-  integrity sha512-aWiCmcYIpPt7xjuqYiceODEMHchDYthrJ4AqI+FXPZrR23PZOqdiktbUVyQl2kGlR3H4i9UJ/uimQrwhz9UouQ==
+"@vueuse/core@^9.9.0":
+  version "9.10.0"
+  resolved "https://registry.yarnpkg.com/@vueuse/core/-/core-9.10.0.tgz#2ef6e55ca773c5b2db1e3f13b8292af96dd32214"
+  integrity sha512-CxMewME07qeuzuT/AOIQGv0EhhDoojniqU6pC3F8m5VC76L47UT18DcX88kWlP3I7d3qMJ4u/PD8iSRsy3bmNA==
   dependencies:
     "@types/web-bluetooth" "^0.0.16"
-    "@vueuse/metadata" "9.8.2"
-    "@vueuse/shared" "9.8.2"
+    "@vueuse/metadata" "9.10.0"
+    "@vueuse/shared" "9.10.0"
     vue-demi "*"
 
-"@vueuse/metadata@9.8.2":
-  version "9.8.2"
-  resolved "https://registry.yarnpkg.com/@vueuse/metadata/-/metadata-9.8.2.tgz#864905e351a88165717c66d35d4b59a84bed2ae1"
-  integrity sha512-N4E/BKS+9VsUeD4WLVRU1J2kCOLh+iikBcMtipFcTyL204132vDYHs27zLAVabJYGnhC0dIVGdhg9pbOZiY2TQ==
+"@vueuse/metadata@9.10.0":
+  version "9.10.0"
+  resolved "https://registry.yarnpkg.com/@vueuse/metadata/-/metadata-9.10.0.tgz#1a5eb94ca755bd8e666505f47da7d88969cffdc7"
+  integrity sha512-G5VZhgTCapzU9rv0Iq2HBrVOSGzOKb+OE668NxhXNcTjUjwYxULkEhAw70FtRLMZc+hxcFAzDZlKYA0xcwNMuw==
 
-"@vueuse/shared@9.8.2":
-  version "9.8.2"
-  resolved "https://registry.yarnpkg.com/@vueuse/shared/-/shared-9.8.2.tgz#fd05866e5626218c9b0758b0422c666676cc4559"
-  integrity sha512-ACjrPQzowd5dnabNJt9EoGVobco9/ENiA5qP53vjiuxndlJYuc/UegwhXC7KdQbPX4F45a50+45K3g1wNqOzmA==
+"@vueuse/shared@9.10.0":
+  version "9.10.0"
+  resolved "https://registry.yarnpkg.com/@vueuse/shared/-/shared-9.10.0.tgz#49874a0f9955d28689b3133de660367c63dbc030"
+  integrity sha512-vakHJ2ZRklAzqmcVBL38RS7BxdBA4+5poG9NsSyqJxrt9kz0zX3P5CXMy0Hm6LFbZXUgvKdqAS3pUH1zX/5qTQ==
   dependencies:
     vue-demi "*"
 
@@ -19769,10 +19769,10 @@ vite@^2.9.9:
   optionalDependencies:
     fsevents "~2.3.2"
 
-vite@^4.0.2:
-  version "4.0.3"
-  resolved "https://registry.yarnpkg.com/vite/-/vite-4.0.3.tgz#de27ad3f263a03ae9419cdc8bc07721eadcba8b9"
-  integrity sha512-HvuNv1RdE7deIfQb8mPk51UKjqptO/4RXZ5yXSAvurd5xOckwS/gg8h9Tky3uSbnjYTgUm0hVCet1cyhKd73ZA==
+vite@^4.0.4:
+  version "4.0.4"
+  resolved "https://registry.yarnpkg.com/vite/-/vite-4.0.4.tgz#4612ce0b47bbb233a887a54a4ae0c6e240a0da31"
+  integrity sha512-xevPU7M8FU0i/80DMR+YhgrzR5KS2ORy1B4xcX/cXLsvnUWvfHuqMmVU6N0YiJ4JWGRJJsLCgjEzKjG9/GKoSw==
   dependencies:
     esbuild "^0.16.3"
     postcss "^8.4.20"
@@ -19781,19 +19781,19 @@ vite@^4.0.2:
   optionalDependencies:
     fsevents "~2.3.2"
 
-vitepress@^1.0.0-alpha.33:
-  version "1.0.0-alpha.33"
-  resolved "https://registry.yarnpkg.com/vitepress/-/vitepress-1.0.0-alpha.33.tgz#5002ce435ad98b8e0c259e9df7770542bb3676c3"
-  integrity sha512-EhMDqWLllYr5mXqAz4GCQ1o/bu5umQ6C2d8voiSaTHMkYCxsGc31ETykflM6NOhGx6yccwXygrYIIeN1l6BUEA==
+vitepress@^1.0.0-alpha.35:
+  version "1.0.0-alpha.35"
+  resolved "https://registry.yarnpkg.com/vitepress/-/vitepress-1.0.0-alpha.35.tgz#5a92f0da5e68b6da2780b4350e216f9b0070bb59"
+  integrity sha512-tJQjJstq+Ryb4pKtlxV4tD8KhxId+DTbR1FRrtJBhA+Vv4nexFHra5M9EgK9jUmoMc3rkyNaw7P3Kkix0ArP1w==
   dependencies:
-    "@docsearch/css" "^3.3.0"
-    "@docsearch/js" "^3.3.0"
+    "@docsearch/css" "^3.3.1"
+    "@docsearch/js" "^3.3.1"
     "@vitejs/plugin-vue" "^4.0.0"
     "@vue/devtools-api" "^6.4.5"
-    "@vueuse/core" "^9.8.2"
+    "@vueuse/core" "^9.9.0"
     body-scroll-lock "4.0.0-beta.0"
     shiki "^0.12.1"
-    vite "^4.0.2"
+    vite "^4.0.4"
     vue "^3.2.45"
 
 vm-browserify@^1.0.1:


### PR DESCRIPTION
# Description

Following up on #1172, this PR replaces the big logo on our homepage with a live demo component like we had before.

# Checklist

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new ESLint warnings
- [x] I have reviewed any generated registry diagram changes

# Open questions

- The specific diagrams we use here could be improved. Most of them have too-small text and don't look great in dark mode. We can make them more presentable for the homepage in a followup.