### PR TITLE
ci: stop publishing canary releases

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,28 +8,15 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
-    env:
-      CI: false # TODO: eliminate warnings so we don't have to do this
     steps:
       - name: Checkout
         uses: actions/checkout@v2
-        with:
-          # https://github.com/lerna/lerna/issues/1893#issuecomment-770614785
-          fetch-depth: 0
       - name: Setup
         uses: ./.github/actions/setup
       - name: Typecheck all packages
         run: yarn typecheck
       - name: Run all builds
         run: yarn build
-      - if: github.event_name == 'push' && github.ref == 'refs/heads/main'
-        name: Authenticate with registry
-        run: echo "//registry.npmjs.org/:_authToken=$NPM_TOKEN" > .npmrc
-        env:
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
-      - if: github.event_name == 'push' && github.ref == 'refs/heads/main'
-        name: Publish canary release
-        run: yarn publish:canary --yes
 
   format:
     runs-on: ubuntu-latest


### PR DESCRIPTION
# Description

I'd like to publish Penrose 1.4.0 after we merge #1173. Before we do that, I'd like to stop publishing canaries for a couple reasons:

- Logistically, this would allow us to safely bump the Penrose version as we get ready to publish 1.4 (since this might take multiple PRs for us to finish).
- Going forward, I'd like to start having releases be an intentional thing that we do periodically (hopefully more often than once a year), rather than automatically release an alpha at every commit to `main`.

# Checklist

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new ESLint warnings
- [x] I have reviewed any generated registry diagram changes