### PR TITLE
chore: bump version to 2.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,18 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [2.1.0](https://github.com/penrose/penrose/compare/v2.0.0...v2.1.0) (2023-01-19)
+
+### Bug Fixes
+
+- Stage reset after dragging ([#1237](https://github.com/penrose/penrose/issues/1237)) ([9bf0a36](https://github.com/penrose/penrose/commit/9bf0a363e2554451c0685157c099e91b8134445a))
+- style relation checker using substance variables ([#1239](https://github.com/penrose/penrose/issues/1239)) ([2e7de5e](https://github.com/penrose/penrose/commit/2e7de5e7729ae6f54ed378fb98c843f821b72ccf))
+- Wrong flipped start arrowhead X offset ([#1236](https://github.com/penrose/penrose/issues/1236)) ([ce7a348](https://github.com/penrose/penrose/commit/ce7a34823bb9cf71da6749366222ef72e4c8e0cb))
+
+### Features
+
+- Functions/Constraints for curves ([#1206](https://github.com/penrose/penrose/issues/1206)) ([6edc412](https://github.com/penrose/penrose/commit/6edc412fadeb8c1cb813719ea1b189bd35fa7ecb))
+
 # [2.0.0](https://github.com/penrose/penrose/compare/v1.3.0...v2.0.0) (2023-01-17)
 
 ### Bug Fixes

--- a/lerna.json
+++ b/lerna.json
@@ -1,6 +1,6 @@
 {
   "packages": ["packages/*"],
   "npmClient": "yarn",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "useWorkspaces": true
 }

--- a/packages/automator/CHANGELOG.md
+++ b/packages/automator/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [2.1.0](https://github.com/penrose/penrose/compare/v2.0.0...v2.1.0) (2023-01-19)
+
+**Note:** Version bump only for package @penrose/automator
+
 # [2.0.0](https://github.com/penrose/penrose/compare/v1.3.0...v2.0.0) (2023-01-17)
 
 ### Bug Fixes

--- a/packages/automator/package.json
+++ b/packages/automator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@penrose/automator",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "private": true,
   "description": "",
   "type": "module",
@@ -26,7 +26,7 @@
   "author": "Penrose Team (https://penrose.cs.cmu.edu/)",
   "license": "MIT",
   "dependencies": {
-    "@penrose/core": "^2.0.0",
+    "@penrose/core": "^2.1.0",
     "@types/react": "^18.0.26",
     "canvas": "^2.8.0",
     "chalk": "^3.0.0",

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [2.1.0](https://github.com/penrose/penrose/compare/v2.0.0...v2.1.0) (2023-01-19)
+
+**Note:** Version bump only for package @penrose/components
+
 # [2.0.0](https://github.com/penrose/penrose/compare/v1.3.0...v2.0.0) (2023-01-17)
 
 ### Bug Fixes

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@penrose/components",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "license": "MIT",
   "type": "module",
   "main": "dist/index.js",
@@ -49,7 +49,7 @@
   },
   "dependencies": {
     "@monaco-editor/react": "^4.0.11",
-    "@penrose/core": "^2.0.0",
+    "@penrose/core": "^2.1.0",
     "monaco-editor": "^0.31.0",
     "monaco-vim": "^0.3.4"
   },

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -3,6 +3,18 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [2.1.0](https://github.com/penrose/penrose/compare/v2.0.0...v2.1.0) (2023-01-19)
+
+### Bug Fixes
+
+- Stage reset after dragging ([#1237](https://github.com/penrose/penrose/issues/1237)) ([9bf0a36](https://github.com/penrose/penrose/commit/9bf0a363e2554451c0685157c099e91b8134445a))
+- style relation checker using substance variables ([#1239](https://github.com/penrose/penrose/issues/1239)) ([2e7de5e](https://github.com/penrose/penrose/commit/2e7de5e7729ae6f54ed378fb98c843f821b72ccf))
+- Wrong flipped start arrowhead X offset ([#1236](https://github.com/penrose/penrose/issues/1236)) ([ce7a348](https://github.com/penrose/penrose/commit/ce7a34823bb9cf71da6749366222ef72e4c8e0cb))
+
+### Features
+
+- Functions/Constraints for curves ([#1206](https://github.com/penrose/penrose/issues/1206)) ([6edc412](https://github.com/penrose/penrose/commit/6edc412fadeb8c1cb813719ea1b189bd35fa7ecb))
+
 # [2.0.0](https://github.com/penrose/penrose/compare/v1.3.0...v2.0.0) (2023-01-17)
 
 ### Bug Fixes

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@penrose/core",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "type": "module",
   "main": "dist/index.js",
   "module": "dist/index.js",
@@ -77,7 +77,7 @@
   "dependencies": {
     "@datastructures-js/heap": "^3.2.0",
     "@datastructures-js/queue": "^4.1.3",
-    "@penrose/optimizer": "^2.0.0",
+    "@penrose/optimizer": "^2.1.0",
     "consola": "^2.15.2",
     "immutable": "^4.0.0-rc.12",
     "lodash": "^4.17.15",
@@ -90,7 +90,7 @@
     "true-myth": "^4.1.0"
   },
   "devDependencies": {
-    "@penrose/examples": "^2.0.0",
+    "@penrose/examples": "^2.1.0",
     "@types/jest": "^27.4.1",
     "@types/jscodeshift": "^0.11.0",
     "@types/lodash": "^4.14.149",

--- a/packages/docs-site/CHANGELOG.md
+++ b/packages/docs-site/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [2.1.0](https://github.com/penrose/penrose/compare/v2.0.0...v2.1.0) (2023-01-19)
+
+**Note:** Version bump only for package @penrose/docs-site
+
 # [2.0.0](https://github.com/penrose/penrose/compare/v1.3.0...v2.0.0) (2023-01-17)
 
 ### Bug Fixes

--- a/packages/docs-site/package.json
+++ b/packages/docs-site/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@penrose/docs-site",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "private": true,
   "scripts": {
     "build": "vitepress build",
@@ -37,13 +37,13 @@
     }
   },
   "dependencies": {
-    "@penrose/components": "^2.0.0",
-    "@penrose/examples": "^2.0.0",
+    "@penrose/components": "^2.1.0",
+    "@penrose/examples": "^2.1.0",
     "veaury": "^2.3.11"
   },
   "devDependencies": {
-    "@penrose/automator": "^2.0.0",
-    "@penrose/editor": "^2.0.0",
+    "@penrose/automator": "^2.1.0",
+    "@penrose/editor": "^2.1.0",
     "markdown-it-katex": "^2.0.3",
     "shx": "^0.3.3",
     "vitepress": "^1.0.0-alpha.35"

--- a/packages/editor/CHANGELOG.md
+++ b/packages/editor/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [2.1.0](https://github.com/penrose/penrose/compare/v2.0.0...v2.1.0) (2023-01-19)
+
+**Note:** Version bump only for package @penrose/editor
+
 # [2.0.0](https://github.com/penrose/penrose/compare/v1.3.0...v2.0.0) (2023-01-17)
 
 ### Bug Fixes

--- a/packages/editor/package.json
+++ b/packages/editor/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@penrose/editor",
   "private": true,
-  "version": "2.0.0",
+  "version": "2.1.0",
   "scripts": {
     "start": "cross-env NODE_OPTIONS='--max-old-space-size=8192' vite",
     "dev": "cross-env NODE_OPTIONS='--max-old-space-size=8192' vite",
@@ -41,8 +41,8 @@
     }
   },
   "dependencies": {
-    "@penrose/components": "^2.0.0",
-    "@penrose/core": "^2.0.0",
+    "@penrose/components": "^2.1.0",
+    "@penrose/core": "^2.1.0",
     "animals": "^0.0.3",
     "color-name-list": "^8.38.0",
     "flexlayout-react": "^0.7.3",

--- a/packages/examples/CHANGELOG.md
+++ b/packages/examples/CHANGELOG.md
@@ -3,6 +3,12 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [2.1.0](https://github.com/penrose/penrose/compare/v2.0.0...v2.1.0) (2023-01-19)
+
+### Features
+
+- Functions/Constraints for curves ([#1206](https://github.com/penrose/penrose/issues/1206)) ([6edc412](https://github.com/penrose/penrose/commit/6edc412fadeb8c1cb813719ea1b189bd35fa7ecb))
+
 # [2.0.0](https://github.com/penrose/penrose/compare/v1.3.0...v2.0.0) (2023-01-17)
 
 ### Bug Fixes

--- a/packages/examples/package.json
+++ b/packages/examples/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@penrose/examples",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "private": true,
   "scripts": {
     "build": ":",

--- a/packages/optimizer/CHANGELOG.md
+++ b/packages/optimizer/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [2.1.0](https://github.com/penrose/penrose/compare/v2.0.0...v2.1.0) (2023-01-19)
+
+**Note:** Version bump only for package @penrose/optimizer
+
 # [2.0.0](https://github.com/penrose/penrose/compare/v1.3.0...v2.0.0) (2023-01-17)
 
 ### Bug Fixes

--- a/packages/optimizer/Cargo.lock
+++ b/packages/optimizer/Cargo.lock
@@ -168,7 +168,7 @@ checksum = "b1de2e551fb905ac83f73f7aedf2f0cb4a0da7e35efa24a202a936269f1f18e1"
 
 [[package]]
 name = "penrose-optimizer"
-version = "2.0.0"
+version = "2.1.0"
 dependencies = [
  "console_error_panic_hook",
  "console_log",

--- a/packages/optimizer/Cargo.toml
+++ b/packages/optimizer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "penrose-optimizer"
-version = "2.0.0"
+version = "2.1.0"
 edition = "2021"
 publish = false
 

--- a/packages/optimizer/package.json
+++ b/packages/optimizer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@penrose/optimizer",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "type": "module",
   "author": "Penrose Team (https://penrose.cs.cmu.edu/)",
   "license": "MIT",

--- a/packages/roger/CHANGELOG.md
+++ b/packages/roger/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [2.1.0](https://github.com/penrose/penrose/compare/v2.0.0...v2.1.0) (2023-01-19)
+
+**Note:** Version bump only for package @penrose/roger
+
 # [2.0.0](https://github.com/penrose/penrose/compare/v1.3.0...v2.0.0) (2023-01-17)
 
 ### Bug Fixes

--- a/packages/roger/README.md
+++ b/packages/roger/README.md
@@ -18,7 +18,7 @@ $ npm install -g @penrose/roger
 $ roger COMMAND
 running command...
 $ roger (--version)
-@penrose/roger/2.0.0 darwin-arm64 node-v16.17.0
+@penrose/roger/2.1.0 darwin-arm64 node-v18.12.1
 $ roger --help [COMMAND]
 USAGE
   $ roger COMMAND
@@ -51,6 +51,6 @@ EXAMPLES
   $ roger watch
 ```
 
-_See code: [dist/commands/watch.js](https://github.com/penrose/penrose/blob/v2.0.0/dist/commands/watch.js)_
+_See code: [dist/commands/watch.js](https://github.com/penrose/penrose/blob/v2.1.0/dist/commands/watch.js)_
 
 <!-- commandsstop -->

--- a/packages/roger/package.json
+++ b/packages/roger/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@penrose/roger",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "description": "The Penrose CLI",
   "author": "Penrose Team (https://penrose.cs.cmu.edu/)",
   "bin": {

--- a/packages/synthesizer-ui/CHANGELOG.md
+++ b/packages/synthesizer-ui/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [2.1.0](https://github.com/penrose/penrose/compare/v2.0.0...v2.1.0) (2023-01-19)
+
+**Note:** Version bump only for package @penrose/synthesizer-ui
+
 # [2.0.0](https://github.com/penrose/penrose/compare/v1.3.0...v2.0.0) (2023-01-17)
 
 ### Bug Fixes

--- a/packages/synthesizer-ui/package.json
+++ b/packages/synthesizer-ui/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@penrose/synthesizer-ui",
   "private": true,
-  "version": "2.0.0",
+  "version": "2.1.0",
   "scripts": {
     "dev": "vite",
     "watch": "vite",
@@ -42,9 +42,9 @@
   },
   "dependencies": {
     "@material-ui/core": "^4.12.3",
-    "@penrose/components": "^2.0.0",
-    "@penrose/core": "^2.0.0",
-    "@penrose/examples": "^2.0.0",
+    "@penrose/components": "^2.1.0",
+    "@penrose/core": "^2.1.0",
+    "@penrose/examples": "^2.1.0",
     "@types/file-saver": "^2.0.5",
     "@types/jszip": "^3.4.1",
     "file-saver": "^2.0.5",

--- a/packages/synthesizer/CHANGELOG.md
+++ b/packages/synthesizer/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [2.1.0](https://github.com/penrose/penrose/compare/v2.0.0...v2.1.0) (2023-01-19)
+
+**Note:** Version bump only for package @penrose/synthesizer
+
 # [2.0.0](https://github.com/penrose/penrose/compare/v1.3.0...v2.0.0) (2023-01-17)
 
 ### Bug Fixes

--- a/packages/synthesizer/package.json
+++ b/packages/synthesizer/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@penrose/synthesizer",
   "private": true,
-  "version": "2.0.0",
+  "version": "2.1.0",
   "description": "Synthesis engine for Penrose",
   "keywords": [
     "program synthesis",
@@ -39,7 +39,7 @@
     "url": "https://github.com/penrose/penrose/issues"
   },
   "dependencies": {
-    "@penrose/core": "^2.0.0",
+    "@penrose/core": "^2.1.0",
     "chalk": "^3.0.0",
     "global-jsdom": "^8.0.0",
     "neodoc": "^2.0.2",


### PR DESCRIPTION
# Description

We need to release a new version because of #1241. This PR was generated by running the following commands:

```sh
yarn new-version 2.1.0
yarn format
```

I also manually modified `packages/optimizer/Cargo.toml`, and then VS Code automatically generated the change to `packages/optimizer/Cargo.lock`.

# Checklist

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new ESLint warnings
- [x] I have reviewed any generated registry diagram changes