### PR TITLE
chore: remove full moon trio

### DIFF
--- a/packages/examples/src/registry.json
+++ b/packages/examples/src/registry.json
@@ -230,12 +230,6 @@
       "variation": "PlumeAnt46950"
     },
     {
-      "substance": "full-moon",
-      "style": "full-moon",
-      "domain": "full-moon",
-      "variation": "RinseElk0268"
-    },
-    {
       "substance": "glutamine",
       "style": "molecules-basic",
       "domain": "molecules",


### PR DESCRIPTION
# Description
Temporary removes the full-moon trio as a workaround for issue #1258. 
