### PR TITLE
fix: render shapes in order for determinism

### DIFF
--- a/packages/core/src/renderer/Renderer.ts
+++ b/packages/core/src/renderer/Renderer.ts
@@ -196,23 +196,19 @@ export const RenderStatic = async (
   svg.setAttribute("xmlns", "http://www.w3.org/2000/svg");
   svg.setAttribute("viewBox", `0 0 ${canvas.width} ${canvas.height}`);
 
-  return Promise.all(
-    computeShapes(varyingValues).map((shape) =>
-      RenderShape({
-        shape,
-        labels,
-        canvasSize: canvas.size,
-        variation: state.variation,
-        pathResolver,
-        namespace,
-      })
-    )
-  ).then((renderedShapes) => {
-    for (const shape of renderedShapes) {
-      svg.appendChild(shape);
-    }
-    return svg;
-  });
+  const shapes = computeShapes(varyingValues);
+  for (const shape of shapes) {
+    const rendered = await RenderShape({
+      shape,
+      labels,
+      canvasSize: canvas.size,
+      variation: state.variation,
+      pathResolver,
+      namespace,
+    });
+    svg.appendChild(rendered);
+  }
+  return svg;
 };
 
 const clamp = (x: number, min: number, max: number): number =>


### PR DESCRIPTION
# Description

Resolves #1312  

Following up on #1316 

# Implementation strategy and design decisions

Instead of `Promise.all`, sequentially `await` for each shape to render in `RenderStatic`.

