### PR TITLE
build: fix VS Code extension publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,6 +23,6 @@ jobs:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
       - name: Publish VS Code extension
         working-directory: packages/vscode/
-        run: npx vsce publish --baseImagesUrl="https://github.com/penrose/penrose/raw/${GITHUB_REF#refs/tags/}/packages/vscode"
+        run: npx vsce publish
         env:
           VSCE_PAT: ${{ secrets.VSCE_PAT }}


### PR DESCRIPTION
# Description

Fix attempt for #1292 using https://github.com/microsoft/vscode-vsce/issues/300#issuecomment-978256849 (which worked for me to manually publish v2.2.0).

# Checklist

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new ESLint warnings
- [x] I have reviewed any generated registry diagram changes