### PR TITLE
fix: corrected `triangle` function signature

### DIFF
--- a/packages/core/src/contrib/Functions.ts
+++ b/packages/core/src/contrib/Functions.ts
@@ -1054,22 +1054,17 @@ export const compDict = {
    */
   triangle: (
     _context: Context,
-    [t1, l1]: any,
-    [t2, l2]: any,
-    [t3, l3]: any
+    l1: Line<ad.Num>,
+    l2: Line<ad.Num>,
+    l3: Line<ad.Num>
   ): PathDataV<ad.Num> => {
-    if (t1 === "Line" && t2 === "Line" && t3 === "Line") {
-      const path = new PathBuilder();
-      return path
-        .moveTo(toPt(getStart(l1)))
-        .lineTo(toPt(getStart(l2)))
-        .lineTo(toPt(getStart(l3)))
-        .closePath()
-        .getPath();
-    } else {
-      console.error([t1, l1], [t2, l2], [t3, l3]);
-      throw Error("Triangle function expected three lines");
-    }
+    const path = new PathBuilder();
+    return path
+      .moveTo(toPt(getStart(l1)))
+      .lineTo(toPt(getStart(l2)))
+      .lineTo(toPt(getStart(l3)))
+      .closePath()
+      .getPath();
   },
 
   /**


### PR DESCRIPTION
# Description

Resolves #1350.

This PR uses the actual shape types in the function signature of the library function `triangle`. Previously, each parameter is a `ShapeTuple` which was removed as a result of the consolidation shape types. For some reasons, this got left in.