### PR TITLE
docs: remove references to `ready` in docstrings

### DIFF
--- a/packages/optimizer/source.ts
+++ b/packages/optimizer/source.ts
@@ -158,7 +158,6 @@ export class Gradient {
   }
 
   /**
-   * `ready` must be resolved first.
    * @param mod a compiled Wasm module following the conventions of this class
    * @param numSecondary the number of addends for primary output and gradient
    * @param numSecondary the number of secondary outputs
@@ -233,7 +232,6 @@ export class Gradient {
 }
 
 /**
- * `ready` must be resolved first.
  * @param gradMask whether each varying value index should be optimized
  * @param objMask whether each objective should be optimized
  * @param constrMask whether each constraint should be optimized


### PR DESCRIPTION
# Description

#1188 deleted `ready` from `@penrose/optimizer`; this PR deletes lingering references to it from a couple docstrings.

# Checklist

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new ESLint warnings
- [x] I have reviewed any generated registry diagram changes