### PR TITLE
fix: Stage reset after dragging

### DIFF
--- a/packages/core/src/renderer/dragUtils.ts
+++ b/packages/core/src/renderer/dragUtils.ts
@@ -14,7 +14,7 @@ export const dragUpdate = (
 ): State => {
   const xs = [...state.varyingValues];
   const { constraintSets, optStages } = state;
-  const { inputMask, objMask, constrMask } = constraintSets[optStages[0]];
+  const { inputMask, objMask, constrMask } = constraintSets.get(optStages[0])!;
   const gradMask = [...inputMask];
   for (const shape of state.shapes) {
     if (shape.properties.name.contents === id) {


### PR DESCRIPTION
# Description

Related issue/PR: #1199 

In #1199, we changed `optStages` from a list to `Map` last minute and the type checker didn't catch the wrong usage in `dragUtils.ts`. This PR uses `get` instead of `[]` for stage reset.


# Checklist

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new ESLint warnings
- [x] I have reviewed any generated registry diagram changes
