### PR TITLE
fix: style relation checker using substance variables

### DIFF
--- a/packages/core/src/compiler/Style.test.ts
+++ b/packages/core/src/compiler/Style.test.ts
@@ -748,6 +748,7 @@ Bond(O, H2)`;
 where IsSubset(y, x) { }`,
         `forall Setfhjh x { }`,
         `forall Point x, y where Midpointdfsdfds(x, y) { }`,
+        `forall Set a where IsSubset(a, B) {}`,
       ],
 
       // ---------- Block static errors

--- a/packages/core/src/compiler/Style.ts
+++ b/packages/core/src/compiler/Style.ts
@@ -571,7 +571,10 @@ const mergeMapping = (
   return {
     ...varEnv,
     vars: varEnv.vars.set(bindingForm.contents.value, toSubstanceType(styType)),
-    varIDs: [dummyIdentifier(bindingForm.contents.value, "Style"), ...varEnv.varIDs],
+    varIDs: [
+      dummyIdentifier(bindingForm.contents.value, "Style"),
+      ...varEnv.varIDs,
+    ],
   };
 };
 

--- a/packages/core/src/compiler/Style.ts
+++ b/packages/core/src/compiler/Style.ts
@@ -568,22 +568,11 @@ const mergeMapping = (
   }
   const [, bindingForm] = res;
 
-  switch (bindingForm.tag) {
-    case "SubVar": {
-      // G || (x : |T) |-> G
-      return varEnv;
-    }
-    case "StyVar": {
-      // G || (y : |T) |-> G[y : T] (shadowing any existing Sub vars)
-      return {
-        ...varEnv,
-        vars: varEnv.vars.set(
-          bindingForm.contents.value,
-          toSubstanceType(styType)
-        ),
-      };
-    }
-  }
+  return {
+    ...varEnv,
+    vars: varEnv.vars.set(bindingForm.contents.value, toSubstanceType(styType)),
+    varIDs: [dummyIdentifier(bindingForm.contents.value, "Style"), ...varEnv.varIDs],
+  };
 };
 
 // TODO: don't merge the varmaps! just put g as the varMap (otherwise there will be extraneous bindings for the relational statements)
@@ -614,8 +603,9 @@ const checkHeader = (varEnv: Env, header: Header<A>): SelEnv => {
         safeContentsList(sel.with)
       );
 
+      const emptyVarsEnv: Env = { ...varEnv, vars: im.Map(), varIDs: [] };
       const relErrs = checkRelPatterns(
-        mergeEnv(varEnv, selEnv_decls),
+        mergeEnv(emptyVarsEnv, selEnv_decls),
         selEnv_decls,
         safeContentsList(sel.where)
       );

--- a/packages/core/src/compiler/Style.ts
+++ b/packages/core/src/compiler/Style.ts
@@ -571,7 +571,10 @@ const mergeMapping = (
     case "StyVar":
       return {
         ...varEnv,
-        vars: varEnv.vars.set(bindingForm.contents.value, toSubstanceType(styType)),
+        vars: varEnv.vars.set(
+          bindingForm.contents.value,
+          toSubstanceType(styType)
+        ),
         varIDs: [
           dummyIdentifier(bindingForm.contents.value, "Style"),
           ...varEnv.varIDs,
@@ -580,14 +583,16 @@ const mergeMapping = (
     case "SubVar":
       return {
         ...varEnv,
-        vars: varEnv.vars.set(bindingForm.contents.value, toSubstanceType(styType)),
+        vars: varEnv.vars.set(
+          bindingForm.contents.value,
+          toSubstanceType(styType)
+        ),
         varIDs: [
           dummyIdentifier(bindingForm.contents.value, "Substance"),
           ...varEnv.varIDs,
         ],
       };
   }
-
 };
 
 // TODO: don't merge the varmaps! just put g as the varMap (otherwise there will be extraneous bindings for the relational statements)

--- a/packages/core/src/compiler/Style.ts
+++ b/packages/core/src/compiler/Style.ts
@@ -606,6 +606,7 @@ const checkHeader = (varEnv: Env, header: Header<A>): SelEnv => {
         safeContentsList(sel.with)
       );
 
+      // Basically creates a new, empty environment.
       const emptyVarsEnv: Env = { ...varEnv, vars: im.Map(), varIDs: [] };
       const relErrs = checkRelPatterns(
         mergeEnv(emptyVarsEnv, selEnv_decls),

--- a/packages/core/src/compiler/Style.ts
+++ b/packages/core/src/compiler/Style.ts
@@ -567,14 +567,15 @@ const mergeMapping = (
     throw Error("var has no binding form?");
   }
   const [, bindingForm] = res;
+  const vars = varEnv.vars.set(
+    bindingForm.contents.value,
+    toSubstanceType(styType)
+  );
   switch (bindingForm.tag) {
     case "StyVar":
       return {
         ...varEnv,
-        vars: varEnv.vars.set(
-          bindingForm.contents.value,
-          toSubstanceType(styType)
-        ),
+        vars: vars,
         varIDs: [
           dummyIdentifier(bindingForm.contents.value, "Style"),
           ...varEnv.varIDs,
@@ -583,10 +584,7 @@ const mergeMapping = (
     case "SubVar":
       return {
         ...varEnv,
-        vars: varEnv.vars.set(
-          bindingForm.contents.value,
-          toSubstanceType(styType)
-        ),
+        vars: vars,
         varIDs: [
           dummyIdentifier(bindingForm.contents.value, "Substance"),
           ...varEnv.varIDs,

--- a/packages/core/src/compiler/Style.ts
+++ b/packages/core/src/compiler/Style.ts
@@ -567,15 +567,27 @@ const mergeMapping = (
     throw Error("var has no binding form?");
   }
   const [, bindingForm] = res;
+  switch (bindingForm.tag) {
+    case "StyVar":
+      return {
+        ...varEnv,
+        vars: varEnv.vars.set(bindingForm.contents.value, toSubstanceType(styType)),
+        varIDs: [
+          dummyIdentifier(bindingForm.contents.value, "Style"),
+          ...varEnv.varIDs,
+        ],
+      };
+    case "SubVar":
+      return {
+        ...varEnv,
+        vars: varEnv.vars.set(bindingForm.contents.value, toSubstanceType(styType)),
+        varIDs: [
+          dummyIdentifier(bindingForm.contents.value, "Substance"),
+          ...varEnv.varIDs,
+        ],
+      };
+  }
 
-  return {
-    ...varEnv,
-    vars: varEnv.vars.set(bindingForm.contents.value, toSubstanceType(styType)),
-    varIDs: [
-      dummyIdentifier(bindingForm.contents.value, "Style"),
-      ...varEnv.varIDs,
-    ],
-  };
 };
 
 // TODO: don't merge the varmaps! just put g as the varMap (otherwise there will be extraneous bindings for the relational statements)

--- a/packages/core/src/compiler/Style.ts
+++ b/packages/core/src/compiler/Style.ts
@@ -575,7 +575,7 @@ const mergeMapping = (
     case "StyVar":
       return {
         ...varEnv,
-        vars: vars,
+        vars,
         varIDs: [
           dummyIdentifier(bindingForm.contents.value, "Style"),
           ...varEnv.varIDs,

--- a/packages/core/src/compiler/Style.ts
+++ b/packages/core/src/compiler/Style.ts
@@ -584,7 +584,7 @@ const mergeMapping = (
     case "SubVar":
       return {
         ...varEnv,
-        vars: vars,
+        vars,
         varIDs: [
           dummyIdentifier(bindingForm.contents.value, "Substance"),
           ...varEnv.varIDs,

--- a/packages/core/src/utils/Error.ts
+++ b/packages/core/src/utils/Error.ts
@@ -106,7 +106,16 @@ export const showError = (
         variable
       )}) does not exist.`;
       if (possibleVars) {
-        const suggestions = possibleVars.map((v) => v.value).join(", ");
+        const suggestions = possibleVars
+          .map((v) => {
+            switch (v.nodeType) {
+              case "Style":
+                return v.value;
+              case "Substance":
+                return `\`${v.value}\``;
+            }
+          })
+          .join(", ");
         return msg + ` Declared variables are: ${suggestions}`;
       } else return msg;
     }


### PR DESCRIPTION
# Description

Related issue/PR: #1123

This PR fixes the uncaught error in the Style compiler when selector relations refer to a variable not declared in the selector, but exists in the substance program. It now throws an error. We added a test case on this error. Finally, we improved upon how the "suggested" variables in the error message distinguish between Style and Substance variables.

# Implementation strategy and design decisions

The style compiler checks through the relations in the `where` clause, primarily using functions within the Substance checker, which checks the consistency of expressions with respect to a `SubstanceEnv`. In particular, it checks that each variable referred in the expressions are declared inside `SubstanceEnv`.

In order to call the Substance checker, we would need to provide a `SubstanceEnv` that contains all the variables that we want the relations to be able to access. Previously, we just take the current `SubstanceEnv` (as used in the Substance program), and add all the variables declared in the style header. The problem is that now this `SubstanceEnv` contains both variables declared in the style header (which we want to be able to access) and variables not declared in the style header but exists in the substance program.

The solution is simply to create a new, empty `SubstanceEnv` and add in the variables declared in the style header.

# Examples with steps to reproduce them

[This](https://merging-envs.penrose-72l.pages.dev/try/?gist=a7a33751a606a5688cb7c7cdf7aea9e7) is the same example as used in the original issue, running in the version in this PR. Previously, this did not trigger an error, and only fails silently under the browser console. Now it does trigger a sensible error.

# Checklist

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new ESLint warnings
- [x] I have reviewed any generated registry diagram changes
