### PR TITLE
fix: nondeterminism in renderer

### DIFF
--- a/packages/automator/index.tsx
+++ b/packages/automator/index.tsx
@@ -138,7 +138,8 @@ const singleProcess = async (
     const joined = resolve(parentDir, filePath);
     return fs.readFileSync(joined, "utf8").toString();
   };
-  const canvas = (await RenderStatic(optimizedState, resolvePath)).outerHTML;
+  const canvas = (await RenderStatic(optimizedState, resolvePath, "automator"))
+    .outerHTML;
 
   const reactRenderEnd = process.hrtime(reactRenderStart);
   const overallEnd = process.hrtime(overallStart);

--- a/packages/components/src/Demo.tsx
+++ b/packages/components/src/Demo.tsx
@@ -26,6 +26,7 @@ const Demo = (props: {
   return (
     <div style={{ width: props.width, height: props.width }}>
       <Simple
+        name="demo"
         substance={example.sub}
         style={example.sty}
         domain={example.dsl}

--- a/packages/components/src/Embed.tsx
+++ b/packages/components/src/Embed.tsx
@@ -55,6 +55,7 @@ class Embed extends React.Component<SimpleProps, EmbedState> {
     return (
       <div className="embed-container" style={containerStyle}>
         <Simple
+          name={"embed"}
           domain={this.props.domain}
           substance={this.props.substance}
           style={this.props.style}

--- a/packages/components/src/Grid.tsx
+++ b/packages/components/src/Grid.tsx
@@ -62,6 +62,7 @@ export class Grid extends React.Component<GridProps> {
         <Gridbox
           {...this.props.gridBoxProps}
           key={`grid-${i}`}
+          name={`grid-${i}`}
           header={this.props.header(i)}
           metadata={this.props.metadata(i)}
           domain={domain}

--- a/packages/components/src/Gridbox.tsx
+++ b/packages/components/src/Gridbox.tsx
@@ -177,6 +177,7 @@ export class Gridbox extends React.Component<GridboxProps, GridboxState> {
             {...this.props}
             variation={variation}
             key={`gridbox-${this.props.gridIndex}`}
+            name={`gridbox-${this.props.gridIndex}`}
             interactive={false}
             onFrame={(state: PenroseState) => {
               this.setState({ currentState: state });

--- a/packages/components/src/Simple.tsx
+++ b/packages/components/src/Simple.tsx
@@ -16,6 +16,7 @@ import React from "react";
 import fetchResolver from "./fetchPathResolver";
 
 export interface SimpleProps {
+  name: string;
   domain: string;
   substance: string;
   style: string;
@@ -139,7 +140,8 @@ class Simple extends React.Component<SimpleProps, SimpleState> {
         false
           ? RenderStatic(
               this.penroseState,
-              this.props.imageResolver ?? fetchResolver
+              this.props.imageResolver ?? fetchResolver,
+              this.props.name
             )
           : RenderInteractive(
               this.penroseState,
@@ -150,7 +152,8 @@ class Simple extends React.Component<SimpleProps, SimpleState> {
                 }
                 this.renderCanvas();
               },
-              this.props.imageResolver ?? fetchResolver
+              this.props.imageResolver ?? fetchResolver,
+              this.props.name
             ));
         if (node.firstChild !== null) {
           node.replaceChild(renderedState, node.firstChild);

--- a/packages/components/src/Simple.tsx
+++ b/packages/components/src/Simple.tsx
@@ -16,7 +16,6 @@ import React from "react";
 import fetchResolver from "./fetchPathResolver";
 
 export interface SimpleProps {
-  name: string;
   domain: string;
   substance: string;
   style: string;
@@ -26,6 +25,7 @@ export interface SimpleProps {
   animate?: boolean; // considered false by default
   onFrame?: (frame: PenroseState) => void;
   imageResolver?: PathResolver;
+  name?: string;
 }
 
 export interface SimpleState {
@@ -141,7 +141,7 @@ class Simple extends React.Component<SimpleProps, SimpleState> {
           ? RenderStatic(
               this.penroseState,
               this.props.imageResolver ?? fetchResolver,
-              this.props.name
+              this.props.name ?? ""
             )
           : RenderInteractive(
               this.penroseState,
@@ -153,7 +153,7 @@ class Simple extends React.Component<SimpleProps, SimpleState> {
                 this.renderCanvas();
               },
               this.props.imageResolver ?? fetchResolver,
-              this.props.name
+              this.props.name ?? ""
             ));
         if (node.firstChild !== null) {
           node.replaceChild(renderedState, node.firstChild);

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -88,8 +88,7 @@
     "poly-partition": "^1.0.2",
     "recursive-diff": "^1.0.8",
     "seedrandom": "^3.0.5",
-    "true-myth": "^4.1.0",
-    "uuid": "^9.0.0"
+    "true-myth": "^4.1.0"
   },
   "devDependencies": {
     "@penrose/examples": "^2.2.0",
@@ -100,7 +99,6 @@
     "@types/nearley": "^2.11.1",
     "@types/node": "^10.17.21",
     "@types/seedrandom": "^2.4.28",
-    "@types/uuid": "^9.0.0",
     "@typescript-eslint/eslint-plugin": "^4.5.0",
     "@typescript-eslint/eslint-plugin-tslint": "^4.5.0",
     "@typescript-eslint/parser": "^4.5.0",

--- a/packages/core/src/__tests__/overall.test.ts
+++ b/packages/core/src/__tests__/overall.test.ts
@@ -19,7 +19,7 @@ const setDomain = setTHeory["setTheory.domain"];
 
 describe("Determinism", () => {
   const render = async (state: State): Promise<string> =>
-    (await RenderStatic(state, async () => undefined)).outerHTML;
+    (await RenderStatic(state, async () => undefined, "")).outerHTML;
 
   const substance = "Set A, B\nIsSubset(B, A)\nAutoLabel All";
   const style = vennStyle;

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -163,10 +163,10 @@ const stepUntilConvergenceOrThrow = (state: State): State => {
 /**
  * Embed a static Penrose diagram in a DOM node.
  *
- * @param domainProg a Domain program string
- * @param subProg a Substance program string
- * @param styProg a Style program string
+ * @param prog a Penrose trio and variation
  * @param node a node in the DOM tree
+ * @param pathResolver a resolver function for fetching Style imports
+ * @param name the name of the diagram
  */
 export const diagram = async (
   prog: {
@@ -176,13 +176,14 @@ export const diagram = async (
     variation: string;
   },
   node: HTMLElement,
-  pathResolver: PathResolver
+  pathResolver: PathResolver,
+  name: string
 ): Promise<void> => {
   const res = await compileTrio(prog);
   if (res.isOk()) {
     const state: State = await prepareState(res.value);
     const optimized = stepUntilConvergenceOrThrow(state);
-    const rendered = await RenderStatic(optimized, pathResolver);
+    const rendered = await RenderStatic(optimized, pathResolver, name);
     node.appendChild(rendered);
   } else {
     throw Error(
@@ -194,10 +195,10 @@ export const diagram = async (
 /**
  * Embed an interactive Penrose diagram in a DOM node.
  *
- * @param domainProg a Domain program string
- * @param subProg a Substance program string
- * @param styProg a Style program string
+ * @param prog a Penrose trio and variation
+ * @param pathResolver a resolver function for fetching Style imports
  * @param node a node in the DOM tree
+ * @param name the name of the diagram
  */
 export const interactiveDiagram = async (
   prog: {
@@ -207,14 +208,16 @@ export const interactiveDiagram = async (
     variation: string;
   },
   node: HTMLElement,
-  pathResolver: PathResolver
+  pathResolver: PathResolver,
+  name: string
 ): Promise<void> => {
   const updateData = async (state: State) => {
     const stepped = stepUntilConvergenceOrThrow(state);
     const rendering = await RenderInteractive(
       stepped,
       updateData,
-      pathResolver
+      pathResolver,
+      name
     );
     node.replaceChild(rendering, node.firstChild!);
   };
@@ -225,7 +228,8 @@ export const interactiveDiagram = async (
     const rendering = await RenderInteractive(
       optimized,
       updateData,
-      pathResolver
+      pathResolver,
+      name
     );
     node.appendChild(rendering);
   } else {

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -177,13 +177,13 @@ export const diagram = async (
   },
   node: HTMLElement,
   pathResolver: PathResolver,
-  name: string
+  name?: string
 ): Promise<void> => {
   const res = await compileTrio(prog);
   if (res.isOk()) {
     const state: State = await prepareState(res.value);
     const optimized = stepUntilConvergenceOrThrow(state);
-    const rendered = await RenderStatic(optimized, pathResolver, name);
+    const rendered = await RenderStatic(optimized, pathResolver, name ?? "");
     node.appendChild(rendered);
   } else {
     throw Error(
@@ -209,7 +209,7 @@ export const interactiveDiagram = async (
   },
   node: HTMLElement,
   pathResolver: PathResolver,
-  name: string
+  name?: string
 ): Promise<void> => {
   const updateData = async (state: State) => {
     const stepped = stepUntilConvergenceOrThrow(state);
@@ -217,7 +217,7 @@ export const interactiveDiagram = async (
       stepped,
       updateData,
       pathResolver,
-      name
+      name ?? ""
     );
     node.replaceChild(rendering, node.firstChild!);
   };
@@ -229,7 +229,7 @@ export const interactiveDiagram = async (
       optimized,
       updateData,
       pathResolver,
-      name
+      name ?? ""
     );
     node.appendChild(rendering);
   } else {

--- a/packages/core/src/renderer/Line.ts
+++ b/packages/core/src/renderer/Line.ts
@@ -1,4 +1,3 @@
-import { v4 as uuid } from "uuid";
 import { Shape } from "../types/shape";
 import { BoolV, ColorV, FloatV, StrV, VectorV } from "../types/value";
 import {
@@ -128,7 +127,12 @@ const makeRoomForArrows = (
   ];
 };
 
-const Line = ({ shape, canvasSize, variation }: ShapeProps): SVGGElement => {
+const Line = ({
+  shape,
+  canvasSize,
+  namespace,
+  variation,
+}: ShapeProps): SVGGElement => {
   const startArrowhead = getArrowhead(
     (shape.properties.startArrowhead as StrV).contents
   );
@@ -151,8 +155,8 @@ const Line = ({ shape, canvasSize, variation }: ShapeProps): SVGGElement => {
     (shape.properties.strokeColor as ColorV<number>).contents
   );
   const elem = document.createElementNS("http://www.w3.org/2000/svg", "g");
-
-  const unique = uuid();
+  // an unique id for this instance is determined by the variation and namespace
+  const unique = `${namespace}-${variation}`;
   const startArrowId = unique + "-startArrowId";
   const endArrowId = unique + "-endArrowId";
   if (startArrowhead) {

--- a/packages/core/src/renderer/Renderer.ts
+++ b/packages/core/src/renderer/Renderer.ts
@@ -19,6 +19,7 @@ import shapeMap from "./shapeMap";
 export type PathResolver = (path: string) => Promise<string | undefined>;
 
 export interface ShapeProps {
+  namespace: string;
   variation: string;
   shape: Shape;
   labels: LabelCache;
@@ -34,6 +35,7 @@ export const RenderShape = async ({
   labels,
   canvasSize,
   variation,
+  namespace,
   pathResolver,
 }: ShapeProps): Promise<SVGElement> => {
   if (!(shape.shapeType in shapeMap)) {
@@ -44,6 +46,7 @@ export const RenderShape = async ({
   return await shapeMap[shape.shapeType]({
     shape,
     labels,
+    namespace,
     variation,
     canvasSize,
     pathResolver,
@@ -144,7 +147,8 @@ export const DraggableShape = async (
 export const RenderInteractive = async (
   state: State,
   updateState: (newState: State) => void,
-  pathResolver: PathResolver
+  pathResolver: PathResolver,
+  namespace: string
 ): Promise<SVGSVGElement> => {
   const svg = document.createElementNS("http://www.w3.org/2000/svg", "svg");
   svg.setAttribute("xmlns", "http://www.w3.org/2000/svg");
@@ -167,6 +171,7 @@ export const RenderInteractive = async (
           canvasSize: state.canvas.size,
           variation: state.variation,
           pathResolver,
+          namespace,
         },
         onDrag,
         svg
@@ -182,7 +187,8 @@ export const RenderInteractive = async (
  */
 export const RenderStatic = async (
   state: State,
-  pathResolver: PathResolver
+  pathResolver: PathResolver,
+  namespace: string
 ): Promise<SVGSVGElement> => {
   const { varyingValues, computeShapes, labelCache: labels, canvas } = state;
   const svg = document.createElementNS("http://www.w3.org/2000/svg", "svg");
@@ -198,6 +204,7 @@ export const RenderStatic = async (
         canvasSize: canvas.size,
         variation: state.variation,
         pathResolver,
+        namespace,
       })
     )
   ).then((renderedShapes) => {

--- a/packages/editor/src/components/DiagramPanel.tsx
+++ b/packages/editor/src/components/DiagramPanel.tsx
@@ -294,10 +294,13 @@ export default function DiagramPanel() {
                 });
                 step();
               },
-              (path) => pathResolver(path, rogerState, workspace)
+              (path) => pathResolver(path, rogerState, workspace),
+              "diagramPanel"
             )
-          : await RenderStatic(state, (path) =>
-              pathResolver(path, rogerState, workspace)
+          : await RenderStatic(
+              state,
+              (path) => pathResolver(path, rogerState, workspace),
+              "diagramPanel"
             );
         rendered.setAttribute("width", "100%");
         rendered.setAttribute("height", "100%");

--- a/packages/synthesizer-ui/src/components/Content.tsx
+++ b/packages/synthesizer-ui/src/components/Content.tsx
@@ -158,14 +158,18 @@ export class Content extends React.Component<ContentProps, ContentState> {
     for (const idx of indices) {
       const state = this.state.states[idx];
       const { prog, ops } = this.state.progs[idx];
-      const svg = await RenderStatic(state, async (path: string) => {
-        const response = await fetch(path);
-        if (!response.ok) {
-          console.error(`could not fetch ${path}`);
-          return undefined;
-        }
-        return await response.text();
-      });
+      const svg = await RenderStatic(
+        state,
+        async (path: string) => {
+          const response = await fetch(path);
+          if (!response.ok) {
+            console.error(`could not fetch ${path}`);
+            return undefined;
+          }
+          return await response.text();
+        },
+        "diagram" // standalone SVG exports don't require distinct namespaces
+      );
       zip.file(`diagram_${idx}.svg`, svg.outerHTML.toString());
       zip.file(`substance_${idx}.substance`, prettySubstance(prog));
       zip.file(`mutations_${idx}.txt`, showMutations(ops));


### PR DESCRIPTION
# Description

Resolves #1312.

# Implementation strategy and design decisions

* In `Line.ts`, stop using `uuid.v4` for unique ID generation
* Instead, `Render*` functions take in `name`, a client-provided id for the diagram instance to be rendered. And names in the SVG are disambiguated from others instances by a unique instance id. 
* Similarly, `Simple` and `GridBox` take in `name` too.
* Remove `uuid` from `core`'s dependencies
* Note that this PR doesn't solve #1307

# Examples with steps to reproduce them

# Checklist

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new ESLint warnings
- [x] I have reviewed any generated registry diagram changes

# Open questions

Questions that require more discussion or to be addressed in future development:
