### PR TITLE
fix: github action node version

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -2,6 +2,11 @@ name: Packages
 runs:
   using: composite
   steps:
+    - name: setup Node 16
+      uses: actions/setup-node@v3
+      with:
+        registry-url: "https://registry.npmjs.org"
+        node-version: 16
     - name: Install Wasm target
       run: rustup target add wasm32-unknown-unknown
       shell: bash

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,6 +15,7 @@ jobs:
       - uses: actions/setup-node@v3
         with:
           registry-url: "https://registry.npmjs.org"
+          node-version: 16
       - name: Build all packages
         run: yarn build
       - name: Publish npm packages


### PR DESCRIPTION
GitHub action updated to, by default, use Node 18, which breaks some dependencies. See [here](https://github.com/actions/runner-images/issues/7002).

For now, we are forcing GitHub action to use Node 16.
