### PR TITLE
feat: run the optimizer natively

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -11,7 +11,7 @@
 /packages/core/src/renderer/not_found.json
 /packages/docs-site/public/try/
 /packages/docs-site/src/shapedefs.json
-/packages/optimizer/bindings/
+/packages/optimizer/core/bindings/
 /packages/optimizer/index.js
 /packages/optimizer/target/
 /packages/roger/oclif.manifest.json

--- a/packages/automator/index.tsx
+++ b/packages/automator/index.tsx
@@ -11,6 +11,8 @@ import {
   simpleContext,
   stepUntilConvergence,
 } from "@penrose/core";
+import { State } from "@penrose/core/build/dist/types/state";
+import { OptState } from "@penrose/optimizer";
 import chalk from "chalk";
 import convertHrtime from "convert-hrtime";
 import { randomBytes } from "crypto";
@@ -59,6 +61,11 @@ const nonZeroConstraints = (
 };
 
 const toMs = (hr: any) => hr[1] / 1000000;
+
+const optState = ({ varyingValues, params }: State): OptState => ({
+  varyingValues,
+  params,
+});
 
 // In an async context, communicate with the backend to compile and optimize the diagram
 const singleProcess = async (
@@ -215,6 +222,17 @@ const singleProcess = async (
       join(out, "output.svg"),
       prettier.format(canvas, { parser: "html" })
     );
+
+    fs.writeFileSync(
+      join(out, "optimized.json"),
+      JSON.stringify(optState(optimizedState), null, 2)
+    );
+    fs.writeFileSync(
+      join(out, "initial.json"),
+      JSON.stringify(optState(initialState), null, 2)
+    );
+
+    fs.writeFileSync(join(out, "gradient.wasm"), initialState.gradient.bytes);
 
     fs.writeFileSync(join(out, "substance.sub"), subIn);
     fs.writeFileSync(join(out, "style.sty"), styIn);

--- a/packages/core/src/engine/Autodiff.ts
+++ b/packages/core/src/engine/Autodiff.ts
@@ -1584,21 +1584,27 @@ const genBytes = (graphs: ad.Graph[]): Uint8Array => {
  * @param graphs an array of graphs to compile
  * @returns a compiled/instantiated WebAssembly function
  */
-export const genCode = async (...graphs: ad.Graph[]): Promise<Gradient> =>
-  await Gradient.make(
-    await WebAssembly.compile(genBytes(graphs)),
+export const genCode = async (...graphs: ad.Graph[]): Promise<Gradient> => {
+  const bytes = genBytes(graphs);
+  return await Gradient.make(
+    bytes,
+    await WebAssembly.compile(bytes),
     graphs.length,
     Math.max(0, ...graphs.map((g) => g.secondary.length))
   );
+};
 
 /**
  * Synchronous version of `genCode`. Should not be used in the browser because
  * this will fail if the generated module is larger than 4 kilobytes, but
  * currently is used in convex partitioning for convenience.
  */
-export const genCodeSync = (...graphs: ad.Graph[]): Gradient =>
-  Gradient.makeSync(
-    new WebAssembly.Module(genBytes(graphs)),
+export const genCodeSync = (...graphs: ad.Graph[]): Gradient => {
+  const bytes = genBytes(graphs);
+  return Gradient.makeSync(
+    bytes,
+    new WebAssembly.Module(bytes),
     graphs.length,
     Math.max(0, ...graphs.map((g) => g.secondary.length))
   );
+};

--- a/packages/optimizer/.gitignore
+++ b/packages/optimizer/.gitignore
@@ -1,4 +1,6 @@
-/bindings/
+/cargo-flamegraph.stacks
+/core/bindings/
+/flamegraph.svg
 /index.js
 /index.js.map
 /target/

--- a/packages/optimizer/Cargo.lock
+++ b/packages/optimizer/Cargo.lock
@@ -9,6 +9,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fe438c63458706e03479442743baae6c88256498e6431708f6dfc520a26515d3"
 
 [[package]]
+name = "addr2line"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a76fd60b23679b7d19bd066031410fb7e458ccc5e958eb5c325888ce4baedc97"
+dependencies = [
+ "gimli 0.27.0",
+]
+
+[[package]]
+name = "adler"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
+
+[[package]]
+name = "ahash"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fcb51a0695d8f838b1ee009b3fbf66bda078cd64590202a864a8f3e8c4315c47"
+dependencies = [
+ "getrandom",
+ "once_cell",
+ "version_check",
+]
+
+[[package]]
 name = "approx"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -24,16 +50,82 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
+name = "backtrace"
+version = "0.3.67"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "233d376d6d185f2a3093e58f283f60f880315b6c60075b01f36b3b85154564ca"
+dependencies = [
+ "addr2line",
+ "cc",
+ "cfg-if",
+ "libc",
+ "miniz_oxide",
+ "object",
+ "rustc-demangle",
+]
+
+[[package]]
+name = "bitflags"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
+
+[[package]]
 name = "bumpalo"
 version = "3.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "572f695136211188308f16ad2ca5c851a712c464060ae6974944458eb83880ba"
 
 [[package]]
+name = "byte-slice-cast"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3ac9f8b63eca6fd385229b3675f6cc0dc5c8a5c8a54a59d4f52ffd670d87b0c"
+
+[[package]]
+name = "bytecheck"
+version = "0.6.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d11cac2c12b5adc6570dad2ee1b87eff4955dac476fe12d81e5fdd352e52406f"
+dependencies = [
+ "bytecheck_derive",
+ "ptr_meta",
+]
+
+[[package]]
+name = "bytecheck_derive"
+version = "0.6.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13e576ebe98e605500b3c8041bb888e966653577172df6dd97398714eb30b9bf"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "bytemuck"
 version = "1.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2f5715e491b5a1598fc2bef5a606847b5dc1d48ea625bd3c02c00de8285591da"
+
+[[package]]
+name = "byteorder"
+version = "1.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610"
+
+[[package]]
+name = "bytes"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dfb24e866b15a1af2a1b663f10c6b6b8f397a84aadb828f12e5b289ec23a3a3c"
+
+[[package]]
+name = "cc"
+version = "1.0.78"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a20104e2335ce8a659d6dd92a51a767a0c062599c73b343fd152cb401e828c3d"
 
 [[package]]
 name = "cfg-if"
@@ -62,6 +154,298 @@ dependencies = [
 ]
 
 [[package]]
+name = "corosensei"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9847f90f32a50b0dcbd68bc23ff242798b13080b97b0569f6ed96a45ce4cf2cd"
+dependencies = [
+ "autocfg",
+ "cfg-if",
+ "libc",
+ "scopeguard",
+ "windows-sys",
+]
+
+[[package]]
+name = "cranelift-bforest"
+version = "0.86.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "529ffacce2249ac60edba2941672dfedf3d96558b415d0d8083cd007456e0f55"
+dependencies = [
+ "cranelift-entity",
+]
+
+[[package]]
+name = "cranelift-codegen"
+version = "0.86.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "427d105f617efc8cb55f8d036a7fded2e227892d8780b4985e5551f8d27c4a92"
+dependencies = [
+ "cranelift-bforest",
+ "cranelift-codegen-meta",
+ "cranelift-codegen-shared",
+ "cranelift-entity",
+ "cranelift-isle",
+ "gimli 0.26.2",
+ "log",
+ "regalloc2",
+ "smallvec",
+ "target-lexicon",
+]
+
+[[package]]
+name = "cranelift-codegen-meta"
+version = "0.86.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "551674bed85b838d45358e3eab4f0ffaa6790c70dc08184204b9a54b41cdb7d1"
+dependencies = [
+ "cranelift-codegen-shared",
+]
+
+[[package]]
+name = "cranelift-codegen-shared"
+version = "0.86.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b3a63ae57498c3eb495360944a33571754241e15e47e3bcae6082f40fec5866"
+
+[[package]]
+name = "cranelift-entity"
+version = "0.86.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11aa8aa624c72cc1c94ea3d0739fa61248260b5b14d3646f51593a88d67f3e6e"
+
+[[package]]
+name = "cranelift-frontend"
+version = "0.86.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "544ee8f4d1c9559c9aa6d46e7aaeac4a13856d620561094f35527356c7d21bd0"
+dependencies = [
+ "cranelift-codegen",
+ "log",
+ "smallvec",
+ "target-lexicon",
+]
+
+[[package]]
+name = "cranelift-isle"
+version = "0.86.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed16b14363d929b8c37e3c557d0a7396791b383ecc302141643c054343170aad"
+
+[[package]]
+name = "crossbeam-channel"
+version = "0.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2dd04ddaf88237dc3b8d8f9a3c1004b506b54b3313403944054d23c0870c521"
+dependencies = [
+ "cfg-if",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-deque"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "715e8152b692bba2d374b53d4875445368fdf21a94751410af607a5ac677d1fc"
+dependencies = [
+ "cfg-if",
+ "crossbeam-epoch",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.9.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "01a9af1f4c2ef74bb8aa1f7e19706bc72d03598c8a570bb5de72243c7a9d9d5a"
+dependencies = [
+ "autocfg",
+ "cfg-if",
+ "crossbeam-utils",
+ "memoffset 0.7.1",
+ "scopeguard",
+]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.8.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fb766fa798726286dbbb842f174001dab8abc7b627a1dd86e0b7222a95d929f"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
+name = "darling"
+version = "0.14.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0dd3cd20dc6b5a876612a6e5accfe7f3dd883db6d07acfbf14c128f61550dfa"
+dependencies = [
+ "darling_core",
+ "darling_macro",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.14.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a784d2ccaf7c98501746bf0be29b2022ba41fd62a2e622af997a03e9f972859f"
+dependencies = [
+ "fnv",
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.14.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7618812407e9402654622dd402b0a89dff9ba93badd6540781526117b92aab7e"
+dependencies = [
+ "darling_core",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "either"
+version = "1.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90e5c1c8368803113bf0c9584fc495a58b86dc8a29edbf8fe877d21d9507e797"
+
+[[package]]
+name = "enum-iterator"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4eeac5c5edb79e4e39fe8439ef35207780a11f69c52cbe424ce3dfad4cb78de6"
+dependencies = [
+ "enum-iterator-derive",
+]
+
+[[package]]
+name = "enum-iterator-derive"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c134c37760b27a871ba422106eedbb8247da973a09e82558bf26d619c882b159"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "enumset"
+version = "1.0.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19be8061a06ab6f3a6cf21106c873578bf01bd42ad15e0311a9c76161cb1c753"
+dependencies = [
+ "enumset_derive",
+]
+
+[[package]]
+name = "enumset_derive"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "03e7b551eba279bf0fa88b83a46330168c1560a52a94f5126f892f0b364ab3e0"
+dependencies = [
+ "darling",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "fallible-iterator"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4443176a9f2c162692bd3d352d745ef9413eec5782a80d8fd6f8a1ac692a07f7"
+
+[[package]]
+name = "fnv"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
+name = "fxhash"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c31b6d751ae2c7f11320402d34e41349dd1016f8d5d45e48c4312bc8625af50c"
+dependencies = [
+ "byteorder",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.2.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c05aeb6a22b8f62540c194aac980f2115af067bfe15a0734d7277a768d396b31"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "wasi",
+]
+
+[[package]]
+name = "gimli"
+version = "0.26.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22030e2c5a68ec659fde1e949a745124b48e6fa8b045b7ed5bd1fe4ccc5c4e5d"
+dependencies = [
+ "fallible-iterator",
+ "indexmap",
+ "stable_deref_trait",
+]
+
+[[package]]
+name = "gimli"
+version = "0.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dec7af912d60cdbd3677c1af9352ebae6fb8394d165568a2234df0fa00f87793"
+
+[[package]]
+name = "hashbrown"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
+dependencies = [
+ "ahash",
+]
+
+[[package]]
+name = "hermit-abi"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee512640fe35acbfb4bb779db6f0d80704c2cacfa2e39b601ef3e3f47d1ae4c7"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "ident_case"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
+
+[[package]]
+name = "indexmap"
+version = "1.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1885e79c1fc4b10f0e172c475f458b7f7b93061064d98c3293e98c5ba0c8b399"
+dependencies = [
+ "autocfg",
+ "hashbrown",
+]
+
+[[package]]
+name = "itoa"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fad582f4b9e86b6caa621cabeb0963332d92eea04729ab12892c2533951e6440"
+
+[[package]]
 name = "js-sys"
 version = "0.3.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -69,6 +453,24 @@ checksum = "49409df3e3bf0856b916e2ceaca09ee28e6871cf7d9ce97a692cacfdb2a25a47"
 dependencies = [
  "wasm-bindgen",
 ]
+
+[[package]]
+name = "lazy_static"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
+
+[[package]]
+name = "leb128"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "884e2677b40cc8c339eaefcb701c32ef1fd2493d71118dc0ca4b6a736c93bd67"
+
+[[package]]
+name = "libc"
+version = "0.2.139"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "201de327520df007757c1f0adce6e827fe8562fbc28bfd9c15571c66ca1f5f79"
 
 [[package]]
 name = "log"
@@ -80,6 +482,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "mach"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b823e83b2affd8f40a9ee8c29dbc56404c1e34cd2710921f2801e2cf29527afa"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "matrixmultiply"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -87,6 +498,54 @@ checksum = "add85d4dd35074e6fedc608f8c8f513a3548619a9024b751949ef0e8e45a4d84"
 dependencies = [
  "rawpointer",
 ]
+
+[[package]]
+name = "memchr"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2dffe52ecf27772e601905b7522cb4ef790d2cc203488bbd0e2fe85fcb74566d"
+
+[[package]]
+name = "memmap2"
+version = "0.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b182332558b18d807c4ce1ca8ca983b34c3ee32765e47b3f0f69b90355cc1dc"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "memoffset"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5aa361d4faea93603064a027415f07bd8e1d5c88c9fbf68bf56a285428fd79ce"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
+name = "memoffset"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5de893c32cde5f383baa4c04c5d6dbdd735cfd4a794b0debdb2bb1b421da5ff4"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
+name = "miniz_oxide"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b275950c28b37e794e8c55d88aeb5e139d0ce23fdbbeda68f8d7174abdf9e8fa"
+dependencies = [
+ "adler",
+]
+
+[[package]]
+name = "more-asserts"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7843ec2de400bcbc6a6328c958dc38e5359da6e93e72e37bc5246bf1ae776389"
 
 [[package]]
 name = "nalgebra"
@@ -155,6 +614,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "num_cpus"
+version = "1.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fac9e2da13b5eb447a6ce3d392f23a29d8694bff781bf03a16cd9ac8697593b"
+dependencies = [
+ "hermit-abi",
+ "libc",
+]
+
+[[package]]
+name = "object"
+version = "0.30.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "239da7f290cfa979f43f85a8efeee9a8a76d0827c356d37f9d3d7254d6b537fb"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "once_cell"
 version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -170,14 +648,63 @@ checksum = "b1de2e551fb905ac83f73f7aedf2f0cb4a0da7e35efa24a202a936269f1f18e1"
 name = "penrose-optimizer"
 version = "1.3.0"
 dependencies = [
- "console_error_panic_hook",
- "console_log",
  "log",
  "nalgebra",
  "serde",
- "serde-wasm-bindgen",
  "ts-rs",
+]
+
+[[package]]
+name = "penrose-optimizer-cli"
+version = "1.3.0"
+dependencies = [
+ "byte-slice-cast",
+ "penrose-optimizer",
+ "serde_json",
+ "wasmer",
+]
+
+[[package]]
+name = "penrose-optimizer-web"
+version = "1.3.0"
+dependencies = [
+ "console_error_panic_hook",
+ "console_log",
+ "log",
+ "penrose-optimizer",
+ "serde",
+ "serde-wasm-bindgen",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "pin-project-lite"
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0a7ae3ac2f1173085d398531c705756c94a4c56843785df85a60c1a0afac116"
+
+[[package]]
+name = "proc-macro-error"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c"
+dependencies = [
+ "proc-macro-error-attr",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "version_check",
+]
+
+[[package]]
+name = "proc-macro-error-attr"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "version_check",
 ]
 
 [[package]]
@@ -187,6 +714,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0a2ca2c61bc9f3d74d2886294ab7b9853abd9c1ad903a3ac7815c58989bb7bab"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "ptr_meta"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0738ccf7ea06b608c10564b31debd4f5bc5e197fc8bfe088f68ae5ce81e7a4f1"
+dependencies = [
+ "ptr_meta_derive",
+]
+
+[[package]]
+name = "ptr_meta_derive"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "16b845dbfca988fa33db069c0e230574d15a3088f147a87b64c7589eb662c9ac"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -205,6 +752,99 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "60a357793950651c4ed0f3f52338f53b2f809f32d83a07f72909fa13e4c6c1e3"
 
 [[package]]
+name = "rayon"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6db3a213adf02b3bcfd2d3846bb41cb22857d131789e01df434fb7e7bc0759b7"
+dependencies = [
+ "either",
+ "rayon-core",
+]
+
+[[package]]
+name = "rayon-core"
+version = "1.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cac410af5d00ab6884528b4ab69d1e8e146e8d471201800fa1b4524126de6ad3"
+dependencies = [
+ "crossbeam-channel",
+ "crossbeam-deque",
+ "crossbeam-utils",
+ "num_cpus",
+]
+
+[[package]]
+name = "regalloc2"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d43a209257d978ef079f3d446331d0f1794f5e0fc19b306a199983857833a779"
+dependencies = [
+ "fxhash",
+ "log",
+ "slice-group-by",
+ "smallvec",
+]
+
+[[package]]
+name = "region"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76e189c2369884dce920945e2ddf79b3dff49e071a167dd1817fa9c4c00d512e"
+dependencies = [
+ "bitflags",
+ "libc",
+ "mach",
+ "winapi",
+]
+
+[[package]]
+name = "rend"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "79af64b4b6362ffba04eef3a4e10829718a4896dac19daa741851c86781edf95"
+dependencies = [
+ "bytecheck",
+]
+
+[[package]]
+name = "rkyv"
+version = "0.7.39"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cec2b3485b07d96ddfd3134767b8a447b45ea4eb91448d0a35180ec0ffd5ed15"
+dependencies = [
+ "bytecheck",
+ "hashbrown",
+ "indexmap",
+ "ptr_meta",
+ "rend",
+ "rkyv_derive",
+ "seahash",
+]
+
+[[package]]
+name = "rkyv_derive"
+version = "0.7.39"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6eaedadc88b53e36dd32d940ed21ae4d850d5916f2581526921f553a72ac34c4"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "rustc-demangle"
+version = "0.1.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ef03e0a2b150c7a90d01faf6254c9c48a41e95fb2a8c2ac1c6f0d2b9aefc342"
+
+[[package]]
+name = "ryu"
+version = "1.0.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b4b9743ed687d4b4bcedf9ff5eaa7398495ae14e61cba0a295704edbc7decde"
+
+[[package]]
 name = "safe_arch"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -212,6 +852,18 @@ checksum = "794821e4ccb0d9f979512f9c1973480123f9bd62a90d74ab0f9426fcf8f4a529"
 dependencies = [
  "bytemuck",
 ]
+
+[[package]]
+name = "scopeguard"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
+
+[[package]]
+name = "seahash"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c107b6f4780854c8b126e228ea8869f4d7b71260f962fefb57b996b8959ba6b"
 
 [[package]]
 name = "serde"
@@ -245,6 +897,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_json"
+version = "1.0.91"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "877c235533714907a8c2464236f5c4b2a17262ef1bd71f38f35ea592c8da6883"
+dependencies = [
+ "itoa",
+ "ryu",
+ "serde",
+]
+
+[[package]]
 name = "simba"
 version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -258,6 +921,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "slice-group-by"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "03b634d87b960ab1a38c4fe143b508576f075e7c978bfad18217645ebfdfa2ec"
+
+[[package]]
+name = "smallvec"
+version = "1.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a507befe795404456341dfab10cef66ead4c041f62b8b11bbb92bffe5d0953e0"
+
+[[package]]
+name = "stable_deref_trait"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
+
+[[package]]
 name = "syn"
 version = "1.0.99"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -267,6 +948,12 @@ dependencies = [
  "quote",
  "unicode-ident",
 ]
+
+[[package]]
+name = "target-lexicon"
+version = "0.12.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9410d0f6853b1d94f0e519fb95df60f29d2c1eff2d921ffdf01a4c8a3b54f12d"
 
 [[package]]
 name = "termcolor"
@@ -295,6 +982,38 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "tracing"
+version = "0.1.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ce8c33a8d48bd45d624a6e523445fd21ec13d3653cd51f681abf67418f54eb8"
+dependencies = [
+ "cfg-if",
+ "pin-project-lite",
+ "tracing-attributes",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-attributes"
+version = "0.1.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4017f8f45139870ca7e672686113917c71c7a6e02d4924eda67186083c03081a"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "tracing-core"
+version = "0.1.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24eb03ba0eab1fd845050058ce5e616558e8f8d8fca633e6b163fe25c797213a"
+dependencies = [
+ "once_cell",
 ]
 
 [[package]]
@@ -333,6 +1052,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dcc811dc4066ac62f84f11307873c4850cb653bfa9b1719cee2bd2204a4bc5dd"
 
 [[package]]
+name = "unicode-width"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0edd1e5b14653f783770bce4a4dabb4a5108a5370a5f5d8cfe8710c361f6c8b"
+
+[[package]]
+name = "version_check"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
+
+[[package]]
+name = "wasi"
+version = "0.11.0+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
+
+[[package]]
 name = "wasm-bindgen"
 version = "0.2.83"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -355,6 +1092,29 @@ dependencies = [
  "quote",
  "syn",
  "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-downcast"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5dac026d43bcca6e7ce1c0956ba68f59edf6403e8e930a5d891be72c31a44340"
+dependencies = [
+ "js-sys",
+ "once_cell",
+ "wasm-bindgen",
+ "wasm-bindgen-downcast-macros",
+]
+
+[[package]]
+name = "wasm-bindgen-downcast-macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c5020cfa87c7cecefef118055d44e3c1fc122c7ec25701d528ee458a0b45f38f"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -385,6 +1145,162 @@ name = "wasm-bindgen-shared"
 version = "0.2.83"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1c38c045535d93ec4f0b4defec448e4291638ee608530863b1e2ba115d4fff7f"
+
+[[package]]
+name = "wasm-encoder"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05632e0a66a6ed8cca593c24223aabd6262f256c3693ad9822c315285f010614"
+dependencies = [
+ "leb128",
+]
+
+[[package]]
+name = "wasmer"
+version = "3.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "740f96c9e5d49f0056d716977657f3f7f8eea9923b41f46d1046946707aa038f"
+dependencies = [
+ "bytes",
+ "cfg-if",
+ "indexmap",
+ "js-sys",
+ "more-asserts",
+ "serde",
+ "serde-wasm-bindgen",
+ "target-lexicon",
+ "thiserror",
+ "wasm-bindgen",
+ "wasm-bindgen-downcast",
+ "wasmer-compiler",
+ "wasmer-compiler-cranelift",
+ "wasmer-derive",
+ "wasmer-types",
+ "wasmer-vm",
+ "wat",
+ "winapi",
+]
+
+[[package]]
+name = "wasmer-compiler"
+version = "3.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "001d072dd9823e5a06052621eadb531627b4a508d74b67da4590a3d5d9332dc8"
+dependencies = [
+ "backtrace",
+ "cfg-if",
+ "enum-iterator",
+ "enumset",
+ "lazy_static",
+ "leb128",
+ "memmap2",
+ "more-asserts",
+ "region",
+ "rustc-demangle",
+ "smallvec",
+ "thiserror",
+ "wasmer-types",
+ "wasmer-vm",
+ "wasmparser",
+ "winapi",
+]
+
+[[package]]
+name = "wasmer-compiler-cranelift"
+version = "3.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2974856a7ce40eb033efc9db3d480845385c27079b6e33ce51751f2f3c67e9bd"
+dependencies = [
+ "cranelift-codegen",
+ "cranelift-entity",
+ "cranelift-frontend",
+ "gimli 0.26.2",
+ "more-asserts",
+ "rayon",
+ "smallvec",
+ "target-lexicon",
+ "tracing",
+ "wasmer-compiler",
+ "wasmer-types",
+]
+
+[[package]]
+name = "wasmer-derive"
+version = "3.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "36b23b52272494369a1f96428f0056425a85a66154610c988d971bbace8230f1"
+dependencies = [
+ "proc-macro-error",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "wasmer-types"
+version = "3.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3bc6cd7a2d2d3bd901ff491f131188c1030694350685279e16e1233b9922846b"
+dependencies = [
+ "enum-iterator",
+ "enumset",
+ "indexmap",
+ "more-asserts",
+ "rkyv",
+ "target-lexicon",
+ "thiserror",
+]
+
+[[package]]
+name = "wasmer-vm"
+version = "3.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e67d0cd6c0ef4985d1ce9c7d7cccf34e910804417a230fa16ab7ee904efb4c34"
+dependencies = [
+ "backtrace",
+ "cc",
+ "cfg-if",
+ "corosensei",
+ "enum-iterator",
+ "indexmap",
+ "lazy_static",
+ "libc",
+ "mach",
+ "memoffset 0.6.5",
+ "more-asserts",
+ "region",
+ "scopeguard",
+ "thiserror",
+ "wasmer-types",
+ "winapi",
+]
+
+[[package]]
+name = "wasmparser"
+version = "0.83.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "718ed7c55c2add6548cca3ddd6383d738cd73b892df400e96b9aa876f0141d7a"
+
+[[package]]
+name = "wast"
+version = "50.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2cbb59d4ac799842791fe7e806fa5dbbf6b5554d538e51cc8e176db6ff0ae34"
+dependencies = [
+ "leb128",
+ "memchr",
+ "unicode-width",
+ "wasm-encoder",
+]
+
+[[package]]
+name = "wat"
+version = "1.0.52"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "584aaf7a1ecf4d383bbe1a25eeab0cbb8ff96acc6796707ff65cde48f4632f15"
+dependencies = [
+ "wast",
+]
 
 [[package]]
 name = "web-sys"
@@ -436,3 +1352,46 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "windows-sys"
+version = "0.33.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43dbb096663629518eb1dfa72d80243ca5a6aca764cae62a2df70af760a9be75"
+dependencies = [
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_msvc",
+]
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.33.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd761fd3eb9ab8cc1ed81e56e567f02dd82c4c837e48ac3b2181b9ffc5060807"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.33.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cab0cf703a96bab2dc0c02c0fa748491294bf9b7feb27e1f4f96340f208ada0e"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.33.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8cfdbe89cc9ad7ce618ba34abc34bbb6c36d99e96cae2245b7943cd75ee773d0"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.33.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4dd9b0c0e9ece7bb22e84d70d01b71c6d6248b81a3c60d11869451b4cb24784"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.33.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff1e4aa646495048ec7f3ffddc411e1d829c026a2ec62b39da15c1055e406eaa"

--- a/packages/optimizer/Cargo.toml
+++ b/packages/optimizer/Cargo.toml
@@ -1,18 +1,2 @@
-[package]
-name = "penrose-optimizer"
-version = "1.3.0"
-edition = "2021"
-publish = false
-
-[lib]
-crate-type = ["cdylib"]
-
-[dependencies]
-console_error_panic_hook = "0.1"
-console_log = "0.2"
-log = "0.4"
-nalgebra = "0.31"
-serde = { version = "1", features = ["derive"] }
-serde-wasm-bindgen = "0.4"
-ts-rs = "6"
-wasm-bindgen = "0.2"
+[workspace]
+members = ["cli", "core", "web"]

--- a/packages/optimizer/cli/Cargo.toml
+++ b/packages/optimizer/cli/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "penrose-optimizer-cli"
+version = "1.3.0"
+edition = "2021"
+publish = false
+
+[dependencies]
+byte-slice-cast = "1"
+penrose-optimizer = { path = "../core" }
+serde_json = "1"
+wasmer = "3"

--- a/packages/optimizer/cli/src/main.rs
+++ b/packages/optimizer/cli/src/main.rs
@@ -1,0 +1,140 @@
+use std::{
+    cell::RefCell,
+    env,
+    fs::{read_to_string, File},
+    io::Read,
+    path::Path,
+};
+
+use byte_slice_cast::{AsByteSlice, AsMutByteSlice};
+use penrose_optimizer::{inverse, sign, step, Bool, Compiled, OptState, OptStatus};
+use wasmer::{imports, Function, Instance, Memory, MemoryType, Module, Store, Value};
+
+struct FuncRef<'a> {
+    store: RefCell<Store>,
+    memory: Memory,
+    f: &'a Function,
+}
+
+impl<'a> Compiled for FuncRef<'a> {
+    fn call(
+        &self,
+        inputs: &[f64],
+        mask: &[Bool],
+        gradient: &mut [f64],
+        secondary: &mut [f64],
+    ) -> f64 {
+        let store: &mut Store = &mut self.store.borrow_mut();
+        let view = self.memory.view(store);
+
+        let mut offset = 0;
+        let mut alloc = |data| {
+            let p = offset;
+            view.write(p, data).unwrap();
+            offset += u64::try_from(data.len()).unwrap();
+            return p;
+        };
+
+        let offset_inputs = alloc(inputs.as_byte_slice());
+        let offset_mask = alloc(mask.as_byte_slice());
+        let offset_gradient = alloc(gradient.as_byte_slice());
+        let offset_secondary = offset;
+
+        let primary = self
+            .f
+            .call(
+                store,
+                &[
+                    Value::I32(i32::try_from(offset_inputs).unwrap()),
+                    Value::I32(i32::try_from(offset_mask).unwrap()),
+                    Value::I32(i32::try_from(offset_gradient).unwrap()),
+                    Value::I32(i32::try_from(offset_secondary).unwrap()),
+                ],
+            )
+            .unwrap();
+
+        view.read(offset_gradient, gradient.as_mut_byte_slice())
+            .unwrap();
+        view.read(offset_secondary, secondary.as_mut_byte_slice())
+            .unwrap();
+
+        primary[0].unwrap_f64()
+    }
+}
+
+fn my_add_to_stack_pointer(p: i32) -> i32 {
+    unimplemented!("__wbindgen_add_to_stack_pointer {p}")
+}
+
+fn my_poly_roots(p: i32, l: i32) {
+    unimplemented!("penrose_poly_roots {p} {l}")
+}
+
+fn main() {
+    let args: Vec<_> = env::args().collect();
+
+    let dirname = Path::new(&args[1]);
+
+    let mut bytes = vec![];
+    File::open(dirname.join("gradient.wasm"))
+        .unwrap()
+        .read_to_end(&mut bytes)
+        .unwrap();
+
+    let mut store = Store::default();
+    let module = Module::new(&store, bytes).unwrap();
+
+    let memory = Memory::new(&mut store, MemoryType::new(1, None, false)).unwrap();
+    let imp = imports! {
+        "" => {
+            "" => memory.clone(),
+
+            "0" => Function::new_typed(&mut store, my_add_to_stack_pointer),
+
+            "1" => Function::new_typed(&mut store, |x: f64| x.acos()),
+            "2" => Function::new_typed(&mut store, |x: f64| x.acosh()),
+            "3" => Function::new_typed(&mut store, |x: f64| x.asin()),
+            "4" => Function::new_typed(&mut store, |x: f64| x.asinh()),
+            "5" => Function::new_typed(&mut store, |x: f64| x.atan()),
+            "6" => Function::new_typed(&mut store, |x: f64| x.atanh()),
+            "7" => Function::new_typed(&mut store, |x: f64| x.cbrt()),
+            "8" => Function::new_typed(&mut store, |x: f64| x.cos()),
+            "9" => Function::new_typed(&mut store, |x: f64| x.cosh()),
+            "a" => Function::new_typed(&mut store, |x: f64| x.exp()),
+            "b" => Function::new_typed(&mut store, |x: f64| x.exp_m1()),
+            "c" => Function::new_typed(&mut store, |x: f64| x.ln()),
+            "d" => Function::new_typed(&mut store, |x: f64| x.ln_1p()),
+            "e" => Function::new_typed(&mut store, |x: f64| x.log10()),
+            "f" => Function::new_typed(&mut store, |x: f64| x.log2()),
+            "g" => Function::new_typed(&mut store, |x: f64| x.sin()),
+            "h" => Function::new_typed(&mut store, |x: f64| x.sinh()),
+            "i" => Function::new_typed(&mut store, |x: f64| x.tan()),
+            "j" => Function::new_typed(&mut store, |x: f64| x.tanh()),
+            "k" => Function::new_typed(&mut store, |x: f64| inverse(x)),
+            "l" => Function::new_typed(&mut store, |x: f64| sign(x)),
+
+            "m" => Function::new_typed(&mut store, |y: f64, x: f64| y.atan2(x)),
+            "n" => Function::new_typed(&mut store, |x: f64, y: f64| x.powf(y)),
+
+            "o" => Function::new_typed(&mut store, my_poly_roots),
+        },
+    };
+    let instance = Instance::new(&mut store, &module, &imp).unwrap();
+    let f = instance.exports.get_function("").unwrap();
+
+    let json = read_to_string(dirname.join("initial.json")).unwrap();
+    let mut state: OptState = serde_json::from_str(&json).unwrap();
+    let func = FuncRef {
+        store: RefCell::new(store),
+        memory,
+        f,
+    };
+    while state.params.opt_status != OptStatus::EPConverged {
+        state = step(state, &func, 1);
+    }
+
+    if let Some(p) = args.get(2) {
+        let file = File::create(p).unwrap();
+        serde_json::to_writer_pretty(file, &state).unwrap();
+    }
+}

--- a/packages/optimizer/core/Cargo.toml
+++ b/packages/optimizer/core/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "penrose-optimizer"
+version = "1.3.0"
+edition = "2021"
+publish = false
+
+[dependencies]
+log = "0.4"
+nalgebra = "0.31"
+serde = { version = "1", features = ["derive"] }
+ts-rs = "6"

--- a/packages/optimizer/instance.d.ts
+++ b/packages/optimizer/instance.d.ts
@@ -1,4 +1,4 @@
-import { InitOutput } from "./build/penrose_optimizer";
+import { InitOutput } from "./build/penrose_optimizer_web";
 
 export declare let maybeOptimizer: InitOutput | undefined;
 

--- a/packages/optimizer/instance.js
+++ b/packages/optimizer/instance.js
@@ -1,9 +1,9 @@
-import init from "./build/penrose_optimizer";
+import init from "./build/penrose_optimizer_web";
 // the reason we make this file JavaScript with a separate `instance.d.ts` file,
 // instead of just making this file TypeScript directly, is because we customize
 // the loader esbuild uses for the Wasm file, and TypeScript wouldn't understand
 // this `import`
-import bytes from "./build/penrose_optimizer_bg.wasm";
+import bytes from "./build/penrose_optimizer_web_bg.wasm";
 
 // we let this be initialized sometime after module load, because our usage of
 // webpack for `docs-site` prevents us from using top-level `await` here

--- a/packages/optimizer/package.json
+++ b/packages/optimizer/package.json
@@ -6,8 +6,8 @@
   "scripts": {
     "build": "esbuild ./source.ts --outfile=index.js --platform=neutral --bundle --loader:.wasm=binary --define:import.meta.url=null --sourcemap",
     "build-decls": "cargo test",
-    "build-wasm": "cargo build --target=wasm32-unknown-unknown --release",
-    "build-wasm-bindgen": "wasm-bindgen --target=web --keep-lld-exports --out-dir=build target/wasm32-unknown-unknown/release/penrose_optimizer.wasm",
+    "build-wasm": "cargo build --package=penrose-optimizer-web --target=wasm32-unknown-unknown --release",
+    "build-wasm-bindgen": "wasm-bindgen --target=web --keep-lld-exports --out-dir=build target/wasm32-unknown-unknown/release/penrose_optimizer_web.wasm",
     "format": "cargo fmt",
     "format:check": "cargo fmt --check",
     "typecheck": ":"

--- a/packages/optimizer/web/Cargo.toml
+++ b/packages/optimizer/web/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "penrose-optimizer-web"
+version = "1.3.0"
+edition = "2021"
+publish = false
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+console_error_panic_hook = "0.1"
+console_log = "0.2"
+log = "0.4"
+penrose-optimizer = { path = "../core" }
+serde = "1"
+serde-wasm-bindgen = "0.4"
+wasm-bindgen = "0.2"

--- a/packages/optimizer/web/src/builtins.rs
+++ b/packages/optimizer/web/src/builtins.rs
@@ -1,3 +1,4 @@
+use penrose_optimizer::{inverse, poly_roots, sign};
 use wasm_bindgen::prelude::wasm_bindgen;
 
 // WebAssembly doesn't have a lot of math functions built in, so we export all these to allow our
@@ -117,16 +118,12 @@ pub fn penrose_tanh(x: f64) -> f64 {
 
 #[wasm_bindgen]
 pub fn penrose_inverse(x: f64) -> f64 {
-    1. / (x + 10e-6)
+    inverse(x)
 }
 
 #[wasm_bindgen]
 pub fn penrose_sign(x: f64) -> f64 {
-    if x == 0. {
-        x
-    } else {
-        f64::copysign(1., x)
-    }
+    sign(x)
 }
 
 // force `wasm-bindgen` to export `__wbindgen_add_to_stack_pointer`, which we will use to call the
@@ -138,23 +135,5 @@ pub fn penrose_empty_vec() -> Vec<usize> {
 
 #[wasm_bindgen]
 pub fn penrose_poly_roots(v: &mut [f64]) {
-    let n = v.len();
-    // https://en.wikipedia.org/wiki/Companion_matrix
-    let mut m = nalgebra::DMatrix::<f64>::zeros(n, n);
-    for i in 0..(n - 1) {
-        m[(i + 1, i)] = 1.;
-        m[(i, n - 1)] = -v[i];
-    }
-    m[(n - 1, n - 1)] = -v[n - 1];
-
-    // the characteristic polynomial of the companion matrix is equal to the original polynomial, so
-    // by finding the eigenvalues of the companion matrix, we get the roots of its characteristic
-    // polynomial and thus of the original polynomial
-    let r = m.complex_eigenvalues();
-    for i in 0..n {
-        let z = r[i];
-        // as mentioned in the `polyRoots` docstring in `engine/AutodiffFunctions`, we discard any
-        // non-real root and replace with `NaN`
-        v[i] = if z.im == 0. { z.re } else { f64::NAN };
-    }
+    poly_roots(v)
 }

--- a/packages/optimizer/web/src/lib.rs
+++ b/packages/optimizer/web/src/lib.rs
@@ -1,0 +1,97 @@
+pub mod builtins;
+
+use log::Level;
+use penrose_optimizer::{
+    gen_opt_problem, step, Bool, Compiled, OptState, Params, INIT_CONSTRAINT_WEIGHT,
+};
+use serde::Serialize;
+use wasm_bindgen::{prelude::wasm_bindgen, JsValue};
+
+type Func =
+    fn(inputs: *const f64, mask: *const Bool, gradient: *mut f64, secondary: *mut f64) -> f64;
+
+#[derive(Clone)]
+struct FuncPtr {
+    f: Func,
+}
+
+impl Compiled for FuncPtr {
+    fn call(
+        &self,
+        inputs: &[f64],
+        mask: &[Bool],
+        gradient: &mut [f64],
+        secondary: &mut [f64],
+    ) -> f64 {
+        (self.f)(
+            inputs.as_ptr(),
+            mask.as_ptr(),
+            gradient.as_mut_ptr(),
+            secondary.as_mut_ptr(),
+        )
+    }
+}
+
+fn bools(v: Vec<Bool>) -> Vec<bool> {
+    v.into_iter().map(|n| n > 0).collect()
+}
+
+fn to_js_value(value: &(impl Serialize + ?Sized)) -> Result<JsValue, serde_wasm_bindgen::Error> {
+    // ts-rs expects `Option::None` to become `null` instead of `undefined`
+    value.serialize(&serde_wasm_bindgen::Serializer::new().serialize_missing_as_null(true))
+}
+
+#[wasm_bindgen]
+pub fn penrose_init() {
+    // https://docs.rs/console_error_panic_hook/0.1.7/console_error_panic_hook/#usage
+    std::panic::set_hook(Box::new(console_error_panic_hook::hook));
+
+    // https://docs.rs/console_log/0.2.0/console_log/#example
+    console_log::init_with_level(Level::Warn).unwrap();
+}
+
+#[wasm_bindgen]
+pub fn penrose_call(
+    p: usize,
+    inputs: &[f64],
+    mask: &[Bool],
+    gradient: &mut [f64],
+    secondary: &mut [f64],
+) -> f64 {
+    let f = unsafe { std::mem::transmute::<usize, Func>(p) };
+    f(
+        inputs.as_ptr(),
+        mask.as_ptr(),
+        gradient.as_mut_ptr(),
+        secondary.as_mut_ptr(),
+    )
+}
+
+// `wasm-bindgen` doesn't let us export constants
+#[wasm_bindgen]
+pub fn penrose_get_init_constraint_weight() -> f64 {
+    INIT_CONSTRAINT_WEIGHT
+}
+
+#[wasm_bindgen]
+pub fn penrose_gen_opt_problem(
+    grad_mask: Vec<Bool>,
+    obj_mask: Vec<Bool>,
+    constr_mask: Vec<Bool>,
+) -> JsValue {
+    let params: Params = gen_opt_problem(bools(grad_mask), bools(obj_mask), bools(constr_mask));
+    to_js_value(&params).unwrap()
+}
+
+#[wasm_bindgen]
+pub fn penrose_step(state: JsValue, p: usize, steps: i32) -> JsValue {
+    let unstepped: OptState = serde_wasm_bindgen::from_value(state).unwrap();
+    let stepped: OptState = step(
+        unstepped,
+        &FuncPtr {
+            f: unsafe { std::mem::transmute::<usize, Func>(p) },
+        },
+        steps,
+    );
+    to_js_value(&stepped).unwrap()
+}


### PR DESCRIPTION
# Description

Because #1092 rewrote the optimizer in Rust, we now have the ability to compile it not just to WebAssembly but also to native code. This PR provides a CLI for a native Penrose optimizer, which runs a few times faster than the Wasm optimizer.

# Implementation strategy and design decisions

This PR splits the optimizer into three crates:

- `penrose_optimizer` exposes types (with TypeScript declarations generated via ts-rs), constants, and API functions for the optimizer itself, as well as our three autodiff builtins with nontrivial custom implementations (`inverse`, `sign`, and `poly_roots`); the `Compiled` function pointer in the `FnCached` struct is replaced by a `dyn` reference to a `trait` with a `call` function that takes references instead of pointers, which can then be implemented in different ways for different targets
- `penrose_optimizer_web` depends on `penrose_optimizer` and implements the `Compiled` trait for a `struct FuncPtr` that just holds a function pointer like before, then exposes all our Wasm API functions and builtins
- `penrose_optimizer_cli` also depends on `penrose_optimizer`, and uses [Wasmer](https://github.com/wasmerio/wasmer) to compile and run the gradient function, which it reads from a binary Wasm file on disk along with the initial `OptState`

To get those inputs for the CLI, this PR also modifies `core` to put the raw Wasm bytes in the `Gradient`, which `automator` then writes into the output directory along with the initial and optimized diagram states.

# Examples with steps to reproduce them

## Check

To compare the optimized state generated by Wasm vs native, run these commands:

```sh
yarn
yarn build:automator
cd packages/automator
yarn start batch registry.json out/ --src-prefix=../examples/src/ --folders
cd ../optimizer
cargo run --release ../automator/out/tree-venn{,.json}
git diff --no-index ../automator/out/tree-venn{/optimized,}.json
```

## Speedup

To see optimization times for all our registry diagrams, run these commands:

```sh
yarn
yarn build:automator
cd packages/automator
yarn start batch registry.json out/ --src-prefix=../examples/src/ --folders
cd ../optimizer
cargo build --release
for example in ../automator/out/*; do
  echo $example
  time target/release/penrose-optimizer-cli $example
  echo
done
```

Output:

```
../automator/out/3d-projection-fake-3d-linear-algebra
target/release/penrose-optimizer-cli $example  0.04s user 0.01s system 199% cpu 0.023 total

../automator/out/aggregateData.json
thread 'main' panicked at 'called `Result::unwrap()` on an `Err` value: Os { code: 20, kind: NotADirectory, message: "Not a directory" }', cli/src/main.rs:80:10
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
target/release/penrose-optimizer-cli $example  0.00s user 0.00s system 72% cpu 0.004 total

../automator/out/allShapes-allShapes
target/release/penrose-optimizer-cli $example  0.04s user 0.01s system 348% cpu 0.013 total

../automator/out/arrowheads-arrowheads
target/release/penrose-optimizer-cli $example  0.03s user 0.01s system 333% cpu 0.010 total

../automator/out/circle-example-euclidean
target/release/penrose-optimizer-cli $example  0.26s user 0.01s system 133% cpu 0.198 total

../automator/out/collinear-euclidean
target/release/penrose-optimizer-cli $example  0.05s user 0.00s system 204% cpu 0.026 total

../automator/out/congruent-triangles-euclidean
target/release/penrose-optimizer-cli $example  0.12s user 0.01s system 491% cpu 0.025 total

../automator/out/continuousmap-continuousmap
target/release/penrose-optimizer-cli $example  0.03s user 0.00s system 342% cpu 0.010 total

../automator/out/hypergraph-hypergraph
target/release/penrose-optimizer-cli $example  1.37s user 0.51s system 110% cpu 1.702 total

../automator/out/incenter-triangle-euclidean
target/release/penrose-optimizer-cli $example  0.10s user 0.01s system 215% cpu 0.047 total

../automator/out/lagrange-bases-lagrange-bases
target/release/penrose-optimizer-cli $example  0.03s user 0.00s system 323% cpu 0.010 total

../automator/out/midsegment-triangles-euclidean
target/release/penrose-optimizer-cli $example  0.05s user 0.00s system 440% cpu 0.012 total

../automator/out/non-convex-non-convex
target/release/penrose-optimizer-cli $example  0.14s user 0.01s system 291% cpu 0.051 total

../automator/out/one-water-molecule-atoms-and-bonds
target/release/penrose-optimizer-cli $example  0.01s user 0.00s system 253% cpu 0.006 total

../automator/out/parallel-lines-euclidean
target/release/penrose-optimizer-cli $example  0.05s user 0.01s system 228% cpu 0.026 total

../automator/out/persistent-homology-persistent-homology
target/release/penrose-optimizer-cli $example  1.31s user 0.49s system 106% cpu 1.696 total

../automator/out/points-around-line-shape-distance
target/release/penrose-optimizer-cli $example  0.07s user 0.01s system 343% cpu 0.021 total

../automator/out/points-around-polyline-shape-distance
target/release/penrose-optimizer-cli $example  0.14s user 0.01s system 483% cpu 0.031 total

../automator/out/points-around-star-shape-distance
target/release/penrose-optimizer-cli $example  0.24s user 0.01s system 562% cpu 0.045 total

../automator/out/siggraph-teaser-euclidean-teaser
target/release/penrose-optimizer-cli $example  0.07s user 0.01s system 353% cpu 0.022 total

../automator/out/small-graph-disjoint-rect-line-horiz
target/release/penrose-optimizer-cli $example  0.21s user 0.01s system 575% cpu 0.039 total

../automator/out/small-graph-disjoint-rects
target/release/penrose-optimizer-cli $example  0.02s user 0.00s system 377% cpu 0.008 total

../automator/out/small-graph-disjoint-rects-large-canvas
target/release/penrose-optimizer-cli $example  0.02s user 0.01s system 406% cpu 0.007 total

../automator/out/small-graph-disjoint-rects-small-canvas
target/release/penrose-optimizer-cli $example  0.02s user 0.00s system 365% cpu 0.008 total

../automator/out/tree-tree
target/release/penrose-optimizer-cli $example  0.03s user 0.00s system 393% cpu 0.009 total

../automator/out/tree-venn
target/release/penrose-optimizer-cli $example  0.04s user 0.00s system 314% cpu 0.015 total

../automator/out/tree-venn-3d
target/release/penrose-optimizer-cli $example  0.06s user 0.01s system 319% cpu 0.021 total

../automator/out/two-vectors-perp-vectors-dashed
target/release/penrose-optimizer-cli $example  0.02s user 0.01s system 323% cpu 0.009 total

../automator/out/vector-wedge-exterior-algebra
target/release/penrose-optimizer-cli $example  0.03s user 0.01s system 365% cpu 0.011 total

../automator/out/wet-floor-atoms-and-bonds
target/release/penrose-optimizer-cli $example  2.69s user 0.01s system 101% cpu 2.663 total

../automator/out/word-cloud-example-word-cloud
target/release/penrose-optimizer-cli $example  0.11s user 0.00s system 303% cpu 0.037 total

../automator/out/wos-laplace-estimator-walk-on-spheres
target/release/penrose-optimizer-cli $example  0.17s user 0.01s system 429% cpu 0.041 total

../automator/out/wos-nested-estimator-walk-on-spheres
target/release/penrose-optimizer-cli $example  0.72s user 0.01s system 163% cpu 0.445 total

../automator/out/wos-offcenter-estimator-walk-on-spheres
target/release/penrose-optimizer-cli $example  0.21s user 0.01s system 405% cpu 0.053 total

../automator/out/wos-poisson-estimator-walk-on-spheres
target/release/penrose-optimizer-cli $example  0.31s user 0.01s system 223% cpu 0.142 total
```

## Flamegraph

We can also use this native optimizer can be used to generate flamegraphs. [Install `cargo-flamegraph`](https://github.com/flamegraph-rs/flamegraph/tree/b65fd831c825d167ceda0c94055bba782b27da49#installation), then run these commands (note, the `--root` option is only necessary if you're on macOS):

```sh
yarn
yarn build:automator
cd packages/automator
yarn start batch registry.json out/ --src-prefix=../examples/src/ --folders
cd ../optimizer
cargo flamegraph --root -- ../automator/out/persistent-homology-persistent-homology
```

Output (in `packages/optimizer/flamegraph.svg`):

![flamegraph](https://user-images.githubusercontent.com/8246041/211158584-f622daa5-8726-4b2a-bf15-0092f5ef18fa.svg)

# Checklist

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new ESLint warnings
- [x] I have reviewed any generated registry diagram changes