### PR TITLE
build: don't set Yarn registry for synthesizer

### DIFF
--- a/packages/synthesizer/package.json
+++ b/packages/synthesizer/package.json
@@ -17,9 +17,6 @@
   "files": [
     "src"
   ],
-  "publishConfig": {
-    "registry": "https://registry.yarnpkg.com"
-  },
   "repository": {
     "type": "git",
     "url": "git+https://github.com/penrose/penrose.git"


### PR DESCRIPTION
# Description

The v2.1.0 autorelease script worked, but it gave an error at the end: https://github.com/penrose/penrose/actions/runs/3955406466/jobs/6773664245

```
npm notice name:          @penrose/synthesizer                    
npm notice version:       2.1.0                                   
npm notice filename:      @penrose/synthesizer-2.1.0.tgz          
npm notice package size:  3.4 kB                                  
npm notice unpacked size: 10.4 kB                                 
npm notice shasum:        7743e6c6cbc4207f30380241838c6713bc7275a2
npm notice integrity:     sha512-jJzksFjHDEyOP[...]+6ZunKCgBjy1A==
npm notice total files:   3                                       
npm notice 
npm ERR! code ENEEDAUTH
npm ERR! need auth This command requires you to be logged in to https://registry.yarnpkg.com/
npm ERR! need auth You need to authorize this machine using `npm adduser`
```

This PR should fix that error for future releases, by removing the `https://registry.yarnpkg.com/` setting from `@penrose/synthesizer`'s `publishConfig`.

# Checklist

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new ESLint warnings
- [x] I have reviewed any generated registry diagram changes