### PR TITLE
fix: make pandemonium a dependency of core

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -84,6 +84,7 @@
     "mathjax-full": "^3.0.1",
     "moo": "^0.5.1",
     "nearley": "^2.20.1",
+    "pandemonium": "^2.0.0",
     "poly-partition": "^1.0.2",
     "recursive-diff": "^1.0.8",
     "seedrandom": "^3.0.5",

--- a/packages/synthesizer/package.json
+++ b/packages/synthesizer/package.json
@@ -40,7 +40,6 @@
     "chalk": "^3.0.0",
     "global-jsdom": "^8.0.0",
     "neodoc": "^2.0.2",
-    "pandemonium": "^2.0.0",
     "true-myth": "^4.1.1"
   },
   "devDependencies": {


### PR DESCRIPTION
# Description

Currently, trying to use `@penrose/core` v2.1.0 can result in errors because we use [pandemonium](https://www.npmjs.com/package/pandemonium) in `packages/core/src/synthesis/Synthesizer.ts` but don't list it as a dependency of `core`. This PR fixes the issue by moving pandemonium from `@penrose/synthesizer`'s `dependencies` to `@penrose/core`'s `dependencies`.

# Checklist

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new ESLint warnings
- [x] I have reviewed any generated registry diagram changes