### PR TITLE
fix: `inRange` implemented incorrectly

### DIFF
--- a/packages/core/src/contrib/Constraints.ts
+++ b/packages/core/src/contrib/Constraints.ts
@@ -80,7 +80,10 @@ const constrDictSimple = {
    * Require that the value `x` is in the range defined by `[x0, x1]`.
    */
   inRange: (x: ad.Num, x0: ad.Num, x1: ad.Num) => {
-    return mul(sub(x, x0), sub(x, x1));
+    return add(
+      ifCond(lt(x, x1), 0, sub(x, x1)),
+      ifCond(lt(x0, x), 0, sub(x0, x))
+    );
   },
 
   /**

--- a/packages/core/src/contrib/__tests__/Constraints.test.ts
+++ b/packages/core/src/contrib/__tests__/Constraints.test.ts
@@ -82,11 +82,11 @@ describe("simple constraint", () => {
   );
 
   it.each([
-    [0, 1, 3, 3],
+    [0, 1, 3, 1],
     [1, 1, 3, 0],
-    [2, 1, 3, -1],
+    [2, 1, 3, 0],
     [3, 1, 3, 0],
-    [4, 1, 3, 3],
+    [4, 1, 3, 1],
   ])(
     "inRange(%p, %p, %p) should return %p",
     (x: number, x0: number, x1: number, expected: number) => {

--- a/packages/examples/src/geometry-domain/euclidean.style
+++ b/packages/examples/src/geometry-domain/euclidean.style
@@ -104,10 +104,9 @@ where In(p, P) {
 forall Point p, q, r
 where Collinear(p, q, r) {
   ensure collinear(p.icon.center, q.icon.center, r.icon.center)
-  -- HACK: make sure q is between p and r
-  -- TODO: should this be in Substance instead?
   ensure inRange(q.icon.center[0], p.icon.center[0], r.icon.center[0])
   ensure inRange(q.icon.center[1], p.icon.center[1], r.icon.center[1])
+
   encourage notTooClose(p.icon, q.icon, const.repelWeight)
   encourage notTooClose(q.icon, r.icon, const.repelWeight)
 }
@@ -504,9 +503,9 @@ with Point p; Point q; Point r {
     fillColor: none()
     strokeColor: none()
   }
-  ensure length(t.PQ) > const.minSegmentLength
-  ensure length(t.QR) > const.minSegmentLength
-  ensure length(t.RP) > const.minSegmentLength
+  ensure norm(p.vec - q.vec) > const.minSegmentLength
+  ensure norm(q.vec - r.vec) > const.minSegmentLength
+  ensure norm(r.vec - p.vec) > const.minSegmentLength
   ensure disjoint(t.icon, p.text)
   ensure disjoint(t.icon, q.text)
   ensure disjoint(t.icon, r.text)

--- a/packages/examples/src/registry.json
+++ b/packages/examples/src/registry.json
@@ -105,7 +105,7 @@
       "substance": "incenter-triangle",
       "style": "euclidean",
       "domain": "geometry",
-      "variation": "",
+      "variation": "RationalityZebra567",
       "gallery": true
     },
     {
@@ -138,7 +138,7 @@
       "substance": "circle-example",
       "style": "euclidean",
       "domain": "geometry",
-      "variation": "ShiitakeEchidna6061"
+      "variation": "PathwayJellyfish159"
     },
     {
       "name": "Word Cloud",
@@ -235,7 +235,7 @@
       "substance": "3d-projection",
       "style": "fake-3d-linear-algebra",
       "domain": "fake-3d-linear-algebra",
-      "variation": "ConceptualMeerkat694"
+      "variation": "PurpletiniSeahorse9761"
     },
     {
       "substance": "vector-wedge",


### PR DESCRIPTION
# Description

Resolves #860. Resolves #1296 

The current `inRange` implementation is wrong. This PR fixes it.

# Implementation strategy and design decisions

Turn the multiplication into sum of differences guarded by `ifCond`s.

# Examples with steps to reproduce them

# Checklist

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new ESLint warnings
- [x] I have reviewed any generated registry diagram changes

# Open questions

Questions that require more discussion or to be addressed in future development:
