### PR TITLE
chore: bump version to 2.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,50 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [v2.3.0](https://github.com/penrose/penrose/compare/v2.2.0...v2.3.0) (2023-03-14)
+
+### :rocket: New Feature
+
+- Add a function to compute closest points ([#1039](https://github.com/penrose/penrose/issues/1039)) ([c2c8fc6](https://github.com/penrose/penrose/commit/c2c8fc68804943abe3c62ac0d3738bac0e77a870))
+- Add group-theory example to registry ([#1301](https://github.com/penrose/penrose/issues/1301)) ([115a609](https://github.com/penrose/penrose/commit/115a6094025347e525ebe33a2207a944df8aa837))
+- Lewis structures Style ([#1320](https://github.com/penrose/penrose/issues/1320)) ([5411f35](https://github.com/penrose/penrose/commit/5411f35d06039b82a0e77786c24edec7117d7cdf))
+- added "ctrl+enter" binding for recompiling ([#1306](https://github.com/penrose/penrose/issues/1306)) ([d0472d1](https://github.com/penrose/penrose/commit/d0472d1306959f6244ebb64a64894cc0a3fd376b))
+- basic group shape ([#1294](https://github.com/penrose/penrose/issues/1294)) ([cf77bff](https://github.com/penrose/penrose/commit/cf77bffa38273368c489d26ef981975c5d07bf80))
+- compile diagrams in `editor` after detected changes in `roger` ([#1264](https://github.com/penrose/penrose/issues/1264)) ([5ec39dd](https://github.com/penrose/penrose/commit/5ec39ddf92859d653768ddaa088f36f1b522e1af))
+- compute rect-line distance exactly ([#1332](https://github.com/penrose/penrose/issues/1332)) ([b86be31](https://github.com/penrose/penrose/commit/b86be314de09725447707de56039069a92a99f20))
+- experimental example emulating 3D diagramming ([#1299](https://github.com/penrose/penrose/issues/1299)) ([171a1d7](https://github.com/penrose/penrose/commit/171a1d7f3823a268a5c974ebf695a98569d45684))
+- matrix and vector operations in Style ([#1310](https://github.com/penrose/penrose/issues/1310)) ([70d190e](https://github.com/penrose/penrose/commit/70d190eeab2cac3f1c0afb4e760d067bceeb04bf))
+- provide a `shapeDistance` function ([#1328](https://github.com/penrose/penrose/issues/1328)) ([76a91e5](https://github.com/penrose/penrose/commit/76a91e5186c7ae4628417e4e9d6f9df289412ede))
+- show multiple diagram instances on a grid in `editor` ([#1287](https://github.com/penrose/penrose/issues/1287)) ([fbaf03c](https://github.com/penrose/penrose/commit/fbaf03c7b6c4f87cc628111ee080af76c65ef55e))
+- triangle-mesh-3d example improvements ([#1300](https://github.com/penrose/penrose/issues/1300)) ([b308c36](https://github.com/penrose/penrose/commit/b308c368a3c18700e91b9e5af60d5eb488617bab))
+
+### :bug: Bug Fix
+
+- SVG overflow in `Simple` component ([#1321](https://github.com/penrose/penrose/issues/1321)) ([df119ac](https://github.com/penrose/penrose/commit/df119acad87250d0097eeda4f019238bf0d07743))
+- `inRange` implemented incorrectly ([#1297](https://github.com/penrose/penrose/issues/1297)) ([f692a44](https://github.com/penrose/penrose/commit/f692a44b9f55df419db8e0e19998e79cf19ac88c))
+- avoid `EPS_DENOM` in core autodiff ([#1333](https://github.com/penrose/penrose/issues/1333)) ([db9f38b](https://github.com/penrose/penrose/commit/db9f38becbcb628eb9864b3ba7d0a7018e304c64))
+- github action node version ([#1318](https://github.com/penrose/penrose/issues/1318)) ([0d52677](https://github.com/penrose/penrose/commit/0d5267723665816019b84f5bbbe8088f613c2c35))
+- improve performance of pseudoTopsort ([#1302](https://github.com/penrose/penrose/issues/1302)) ([60bc4b5](https://github.com/penrose/penrose/commit/60bc4b5505dec71bb52ff787e0696797748af057))
+- nondeterminism in renderer ([#1316](https://github.com/penrose/penrose/issues/1316)) ([9795420](https://github.com/penrose/penrose/commit/97954202c60c2aab6a11af1694f652f8a3bb8e4d))
+- render shapes in order for determinism ([#1323](https://github.com/penrose/penrose/issues/1323)) ([c479eec](https://github.com/penrose/penrose/commit/c479eecdf4c4cbaa97c075bfd3608073dd576279))
+
+### :memo: Documentation
+
+- guide for creating new releases ([#1304](https://github.com/penrose/penrose/issues/1304)) ([1895d8f](https://github.com/penrose/penrose/commit/1895d8febdf4ced698bd1a478c3f3eaf1452b511))
+- move wiki ([#1331](https://github.com/penrose/penrose/issues/1331)) ([062e8ed](https://github.com/penrose/penrose/commit/062e8edad60249db71238d5a72ff99d9e1cc8239))
+- update Team page ([#1324](https://github.com/penrose/penrose/issues/1324)) ([e61e0ca](https://github.com/penrose/penrose/commit/e61e0ca86546185717cf4b5aff6215c6dc782da8))
+
+### :house: Internal
+
+- add Lewis structures examples to `synthesizer-ui` ([#1334](https://github.com/penrose/penrose/issues/1334)) ([2f1f624](https://github.com/penrose/penrose/commit/2f1f624118d2c48433c6f888075c8b279ff3e387))
+- add graph examples to `synthesizer-ui` ([#1336](https://github.com/penrose/penrose/issues/1336)) ([3b5f964](https://github.com/penrose/penrose/commit/3b5f964f2d9ca0d619ce7291844c36dd181e4345))
+- add more stuff to `.prettierignore` ([#1339](https://github.com/penrose/penrose/issues/1339)) ([e3a3f34](https://github.com/penrose/penrose/commit/e3a3f34f7e9e3a387393e068767232fa36a24a1a))
+- add optimizer `build/` to `.prettierignore` ([#1315](https://github.com/penrose/penrose/issues/1315)) ([3c8b424](https://github.com/penrose/penrose/commit/3c8b424f9042800be68f8ad21404a66c846af2d5))
+- diagram some graphs ([#1317](https://github.com/penrose/penrose/issues/1317)) ([37acb1b](https://github.com/penrose/penrose/commit/37acb1bb78ad5bbdf4b8b8188e09b975a7838113))
+- expand presets in `synthesizer-ui` ([#1149](https://github.com/penrose/penrose/issues/1149)) ([58c288a](https://github.com/penrose/penrose/commit/58c288a2ec5b124f008222e8c3807dfa550dcd6f))
+- layout tweaks in `euclidean.style` ([#1335](https://github.com/penrose/penrose/issues/1335)) ([12363c9](https://github.com/penrose/penrose/commit/12363c94c1325ef6e47da157f1e82d77d05d73fd))
+- remove ESLint from PR template checklist ([#1330](https://github.com/penrose/penrose/issues/1330)) ([ef74877](https://github.com/penrose/penrose/commit/ef748779359f8da04a2baf95036d67274c44929a))
+
 ## [v2.2.0](https://github.com/penrose/penrose/compare/v2.1.1...v2.2.0) (2023-02-02)
 
 ### :rocket: New Feature

--- a/lerna.json
+++ b/lerna.json
@@ -1,7 +1,7 @@
 {
   "packages": ["packages/*"],
   "npmClient": "yarn",
-  "version": "2.2.0",
+  "version": "2.3.0",
   "useWorkspaces": true,
   "changelogPreset": {
     "name": "@spyke/conventional-changelog-preset"

--- a/packages/automator/CHANGELOG.md
+++ b/packages/automator/CHANGELOG.md
@@ -3,6 +3,12 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [v2.3.0](https://github.com/penrose/penrose/compare/v2.2.0...v2.3.0) (2023-03-14)
+
+### :bug: Bug Fix
+
+- nondeterminism in renderer ([#1316](https://github.com/penrose/penrose/issues/1316)) ([9795420](https://github.com/penrose/penrose/commit/97954202c60c2aab6a11af1694f652f8a3bb8e4d))
+
 ## [v2.2.0](https://github.com/penrose/penrose/compare/v2.1.1...v2.2.0) (2023-02-02)
 
 ### :rocket: New Feature

--- a/packages/automator/package.json
+++ b/packages/automator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@penrose/automator",
-  "version": "2.2.0",
+  "version": "2.3.0",
   "private": true,
   "description": "",
   "type": "module",
@@ -26,7 +26,7 @@
   "author": "Penrose Team (https://penrose.cs.cmu.edu/)",
   "license": "MIT",
   "dependencies": {
-    "@penrose/core": "^2.2.0",
+    "@penrose/core": "^2.3.0",
     "@types/react": "^18.0.26",
     "canvas": "^2.8.0",
     "chalk": "^3.0.0",

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -3,6 +3,22 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [v2.3.0](https://github.com/penrose/penrose/compare/v2.2.0...v2.3.0) (2023-03-14)
+
+### :rocket: New Feature
+
+- added "ctrl+enter" binding for recompiling ([#1306](https://github.com/penrose/penrose/issues/1306)) ([d0472d1](https://github.com/penrose/penrose/commit/d0472d1306959f6244ebb64a64894cc0a3fd376b))
+- show multiple diagram instances on a grid in `editor` ([#1287](https://github.com/penrose/penrose/issues/1287)) ([fbaf03c](https://github.com/penrose/penrose/commit/fbaf03c7b6c4f87cc628111ee080af76c65ef55e))
+
+### :bug: Bug Fix
+
+- SVG overflow in `Simple` component ([#1321](https://github.com/penrose/penrose/issues/1321)) ([df119ac](https://github.com/penrose/penrose/commit/df119acad87250d0097eeda4f019238bf0d07743))
+- nondeterminism in renderer ([#1316](https://github.com/penrose/penrose/issues/1316)) ([9795420](https://github.com/penrose/penrose/commit/97954202c60c2aab6a11af1694f652f8a3bb8e4d))
+
+### :house: Internal
+
+- expand presets in `synthesizer-ui` ([#1149](https://github.com/penrose/penrose/issues/1149)) ([58c288a](https://github.com/penrose/penrose/commit/58c288a2ec5b124f008222e8c3807dfa550dcd6f))
+
 ## [v2.2.0](https://github.com/penrose/penrose/compare/v2.1.1...v2.2.0) (2023-02-02)
 
 ### :rocket: New Feature

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@penrose/components",
-  "version": "2.2.0",
+  "version": "2.3.0",
   "license": "MIT",
   "type": "module",
   "main": "dist/index.js",
@@ -49,7 +49,7 @@
   },
   "dependencies": {
     "@monaco-editor/react": "^4.0.11",
-    "@penrose/core": "^2.2.0",
+    "@penrose/core": "^2.3.0",
     "monaco-editor": "^0.31.0",
     "monaco-vim": "^0.3.4",
     "styled-components": "^5.3.5"

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -3,6 +3,31 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [v2.3.0](https://github.com/penrose/penrose/compare/v2.2.0...v2.3.0) (2023-03-14)
+
+### :rocket: New Feature
+
+- Add a function to compute closest points ([#1039](https://github.com/penrose/penrose/issues/1039)) ([c2c8fc6](https://github.com/penrose/penrose/commit/c2c8fc68804943abe3c62ac0d3738bac0e77a870))
+- Lewis structures Style ([#1320](https://github.com/penrose/penrose/issues/1320)) ([5411f35](https://github.com/penrose/penrose/commit/5411f35d06039b82a0e77786c24edec7117d7cdf))
+- basic group shape ([#1294](https://github.com/penrose/penrose/issues/1294)) ([cf77bff](https://github.com/penrose/penrose/commit/cf77bffa38273368c489d26ef981975c5d07bf80))
+- compute rect-line distance exactly ([#1332](https://github.com/penrose/penrose/issues/1332)) ([b86be31](https://github.com/penrose/penrose/commit/b86be314de09725447707de56039069a92a99f20))
+- matrix and vector operations in Style ([#1310](https://github.com/penrose/penrose/issues/1310)) ([70d190e](https://github.com/penrose/penrose/commit/70d190eeab2cac3f1c0afb4e760d067bceeb04bf))
+- provide a `shapeDistance` function ([#1328](https://github.com/penrose/penrose/issues/1328)) ([76a91e5](https://github.com/penrose/penrose/commit/76a91e5186c7ae4628417e4e9d6f9df289412ede))
+- show multiple diagram instances on a grid in `editor` ([#1287](https://github.com/penrose/penrose/issues/1287)) ([fbaf03c](https://github.com/penrose/penrose/commit/fbaf03c7b6c4f87cc628111ee080af76c65ef55e))
+
+### :bug: Bug Fix
+
+- `inRange` implemented incorrectly ([#1297](https://github.com/penrose/penrose/issues/1297)) ([f692a44](https://github.com/penrose/penrose/commit/f692a44b9f55df419db8e0e19998e79cf19ac88c))
+- avoid `EPS_DENOM` in core autodiff ([#1333](https://github.com/penrose/penrose/issues/1333)) ([db9f38b](https://github.com/penrose/penrose/commit/db9f38becbcb628eb9864b3ba7d0a7018e304c64))
+- improve performance of pseudoTopsort ([#1302](https://github.com/penrose/penrose/issues/1302)) ([60bc4b5](https://github.com/penrose/penrose/commit/60bc4b5505dec71bb52ff787e0696797748af057))
+- nondeterminism in renderer ([#1316](https://github.com/penrose/penrose/issues/1316)) ([9795420](https://github.com/penrose/penrose/commit/97954202c60c2aab6a11af1694f652f8a3bb8e4d))
+- render shapes in order for determinism ([#1323](https://github.com/penrose/penrose/issues/1323)) ([c479eec](https://github.com/penrose/penrose/commit/c479eecdf4c4cbaa97c075bfd3608073dd576279))
+
+### :house: Internal
+
+- add Lewis structures examples to `synthesizer-ui` ([#1334](https://github.com/penrose/penrose/issues/1334)) ([2f1f624](https://github.com/penrose/penrose/commit/2f1f624118d2c48433c6f888075c8b279ff3e387))
+- expand presets in `synthesizer-ui` ([#1149](https://github.com/penrose/penrose/issues/1149)) ([58c288a](https://github.com/penrose/penrose/commit/58c288a2ec5b124f008222e8c3807dfa550dcd6f))
+
 ## [v2.2.0](https://github.com/penrose/penrose/compare/v2.1.1...v2.2.0) (2023-02-02)
 
 ### :rocket: New Feature

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@penrose/core",
-  "version": "2.2.0",
+  "version": "2.3.0",
   "type": "module",
   "main": "dist/index.js",
   "module": "dist/index.js",
@@ -76,7 +76,7 @@
   },
   "dependencies": {
     "@datastructures-js/queue": "^4.1.3",
-    "@penrose/optimizer": "^2.2.0",
+    "@penrose/optimizer": "^2.3.0",
     "consola": "^2.15.2",
     "immutable": "^4.0.0-rc.12",
     "lodash": "^4.17.15",
@@ -90,7 +90,7 @@
     "true-myth": "^4.1.0"
   },
   "devDependencies": {
-    "@penrose/examples": "^2.2.0",
+    "@penrose/examples": "^2.3.0",
     "@types/jest": "^27.4.1",
     "@types/jscodeshift": "^0.11.0",
     "@types/lodash": "^4.14.149",

--- a/packages/docs-site/CHANGELOG.md
+++ b/packages/docs-site/CHANGELOG.md
@@ -3,6 +3,21 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [v2.3.0](https://github.com/penrose/penrose/compare/v2.2.0...v2.3.0) (2023-03-14)
+
+### :rocket: New Feature
+
+- basic group shape ([#1294](https://github.com/penrose/penrose/issues/1294)) ([cf77bff](https://github.com/penrose/penrose/commit/cf77bffa38273368c489d26ef981975c5d07bf80))
+
+### :bug: Bug Fix
+
+- avoid `EPS_DENOM` in core autodiff ([#1333](https://github.com/penrose/penrose/issues/1333)) ([db9f38b](https://github.com/penrose/penrose/commit/db9f38becbcb628eb9864b3ba7d0a7018e304c64))
+
+### :memo: Documentation
+
+- move wiki ([#1331](https://github.com/penrose/penrose/issues/1331)) ([062e8ed](https://github.com/penrose/penrose/commit/062e8edad60249db71238d5a72ff99d9e1cc8239))
+- update Team page ([#1324](https://github.com/penrose/penrose/issues/1324)) ([e61e0ca](https://github.com/penrose/penrose/commit/e61e0ca86546185717cf4b5aff6215c6dc782da8))
+
 ## [v2.2.0](https://github.com/penrose/penrose/compare/v2.1.1...v2.2.0) (2023-02-02)
 
 ### :rocket: New Feature

--- a/packages/docs-site/package.json
+++ b/packages/docs-site/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@penrose/docs-site",
-  "version": "2.2.0",
+  "version": "2.3.0",
   "private": true,
   "scripts": {
     "build": "vitepress build",
@@ -37,13 +37,13 @@
     }
   },
   "dependencies": {
-    "@penrose/components": "^2.2.0",
-    "@penrose/examples": "^2.2.0",
+    "@penrose/components": "^2.3.0",
+    "@penrose/examples": "^2.3.0",
     "veaury": "^2.3.11"
   },
   "devDependencies": {
-    "@penrose/automator": "^2.2.0",
-    "@penrose/editor": "^2.2.0",
+    "@penrose/automator": "^2.3.0",
+    "@penrose/editor": "^2.3.0",
     "markdown-it-katex": "^2.0.3",
     "shx": "^0.3.3",
     "vitepress": "^1.0.0-alpha.35"

--- a/packages/editor/CHANGELOG.md
+++ b/packages/editor/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [v2.3.0](https://github.com/penrose/penrose/compare/v2.2.0...v2.3.0) (2023-03-14)
+
+### :rocket: New Feature
+
+- compile diagrams in `editor` after detected changes in `roger` ([#1264](https://github.com/penrose/penrose/issues/1264)) ([5ec39dd](https://github.com/penrose/penrose/commit/5ec39ddf92859d653768ddaa088f36f1b522e1af))
+- show multiple diagram instances on a grid in `editor` ([#1287](https://github.com/penrose/penrose/issues/1287)) ([fbaf03c](https://github.com/penrose/penrose/commit/fbaf03c7b6c4f87cc628111ee080af76c65ef55e))
+
+### :bug: Bug Fix
+
+- nondeterminism in renderer ([#1316](https://github.com/penrose/penrose/issues/1316)) ([9795420](https://github.com/penrose/penrose/commit/97954202c60c2aab6a11af1694f652f8a3bb8e4d))
+
 ## [v2.2.0](https://github.com/penrose/penrose/compare/v2.1.1...v2.2.0) (2023-02-02)
 
 ### :rocket: New Feature

--- a/packages/editor/package.json
+++ b/packages/editor/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@penrose/editor",
   "private": true,
-  "version": "2.2.0",
+  "version": "2.3.0",
   "scripts": {
     "start": "cross-env NODE_OPTIONS='--max-old-space-size=8192' vite",
     "dev": "cross-env NODE_OPTIONS='--max-old-space-size=8192' vite",
@@ -41,8 +41,8 @@
     }
   },
   "dependencies": {
-    "@penrose/components": "^2.2.0",
-    "@penrose/core": "^2.2.0",
+    "@penrose/components": "^2.3.0",
+    "@penrose/core": "^2.3.0",
     "animals": "^0.0.3",
     "color-name-list": "^8.38.0",
     "flexlayout-react": "^0.7.3",

--- a/packages/examples/CHANGELOG.md
+++ b/packages/examples/CHANGELOG.md
@@ -3,6 +3,34 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [v2.3.0](https://github.com/penrose/penrose/compare/v2.2.0...v2.3.0) (2023-03-14)
+
+### :rocket: New Feature
+
+- Add a function to compute closest points ([#1039](https://github.com/penrose/penrose/issues/1039)) ([c2c8fc6](https://github.com/penrose/penrose/commit/c2c8fc68804943abe3c62ac0d3738bac0e77a870))
+- Add group-theory example to registry ([#1301](https://github.com/penrose/penrose/issues/1301)) ([115a609](https://github.com/penrose/penrose/commit/115a6094025347e525ebe33a2207a944df8aa837))
+- Lewis structures Style ([#1320](https://github.com/penrose/penrose/issues/1320)) ([5411f35](https://github.com/penrose/penrose/commit/5411f35d06039b82a0e77786c24edec7117d7cdf))
+- basic group shape ([#1294](https://github.com/penrose/penrose/issues/1294)) ([cf77bff](https://github.com/penrose/penrose/commit/cf77bffa38273368c489d26ef981975c5d07bf80))
+- compute rect-line distance exactly ([#1332](https://github.com/penrose/penrose/issues/1332)) ([b86be31](https://github.com/penrose/penrose/commit/b86be314de09725447707de56039069a92a99f20))
+- experimental example emulating 3D diagramming ([#1299](https://github.com/penrose/penrose/issues/1299)) ([171a1d7](https://github.com/penrose/penrose/commit/171a1d7f3823a268a5c974ebf695a98569d45684))
+- matrix and vector operations in Style ([#1310](https://github.com/penrose/penrose/issues/1310)) ([70d190e](https://github.com/penrose/penrose/commit/70d190eeab2cac3f1c0afb4e760d067bceeb04bf))
+- provide a `shapeDistance` function ([#1328](https://github.com/penrose/penrose/issues/1328)) ([76a91e5](https://github.com/penrose/penrose/commit/76a91e5186c7ae4628417e4e9d6f9df289412ede))
+- show multiple diagram instances on a grid in `editor` ([#1287](https://github.com/penrose/penrose/issues/1287)) ([fbaf03c](https://github.com/penrose/penrose/commit/fbaf03c7b6c4f87cc628111ee080af76c65ef55e))
+- triangle-mesh-3d example improvements ([#1300](https://github.com/penrose/penrose/issues/1300)) ([b308c36](https://github.com/penrose/penrose/commit/b308c368a3c18700e91b9e5af60d5eb488617bab))
+
+### :bug: Bug Fix
+
+- `inRange` implemented incorrectly ([#1297](https://github.com/penrose/penrose/issues/1297)) ([f692a44](https://github.com/penrose/penrose/commit/f692a44b9f55df419db8e0e19998e79cf19ac88c))
+- avoid `EPS_DENOM` in core autodiff ([#1333](https://github.com/penrose/penrose/issues/1333)) ([db9f38b](https://github.com/penrose/penrose/commit/db9f38becbcb628eb9864b3ba7d0a7018e304c64))
+
+### :house: Internal
+
+- add Lewis structures examples to `synthesizer-ui` ([#1334](https://github.com/penrose/penrose/issues/1334)) ([2f1f624](https://github.com/penrose/penrose/commit/2f1f624118d2c48433c6f888075c8b279ff3e387))
+- add graph examples to `synthesizer-ui` ([#1336](https://github.com/penrose/penrose/issues/1336)) ([3b5f964](https://github.com/penrose/penrose/commit/3b5f964f2d9ca0d619ce7291844c36dd181e4345))
+- diagram some graphs ([#1317](https://github.com/penrose/penrose/issues/1317)) ([37acb1b](https://github.com/penrose/penrose/commit/37acb1bb78ad5bbdf4b8b8188e09b975a7838113))
+- expand presets in `synthesizer-ui` ([#1149](https://github.com/penrose/penrose/issues/1149)) ([58c288a](https://github.com/penrose/penrose/commit/58c288a2ec5b124f008222e8c3807dfa550dcd6f))
+- layout tweaks in `euclidean.style` ([#1335](https://github.com/penrose/penrose/issues/1335)) ([12363c9](https://github.com/penrose/penrose/commit/12363c94c1325ef6e47da157f1e82d77d05d73fd))
+
 ## [v2.2.0](https://github.com/penrose/penrose/compare/v2.1.1...v2.2.0) (2023-02-02)
 
 ### :rocket: New Feature

--- a/packages/examples/package.json
+++ b/packages/examples/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@penrose/examples",
-  "version": "2.2.0",
+  "version": "2.3.0",
   "private": true,
   "scripts": {
     "build": ":",

--- a/packages/optimizer/CHANGELOG.md
+++ b/packages/optimizer/CHANGELOG.md
@@ -3,6 +3,12 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [v2.3.0](https://github.com/penrose/penrose/compare/v2.2.0...v2.3.0) (2023-03-14)
+
+### :bug: Bug Fix
+
+- avoid `EPS_DENOM` in core autodiff ([#1333](https://github.com/penrose/penrose/issues/1333)) ([db9f38b](https://github.com/penrose/penrose/commit/db9f38becbcb628eb9864b3ba7d0a7018e304c64))
+
 ## [v2.2.0](https://github.com/penrose/penrose/compare/v2.1.1...v2.2.0) (2023-02-02)
 
 ### :rocket: New Feature

--- a/packages/optimizer/Cargo.lock
+++ b/packages/optimizer/Cargo.lock
@@ -168,7 +168,7 @@ checksum = "b1de2e551fb905ac83f73f7aedf2f0cb4a0da7e35efa24a202a936269f1f18e1"
 
 [[package]]
 name = "penrose-optimizer"
-version = "2.2.0"
+version = "2.3.0"
 dependencies = [
  "console_error_panic_hook",
  "console_log",

--- a/packages/optimizer/Cargo.toml
+++ b/packages/optimizer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "penrose-optimizer"
-version = "2.2.0"
+version = "2.3.0"
 edition = "2021"
 publish = false
 

--- a/packages/optimizer/package.json
+++ b/packages/optimizer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@penrose/optimizer",
-  "version": "2.2.0",
+  "version": "2.3.0",
   "type": "module",
   "author": "Penrose Team (https://penrose.cs.cmu.edu/)",
   "license": "MIT",

--- a/packages/roger/CHANGELOG.md
+++ b/packages/roger/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [v2.3.0](https://github.com/penrose/penrose/compare/v2.2.0...v2.3.0) (2023-03-14)
+
+**Note:** Version bump only for package @penrose/roger
+
 ## [v2.2.0](https://github.com/penrose/penrose/compare/v2.1.1...v2.2.0) (2023-02-02)
 
 ### :rocket: New Feature

--- a/packages/roger/README.md
+++ b/packages/roger/README.md
@@ -18,7 +18,7 @@ $ npm install -g @penrose/roger
 $ roger COMMAND
 running command...
 $ roger (--version)
-@penrose/roger/2.2.0 darwin-arm64 node-v18.12.1
+@penrose/roger/2.3.0 darwin-arm64 node-v16.19.1
 $ roger --help [COMMAND]
 USAGE
   $ roger COMMAND
@@ -51,6 +51,6 @@ EXAMPLES
   $ roger watch
 ```
 
-_See code: [dist/commands/watch.js](https://github.com/penrose/penrose/blob/v2.2.0/dist/commands/watch.js)_
+_See code: [dist/commands/watch.js](https://github.com/penrose/penrose/blob/v2.3.0/dist/commands/watch.js)_
 
 <!-- commandsstop -->

--- a/packages/roger/package.json
+++ b/packages/roger/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@penrose/roger",
-  "version": "2.2.0",
+  "version": "2.3.0",
   "description": "The Penrose CLI",
   "author": "Penrose Team (https://penrose.cs.cmu.edu/)",
   "bin": {

--- a/packages/synthesizer-ui/CHANGELOG.md
+++ b/packages/synthesizer-ui/CHANGELOG.md
@@ -3,6 +3,22 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [v2.3.0](https://github.com/penrose/penrose/compare/v2.2.0...v2.3.0) (2023-03-14)
+
+### :rocket: New Feature
+
+- show multiple diagram instances on a grid in `editor` ([#1287](https://github.com/penrose/penrose/issues/1287)) ([fbaf03c](https://github.com/penrose/penrose/commit/fbaf03c7b6c4f87cc628111ee080af76c65ef55e))
+
+### :bug: Bug Fix
+
+- nondeterminism in renderer ([#1316](https://github.com/penrose/penrose/issues/1316)) ([9795420](https://github.com/penrose/penrose/commit/97954202c60c2aab6a11af1694f652f8a3bb8e4d))
+
+### :house: Internal
+
+- add Lewis structures examples to `synthesizer-ui` ([#1334](https://github.com/penrose/penrose/issues/1334)) ([2f1f624](https://github.com/penrose/penrose/commit/2f1f624118d2c48433c6f888075c8b279ff3e387))
+- add graph examples to `synthesizer-ui` ([#1336](https://github.com/penrose/penrose/issues/1336)) ([3b5f964](https://github.com/penrose/penrose/commit/3b5f964f2d9ca0d619ce7291844c36dd181e4345))
+- expand presets in `synthesizer-ui` ([#1149](https://github.com/penrose/penrose/issues/1149)) ([58c288a](https://github.com/penrose/penrose/commit/58c288a2ec5b124f008222e8c3807dfa550dcd6f))
+
 ## [v2.2.0](https://github.com/penrose/penrose/compare/v2.1.1...v2.2.0) (2023-02-02)
 
 ### :rocket: New Feature

--- a/packages/synthesizer-ui/package.json
+++ b/packages/synthesizer-ui/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@penrose/synthesizer-ui",
   "private": true,
-  "version": "2.2.0",
+  "version": "2.3.0",
   "scripts": {
     "dev": "vite",
     "watch": "vite",
@@ -42,9 +42,9 @@
   },
   "dependencies": {
     "@material-ui/core": "^4.12.3",
-    "@penrose/components": "^2.2.0",
-    "@penrose/core": "^2.2.0",
-    "@penrose/examples": "^2.2.0",
+    "@penrose/components": "^2.3.0",
+    "@penrose/core": "^2.3.0",
+    "@penrose/examples": "^2.3.0",
     "@types/file-saver": "^2.0.5",
     "@types/jszip": "^3.4.1",
     "file-saver": "^2.0.5",

--- a/packages/synthesizer/CHANGELOG.md
+++ b/packages/synthesizer/CHANGELOG.md
@@ -3,6 +3,12 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [v2.3.0](https://github.com/penrose/penrose/compare/v2.2.0...v2.3.0) (2023-03-14)
+
+### :house: Internal
+
+- expand presets in `synthesizer-ui` ([#1149](https://github.com/penrose/penrose/issues/1149)) ([58c288a](https://github.com/penrose/penrose/commit/58c288a2ec5b124f008222e8c3807dfa550dcd6f))
+
 ## [v2.2.0](https://github.com/penrose/penrose/compare/v2.1.1...v2.2.0) (2023-02-02)
 
 ### :rocket: New Feature

--- a/packages/synthesizer/package.json
+++ b/packages/synthesizer/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@penrose/synthesizer",
   "private": true,
-  "version": "2.2.0",
+  "version": "2.3.0",
   "description": "Synthesis engine for Penrose",
   "keywords": [
     "program synthesis",
@@ -36,7 +36,7 @@
     "url": "https://github.com/penrose/penrose/issues"
   },
   "dependencies": {
-    "@penrose/core": "^2.2.0",
+    "@penrose/core": "^2.3.0",
     "chalk": "^3.0.0",
     "global-jsdom": "^8.0.0",
     "neodoc": "^2.0.2",

--- a/packages/vscode/CHANGELOG.md
+++ b/packages/vscode/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [v2.3.0](https://github.com/penrose/penrose/compare/v2.2.0...v2.3.0) (2023-03-14)
+
+**Note:** Version bump only for package penrose-vs
+
 ## [v2.2.0](https://github.com/penrose/penrose/compare/v2.1.1...v2.2.0) (2023-02-02)
 
 ### :nail_care: Polish

--- a/packages/vscode/package.json
+++ b/packages/vscode/package.json
@@ -3,7 +3,7 @@
   "displayName": "Penrose",
   "publisher": "penrose",
   "description": "Penrose languages bundle",
-  "version": "2.2.0",
+  "version": "2.3.0",
   "author": "Penrose Team (https://penrose.cs.cmu.edu/)",
   "license": "MIT",
   "private": true,


### PR DESCRIPTION
# Description

Diff generated using analogous commands to #1290, plus again modifications to `packages/optimizer/Cargo.{toml,lock}`:

```sh
yarn new-version 2.3.0
yarn format
```

Also, for some reason, when I ran those commands, it deleted the contents of the "Commands" section in `packages/roger/README.md`, so I added that back manually. @wodeni, any idea why that might be happening?

# Checklist

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have reviewed any generated registry diagram changes