### PR TITLE
build(deps): upgrade `wasm-bindgen` to 0.2.84

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -6,14 +6,11 @@ runs:
       run: rustup target add wasm32-unknown-unknown
       shell: bash
     - name: Install wasm-bindgen
-      # as mentioned in CONTRIBUTING.md, we need the --keep-lld-exports flag,
-      # which will be available in the next wasm-bindgen release, but for now
-      # the latest release is 0.2.83 which does not have it, so we are using our
-      # own Linux binary which we built and uploaded to a GitHub Gist
       run: |
-        wget -P ~/.cargo/bin \
-          https://gist.github.com/samestep/2cf703cfd81691f2cb3c23422fce7e56/raw/f27692e7269f798faaf259b9c75942b151d8b69b/wasm-bindgen
-        chmod +x ~/.cargo/bin/wasm-bindgen
+        wget https://github.com/rustwasm/wasm-bindgen/releases/download/0.2.84/wasm-bindgen-0.2.84-x86_64-unknown-linux-musl.tar.gz
+        tar -xzf wasm-bindgen-0.2.84-x86_64-unknown-linux-musl.tar.gz
+        mv wasm-bindgen-0.2.84-x86_64-unknown-linux-musl/wasm-bindgen ~/.cargo/bin
+        rm -r wasm-bindgen-0.2.84-x86_64-unknown-linux-musl*
       shell: bash
     - name: Restore cache
       id: cache

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -35,23 +35,17 @@ Be sure you have these tools installed:
 
 - [Node.js][] v16+ (if using Linux or Mac, we recommend installing via [nvm][])
 
+  - [Yarn][] v1.x
+
 - [Rust][]
 
-- The WebAssembly target:
+  - the WebAssembly target for Rust:
 
-  ```sh
-  rustup target add wasm32-unknown-unknown
-  ```
+    ```sh
+    rustup target add wasm32-unknown-unknown
+    ```
 
-- [`wasm-bindgen` CLI][] (you need to install Rust first), specifically a
-  version which has the `--keep-lld-exports` flag; use this command:
-
-  ```sh
-  cargo install wasm-bindgen-cli \
-    --git https://github.com/rustwasm/wasm-bindgen --rev 7c626e4b3
-  ```
-
-- [Yarn][] v1.x (you need to install Node.js first)
+  - [`wasm-bindgen` CLI][] v0.2.84+
 
 Depending on your platform, here are some extra instructions:
 

--- a/cloudflare.sh
+++ b/cloudflare.sh
@@ -4,12 +4,9 @@ set -euxo pipefail
 curl https://sh.rustup.rs -sSf | sh -s -- -yt wasm32-unknown-unknown
 source "$HOME/.cargo/env"
 
-# as mentioned in CONTRIBUTING.md, we need the --keep-lld-exports flag, which
-# will be available in the next wasm-bindgen release, but for now the latest
-# release is 0.2.83 which does not have it, so we are using our own Linux binary
-# which we built and uploaded to a GitHub Gist
-wget -P ~/.cargo/bin \
-  https://gist.github.com/samestep/2cf703cfd81691f2cb3c23422fce7e56/raw/f27692e7269f798faaf259b9c75942b151d8b69b/wasm-bindgen
-chmod +x ~/.cargo/bin/wasm-bindgen
+wget https://github.com/rustwasm/wasm-bindgen/releases/download/0.2.84/wasm-bindgen-0.2.84-x86_64-unknown-linux-musl.tar.gz
+tar -xzf wasm-bindgen-0.2.84-x86_64-unknown-linux-musl.tar.gz
+mv wasm-bindgen-0.2.84-x86_64-unknown-linux-musl/wasm-bindgen ~/.cargo/bin
+rm -r wasm-bindgen-0.2.84-x86_64-unknown-linux-musl*
 
 yarn build:docs-site

--- a/packages/optimizer/Cargo.lock
+++ b/packages/optimizer/Cargo.lock
@@ -334,9 +334,9 @@ checksum = "dcc811dc4066ac62f84f11307873c4850cb653bfa9b1719cee2bd2204a4bc5dd"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.83"
+version = "0.2.84"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eaf9f5aceeec8be17c128b2e93e031fb8a4d469bb9c4ae2d7dc1888b26887268"
+checksum = "31f8dcbc21f30d9b8f2ea926ecb58f6b91192c17e9d33594b3df58b2007ca53b"
 dependencies = [
  "cfg-if",
  "wasm-bindgen-macro",
@@ -344,9 +344,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.83"
+version = "0.2.84"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c8ffb332579b0557b52d268b91feab8df3615f265d5270fec2a8c95b17c1142"
+checksum = "95ce90fd5bcc06af55a641a86428ee4229e44e07033963a2290a8e241607ccb9"
 dependencies = [
  "bumpalo",
  "log",
@@ -359,9 +359,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.83"
+version = "0.2.84"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "052be0f94026e6cbc75cdefc9bae13fd6052cdcaf532fa6c45e7ae33a1e6c810"
+checksum = "4c21f77c0bedc37fd5dc21f897894a5ca01e7bb159884559461862ae90c0b4c5"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -369,9 +369,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.83"
+version = "0.2.84"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07bc0c051dc5f23e307b13285f9d75df86bfdf816c5721e573dec1f9b8aa193c"
+checksum = "2aff81306fcac3c7515ad4e177f521b5c9a15f2b08f4e32d823066102f35a5f6"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -382,9 +382,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.83"
+version = "0.2.84"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c38c045535d93ec4f0b4defec448e4291638ee608530863b1e2ba115d4fff7f"
+checksum = "0046fef7e28c3804e5e38bfa31ea2a0f73905319b677e57ebe37e49358989b5d"
 
 [[package]]
 name = "web-sys"

--- a/packages/optimizer/Cargo.toml
+++ b/packages/optimizer/Cargo.toml
@@ -15,4 +15,4 @@ nalgebra = "0.31"
 serde = { version = "1", features = ["derive"] }
 serde-wasm-bindgen = "0.4"
 ts-rs = "6"
-wasm-bindgen = "0.2"
+wasm-bindgen = "0.2.84"


### PR DESCRIPTION
# Description

[`wasm-bindgen` v0.2.84 released today](https://github.com/rustwasm/wasm-bindgen/releases/tag/0.2.84), so now we can finally move off of the GitHub Gist I created for #1092.

# Checklist

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new ESLint warnings
- [x] I have reviewed any generated registry diagram changes