### PR TITLE
chore: add optimizer `build/` to `.prettierignore`

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -13,6 +13,7 @@
 /packages/docs-site/public/try/
 /packages/docs-site/src/shapedefs.json
 /packages/optimizer/bindings/
+/packages/optimizer/build/
 /packages/optimizer/index.js
 /packages/optimizer/target/
 /packages/roger/oclif.manifest.json


### PR DESCRIPTION
# Description

We removed `build/` from `.prettierignore` in #1173, and remembered to add `/packages/docs-site/build/`, but forgot to add `/packages/optimizer/build/`.

# Checklist

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new ESLint warnings
- [x] I have reviewed any generated registry diagram changes