### PR TITLE
feat: Add link to Wiki

### DIFF
--- a/packages/docs-site/docs/ref.md
+++ b/packages/docs-site/docs/ref.md
@@ -1,6 +1,6 @@
 # Penrose Overview
 
-For more information on any of the items summarized below, please use the navigation.  More detailed documentation and example snippets for several aspects of Penrose (such as, types, shapes, and functions) can be found on the [wiki](https://github.com/penrose/penrose/wiki/).
+For more information on any of the items summarized below, please use the navigation. More detailed documentation and example snippets for several aspects of Penrose (such as, types, shapes, and functions) can be found on the [wiki](https://github.com/penrose/penrose/wiki/).
 
 Penrose effortlessly creates beautiful diagrams using a 'trio':
 

--- a/packages/docs-site/docs/ref.md
+++ b/packages/docs-site/docs/ref.md
@@ -1,6 +1,6 @@
 # Penrose Overview
 
-For more information on any of the items summarized below, please use the navigation.
+For more information on any of the items summarized below, please use the navigation.  More detailed documentation and example snippets for several aspects of Penrose (such as, types, shapes, and functions) can be found on the [wiki](https://github.com/penrose/penrose/wiki/).
 
 Penrose effortlessly creates beautiful diagrams using a 'trio':
 


### PR DESCRIPTION
# Description

This PR adds a link to the GitHub wiki as a stopgap solution to the fact that the doc site is missing a lot of critical information needed to get end users up and running.  It literally adds a single sentence to the docs on the docs landing page, making readers aware that the GitHub wiki exists.