### PR TITLE
chore: change server ports for `editor` and `synthesizer-ui`

### DIFF
--- a/packages/editor/vite.config.ts
+++ b/packages/editor/vite.config.ts
@@ -6,4 +6,7 @@ export default defineConfig({
   base: "/try/",
   plugins: [react({ jsxRuntime: "classic" })],
   build: { target: "esnext" },
+  server: {
+    port: 3000,
+  },
 });

--- a/packages/synthesizer-ui/vite.config.ts
+++ b/packages/synthesizer-ui/vite.config.ts
@@ -6,4 +6,7 @@ export default defineConfig({
   base: "./",
   plugins: [react({ jsxRuntime: "classic" })],
   build: { target: "esnext" },
+  server: {
+    port: 3001,
+  },
 });


### PR DESCRIPTION
# Description

Related issue/PR: N/A

In our [docs](https://github.com/penrose/penrose/blob/main/CONTRIBUTING.md), the default port for `editor` for local development is `3000`, but Vite updated it to another port. This PR explicitly set the ports for `editor` and `synthesizer-ui` (to avoid collision).

An explicitly specified port also allow all Penrose devs to log in through GitHub when developing locally.

# Checklist

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new ESLint warnings
- [x] I have reviewed any generated registry diagram changes