### PR TITLE
chore: sum Edgeworth weights to 100%

### DIFF
--- a/packages/synthesizer-ui/src/examples.ts
+++ b/packages/synthesizer-ui/src/examples.ts
@@ -20,14 +20,14 @@ const lewisParams: SynthesizerSetting = {
   argOption: "existing",
   argReuse: "distinct",
   weights: {
-    type: 0.1,
-    predicate: 0.3,
-    constructor: 0.3,
+    type: 0.15,
+    predicate: 0.5,
+    constructor: 0.35,
   },
   opWeights: {
-    add: 0.01,
-    delete: 0.01,
-    edit: 0.8,
+    add: 0,
+    delete: 0,
+    edit: 1,
   },
   add: {
     type: "*",
@@ -54,12 +54,12 @@ const geometryParams: SynthesizerSetting = {
   argOption: "existing",
   argReuse: "distinct",
   weights: {
-    type: 0.1,
-    predicate: 0.3,
-    constructor: 0.2,
+    type: 0.15,
+    predicate: 0.5,
+    constructor: 0.35,
   },
   opWeights: {
-    add: 0.01,
+    add: 0,
     delete: 0.2,
     edit: 0.8,
   },
@@ -89,9 +89,9 @@ const graphParams: SynthesizerSetting = {
   argOption: "existing",
   argReuse: "distinct",
   weights: {
-    type: 0.1,
-    predicate: 0.3,
-    constructor: 0.2,
+    type: 0.15,
+    predicate: 0.5,
+    constructor: 0.35,
   },
   opWeights: {
     add: 0.5,


### PR DESCRIPTION
# Description

This PR changes all our Edgeworth `weights` and `opWeights` to sum to 100%. Also, since our `weights` were already almost the same across all domains, I changed them so now they are actually the same across all domains (so that we can say as much in the paper). Then for everything that was previously weighted `0.01`, I just set it to actually zero.

# Checklist

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have reviewed any generated registry diagram changes