### PR TITLE
docs: update `core` usage in README

### DIFF
--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -23,12 +23,32 @@ In a HTML document, use [JavaScript modules](https://developer.mozilla.org/en-US
   <body>
     <!--
     JSPM Generator Import Map
-    Edit URL: https://generator.jspm.io/#U2VhYGBkDM0rySzJSU1hcChIzSvKL07VT84vSnUw1DPWMwAA/5OhSyIA
+    Edit URL: https://generator.jspm.io/#U2VhYGBkDM0rySzJSU1hcChIzSvKL07VT84vSnUw0jPUMwAAQT2FDyIA
   -->
     <script type="importmap">
       {
         "imports": {
-          "@penrose/core": "https://ga.jspm.io/npm:@penrose/core@1.3.1-alpha.363/build/dist/index.js"
+          "@penrose/core": "https://ga.jspm.io/npm:@penrose/core@2.1.0/dist/index.js"
+        },
+        "scopes": {
+          "https://ga.jspm.io/": {
+            "@datastructures-js/heap": "https://ga.jspm.io/npm:@datastructures-js/heap@3.2.0/index.js",
+            "@datastructures-js/queue": "https://ga.jspm.io/npm:@datastructures-js/queue@4.2.3/index.js",
+            "@penrose/optimizer": "https://ga.jspm.io/npm:@penrose/optimizer@2.1.0/index.js",
+            "consola": "https://ga.jspm.io/npm:consola@2.15.3/dist/consola.browser.js",
+            "crypto": "https://ga.jspm.io/npm:@jspm/core@2.0.0/nodelibs/browser/crypto.js",
+            "immutable": "https://ga.jspm.io/npm:immutable@4.2.2/dist/immutable.es.js",
+            "lodash": "https://ga.jspm.io/npm:lodash@4.17.21/lodash.js",
+            "mathjax-full/js/": "https://ga.jspm.io/npm:mathjax-full@3.2.2/js/",
+            "mhchemparser/dist/mhchemParser.js": "https://ga.jspm.io/npm:mhchemparser@4.1.1/dist/mhchemParser.js",
+            "moo": "https://ga.jspm.io/npm:moo@0.5.2/moo.js",
+            "nearley": "https://ga.jspm.io/npm:nearley@2.20.1/lib/nearley.js",
+            "pandemonium/choice": "https://ga.jspm.io/npm:pandemonium@2.4.1/choice.js",
+            "pandemonium/random": "https://ga.jspm.io/npm:pandemonium@2.4.1/random.js",
+            "poly-partition": "https://ga.jspm.io/npm:poly-partition@1.0.2/lib/index.js",
+            "seedrandom": "https://ga.jspm.io/npm:seedrandom@3.0.5/index.js",
+            "true-myth": "https://ga.jspm.io/npm:true-myth@4.1.1/dist/cjs/index.js"
+          }
         }
       }
     </script>

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -15,18 +15,40 @@ import "global-jsdom/register"; // must come before the Penrose import
 import * as Penrose from "@penrose/core";
 ```
 
-In a HTML document, use [JavaScript modules](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Modules) to import functions from `@penrose/core` through a CDN. For example:
+In a HTML document, use [JavaScript modules](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Modules) to import functions from `@penrose/core` through a CDN. For example, here we use [JSPM](https://jspm.org/) to generate an import map for dependencies and draw a simple diagram with Penrose:
 
 ```html
-<head>
-  <script type="module">
-    import { diagram } from "http://unpkg.com/@penrose/core";
-    diagram({
-        substance: `
+<!DOCTYPE html>
+<html>
+  <body>
+    <!--
+    JSPM Generator Import Map
+    Edit URL: https://generator.jspm.io/#U2VhYGBkDM0rySzJSU1hcChIzSvKL07VT84vSnUw1DPWMwAA/5OhSyIA
+  -->
+    <script type="importmap">
+      {
+        "imports": {
+          "@penrose/core": "https://ga.jspm.io/npm:@penrose/core@1.3.1-alpha.363/build/dist/index.js"
+        }
+      }
+    </script>
+
+    <!-- ES Module Shims: Import maps polyfill for modules browsers without import maps support (all except Chrome 89+) -->
+    <script
+      async
+      src="https://ga.jspm.io/npm:es-module-shims@1.5.1/dist/es-module-shims.js"
+      crossorigin="anonymous"
+    ></script>
+
+    <script type="module">
+      import * as Penrose from "@penrose/core";
+      Penrose.diagram(
+        {
+          substance: `
         Set A, B
         IsSubset(A, B)
         `,
-        style: `
+          style: `
         canvas {
             width = 400
             height = 400
@@ -41,17 +63,15 @@ In a HTML document, use [JavaScript modules](https://developer.mozilla.org/en-US
             s2.shape above s1.shape
         }
         `,
-        domain: `type Set
-        predicate IsSubset(Set, Set)`
-    },
-    document.getElementById("penrose-diagram")
-    )
-
-  </script>
-</head>
-<body>
-    <div id="penrose-diagram">
-</body>
+          domain: `type Set
+        predicate IsSubset(Set, Set)`,
+        },
+        document.getElementById("penrose-diagram")
+      );
+    </script>
+    <div id="penrose-diagram" />
+  </body>
+</html>
 ```
 
 ## Exported functions

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -15,7 +15,7 @@ import "global-jsdom/register"; // must come before the Penrose import
 import * as Penrose from "@penrose/core";
 ```
 
-Use [JavaScript modules](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Modules) to import functions from `@penrose/core`. Use either a CDN that supports ES modules (e.g. [JSPM](https://jspm.org/)) or a bundler (e.g. [vite](https://vitejs.dev/)). For example, run the following to set up  starter project with vite:
+Use [JavaScript modules](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Modules) to import functions from `@penrose/core`. Use either a CDN that supports ES modules (e.g. [JSPM](https://jspm.org/)) or a bundler (e.g. [vite](https://vitejs.dev/)). For example, run the following to set up starter project with vite:
 
 ```shell
 yarn create vite
@@ -25,7 +25,6 @@ yarn
 ```
 
 In `index.html`:
-
 
 ```html
 <!DOCTYPE html>

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -19,9 +19,18 @@ Use [JavaScript modules](https://developer.mozilla.org/en-US/docs/Web/JavaScript
 
 ```shell
 yarn create vite
+cd vite-project
 yarn add @penrose/core
 yarn add -D vite-plugin-top-level-await # `@penrose/optimizer` uses top-level await and this vite plugin adds support for that
-yarn
+```
+
+In `vite.config.js`:
+
+```js
+import { defineConfig } from "vite";
+import topLevelAwait from "vite-plugin-top-level-await";
+
+export default defineConfig({ plugins: [topLevelAwait()] });
 ```
 
 In `index.html`:
@@ -30,7 +39,7 @@ In `index.html`:
 <!DOCTYPE html>
 <html>
   <body>
-    <div id="penrose-diagram" />
+    <div id="penrose-diagram"></div>
     <script type="module" src="/main.js"></script>
   </body>
 </html>

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -15,83 +15,64 @@ import "global-jsdom/register"; // must come before the Penrose import
 import * as Penrose from "@penrose/core";
 ```
 
-In a HTML document, use [JavaScript modules](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Modules) to import functions from `@penrose/core` through a CDN. For example, here we use [JSPM](https://jspm.org/) to generate an import map for dependencies and draw a simple diagram with Penrose:
+Use [JavaScript modules](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Modules) to import functions from `@penrose/core`. Use either a CDN that supports ES modules (e.g. [JSPM](https://jspm.org/)) or a bundler (e.g. [vite](https://vitejs.dev/)). For example, run the following to set up  starter project with vite:
+
+```shell
+yarn create vite
+yarn add @penrose/core
+yarn add -D vite-plugin-top-level-await # `@penrose/optimizer` uses top-level await and this vite plugin adds support for that
+yarn
+```
+
+In `index.html`:
+
 
 ```html
 <!DOCTYPE html>
 <html>
   <body>
-    <!--
-    JSPM Generator Import Map
-    Edit URL: https://generator.jspm.io/#U2VhYGBkDM0rySzJSU1hcChIzSvKL07VT84vSnUw0jPUMwAAQT2FDyIA
-  -->
-    <script type="importmap">
-      {
-        "imports": {
-          "@penrose/core": "https://ga.jspm.io/npm:@penrose/core@2.1.0/dist/index.js"
-        },
-        "scopes": {
-          "https://ga.jspm.io/": {
-            "@datastructures-js/heap": "https://ga.jspm.io/npm:@datastructures-js/heap@3.2.0/index.js",
-            "@datastructures-js/queue": "https://ga.jspm.io/npm:@datastructures-js/queue@4.2.3/index.js",
-            "@penrose/optimizer": "https://ga.jspm.io/npm:@penrose/optimizer@2.1.0/index.js",
-            "consola": "https://ga.jspm.io/npm:consola@2.15.3/dist/consola.browser.js",
-            "crypto": "https://ga.jspm.io/npm:@jspm/core@2.0.0/nodelibs/browser/crypto.js",
-            "immutable": "https://ga.jspm.io/npm:immutable@4.2.2/dist/immutable.es.js",
-            "lodash": "https://ga.jspm.io/npm:lodash@4.17.21/lodash.js",
-            "mathjax-full/js/": "https://ga.jspm.io/npm:mathjax-full@3.2.2/js/",
-            "mhchemparser/dist/mhchemParser.js": "https://ga.jspm.io/npm:mhchemparser@4.1.1/dist/mhchemParser.js",
-            "moo": "https://ga.jspm.io/npm:moo@0.5.2/moo.js",
-            "nearley": "https://ga.jspm.io/npm:nearley@2.20.1/lib/nearley.js",
-            "pandemonium/choice": "https://ga.jspm.io/npm:pandemonium@2.4.1/choice.js",
-            "pandemonium/random": "https://ga.jspm.io/npm:pandemonium@2.4.1/random.js",
-            "poly-partition": "https://ga.jspm.io/npm:poly-partition@1.0.2/lib/index.js",
-            "seedrandom": "https://ga.jspm.io/npm:seedrandom@3.0.5/index.js",
-            "true-myth": "https://ga.jspm.io/npm:true-myth@4.1.1/dist/cjs/index.js"
-          }
-        }
-      }
-    </script>
-
-    <!-- ES Module Shims: Import maps polyfill for modules browsers without import maps support (all except Chrome 89+) -->
-    <script
-      async
-      src="https://ga.jspm.io/npm:es-module-shims@1.5.1/dist/es-module-shims.js"
-      crossorigin="anonymous"
-    ></script>
-
-    <script type="module">
-      import * as Penrose from "@penrose/core";
-      Penrose.diagram(
-        {
-          substance: `
-        Set A, B
-        IsSubset(A, B)
-        `,
-          style: `
-        canvas {
-            width = 400
-            height = 400
-        }
-        forall Set s {
-            s.shape = Circle {}
-            ensure lessThan(20, s.shape.r)
-        }
-        forall Set s1, s2
-        where IsSubset(s1, s2) {
-            ensure contains(s2.shape, s1.shape)
-            s2.shape above s1.shape
-        }
-        `,
-          domain: `type Set
-        predicate IsSubset(Set, Set)`,
-        },
-        document.getElementById("penrose-diagram")
-      );
-    </script>
     <div id="penrose-diagram" />
+    <script type="module" src="/main.js"></script>
   </body>
 </html>
+```
+
+In `main.js`:
+
+```js
+import * as Penrose from "@penrose/core";
+Penrose.diagram(
+  {
+    substance: `
+  Set A, B
+  IsSubset(A, B)
+  `,
+    style: `
+  canvas {
+      width = 400
+      height = 400
+  }
+  forall Set s {
+      s.shape = Circle {}
+      ensure lessThan(20, s.shape.r)
+  }
+  forall Set s1, s2
+  where IsSubset(s1, s2) {
+      ensure contains(s2.shape, s1.shape)
+      s2.shape above s1.shape
+  }
+  `,
+    domain: `type Set
+  predicate IsSubset(Set, Set)`,
+  },
+  document.getElementById("penrose-diagram")
+);
+```
+
+Finally, run the following to see the output:
+
+```shell
+yarn dev
 ```
 
 ## Exported functions


### PR DESCRIPTION
# Description

Now that `core` is modules-only and bundle-less, the user can't just import `core` through CDNs such as unpkg because it's difficult to resolve dependencies. The unpkg `?module` suffix doesn't seem to work in our case. Therefore, this PR updates the README to include an example that uses JSPM, a service that resolves ES modules properly and generates import maps.

# Checklist

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new ESLint warnings
- [x] I have reviewed any generated registry diagram changes

