### PR TITLE
docs: update prerequisites for Ubuntu

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -71,6 +71,14 @@ Here are some WSL-specific guides:
 - [Guide for installing nvm and Node.js][]
 - [Guide for installing Yarn][]
 
+### Linux
+
+For `wasm-bindgen`, install an OpenSSL development package:
+
+```sh
+apt-get install libssl-dev
+```
+
 ## Setup
 
 Once you've installed all prerequisites, [clone][] [this repo][]. Then open a

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,6 +5,7 @@
 - [Prerequisites](#prerequisites)
   - [Apple Silicon](#apple-silicon)
   - [Windows WSL](#windows-wsl)
+  - [Linux](#linux)v
 - [Setup](#setup)
 - [Editor](#editor)
 - [Development](#development)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,7 +5,7 @@
 - [Prerequisites](#prerequisites)
   - [Apple Silicon](#apple-silicon)
   - [Windows WSL](#windows-wsl)
-  - [Linux](#linux)v
+  - [Linux](#linux)
 - [Setup](#setup)
 - [Editor](#editor)
 - [Development](#development)


### PR DESCRIPTION
# Description

Related issue/PR: N/A

Installing on Ubuntu breaks on the `wasm-bindgen` step. Fixed by following to [this comment](https://github.com/sfackler/rust-openssl/issues/649#issuecomment-308605644).