### PR TITLE
feat: Warning Inspector

### DIFF
--- a/packages/editor/src/App.tsx
+++ b/packages/editor/src/App.tsx
@@ -24,6 +24,7 @@ import RogerPanel from "./components/RogerPanel";
 import SavedFilesBrowser from "./components/SavedBrowser";
 import Settings from "./components/Settings";
 import StateInspector from "./components/StateInspector";
+import WarningInspector from "./components/WarningInspector";
 import SvgUploader from "./components/SvgUploader";
 import TopBar from "./components/TopBar";
 import {
@@ -96,6 +97,7 @@ const mainRowLayout: IJsonRowNode = {
           component: "grid",
           enableRename: false,
         },
+        { type: "tab", name: "warnings", component: "warningInspector" },
       ],
     },
   ],
@@ -181,6 +183,8 @@ function App() {
           return <DiagramOptions />;
         case "stateInspector":
           return <StateInspector />;
+        case "warningInspector":
+          return <WarningInspector />;
         case "optInspector":
           return <Opt />;
         case "rogerPanel":

--- a/packages/editor/src/App.tsx
+++ b/packages/editor/src/App.tsx
@@ -97,7 +97,7 @@ const mainRowLayout: IJsonRowNode = {
           component: "grid",
           enableRename: false,
         },
-        { type: "tab", name: "warnings", component: "warningInspector" },
+        { type: "tab", name: "Warnings", component: "warningInspector" },
       ],
     },
   ],

--- a/packages/editor/src/App.tsx
+++ b/packages/editor/src/App.tsx
@@ -24,9 +24,9 @@ import RogerPanel from "./components/RogerPanel";
 import SavedFilesBrowser from "./components/SavedBrowser";
 import Settings from "./components/Settings";
 import StateInspector from "./components/StateInspector";
-import WarningInspector from "./components/WarningInspector";
 import SvgUploader from "./components/SvgUploader";
 import TopBar from "./components/TopBar";
+import WarningInspector from "./components/WarningInspector";
 import {
   currentRogerState,
   currentWorkspaceState,

--- a/packages/editor/src/components/WarningInspector.tsx
+++ b/packages/editor/src/components/WarningInspector.tsx
@@ -18,7 +18,6 @@ const warningDivStyle = {
   minHeight: "100px",
   overflow: "auto",
   padding: "5px",
-  // whiteSpace: "pre-wrap"
 };
 
 const warningHeaderStyle = {
@@ -44,7 +43,7 @@ function FormatWarning(warning: StyleWarning, index: number) {
       );
     case "ImplicitOverrideWarning":
       return (
-        <div>
+        <div style={warningDivStyle}>
           <span style={warningHeaderStyle}> warning (ImplicitOverrideWarning) </span>
           <p key={`${warning.tag},${index}`}>
             Implicitly overriding '{warning.path.name}' <br></br>
@@ -54,7 +53,7 @@ function FormatWarning(warning: StyleWarning, index: number) {
       );
     case "LayerCycleWarning":
       return (
-        <div>
+        <div style={warningDivStyle}>
           <span style={warningHeaderStyle}> warning (LayerCycleWarning) </span>
           <p key={`${warning.tag},${index}`}>
             Cycles detected in layering order:{""} <br></br>

--- a/packages/editor/src/components/WarningInspector.tsx
+++ b/packages/editor/src/components/WarningInspector.tsx
@@ -1,0 +1,83 @@
+import { StyleWarning } from "@penrose/core/dist/types/errors";
+import { useRecoilValue } from "recoil";
+import { diagramState } from "../state/atoms";
+
+import { NodeType, SourceRange } from "@penrose/core/dist/types/ast";
+
+const locc = (nodeType: NodeType, node: SourceRange): string => {
+  return `line ${node.start.line}, column ${
+    node.start.col + 1
+  } of ${nodeType} program`;
+};
+
+const warningDivStyle = {
+  bottom: "0px",
+  backgroundColor: "rgb(255, 218, 218)",
+  maxHeight: "100%",
+  maxWidth: "100%",
+  minHeight: "100px",
+  overflow: "auto",
+  padding: "5px",
+  // whiteSpace: "pre-wrap"
+};
+
+const warningHeaderStyle = {
+  fontWeight: "bold",
+  color: "rgb(238, 78, 78)",
+  fontSize: "14px",
+};
+
+// NOTE: using index just for unique keys
+// TODO: figure out key naming conventions
+function FormatWarning(warning: StyleWarning, index: number) {
+  switch (warning.tag) {
+    case "NoopDeleteWarning":
+      return (
+        <div style={warningDivStyle}>
+          <span style={warningHeaderStyle}> warning (NoopDeleteWarning) </span>
+          <p key={`${warning.tag},${index}`}>
+            {" "}
+            Deleting nonexistent '{warning.path.name}' <br></br>
+            (at{" "} {locc("Style", warning.path)}).{" "}
+          </p>
+        </div>
+      );
+    case "ImplicitOverrideWarning":
+      return (
+        <div>
+          <span style={warningHeaderStyle}> warning (ImplicitOverrideWarning) </span>
+          <p key={`${warning.tag},${index}`}>
+            Implicitly overriding '{warning.path.name}' <br></br>
+            (at{" "} {locc("Style", warning.path)}).{" "}
+          </p>
+        </div>
+      );
+    case "LayerCycleWarning":
+      return (
+        <div>
+          <span style={warningHeaderStyle}> warning (LayerCycleWarning) </span>
+          <p key={`${warning.tag},${index}`}>
+            Cycles detected in layering order:{""} <br></br>
+            {warning.cycles.map((c) => c.join(" ➔ "))}. <br></br>
+            The system approximated a global layering order instead:<br></br>
+            {warning.approxOrdering.join(" ➔ ")};
+          </p>
+        </div>
+      );
+  }
+}
+
+export default function WarningInspector() {
+  const {state} = useRecoilValue(diagramState);
+  // NOTE: can only get one error at a time currently, 
+  // and right now it's being displayed in the diagram potion.
+  // Would likely need some refactoring to display all errors 
+
+  let warnings = state?.warnings || [];
+
+  return (
+    <div key={`${warnings.toString()}`}>
+      {warnings.map((warning, index) => FormatWarning(warning, index))}
+    </div>
+  );
+}

--- a/packages/editor/src/components/WarningInspector.tsx
+++ b/packages/editor/src/components/WarningInspector.tsx
@@ -37,17 +37,20 @@ function FormatWarning(warning: StyleWarning, index: number) {
           <p key={`${warning.tag},${index}`}>
             {" "}
             Deleting nonexistent '{warning.path.name}' <br></br>
-            (at{" "} {locc("Style", warning.path)}).{" "}
+            (at {locc("Style", warning.path)}).{" "}
           </p>
         </div>
       );
     case "ImplicitOverrideWarning":
       return (
         <div style={warningDivStyle}>
-          <span style={warningHeaderStyle}> warning (ImplicitOverrideWarning) </span>
+          <span style={warningHeaderStyle}>
+            {" "}
+            warning (ImplicitOverrideWarning){" "}
+          </span>
           <p key={`${warning.tag},${index}`}>
             Implicitly overriding '{warning.path.name}' <br></br>
-            (at{" "} {locc("Style", warning.path)}).{" "}
+            (at {locc("Style", warning.path)}).{" "}
           </p>
         </div>
       );
@@ -67,10 +70,10 @@ function FormatWarning(warning: StyleWarning, index: number) {
 }
 
 export default function WarningInspector() {
-  const {state} = useRecoilValue(diagramState);
-  // NOTE: can only get one error at a time currently, 
+  const { state } = useRecoilValue(diagramState);
+  // NOTE: can only get one error at a time currently,
   // and right now it's being displayed in the diagram potion.
-  // Would likely need some refactoring to display all errors 
+  // Would likely need some refactoring to display all errors
 
   let warnings = state?.warnings || [];
 


### PR DESCRIPTION
# Description

Addresses #1305 
Warnings now show up in a pane called "Warnings"

It's not yet ready to merge.
Still need to make styling more consistent with the error tab, and make the cycle warning text nicer. Currently it's a little ugly.
Also need to check for ESLint warnings.


# Checklist

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new ESLint warnings
- [ ] I have reviewed any generated registry diagram changes

# Open questions

Thinking whether or not we should also display errors here, given that they're already displayed when the diagram fails to compile. Would probably be useful if you had to view with a large volume of errors at once so the `Diagram` tab doesn't become the `Diagram and also errors` tab.