### PR TITLE
fix: broken Edgeworth geometry examples

### DIFF
--- a/packages/examples/src/geometry-domain/euclidean.style
+++ b/packages/examples/src/geometry-domain/euclidean.style
@@ -1,6 +1,6 @@
 canvas {
-  width = 800
-  height = 700
+  width = 500
+  height = 500
 }
 
 Colors {

--- a/packages/examples/src/geometry-domain/textbook_problems/c04p12.substance
+++ b/packages/examples/src/geometry-domain/textbook_problems/c04p12.substance
@@ -1,10 +1,4 @@
-Plane P
 Point A, B, C, D, E
-In(A, P)
-In(B, P)
-In(C, P)
-In(D, P)
-In(E, P)
 Collinear(A, C, E)
 Collinear(B, C, D)
 Segment BC := MkSegment(B, C)
@@ -22,5 +16,5 @@ EqualAngle(aABC, aBAC)
 EqualAngleMarker(aABC, aBAC)
 EqualAngle(aDCE, aDEC)
 EqualAngleMarker(aDCE, aDEC)
-AutoLabel A, B, C, D, E, P
+AutoLabel A, B, C, D, E
 Label aCDE $x$

--- a/packages/examples/src/geometry-domain/textbook_problems/c07p06.substance
+++ b/packages/examples/src/geometry-domain/textbook_problems/c07p06.substance
@@ -10,4 +10,4 @@ Segment AD := MkSegment(A, D)
 Segment CB := MkSegment(C, B)
 EqualLengthMarker(AB, CD)
 EqualLength(AB, CD)
-AutoLabel All
+AutoLabel A, B, C, D, E

--- a/packages/examples/src/geometry-domain/textbook_problems/c11p25.substance
+++ b/packages/examples/src/geometry-domain/textbook_problems/c11p25.substance
@@ -13,4 +13,4 @@ Segment AC := Diameter(c, A, C)
 Quadrilateral ABCD := MkQuadrilateral(A, B, C, D)
 ParallelMarker1(AB, DC)
 Parallel(AB, DC)
-AutoLabel All
+AutoLabel A, B, C, D, O

--- a/packages/examples/src/geometry-domain/textbook_problems/c12p20.substance
+++ b/packages/examples/src/geometry-domain/textbook_problems/c12p20.substance
@@ -12,4 +12,4 @@ EqualLengthMarker(AB, BC)
 EqualLengthMarker(BC, DC)
 Parallel(AC, BD)
 EqualLength(AC, BD)
-AutoLabel All
+AutoLabel A, B, C, D

--- a/packages/examples/src/registry.json
+++ b/packages/examples/src/registry.json
@@ -281,7 +281,7 @@
       "substance": "collinear",
       "style": "euclidean",
       "domain": "geometry",
-      "variation": "HighlighterChicken10318",
+      "variation": "GoldbrownFly7869",
       "gallery": true
     },
     {


### PR DESCRIPTION
# Description

This PR fixes two minor issues with geometry examples in `synthesizer-ui`:

* The diagrams are not very legible with the current canvas size of `(800, 700)`. Adjusted to `(500, 500)`
* Three examples (c07p06, c11p25, c12p20) errored out because of the new `notTooClose` on all labels. They failed because some shapes are auto-labeled but don't have `.text` shapes assigned. 
* Also removed `Plane` in `c04p12` because it's not meaningful.

# Checklist

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have reviewed any generated registry diagram changes

