### PR TITLE
ci: upload optimizer Wasm artifact

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,6 +17,10 @@ jobs:
         run: yarn typecheck
       - name: Run all builds
         run: yarn build
+      - uses: actions/upload-artifact@v3
+        with:
+          name: optimizer
+          path: packages/optimizer/build/penrose_optimizer_bg.wasm
 
   format:
     runs-on: ubuntu-latest


### PR DESCRIPTION
# Description

As mentioned in #1092:

> As you can verify by running `strings packages/optimizer/target/wasm32-unknown-unknown/release/penrose_optimizer.wasm`, the built WebAssembly binary contains absolute paths (starting with `/Users/samueles/.cargo/registry/src/github.com-1ecc6299db9ec823/` in my case) to local files on whatever machine built the binary. See this Rust issue: rust-lang/rust#40552

This PR will allow us to publish `@penrose/optimizer` to npm without paths from our local machines, by downloading this new artifact and then rebundling via esbuild.

# Checklist

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new ESLint warnings
- [x] I have reviewed any generated registry diagram changes