### PR TITLE
fix: make website routing work

### DIFF
--- a/packages/docs-site/.vitepress/config.ts
+++ b/packages/docs-site/.vitepress/config.ts
@@ -95,7 +95,7 @@ export default defineConfig({
   description:
     "Create beautiful diagrams just by typing math notation in plain text.",
 
-  cleanUrls: "with-subfolders",
+  cleanUrls: "without-subfolders",
   ignoreDeadLinks: true,
   outDir: "build",
 


### PR DESCRIPTION
# Description

Currently if you refresh the page on the website, it adds a trailing slash to the URL and breaks subsequent routing. This PR fixes that by switching our [VitePress `cleanUrls` setting](https://vitepress.vuejs.org/config/app-configs#cleanurls-experimental) to [the one VitePress uses for its own website](https://github.com/vuejs/vitepress/blob/v1.0.0-alpha.33/docs/.vitepress/config.ts#L10).

# Checklist

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new ESLint warnings
- [x] I have reviewed any generated registry diagram changes