### PR TITLE
chore: bump version to 2.2.0

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,6 +22,7 @@ jobs:
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
       - name: Publish VS Code extension
+        working-directory: packages/vscode/
         run: npx vsce publish --baseImagesUrl="https://github.com/penrose/penrose/raw/${GITHUB_REF#refs/tags/}/packages/vscode"
         env:
           VSCE_PAT: ${{ secrets.VSCE_PAT }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,35 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [v2.2.0](https://github.com/penrose/penrose/compare/v2.1.1...v2.2.0) (2023-02-02)
+
+### :rocket: New Feature
+
+- Add link to Wiki ([#1275](https://github.com/penrose/penrose/issues/1275)) ([5c2f368](https://github.com/penrose/penrose/commit/5c2f368ead39c8b28af087350153e1228f5a8531))
+- Group theory ([#1276](https://github.com/penrose/penrose/issues/1276)) ([16c64fa](https://github.com/penrose/penrose/commit/16c64fa54748f6ed9d8fcdb4c03c766f553dd720))
+- Group theory - multiplication table style ([#1277](https://github.com/penrose/penrose/issues/1277)) ([fea6d0b](https://github.com/penrose/penrose/commit/fea6d0b2e25f88fad54331610b4ac541677fc658))
+- improve registry schema and loading ([#1212](https://github.com/penrose/penrose/issues/1212)) ([d6bbc30](https://github.com/penrose/penrose/commit/d6bbc302de494e08fa4ca0602ccfa29bdfcd65ae))
+- inline comparison operators ([#1257](https://github.com/penrose/penrose/issues/1257)) ([b3c7c2f](https://github.com/penrose/penrose/commit/b3c7c2f0547a245ece5865d94184d04f7edf334e))
+- support longer file extensions ([#1280](https://github.com/penrose/penrose/issues/1280)) ([6e83596](https://github.com/penrose/penrose/commit/6e835968280a784a91c4a2ca47a226516a3067d0))
+
+### :bug: Bug Fix
+
+- enforcing ordering in `collinearOrdered` constraint ([#1265](https://github.com/penrose/penrose/issues/1265)) ([2336b4b](https://github.com/penrose/penrose/commit/2336b4b2a567fa520219fef4768c6e0406c310d9))
+
+### :nail_care: Polish
+
+- bring VS Code extension into this repo ([#1271](https://github.com/penrose/penrose/issues/1271)) ([a74a7e2](https://github.com/penrose/penrose/commit/a74a7e2746069c5b6c5c657b84a24f3d2b9bf897))
+
+### :memo: Documentation
+
+- fix `import` typo in components README ([#1253](https://github.com/penrose/penrose/issues/1253)) ([05b1f68](https://github.com/penrose/penrose/commit/05b1f68a80a3fc36868e226038f450ae8cd65cf5))
+
+### :house: Internal
+
+- clarify a couple `Graph` method docstrings ([#1285](https://github.com/penrose/penrose/issues/1285)) ([6da46aa](https://github.com/penrose/penrose/commit/6da46aa79599f29a69301ea777be16ff8bfb616e))
+- fix Twitter badge in README ([#1260](https://github.com/penrose/penrose/issues/1260)) ([e60b3ed](https://github.com/penrose/penrose/commit/e60b3ed6e6635f76d00e8e2920edcb6abb3fb462))
+- remove full moon trio ([#1259](https://github.com/penrose/penrose/issues/1259)) ([664595b](https://github.com/penrose/penrose/commit/664595bac0e849f326f9a3a2bc3fc0c41e085b39))
+
 ## [v2.1.1](https://github.com/penrose/penrose/compare/v2.1.0...v2.1.1) (2023-01-19)
 
 ### :bug: Bug Fix

--- a/lerna.json
+++ b/lerna.json
@@ -1,7 +1,7 @@
 {
   "packages": ["packages/*"],
   "npmClient": "yarn",
-  "version": "2.1.1",
+  "version": "2.2.0",
   "useWorkspaces": true,
   "changelogPreset": {
     "name": "@spyke/conventional-changelog-preset"

--- a/packages/automator/CHANGELOG.md
+++ b/packages/automator/CHANGELOG.md
@@ -3,6 +3,12 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [v2.2.0](https://github.com/penrose/penrose/compare/v2.1.1...v2.2.0) (2023-02-02)
+
+### :rocket: New Feature
+
+- support longer file extensions ([#1280](https://github.com/penrose/penrose/issues/1280)) ([6e83596](https://github.com/penrose/penrose/commit/6e835968280a784a91c4a2ca47a226516a3067d0))
+
 ## [v2.1.1](https://github.com/penrose/penrose/compare/v2.1.0...v2.1.1) (2023-01-19)
 
 **Note:** Version bump only for package @penrose/automator

--- a/packages/automator/package.json
+++ b/packages/automator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@penrose/automator",
-  "version": "2.1.1",
+  "version": "2.2.0",
   "private": true,
   "description": "",
   "type": "module",
@@ -26,7 +26,7 @@
   "author": "Penrose Team (https://penrose.cs.cmu.edu/)",
   "license": "MIT",
   "dependencies": {
-    "@penrose/core": "^2.1.1",
+    "@penrose/core": "^2.2.0",
     "@types/react": "^18.0.26",
     "canvas": "^2.8.0",
     "chalk": "^3.0.0",

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [v2.2.0](https://github.com/penrose/penrose/compare/v2.1.1...v2.2.0) (2023-02-02)
+
+### :rocket: New Feature
+
+- improve registry schema and loading ([#1212](https://github.com/penrose/penrose/issues/1212)) ([d6bbc30](https://github.com/penrose/penrose/commit/d6bbc302de494e08fa4ca0602ccfa29bdfcd65ae))
+- support longer file extensions ([#1280](https://github.com/penrose/penrose/issues/1280)) ([6e83596](https://github.com/penrose/penrose/commit/6e835968280a784a91c4a2ca47a226516a3067d0))
+
+### :memo: Documentation
+
+- fix `import` typo in components README ([#1253](https://github.com/penrose/penrose/issues/1253)) ([05b1f68](https://github.com/penrose/penrose/commit/05b1f68a80a3fc36868e226038f450ae8cd65cf5))
+
 ## [v2.1.1](https://github.com/penrose/penrose/compare/v2.1.0...v2.1.1) (2023-01-19)
 
 **Note:** Version bump only for package @penrose/components

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@penrose/components",
-  "version": "2.1.1",
+  "version": "2.2.0",
   "license": "MIT",
   "type": "module",
   "main": "dist/index.js",
@@ -49,7 +49,7 @@
   },
   "dependencies": {
     "@monaco-editor/react": "^4.0.11",
-    "@penrose/core": "^2.1.1",
+    "@penrose/core": "^2.2.0",
     "monaco-editor": "^0.31.0",
     "monaco-vim": "^0.3.4"
   },

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -3,6 +3,22 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [v2.2.0](https://github.com/penrose/penrose/compare/v2.1.1...v2.2.0) (2023-02-02)
+
+### :rocket: New Feature
+
+- improve registry schema and loading ([#1212](https://github.com/penrose/penrose/issues/1212)) ([d6bbc30](https://github.com/penrose/penrose/commit/d6bbc302de494e08fa4ca0602ccfa29bdfcd65ae))
+- inline comparison operators ([#1257](https://github.com/penrose/penrose/issues/1257)) ([b3c7c2f](https://github.com/penrose/penrose/commit/b3c7c2f0547a245ece5865d94184d04f7edf334e))
+- support longer file extensions ([#1280](https://github.com/penrose/penrose/issues/1280)) ([6e83596](https://github.com/penrose/penrose/commit/6e835968280a784a91c4a2ca47a226516a3067d0))
+
+### :bug: Bug Fix
+
+- enforcing ordering in `collinearOrdered` constraint ([#1265](https://github.com/penrose/penrose/issues/1265)) ([2336b4b](https://github.com/penrose/penrose/commit/2336b4b2a567fa520219fef4768c6e0406c310d9))
+
+### :house: Internal
+
+- clarify a couple `Graph` method docstrings ([#1285](https://github.com/penrose/penrose/issues/1285)) ([6da46aa](https://github.com/penrose/penrose/commit/6da46aa79599f29a69301ea777be16ff8bfb616e))
+
 ## [v2.1.1](https://github.com/penrose/penrose/compare/v2.1.0...v2.1.1) (2023-01-19)
 
 ### :bug: Bug Fix

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@penrose/core",
-  "version": "2.1.1",
+  "version": "2.2.0",
   "type": "module",
   "main": "dist/index.js",
   "module": "dist/index.js",
@@ -77,7 +77,7 @@
   "dependencies": {
     "@datastructures-js/heap": "^3.2.0",
     "@datastructures-js/queue": "^4.1.3",
-    "@penrose/optimizer": "^2.1.1",
+    "@penrose/optimizer": "^2.2.0",
     "consola": "^2.15.2",
     "immutable": "^4.0.0-rc.12",
     "lodash": "^4.17.15",
@@ -91,7 +91,7 @@
     "true-myth": "^4.1.0"
   },
   "devDependencies": {
-    "@penrose/examples": "^2.1.1",
+    "@penrose/examples": "^2.2.0",
     "@types/jest": "^27.4.1",
     "@types/jscodeshift": "^0.11.0",
     "@types/lodash": "^4.14.149",

--- a/packages/docs-site/CHANGELOG.md
+++ b/packages/docs-site/CHANGELOG.md
@@ -3,6 +3,15 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [v2.2.0](https://github.com/penrose/penrose/compare/v2.1.1...v2.2.0) (2023-02-02)
+
+### :rocket: New Feature
+
+- Add link to Wiki ([#1275](https://github.com/penrose/penrose/issues/1275)) ([5c2f368](https://github.com/penrose/penrose/commit/5c2f368ead39c8b28af087350153e1228f5a8531))
+- improve registry schema and loading ([#1212](https://github.com/penrose/penrose/issues/1212)) ([d6bbc30](https://github.com/penrose/penrose/commit/d6bbc302de494e08fa4ca0602ccfa29bdfcd65ae))
+- inline comparison operators ([#1257](https://github.com/penrose/penrose/issues/1257)) ([b3c7c2f](https://github.com/penrose/penrose/commit/b3c7c2f0547a245ece5865d94184d04f7edf334e))
+- support longer file extensions ([#1280](https://github.com/penrose/penrose/issues/1280)) ([6e83596](https://github.com/penrose/penrose/commit/6e835968280a784a91c4a2ca47a226516a3067d0))
+
 ## [v2.1.1](https://github.com/penrose/penrose/compare/v2.1.0...v2.1.1) (2023-01-19)
 
 **Note:** Version bump only for package @penrose/docs-site

--- a/packages/docs-site/package.json
+++ b/packages/docs-site/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@penrose/docs-site",
-  "version": "2.1.1",
+  "version": "2.2.0",
   "private": true,
   "scripts": {
     "build": "vitepress build",
@@ -37,13 +37,13 @@
     }
   },
   "dependencies": {
-    "@penrose/components": "^2.1.1",
-    "@penrose/examples": "^2.1.1",
+    "@penrose/components": "^2.2.0",
+    "@penrose/examples": "^2.2.0",
     "veaury": "^2.3.11"
   },
   "devDependencies": {
-    "@penrose/automator": "^2.1.1",
-    "@penrose/editor": "^2.1.1",
+    "@penrose/automator": "^2.2.0",
+    "@penrose/editor": "^2.2.0",
     "markdown-it-katex": "^2.0.3",
     "shx": "^0.3.3",
     "vitepress": "^1.0.0-alpha.35"

--- a/packages/editor/CHANGELOG.md
+++ b/packages/editor/CHANGELOG.md
@@ -3,6 +3,13 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [v2.2.0](https://github.com/penrose/penrose/compare/v2.1.1...v2.2.0) (2023-02-02)
+
+### :rocket: New Feature
+
+- improve registry schema and loading ([#1212](https://github.com/penrose/penrose/issues/1212)) ([d6bbc30](https://github.com/penrose/penrose/commit/d6bbc302de494e08fa4ca0602ccfa29bdfcd65ae))
+- support longer file extensions ([#1280](https://github.com/penrose/penrose/issues/1280)) ([6e83596](https://github.com/penrose/penrose/commit/6e835968280a784a91c4a2ca47a226516a3067d0))
+
 ## [v2.1.1](https://github.com/penrose/penrose/compare/v2.1.0...v2.1.1) (2023-01-19)
 
 **Note:** Version bump only for package @penrose/editor

--- a/packages/editor/package.json
+++ b/packages/editor/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@penrose/editor",
   "private": true,
-  "version": "2.1.1",
+  "version": "2.2.0",
   "scripts": {
     "start": "cross-env NODE_OPTIONS='--max-old-space-size=8192' vite",
     "dev": "cross-env NODE_OPTIONS='--max-old-space-size=8192' vite",
@@ -41,8 +41,8 @@
     }
   },
   "dependencies": {
-    "@penrose/components": "^2.1.1",
-    "@penrose/core": "^2.1.1",
+    "@penrose/components": "^2.2.0",
+    "@penrose/core": "^2.2.0",
     "animals": "^0.0.3",
     "color-name-list": "^8.38.0",
     "flexlayout-react": "^0.7.3",

--- a/packages/examples/CHANGELOG.md
+++ b/packages/examples/CHANGELOG.md
@@ -3,6 +3,24 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [v2.2.0](https://github.com/penrose/penrose/compare/v2.1.1...v2.2.0) (2023-02-02)
+
+### :rocket: New Feature
+
+- Group theory ([#1276](https://github.com/penrose/penrose/issues/1276)) ([16c64fa](https://github.com/penrose/penrose/commit/16c64fa54748f6ed9d8fcdb4c03c766f553dd720))
+- Group theory - multiplication table style ([#1277](https://github.com/penrose/penrose/issues/1277)) ([fea6d0b](https://github.com/penrose/penrose/commit/fea6d0b2e25f88fad54331610b4ac541677fc658))
+- improve registry schema and loading ([#1212](https://github.com/penrose/penrose/issues/1212)) ([d6bbc30](https://github.com/penrose/penrose/commit/d6bbc302de494e08fa4ca0602ccfa29bdfcd65ae))
+- inline comparison operators ([#1257](https://github.com/penrose/penrose/issues/1257)) ([b3c7c2f](https://github.com/penrose/penrose/commit/b3c7c2f0547a245ece5865d94184d04f7edf334e))
+- support longer file extensions ([#1280](https://github.com/penrose/penrose/issues/1280)) ([6e83596](https://github.com/penrose/penrose/commit/6e835968280a784a91c4a2ca47a226516a3067d0))
+
+### :bug: Bug Fix
+
+- enforcing ordering in `collinearOrdered` constraint ([#1265](https://github.com/penrose/penrose/issues/1265)) ([2336b4b](https://github.com/penrose/penrose/commit/2336b4b2a567fa520219fef4768c6e0406c310d9))
+
+### :house: Internal
+
+- remove full moon trio ([#1259](https://github.com/penrose/penrose/issues/1259)) ([664595b](https://github.com/penrose/penrose/commit/664595bac0e849f326f9a3a2bc3fc0c41e085b39))
+
 ## [v2.1.1](https://github.com/penrose/penrose/compare/v2.1.0...v2.1.1) (2023-01-19)
 
 **Note:** Version bump only for package @penrose/examples

--- a/packages/examples/package.json
+++ b/packages/examples/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@penrose/examples",
-  "version": "2.1.1",
+  "version": "2.2.0",
   "private": true,
   "scripts": {
     "build": ":",

--- a/packages/optimizer/CHANGELOG.md
+++ b/packages/optimizer/CHANGELOG.md
@@ -3,6 +3,12 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [v2.2.0](https://github.com/penrose/penrose/compare/v2.1.1...v2.2.0) (2023-02-02)
+
+### :rocket: New Feature
+
+- support longer file extensions ([#1280](https://github.com/penrose/penrose/issues/1280)) ([6e83596](https://github.com/penrose/penrose/commit/6e835968280a784a91c4a2ca47a226516a3067d0))
+
 ## [v2.1.1](https://github.com/penrose/penrose/compare/v2.1.0...v2.1.1) (2023-01-19)
 
 **Note:** Version bump only for package @penrose/optimizer

--- a/packages/optimizer/Cargo.lock
+++ b/packages/optimizer/Cargo.lock
@@ -168,7 +168,7 @@ checksum = "b1de2e551fb905ac83f73f7aedf2f0cb4a0da7e35efa24a202a936269f1f18e1"
 
 [[package]]
 name = "penrose-optimizer"
-version = "2.1.1"
+version = "2.2.0"
 dependencies = [
  "console_error_panic_hook",
  "console_log",

--- a/packages/optimizer/Cargo.toml
+++ b/packages/optimizer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "penrose-optimizer"
-version = "2.1.1"
+version = "2.2.0"
 edition = "2021"
 publish = false
 

--- a/packages/optimizer/package.json
+++ b/packages/optimizer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@penrose/optimizer",
-  "version": "2.1.1",
+  "version": "2.2.0",
   "type": "module",
   "author": "Penrose Team (https://penrose.cs.cmu.edu/)",
   "license": "MIT",

--- a/packages/roger/CHANGELOG.md
+++ b/packages/roger/CHANGELOG.md
@@ -3,6 +3,12 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [v2.2.0](https://github.com/penrose/penrose/compare/v2.1.1...v2.2.0) (2023-02-02)
+
+### :rocket: New Feature
+
+- support longer file extensions ([#1280](https://github.com/penrose/penrose/issues/1280)) ([6e83596](https://github.com/penrose/penrose/commit/6e835968280a784a91c4a2ca47a226516a3067d0))
+
 ## [v2.1.1](https://github.com/penrose/penrose/compare/v2.1.0...v2.1.1) (2023-01-19)
 
 **Note:** Version bump only for package @penrose/roger

--- a/packages/roger/README.md
+++ b/packages/roger/README.md
@@ -18,7 +18,7 @@ $ npm install -g @penrose/roger
 $ roger COMMAND
 running command...
 $ roger (--version)
-@penrose/roger/2.1.1 darwin-arm64 node-v18.12.1
+@penrose/roger/2.2.0 darwin-arm64 node-v18.12.1
 $ roger --help [COMMAND]
 USAGE
   $ roger COMMAND
@@ -51,6 +51,6 @@ EXAMPLES
   $ roger watch
 ```
 
-_See code: [dist/commands/watch.js](https://github.com/penrose/penrose/blob/v2.1.1/dist/commands/watch.js)_
+_See code: [dist/commands/watch.js](https://github.com/penrose/penrose/blob/v2.2.0/dist/commands/watch.js)_
 
 <!-- commandsstop -->

--- a/packages/roger/package.json
+++ b/packages/roger/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@penrose/roger",
-  "version": "2.1.1",
+  "version": "2.2.0",
   "description": "The Penrose CLI",
   "author": "Penrose Team (https://penrose.cs.cmu.edu/)",
   "bin": {

--- a/packages/synthesizer-ui/CHANGELOG.md
+++ b/packages/synthesizer-ui/CHANGELOG.md
@@ -3,6 +3,13 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [v2.2.0](https://github.com/penrose/penrose/compare/v2.1.1...v2.2.0) (2023-02-02)
+
+### :rocket: New Feature
+
+- improve registry schema and loading ([#1212](https://github.com/penrose/penrose/issues/1212)) ([d6bbc30](https://github.com/penrose/penrose/commit/d6bbc302de494e08fa4ca0602ccfa29bdfcd65ae))
+- support longer file extensions ([#1280](https://github.com/penrose/penrose/issues/1280)) ([6e83596](https://github.com/penrose/penrose/commit/6e835968280a784a91c4a2ca47a226516a3067d0))
+
 ## [v2.1.1](https://github.com/penrose/penrose/compare/v2.1.0...v2.1.1) (2023-01-19)
 
 **Note:** Version bump only for package @penrose/synthesizer-ui

--- a/packages/synthesizer-ui/package.json
+++ b/packages/synthesizer-ui/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@penrose/synthesizer-ui",
   "private": true,
-  "version": "2.1.1",
+  "version": "2.2.0",
   "scripts": {
     "dev": "vite",
     "watch": "vite",
@@ -42,9 +42,9 @@
   },
   "dependencies": {
     "@material-ui/core": "^4.12.3",
-    "@penrose/components": "^2.1.1",
-    "@penrose/core": "^2.1.1",
-    "@penrose/examples": "^2.1.1",
+    "@penrose/components": "^2.2.0",
+    "@penrose/core": "^2.2.0",
+    "@penrose/examples": "^2.2.0",
     "@types/file-saver": "^2.0.5",
     "@types/jszip": "^3.4.1",
     "file-saver": "^2.0.5",

--- a/packages/synthesizer/CHANGELOG.md
+++ b/packages/synthesizer/CHANGELOG.md
@@ -3,6 +3,13 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [v2.2.0](https://github.com/penrose/penrose/compare/v2.1.1...v2.2.0) (2023-02-02)
+
+### :rocket: New Feature
+
+- improve registry schema and loading ([#1212](https://github.com/penrose/penrose/issues/1212)) ([d6bbc30](https://github.com/penrose/penrose/commit/d6bbc302de494e08fa4ca0602ccfa29bdfcd65ae))
+- support longer file extensions ([#1280](https://github.com/penrose/penrose/issues/1280)) ([6e83596](https://github.com/penrose/penrose/commit/6e835968280a784a91c4a2ca47a226516a3067d0))
+
 ## [v2.1.1](https://github.com/penrose/penrose/compare/v2.1.0...v2.1.1) (2023-01-19)
 
 ### :bug: Bug Fix

--- a/packages/synthesizer/package.json
+++ b/packages/synthesizer/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@penrose/synthesizer",
   "private": true,
-  "version": "2.1.1",
+  "version": "2.2.0",
   "description": "Synthesis engine for Penrose",
   "keywords": [
     "program synthesis",
@@ -36,7 +36,7 @@
     "url": "https://github.com/penrose/penrose/issues"
   },
   "dependencies": {
-    "@penrose/core": "^2.1.1",
+    "@penrose/core": "^2.2.0",
     "chalk": "^3.0.0",
     "global-jsdom": "^8.0.0",
     "neodoc": "^2.0.2",

--- a/packages/vscode/CHANGELOG.md
+++ b/packages/vscode/CHANGELOG.md
@@ -1,0 +1,10 @@
+# Change Log
+
+All notable changes to this project will be documented in this file.
+See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
+
+## [v2.2.0](https://github.com/penrose/penrose/compare/v2.1.1...v2.2.0) (2023-02-02)
+
+### :nail_care: Polish
+
+- bring VS Code extension into this repo ([#1271](https://github.com/penrose/penrose/issues/1271)) ([a74a7e2](https://github.com/penrose/penrose/commit/a74a7e2746069c5b6c5c657b84a24f3d2b9bf897))

--- a/packages/vscode/package.json
+++ b/packages/vscode/package.json
@@ -3,7 +3,7 @@
   "displayName": "Penrose",
   "publisher": "penrose",
   "description": "Penrose languages bundle",
-  "version": "2.1.1",
+  "version": "2.2.0",
   "author": "Penrose Team (https://penrose.cs.cmu.edu/)",
   "license": "MIT",
   "private": true,


### PR DESCRIPTION
# Description

We need to release a new version because of #1253, #1280, and #1271. Diff generated using analogous commands to #1252, plus again modifications to `packages/optimizer/Cargo.{toml,lock}`:

```sh
yarn new-version 2.2.0
yarn format
```

In this case I also made a manual change to `.github/workflows/release.yml` because I realized it had an error.

# Checklist

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new ESLint warnings
- [x] I have reviewed any generated registry diagram changes