### PR TITLE
chore: remove ESLint from PR template checklist

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -13,7 +13,6 @@ Include a high-level summary of the implementation strategy and list important d
 # Checklist
 
 - [ ] I have commented my code, particularly in hard-to-understand areas
-- [ ] My changes generate no new ESLint warnings
 - [ ] I have reviewed any generated registry diagram changes
 
 # Open questions


### PR DESCRIPTION
# Description

Sometimes ESLint warnings are necessary, as in #1211.

# Checklist

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have reviewed any generated registry diagram changes