### PR TITLE
fix: `ReferenceError` in storybook

### DIFF
--- a/packages/components/.storybook/preview-head.html
+++ b/packages/components/.storybook/preview-head.html
@@ -1,0 +1,4 @@
+<script>
+  // https://github.com/storybookjs/storybook/issues/15391
+  window.global = window;
+</script>


### PR DESCRIPTION
# Description

@wodeni is adding this in #1225, but we actually need it even before that PR is merged; for instance, it's a prerequisite for #1227.

# Checklist

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new ESLint warnings
- [x] I have reviewed any generated registry diagram changes