### PR TITLE
fix: Wrong flipped start arrowhead X offset

### DIFF
--- a/packages/core/src/renderer/Line.ts
+++ b/packages/core/src/renderer/Line.ts
@@ -101,7 +101,7 @@ const makeRoomForArrows = (
       thickness;
     const dx = (startArrowWidth / length) * (lineSX - lineEX);
     [arrowSX, arrowSY] = [
-      lineSX - (startFlip ? -startArrowhead.refX : dx),
+      lineSX - dx,
       lineSY - (startArrowWidth / length) * (lineSY - lineEY),
     ];
   } else {


### PR DESCRIPTION
# Description

Fix #1220  

The renderer doesn't compute the X-offset of line `start` with a flipped arrowhead correctly. This PR fixes this issue.

# Implementation strategy and design decisions

Include a high-level summary of the implementation strategy and list important design decisions made, if any.

# Examples with steps to reproduce them

?gist=0d23bb22d18cfebcda7d9febd2513089

# Checklist

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new ESLint warnings
- [x] I have reviewed any generated registry diagram changes

