### PR TITLE
docs: move wiki

### DIFF
--- a/packages/docs-site/.vitepress/config.ts
+++ b/packages/docs-site/.vitepress/config.ts
@@ -183,7 +183,7 @@ export default defineConfig({
               text: "Domain",
               items: [
                 { text: "Overview", link: "/docs/ref/domain" },
-                { text: "Syntax", link: "/docs/ref/domain/syntax" },
+                { text: "Usage", link: "/docs/ref/domain/usage" },
                 { text: "Examples", link: "/docs/ref/domain/examples" },
               ],
             },
@@ -191,7 +191,7 @@ export default defineConfig({
               text: "Substance",
               items: [
                 { text: "Overview", link: "/docs/ref/substance" },
-                { text: "Syntax", link: "/docs/ref/substance/syntax" },
+                { text: "Usage", link: "/docs/ref/substance/usage" },
                 { text: "Examples", link: "/docs/ref/substance/examples" },
               ],
             },
@@ -204,7 +204,8 @@ export default defineConfig({
                   link: "/docs/ref/style/syntax",
                 },
                 {
-                  text: "Shape Library",
+                  text: "Shapes",
+                  link: "/docs/ref/style/shapes-overview",
                   items: [
                     // Please make sure the shapes are in alphabetical order.
                     { text: "Circle", link: "/docs/ref/style/shapes/circle" },

--- a/packages/docs-site/.vitepress/config.ts
+++ b/packages/docs-site/.vitepress/config.ts
@@ -200,6 +200,10 @@ export default defineConfig({
               items: [
                 { text: "Overview", link: "/docs/ref/style" },
                 {
+                  text: "Usage",
+                  link: "/docs/ref/style/syntax",
+                },
+                {
                   text: "Shape Library",
                   items: [
                     // Please make sure the shapes are in alphabetical order.
@@ -229,10 +233,6 @@ export default defineConfig({
                 {
                   text: "Passthrough SVG",
                   link: "/docs/ref/style/passthrough",
-                },
-                {
-                  text: "Syntax and Semantics",
-                  link: "/docs/ref/style/syntax",
                 },
                 { text: "Examples", link: "/docs/ref/style/examples" },
               ],

--- a/packages/docs-site/.vitepress/config.ts
+++ b/packages/docs-site/.vitepress/config.ts
@@ -126,7 +126,7 @@ export default defineConfig({
 
   themeConfig: {
     logo: "img/favicon.ico",
-
+    outline: "deep",
     nav: [
       {
         text: "Learn Penrose",
@@ -201,7 +201,7 @@ export default defineConfig({
                 { text: "Overview", link: "/docs/ref/style" },
                 {
                   text: "Usage",
-                  link: "/docs/ref/style/syntax",
+                  link: "/docs/ref/style/usage",
                 },
                 {
                   text: "Shapes",

--- a/packages/docs-site/docs/ref/domain/usage.md
+++ b/packages/docs-site/docs/ref/domain/usage.md
@@ -1,4 +1,4 @@
-# Syntax
+# Usage
 
 A _domain_ schema describes the types of objects, as well as relations between these objects, that Penrose diagrams work with. For example, say we want to use Penrose to draw a Venn diagram that represents the relationship between mathematical sets. We can declare the following domain schema:
 

--- a/packages/docs-site/docs/ref/domain/usage.md
+++ b/packages/docs-site/docs/ref/domain/usage.md
@@ -1,4 +1,4 @@
-# Usage
+# Domain Usage
 
 A _domain_ schema describes the types of objects, as well as relations between these objects, that Penrose diagrams work with. For example, say we want to use Penrose to draw a Venn diagram that represents the relationship between mathematical sets. We can declare the following domain schema:
 

--- a/packages/docs-site/docs/ref/style/shapes-overview.md
+++ b/packages/docs-site/docs/ref/style/shapes-overview.md
@@ -25,7 +25,7 @@ forall Point x {
 }
 ```
 
-Notice that this definition, the `center:` attribute of the circle is not set. Undefined parameters like these will be automatically optimized by Penrose.
+Notice that this definition, the `center:` attribute of the circle is not set. Undefined parameters like these has default values which may or may not be adjusted upon optimization. Information about which default parameters are automatically adjusted can be found within each shape's specification.
 
 ## Keeping shapes on the canvas
 

--- a/packages/docs-site/docs/ref/style/shapes-overview.md
+++ b/packages/docs-site/docs/ref/style/shapes-overview.md
@@ -1,6 +1,6 @@
 # Shapes
 
-Style currently supports a variety of shapes, listed as sub-entries under this page. Note that the system is constantly evolving and this page may be out of date. Updated attributes for individual shapes can be found in the individual `Shapes.ts` files in the [`/shapes` subdirectory](https://github.com/penrose/penrose/tree/main/packages/core/src/shapes). In the attribute lists below, the `vec2` type describes a 2D vector `u`, whose scalar components can be accessed via `u[0]` and `u[1]`.
+Style currently supports a variety of shapes, listed as sub-entries under this page. In the attribute lists below, the `vec2` type describes a 2D vector `u`, whose scalar components can be accessed via `u[0]` and `u[1]`.
 
 ## Using shapes in Style
 

--- a/packages/docs-site/docs/ref/style/shapes-overview.md
+++ b/packages/docs-site/docs/ref/style/shapes-overview.md
@@ -1,0 +1,32 @@
+# Shapes
+
+Style currently supports a variety of shapes, listed as sub-entries under this page. Note that the system is constantly evolving and this page may be out of date. Updated attributes for individual shapes can be found in the individual `Shapes.ts` files in the [`/shapes` subdirectory](https://github.com/penrose/penrose/tree/main/packages/core/src/shapes). In the attribute lists below, the `vec2` type describes a 2D vector `u`, whose scalar components can be accessed via `u[0]` and `u[1]`.
+
+## Using shapes in Style
+
+In Style, a shape instance is declared inside a rule using a statement of the form
+
+```
+x.myShape = Shape {
+   attribute1: value1
+   attribute2: value2
+   ...
+}
+```
+
+For instance, to associate all Substance objects `x` of type `Point` with a red circle of radius 5, you would write
+
+```
+forall Point x {
+   x.myCircle = Circle {
+      radius: 5
+      fillColor: rgba(1,0,0,1)
+   }
+}
+```
+
+Notice that this definition, the `center:` attribute of the circle is not set. Undefined parameters like these will be automatically optimized by Penrose.
+
+## Keeping shapes on the canvas
+
+All shapes have a property `ensureOnCanvas`, which by default is set to `true`. This special constraint ensures that the shape remains within the bounding rectangle of the canvas (which must be declared at the top of each Style file). This constraint can be omitted by setting `ensureOnCanvas: false`.

--- a/packages/docs-site/docs/ref/style/shapes/equation.md
+++ b/packages/docs-site/docs/ref/style/shapes/equation.md
@@ -4,4 +4,8 @@ import ShapeProps from "../../../../src/components/ShapeProps.vue";
 
 # Equation
 
+An `Equation` is used to typeset mathematical expressions. It assumes that the `string` field corresponds to a math mode TeX expression, and uses MathJax to render this string. Note that ordinary (non-math) text can be drawn via the `Text` shape.
+
+## Properties
+
 <ShapeProps shape-name="Equation" />

--- a/packages/docs-site/docs/ref/style/shapes/group.md
+++ b/packages/docs-site/docs/ref/style/shapes/group.md
@@ -36,7 +36,7 @@ and get something like,
 </svg>
 ```
 
-## Parameters
+## Properties
 
 <ShapeProps shape-name="Group" />
 

--- a/packages/docs-site/docs/ref/style/shapes/path.md
+++ b/packages/docs-site/docs/ref/style/shapes/path.md
@@ -4,4 +4,28 @@ import ShapeProps from "../../../../src/components/ShapeProps.vue";
 
 # Path
 
+## Properties
+
 <ShapeProps shape-name="Path" />
+
+## Defining an SVG path using `d`
+
+The `d` attribute should receive information about the particular points you want to draw your path on. Currently, `Path` can handle SVG commands for lines and arcs. For detailed information about the information that each SVG command expects, check out [this](https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/d) resource.
+In your style program, to render each of the following types of SVG commands, pass `d` the return value of the following functions:
+
+- **Line or series of connected line segments**: `pathFromPoints(complete, [[x1, y1], [x2, y2],...,[xn, yn]])` where:
+  - `complete`: `"open"` to keep the SVG path open, `"closed"` to draw a line from the last point to the first
+  - `[[x1, y1], [x2, y2],...,[xn, yn]]` is the list of ordered points to make up the SVG path
+- **Arc**: `arc(complete, start, end, radius, rotation, largeArc, arcSweep)` (well-illustrated documentation on the purpose of each of the arc attributes in SVG can be found [here](https://developer.mozilla.org/en-US/docs/Web/SVG/Tutorial/Paths#arcs)):
+  - `complete`: `"open"` to keep the SVG path open, `"closed"` to draw a line from the last point to the first
+  - `start`: Coordinate `[x,y]` representing the beginning of the arc
+  - `end`: Coordinate `[x,y]` representing the endpoint of the arc
+  - `radius`: List of length 2 `[rx, ry]`, where `rx` is the radius of the ellipse to draw the arc along in the `x` direction (i.e. the width), and `ry` is the radius of the ellipse in the `y` direction.
+  - `rotation` Number representing the degree of rotation of the ellipse
+  - `largeArc`: `0` to draw shorter of 2 arcs, `1` to draw the longer
+  - `arcSweep`: `0` to draw in the counter-clockwise direction from `start` to `end`, `1` to draw in the clockwise direction
+- **Curve passing through three points**: `interpolateQuadraticFromPoints(pathType,p0,p1,p2)` where:
+  - `pathType`: `"open"` to keep the SVG path open, `"closed"` to draw a line from the last point to the first
+  - `p0`: start point
+  - `p1`: middle point — unlike a standard quadratic Bézier curve, which will _not_ pass through the middle control point, this curve will actually pass exactly through this point.
+  - `p2`: end point

--- a/packages/docs-site/docs/ref/style/shapes/text.md
+++ b/packages/docs-site/docs/ref/style/shapes/text.md
@@ -4,4 +4,10 @@ import ShapeProps from "../../../../src/components/ShapeProps.vue";
 
 # Text
 
+A `Text` shape is used to display plain text; see `Equation` for mathematical expressions. The `Text` shape supports many of the same attributes as SVG text. Note that by default, all text is centered vertically and horizontally, via the [`textAnchor`](https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/text-anchor) and [`alignmentBaseline`](https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/alignment-baseline) fields (which can be changed to left, bottom, etc.).
+
+The width and height of every `Text` shape is automatically set to the width/height of its bounding box—you do not have to set these values. In fact, it is often convenient to use these values when defining other shapes. For instance, to draw a `Rectangle` around an existing `Text` shape called `t`, you can set the rectangle's width/height/center fields to `width: t.width`, `height: t.height`, and `center: t.center`. (Note that this rectangle will be properly centered on the text only if the text retains the default values `textAnchor: middle` and `alignmentBaseline: alphabetic`; changing these values may cause the two shapes to become misaligned).
+
+## Properties
+
 <ShapeProps shape-name="Text" />

--- a/packages/docs-site/docs/ref/style/usage.md
+++ b/packages/docs-site/docs/ref/style/usage.md
@@ -299,7 +299,7 @@ forall Set `A` {
 
 the radius of the circle for every `Set` is `100`, except if the `Set` has name `A`, then the radius is `200`.
 
-Deletion of fields work similarly, with the `delete` keyword. This feature can be helpful for, e.g., removing visual elements for a subtype. For instance,
+Deletion of fields works similarly, with the `delete` keyword. This feature can be helpful for, e.g., removing visual elements for a subtype. For instance,
 
 ```
 -- by default, draw a circle for all instances of type T

--- a/packages/docs-site/docs/ref/style/usage.md
+++ b/packages/docs-site/docs/ref/style/usage.md
@@ -55,7 +55,7 @@ where
 
 - `list_object_declarations` is a **semicolon**-separated list of object declarations, similar to the object declarations in the _substance_ schema. Each object declaration has syntax `type_name object_name`. The names declared in `list_object_declarations` are referred to as _style variables_.
 - `list_relations` is a **semicolon**-separated list of constraints (about objects in `list_object_declaration`) that must be satisfied in order for this style block to be triggered.
-- `list_body_expressions` is the body of this _style_ block, containing statements that represent the computational and graphical aspects of the diagrams that are triggered when this style block is triggered. Refer to [this section](usage#blody-body) for a detailed explanation of what may appear in the body of a _style_ block.
+- `list_body_expressions` is the body of this _style_ block, containing statements that represent the computational and graphical aspects of the diagrams that are triggered when this style block is triggered. Refer to [this section](usage#block-body) for a detailed explanation of what may appear in the body of a _style_ block.
 
 If `list_relations` is empty, then the clause `where ...` needs to be omitted.
 

--- a/packages/docs-site/docs/ref/style/usage.md
+++ b/packages/docs-site/docs/ref/style/usage.md
@@ -241,7 +241,7 @@ Within a _style_ block body, some variable names are reserved for metadata purpo
 - `match_count` is an integer that refers to the number of times that this _style_ blocks will be triggered (or matched) in total; and
 - `match_id` is the 1-indexed ordinal of this current matching.
 
-These values can directly be read or overwritten within the style block body, or overwritten, if needed.
+These values can directly be read or overwritten within the style block body if needed.
 
 ## Block Body
 

--- a/packages/docs-site/docs/ref/style/usage.md
+++ b/packages/docs-site/docs/ref/style/usage.md
@@ -1,4 +1,4 @@
-# Syntax and Semantics
+# Style Usage
 
 Given a _domain_ schema (specifying the domain of the diagram) and a _substance_ program (specifying _what_ to draw), the _style_ schema describes the recipe of drawing the objects and relations on a canvas.
 
@@ -17,7 +17,7 @@ namespace_name {
 }
 ```
 
-Refer to [this section](syntax#blody-body) for a detailed explanation of what may appear in the body of a namespace.
+Refer to [this section](usage#block-body) for a detailed explanation of what may appear in the body of a namespace.
 
 Values declared within a namespace can be read outside of the namespace using the "dot" operator:
 
@@ -55,7 +55,7 @@ where
 
 - `list_object_declarations` is a **semicolon**-separated list of object declarations, similar to the object declarations in the _substance_ schema. Each object declaration has syntax `type_name object_name`. The names declared in `list_object_declarations` are referred to as _style variables_.
 - `list_relations` is a **semicolon**-separated list of constraints (about objects in `list_object_declaration`) that must be satisfied in order for this style block to be triggered.
-- `list_body_expressions` is the body of this _style_ block, containing statements that represent the computational and graphical aspects of the diagrams that are triggered when this style block is triggered. Refer to [this section](syntax#blody-body) for a detailed explanation of what may appear in the body of a _style_ block.
+- `list_body_expressions` is the body of this _style_ block, containing statements that represent the computational and graphical aspects of the diagrams that are triggered when this style block is triggered. Refer to [this section](usage#blody-body) for a detailed explanation of what may appear in the body of a _style_ block.
 
 If `list_relations` is empty, then the clause `where ...` needs to be omitted.
 
@@ -212,6 +212,8 @@ where s has label {
 
 If a certain `Set A` in the _substance_ program does not have a label (perhaps due to `NoLabel` declarations), then `s` will not be mapped to `A`, thus preventing an access of nonexistent properties.
 
+We can further distinguish between math labels and text labels (see [substance labeling](../substance/usage#labeling-statements)): `where p has math label` matches math labels, whereas `where p has text label` matches text labels.
+
 ### Matching Deduplication
 
 The matching algorithm is designed to avoid duplicated mappings. If two mappings give us the same set of matched objects (in the _substance_ program) and the equivalent set of matched substance relations (predicate applications and function or constructor applications), then the algorithm only triggers on one of them.
@@ -275,7 +277,7 @@ where MyPredicate (t1, t2) as r1 {
 }
 ```
 
-Refer to [this section](syntax#expressions-and-their-types) for a detailed explanation of the available expressions and their associated types.
+Refer to [this section](usage#expressions-and-their-types) for a detailed explanation of the available expressions and their associated types.
 
 ### Override and Deletion
 
@@ -497,7 +499,30 @@ scalar trM = M[0][0] + M[1][1]
 
 constructs an expression for the trace of `M`. In this case, since the elements of `M` are declared as unknown scalars, the value of the trace will depend on the entry values of the optimized matrix.
 
-### Operations between Expressions
+### Colors
+
+Colors have type `color`, and include an alpha (i.e., opacity) channel. Colors can be specified via two different color models:
+
+- `rgba(r, g, b, a)` defines a color via the RGB color model, with red, green, blue, and alpha values in the range [0, 1].
+  - If the required color is fixed and known, one can also use the hexadecimal representation `#rrggbbaa`, which gets converted to the corresponding color in `rgba(r, g, b, a)`. If the alpha value is not provided in the hexadecimal representation, it defaults to 1.0.
+- `hsva(h, s, v, a)` defines a color via the HSV color model, with hue in the range [0, 360], saturation and value in the range [0, 100], and alpha in the range [0, 1].
+
+To specify that a color should be omitted altogether, you can also use `none()`. E.g.,
+
+```
+fillColor: none()
+strokeColor: none()
+```
+
+Note that `none()` is different from using a 100% transparent color: it really prevents the fill or stroke from being drawn altogether.
+
+### Computation Functions
+
+Computation functions take in multiple values, and return a new value. The aforementioned functions `rgba`, `hsva`, and `none` are examples of computation functions. Other computation functions also exist, including many mathematical functions.
+
+See [the list of computation functions](functions#computation-functions).
+
+### Operations between Numerical Expressions
 
 Aside from concatenation of strings using the operator `+`, the _style_ language supports the operations listed below on scalars, vectors, and matrices. Here we assume that `c` and `d` have type `scalar`, `u` and `v` have type `vecN`, and `A` and `B` have type `matNxN` (all for the same `N`).
 

--- a/packages/docs-site/docs/ref/substance/usage.md
+++ b/packages/docs-site/docs/ref/substance/usage.md
@@ -1,4 +1,4 @@
-# Usage
+# Substance Usage
 
 The _substance_ program tells Penrose _what_ objects and relations to draw. In the set-theory example, for example, we can have the following _substance_ program:
 

--- a/packages/docs-site/docs/ref/substance/usage.md
+++ b/packages/docs-site/docs/ref/substance/usage.md
@@ -1,4 +1,4 @@
-# Syntax
+# Usage
 
 The _substance_ program tells Penrose _what_ objects and relations to draw. In the set-theory example, for example, we can have the following _substance_ program:
 

--- a/packages/docs-site/docs/ref/substance/usage.md
+++ b/packages/docs-site/docs/ref/substance/usage.md
@@ -110,8 +110,10 @@ Each declared object has a label, which can be accessed in the _style_ schema. I
 
 There are three types of labeling statements:
 
-- `AutoLabel All`: this statement assigns the label of each object in the _substance_ program to be its name. For instance, if we declare object `Atom A`, then `AutoLabel All` will automatically assign `A` as its label;
-- `Label object_name label_value`: this statement manually assign object `object_name`'s label to be `label_value`; and
+- `AutoLabel All`: this statement assigns the label of each object in the _substance_ program to be its name. For instance, if we declare object `Atom A`, then `AutoLabel All` will automatically assign `A` as its label.
+- `Label object_name label_value`: this statement manually assign object `object_name`'s label to be `label_value`. There are two types of `label_value`s:
+  - A math label is a TeX string delimited by dollar signs, e.g., `Label p $p_0$`
+  - A text label is a plain-text string delimited by double quotes, e.g., `Label p "a point"`.
 - `NoLabel object_list`: this statement ensures that objects in `object_list` do not have a label.
 
 If an object has an assigned label, then in the _style_ schema, we can access the object's `label` property.


### PR DESCRIPTION
# Description

Resolves #1314.

Moves applicable parts of the wiki documentations to the docs-site, including:
* `override` and `delete`
* strings
* matrix / vector
* type annotations
* some details of shapes
* colors
* computation functions
* labeling

Renamed `syntax and semantics` to `usage` with appropriate ordering.

Each page's outline is now a deep-outline, meaning that each sections and subsections will be shown in the outline. This makes navigation easier.