### PR TITLE
feat: triangle-mesh-3d example improvements

### DIFF
--- a/packages/examples/src/triangle-mesh-3d/README.md
+++ b/packages/examples/src/triangle-mesh-3d/README.md
@@ -1,6 +1,6 @@
 # triangle-mesh-3d
 
-This example is an experiment with using Penrose to generate 3D diagrams. _Note that Penrose does not yet natively support 3D vector operations!_ However, nothing prevents us from performing all the necessary 3D calculations (such as 3D rotations, perspective projection, etc.) using scalar coordinates---it just requires a whole lot of typing...
+This example is an experiment with using Penrose to generate 3D diagrams. _Note that Penrose does not yet natively support many 3D vector operations!_ However, nothing prevents us from performing all the necessary calculations (3D rotations, perspective projection, etc.) inline---it just requires a whole lot of typing...
 
 The example works by defining points as 3D coordinates, then using a simplistic camera model to project these 3D coordinates to 2D coordinates, which are drawn as usual.
 
@@ -12,4 +12,4 @@ What's particularly cool (and ultimately, useful) about this setup is that we ca
 - 2D projections of triangle have reasonable angles in screen space
 - their shadows project onto the ground plane (enforced via a 2D polygon inclusion constraint)
 
-Future development on Penrose should make such examples easier, by introducing native `vec3` (and `vec4`) types, akin to [GLSL](https://en.wikipedia.org/wiki/OpenGL_Shading_Language), as well as associated matrix types and convenience functions (e.g., building a nice modelview and/or projection matrix from intuitive parameters, a la standard libraries in the OpenGL ecosystem, like [glm](https://github.com/g-truc/glm)).
+Future development on Penrose should make such examples easier, by better support for `vec3` (and `vec4`) types, akin to [GLSL](https://en.wikipedia.org/wiki/OpenGL_Shading_Language), as well as associated matrix types and convenience functions (e.g., building a nice modelview and/or projection matrix from intuitive parameters, a la standard libraries in the OpenGL ecosystem, like [glm](https://github.com/g-truc/glm)).

--- a/packages/examples/src/triangle-mesh-3d/triangle-mesh-3d.style
+++ b/packages/examples/src/triangle-mesh-3d/triangle-mesh-3d.style
@@ -53,41 +53,35 @@ forall Triangle t
    scalar c = .9*min( global.planeSize, abs(global.planeHeight) )
 
    -- triangle vertex coordinates in 3D
-   scalar xi = ?
-   scalar xj = ?
-   scalar xk = ?
-   scalar yi = ?
-   scalar yj = ?
-   scalar yk = ?
-   scalar zi = ?
-   scalar zj = ?
-   scalar zk = ?
-   ensure -c < xi
-   ensure xi < c
-   ensure -c < xj
-   ensure xj < c
-   ensure -c < xk
-   ensure xk < c
-   ensure -c < yi
-   ensure yi < c
-   ensure -c < yj
-   ensure yj < c
-   ensure -c < yk
-   ensure yk < c
-   ensure -c < zi
-   ensure zi < c
-   ensure -c < zj
-   ensure zj < c
-   ensure -c < zk
-   ensure zk < c
+   vec3 qi = (?,?,?)
+   vec3 qj = (?,?,?)
+   vec3 qk = (?,?,?)
+
+   ensure -c < qi[0]
+   ensure qi[0] < c
+   ensure -c < qi[1]
+   ensure qi[1] < c
+   ensure -c < qi[2]
+   ensure qi[2] < c
+
+   ensure -c < qj[0]
+   ensure qj[0] < c
+   ensure -c < qj[1]
+   ensure qj[1] < c
+   ensure -c < qj[2]
+   ensure qj[2] < c
+
+   ensure -c < qk[0]
+   ensure qk[0] < c
+   ensure -c < qk[1]
+   ensure qk[1] < c
+   ensure -c < qk[2]
+   ensure qk[2] < c
 
    -- Perform perspective projection on 3D coordinates to get 2D coordinates p
-   vec2 qi = (xi,yi)
-   vec2 qj = (xj,yj)
-   vec2 qk = (xk,yk)
-   vec2 t.pi = canvas.width * qi/(zi-global.cZ)
-   vec2 t.pj = canvas.width * qj/(zj-global.cZ)
-   vec2 t.pk = canvas.width * qk/(zk-global.cZ)
+   vec2 t.pi = canvas.width * (qi[0],qi[1])/(qi[2]-global.cZ)
+   vec2 t.pj = canvas.width * (qj[0],qj[1])/(qj[2]-global.cZ)
+   vec2 t.pk = canvas.width * (qk[0],qk[1])/(qk[2]-global.cZ)
 
    -- Draw polygon using projected 2D coordinates p
    shape t.icon = Polygon {
@@ -151,14 +145,14 @@ forall Triangle t
    -- Finally, draw a shadow of the triangle on the global ground plane
    -- by just replacing the y-coordinate with the height of the ground plane
    scalar h = global.planeHeight
-   vec2 ri = (xi,h)
-   vec2 rj = (xj,h)
-   vec2 rk = (xk,h)
+   vec2 ri = (qi[0],h)
+   vec2 rj = (qj[0],h)
+   vec2 rk = (qk[0],h)
 
    -- Perform perspective projection on 3D coordinates r to get 2D coordinates s
-   vec2 si = canvas.width * ri/(zi-global.cZ)
-   vec2 sj = canvas.width * rj/(zj-global.cZ)
-   vec2 sk = canvas.width * rk/(zk-global.cZ)
+   vec2 si = canvas.width * ri/(qi[2]-global.cZ)
+   vec2 sj = canvas.width * rj/(qj[2]-global.cZ)
+   vec2 sk = canvas.width * rk/(qk[2]-global.cZ)
 
    -- Draw shadow polygon using projected 2D coordinates s
    shape t.shadow = Polygon {

--- a/packages/examples/src/triangle-mesh-3d/triangle-mesh-3d.style
+++ b/packages/examples/src/triangle-mesh-3d/triangle-mesh-3d.style
@@ -1,5 +1,3 @@
--- Experimental style that emulates 3D diagramming
-
 canvas {
    width = 200
    height = 200
@@ -16,45 +14,26 @@ global {
    scalar cZ = -160 -- camera z coordinate
 
    -- Corner coordinates of the global ground plane
-   scalar x00 = -planeSize
-   scalar y00 =  planeHeight
-   scalar z00 = -planeSize
-
-   scalar x10 =  planeSize
-   scalar y10 =  planeHeight
-   scalar z10 = -planeSize
-
-   scalar x01 = -planeSize
-   scalar y01 =  planeHeight
-   scalar z01 =  planeSize
-
-   scalar x11 =  planeSize
-   scalar y11 =  planeHeight
-   scalar z11 =  planeSize
+   vec3 q00 = ( -planeSize, planeHeight, -planeSize )
+   vec3 q10 = (  planeSize, planeHeight, -planeSize )
+   vec3 q01 = ( -planeSize, planeHeight,  planeSize )
+   vec3 q11 = (  planeSize, planeHeight,  planeSize )
 
    -- Apply a random rotation to the ground plane
    -- (Note that we could also apply this rotation to the triangle
    -- vertices, but since they're sampled randomly, it wouldn't
    -- really change the appearance of the kinds of diagrams we sample).
    scalar θ = ?
-   scalar X00 = x00*cos(θ) + z00*sin(θ)
-   scalar Y00 = y00
-   scalar Z00 = z00*cos(θ) - x00*sin(θ)
-   scalar X01 = x01*cos(θ) + z01*sin(θ)
-   scalar Y01 = y01
-   scalar Z01 = z01*cos(θ) - x01*sin(θ)
-   scalar X10 = x10*cos(θ) + z10*sin(θ)
-   scalar Y10 = y10
-   scalar Z10 = z10*cos(θ) - x10*sin(θ)
-   scalar X11 = x11*cos(θ) + z11*sin(θ)
-   scalar Y11 = y11
-   scalar Z11 = z11*cos(θ) - x11*sin(θ)
+   vec3 Q00 = ( q00[0]*cos(θ) + q00[2]*sin(θ), q00[1], q00[2]*cos(θ) - q00[0]*sin(θ) )
+   vec3 Q10 = ( q10[0]*cos(θ) + q10[2]*sin(θ), q10[1], q10[2]*cos(θ) - q10[0]*sin(θ) )
+   vec3 Q01 = ( q01[0]*cos(θ) + q01[2]*sin(θ), q01[1], q01[2]*cos(θ) - q01[0]*sin(θ) )
+   vec3 Q11 = ( q11[0]*cos(θ) + q11[2]*sin(θ), q11[1], q11[2]*cos(θ) - q11[0]*sin(θ) )
 
    -- Perform perspective projection on 3D coordinates to get 2D coordinates p
-   vec2 p00 = canvas.width * (X00,Y00)/(Z00 - global.cZ)
-   vec2 p10 = canvas.width * (X10,Y10)/(Z10 - global.cZ)
-   vec2 p01 = canvas.width * (X01,Y01)/(Z01 - global.cZ)
-   vec2 p11 = canvas.width * (X11,Y11)/(Z11 - global.cZ)
+   vec2 p00 = canvas.width * (Q00[0],Q00[1])/(Q00[2] - global.cZ)
+   vec2 p10 = canvas.width * (Q10[0],Q10[1])/(Q10[2] - global.cZ)
+   vec2 p01 = canvas.width * (Q01[0],Q01[1])/(Q01[2] - global.cZ)
+   vec2 p11 = canvas.width * (Q11[0],Q11[1])/(Q11[2] - global.cZ)
 
    -- Draw polygon using projected 2D coordinates p
    shape groundPlane = Polygon {
@@ -192,7 +171,7 @@ forall Triangle t
    }
 
    -- Make sure the triangle shadow lands on the ground plane
-   ensure contains( global.groundPlane, t.shadow )
+   --ensure contains( global.groundPlane, t.shadow )
 }
 
 -- For any pair of triangles, make sure that triangles

--- a/packages/examples/src/triangle-mesh-3d/two-triangles.substance
+++ b/packages/examples/src/triangle-mesh-3d/two-triangles.substance
@@ -1,2 +1,4 @@
 Triangle s, t
 
+Label s $\mathbf{f}$
+Label t $\widetilde{\mathbf{f}}$


### PR DESCRIPTION
# Description

Simplifies example to make use of `vec3` type, and updates README accordingly.  Also adds labels to vertices, and disables shadow constraint (that makes optimization tougher for no clear visual gain).