### PR TITLE
fix: SVG overflow in `Simple` component

### DIFF
--- a/packages/components/src/Simple.tsx
+++ b/packages/components/src/Simple.tsx
@@ -152,6 +152,9 @@ class Simple extends React.Component<SimpleProps, SimpleState> {
               },
               this.props.imageResolver ?? fetchResolver
             ));
+        // to avoid overflowing the parent div, force the height to be 100%
+        renderedState.setAttribute("height", "100%");
+        renderedState.setAttribute("width", "100%");
         if (node.firstChild !== null) {
           node.replaceChild(renderedState, node.firstChild);
         } else {

--- a/packages/components/src/Simple.tsx
+++ b/packages/components/src/Simple.tsx
@@ -152,7 +152,7 @@ class Simple extends React.Component<SimpleProps, SimpleState> {
               },
               this.props.imageResolver ?? fetchResolver
             ));
-        // to avoid overflowing the parent div, force the height to be 100%
+        // to avoid overflowing the parent div, force the height and width to be 100%
         renderedState.setAttribute("height", "100%");
         renderedState.setAttribute("width", "100%");
         if (node.firstChild !== null) {


### PR DESCRIPTION
# Description

Because the render doesn't set SVG width and height, `<Simple>` will overflow if the diagram height exceed 90% of the diagram width. 

![image](https://user-images.githubusercontent.com/11740102/220728552-70eefac7-f6d2-4a57-9e7b-7d4950811fed.png)

# Implementation strategy and design decisions

This PR sets the SVG width and height after rendering, thereby scaling the SVG to the parent `<div>`.

![image](https://user-images.githubusercontent.com/11740102/220728863-eebb1b99-e147-4c53-9391-d3a5f16c3fb6.png)


# Checklist

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new ESLint warnings
- [x] I have reviewed any generated registry diagram changes
