### PR TITLE
fix: avoid `EPS_DENOM` in core autodiff

### DIFF
--- a/packages/core/src/contrib/Objectives.ts
+++ b/packages/core/src/contrib/Objectives.ts
@@ -150,7 +150,12 @@ export const objDictGeneral = {
     } else {
       // Repel any two shapes with a center.
       // 1 / (d^2(cx, cy) + eps)
-      res = inverse(ops.vdistsq(shapeCenter([t1, s1]), shapeCenter([t2, s2])));
+      res = inverse(
+        add(
+          ops.vdistsq(shapeCenter([t1, s1]), shapeCenter([t2, s2])),
+          EPS_DENOM
+        )
+      );
     }
 
     return mul(res, repelWeight);

--- a/packages/core/src/contrib/Objectives.ts
+++ b/packages/core/src/contrib/Objectives.ts
@@ -1,4 +1,4 @@
-import { ops } from "../engine/Autodiff";
+import { EPS_DENOM, ops } from "../engine/Autodiff";
 import {
   absVal,
   add,
@@ -56,14 +56,14 @@ export const objDictSimple = {
    * Repel point `a` from another scalar `b` with weight `weight`.
    */
   repelPt: (weight: ad.Num, a: ad.Num[], b: ad.Num[]): ad.Num =>
-    mul(weight, inverse(ops.vdistsq(a, b))),
+    mul(weight, inverse(add(ops.vdistsq(a, b), EPS_DENOM))),
 
   /**
    * Repel scalar `c` from another scalar `d`.
    */
   repelScalar: (c: ad.Num, d: ad.Num): ad.Num => {
     // 1/(c-d)^2
-    return inverse(squared(sub(c, d)));
+    return inverse(add(squared(sub(c, d)), EPS_DENOM));
   },
 };
 

--- a/packages/core/src/engine/Autodiff.ts
+++ b/packages/core/src/engine/Autodiff.ts
@@ -27,7 +27,6 @@ import {
   exp,
   gt,
   ifCond,
-  inverse,
   ln,
   lt,
   max,
@@ -116,12 +115,10 @@ const unarySensitivity = (z: ad.Unary): ad.Num => {
       return mul(2, v);
     }
     case "sqrt": {
-      // NOTE: Watch out for divide by zero in 1 / [2 sqrt(x)]
-      return div(1, mul(2, max(EPS_DENOM, z)));
+      return div(1 / 2, z);
     }
     case "inverse": {
-      // This takes care of the divide-by-zero gradient problem
-      return neg(inverse(add(squared(v), EPS_DENOM)));
+      return neg(squared(z));
     }
     case "abs": {
       return sign(v);

--- a/packages/docs-site/docs/ref/constraints.md
+++ b/packages/docs-site/docs/ref/constraints.md
@@ -173,9 +173,12 @@ Now we look at an objective that makes two circles repel, encouraging the two ci
 
 ```typescript
 repel: ([t1, s1]: [string, any], [t2, s2]: [string, any]) => {
+  const epsDenom = 10e-6;
   const repelWeight = 10e6;
-  let res = inverse(ops.vdistsq(s1.center.contents, s2.center.contents));
-  return mul(res, constOf(repelWeight));
+  let res = inverse(
+    add(ops.vdistsq(s1.center.contents, s2.center.contents), epsDenom)
+  );
+  return mul(res, repelWeight);
 };
 ```
 

--- a/packages/examples/src/registry.json
+++ b/packages/examples/src/registry.json
@@ -162,7 +162,7 @@
       "substance": "circle-example",
       "style": "euclidean",
       "domain": "geometry",
-      "variation": "PathwayJellyfish159"
+      "variation": "FantasiaKangaroo337"
     },
     {
       "name": "Word Cloud",

--- a/packages/optimizer/src/builtins.rs
+++ b/packages/optimizer/src/builtins.rs
@@ -112,14 +112,15 @@ pub fn penrose_tanh(x: f64) -> f64 {
     x.tanh()
 }
 
-// the following two functions have quirky implementations for historical reasons predating our
-// switch to WebAssembly and Rust
-
+// we make this a function rather than inlining the definition when we generate code, because it
+// includes a floating-point literal and those cost 8 bytes each to write into a WebAssembly binary
 #[wasm_bindgen]
 pub fn penrose_inverse(x: f64) -> f64 {
-    1. / (x + 10e-6)
+    1. / x
 }
 
+// this function has a quirky implementation for historical reasons predating our switch to
+// WebAssembly and Rust
 #[wasm_bindgen]
 pub fn penrose_sign(x: f64) -> f64 {
     if x == 0. {

--- a/packages/optimizer/src/builtins.rs
+++ b/packages/optimizer/src/builtins.rs
@@ -119,8 +119,8 @@ pub fn penrose_inverse(x: f64) -> f64 {
     1. / x
 }
 
-// this function has a quirky implementation for historical reasons predating our switch to
-// WebAssembly and Rust
+// before we switched to WebAssembly and Rust, we used JavaScript's `Math.sign` function, so this
+// function is meant to provide the same behavior as that
 #[wasm_bindgen]
 pub fn penrose_sign(x: f64) -> f64 {
     if x == 0. {


### PR DESCRIPTION
# Description

Prior to this PR, `inverse` (both its implementation and its derivative) added `EPS_DENOM = 10e-6` before taking the reciprocal. It seems bad to have this sort of arbitrary tweak in the implementation of a basic autodiff primitive, so this PR removes that and also simplifies several of our other derivative definitions.

# Implementation strategy and design decisions

A couple of our test cases initially broke, so I fixed them by manually adding `EPS_DENOM` to the implementations of our `repelPt` and `repelScalar` objectives.

I also had to change the variation for `circle-example-euclidean`, because that particular example is pretty unreliable. I tried resampling that example a few times on `main` and I got similarly bad results for many variations, so the issue wasn't introduced by this PR.

# Checklist

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have reviewed any generated registry diagram changes

# Open questions

- How can we remove the usage of `EPS_DENOM` from the derivative of `sqrt`? I tried in this PR and it caused a lot of failures, so I reverted that change in favor of just doing the others for now: https://github.com/penrose/penrose/actions/runs/4355028613/jobs/7611098998