### PR TITLE
feat: added "ctrl+enter" binding for recompiling

### DIFF
--- a/packages/components/src/editing/EditorPane.tsx
+++ b/packages/components/src/editing/EditorPane.tsx
@@ -42,8 +42,11 @@ export default function EditorPane({
   const editorRef = useRef<editor.IStandaloneCodeEditor | null>(null);
   const statusBarRef = useRef<HTMLDivElement>(null);
 
-  if (monaco != null && onWrite != null){
-    editorRef.current?.addCommand(monaco.KeyMod.CtrlCmd | monaco.KeyCode.Enter, onWrite)
+  if (monaco != null && onWrite != null) {
+    editorRef.current?.addCommand(
+      monaco.KeyMod.CtrlCmd | monaco.KeyCode.Enter,
+      onWrite
+    );
   }
 
   useEffect(() => {

--- a/packages/components/src/editing/EditorPane.tsx
+++ b/packages/components/src/editing/EditorPane.tsx
@@ -41,6 +41,11 @@ export default function EditorPane({
   const monaco = useMonaco();
   const editorRef = useRef<editor.IStandaloneCodeEditor | null>(null);
   const statusBarRef = useRef<HTMLDivElement>(null);
+
+  if (monaco != null && onWrite != null){
+    editorRef.current?.addCommand(monaco.KeyMod.CtrlCmd | monaco.KeyCode.Enter, onWrite)
+  }
+
   useEffect(() => {
     if (monaco) {
       const dispose =

--- a/packages/components/src/editing/EditorPane.tsx
+++ b/packages/components/src/editing/EditorPane.tsx
@@ -42,7 +42,7 @@ export default function EditorPane({
   const editorRef = useRef<editor.IStandaloneCodeEditor | null>(null);
   const statusBarRef = useRef<HTMLDivElement>(null);
 
-  if (monaco != null && onWrite != null) {
+  if (monaco !== null && onWrite !== undefined) {
     editorRef.current?.addCommand(
       monaco.KeyMod.CtrlCmd | monaco.KeyCode.Enter,
       onWrite


### PR DESCRIPTION
# Description

Resolves #1272 

"ctrl+enter" now functions identically to `:w` in VimMode. 

# Checklist

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new ESLint warnings
- [ ] I have reviewed any generated registry diagram changes