### PR TITLE
fix: enforcing ordering in `collinearOrdered` constraint

### DIFF
--- a/packages/core/src/contrib/Constraints.ts
+++ b/packages/core/src/contrib/Constraints.ts
@@ -28,7 +28,6 @@ import {
   lt,
   max,
   min,
-  minN,
   mul,
   neg,
   squared,
@@ -135,10 +134,7 @@ const constrDictSimple = {
     const v3 = ops.vnorm(ops.vsub(c1, c3));
 
     // Use triangle inequality (|v1| + |v2| <= |v3|) to make sure v1, v2, and v3 don't form a triangle (and therefore must be collinear.)
-    return max(
-      0,
-      minN([sub(add(v1, v2), v3), sub(add(v1, v3), v2), sub(add(v2, v3), v1)])
-    );
+    return max(0, sub(add(v1, v2), v3));
   },
 };
 

--- a/packages/core/src/contrib/__tests__/Constraints.test.ts
+++ b/packages/core/src/contrib/__tests__/Constraints.test.ts
@@ -158,7 +158,7 @@ describe("simple constraint", () => {
     [[1, 3], [1, 1], [3, 1], 1.2],
     [[1, 0], [1, 1], [1, 2], 0],
     [[1, 0], [1, 1], [1, 10], 0],
-    [[1, 0], [1, 1], [1, -10], 0],
+    [[1, -10], [1, 0], [1, 1], 0],
   ])(
     "collinearOrdered(%p, %p, %p) should return %p",
     (c1: number[], c2: number[], c3: number[], expected: number) => {

--- a/packages/examples/src/atoms-and-bonds/atoms-and-bonds.sty
+++ b/packages/examples/src/atoms-and-bonds/atoms-and-bonds.sty
@@ -61,6 +61,6 @@ where WBond(a1, a2) as wb {
 
 forall Hydrogen h; Oxygen o; Hydrogen h1; Hydrogen h2; Oxygen o1
 where WBond(h, o); SBond(h, o1); SBond(o, h1); SBond(o, h2) {
-    ensure collinear(o.symbol.center, h.symbol.center, o1.symbol.center)
-    ensure collinear(midpoint(h1.symbol.center, h2.symbol.center), o.symbol.center, h.symbol.center)
+    ensure collinearOrdered(o.symbol.center, h.symbol.center, o1.symbol.center)
+    ensure collinearOrdered(midpoint(h1.symbol.center, h2.symbol.center), o.symbol.center, h.symbol.center)
 }


### PR DESCRIPTION
# Description

Resolves #1262.

# Implementation strategy and design decisions

Somehow the implementation changed to `minN` of all triangle inequalities instead of just one. This PR reverts that change since `collinear` already has an implementation based on cross product.

The `wet-floor` example has been changed to use `collinearOrdered` since that's what we intended.

# Checklist

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new ESLint warnings
- [x] I have reviewed any generated registry diagram changes
