### PR TITLE
docs: fix `import` typo in components README

### DIFF
--- a/packages/components/README.md
+++ b/packages/components/README.md
@@ -13,7 +13,7 @@ yarn add @penrose/components
 For a minimal example, try using the `Simple` component in your React application:
 
 ```ts
-import { Simple } from `@penrose/components`;
+import { Embed } from "@penrose/components";
 
 const domain = `
 type Set


### PR DESCRIPTION
# Description

The example `import` in the `@penrose/components` README is broken. This PR fixes it.

# Checklist

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new ESLint warnings
- [x] I have reviewed any generated registry diagram changes