### PR TITLE
chore: clean up Prettier VS Code settings

### DIFF
--- a/penrose.code-workspace
+++ b/penrose.code-workspace
@@ -57,20 +57,12 @@
     }
   ],
   "settings": {
-    // https://prettier.io/docs/en/index.html
     "[css]": { "editor.defaultFormatter": "esbenp.prettier-vscode" },
-    "[graphql]": { "editor.defaultFormatter": "esbenp.prettier-vscode" },
     "[html]": { "editor.defaultFormatter": "esbenp.prettier-vscode" },
     "[javascript]": { "editor.defaultFormatter": "esbenp.prettier-vscode" },
-    "[javascriptreact]": {
-      "editor.defaultFormatter": "esbenp.prettier-vscode"
-    },
     "[json]": { "editor.defaultFormatter": "esbenp.prettier-vscode" },
     "[jsonc]": { "editor.defaultFormatter": "esbenp.prettier-vscode" },
-    "[less]": { "editor.defaultFormatter": "esbenp.prettier-vscode" },
     "[markdown]": { "editor.defaultFormatter": "esbenp.prettier-vscode" },
-    "[mdx]": { "editor.defaultFormatter": "esbenp.prettier-vscode" },
-    "[scss]": { "editor.defaultFormatter": "esbenp.prettier-vscode" },
     "[typescript]": { "editor.defaultFormatter": "esbenp.prettier-vscode" },
     "[typescriptreact]": {
       "editor.defaultFormatter": "esbenp.prettier-vscode"


### PR DESCRIPTION
# Description

This PR removes VS Code Prettier config for a bunch of languages that we don't use.

# Checklist

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new ESLint warnings
- [x] I have reviewed any generated registry diagram changes