### PR TITLE
build: fix `npm pack`

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -8,8 +8,8 @@
   "types": "dist/index.d.ts",
   "author": "Penrose Team (https://penrose.cs.cmu.edu/)",
   "files": [
-    "dist/**.d.ts",
-    "dist/**.js"
+    "dist/**/*.d.ts",
+    "dist/**/*.js"
   ],
   "scripts": {
     "build": "tsc",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -8,8 +8,8 @@
   "author": "Penrose Team (https://penrose.cs.cmu.edu/)",
   "license": "MIT",
   "files": [
-    "dist/**.d.ts",
-    "dist/**.js"
+    "dist/**/*.d.ts",
+    "dist/**/*.js"
   ],
   "scripts": {
     "build-parsers": "nearleyc src/parser/Domain.ne > src/parser/DomainParser.ts && nearleyc src/parser/Substance.ne > src/parser/SubstanceParser.ts && nearleyc src/parser/Style.ne > src/parser/StyleParser.ts",


### PR DESCRIPTION
# Description

Version 2.0.0 of [`@penrose/core`](https://www.npmjs.com/package/@penrose/core) and [`@penrose/components`](https://www.npmjs.com/package/@penrose/components) are missing a lot of files, specifically everything under `dist/` that isn't a direct child of `dist/`, because I tested them using `yarn pack` instead of `npm pack`, and the two commands handle globs differently. This PR fixes the issue.

# Checklist

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new ESLint warnings
- [x] I have reviewed any generated registry diagram changes