### PR TITLE
perf: don't materialize any Hessian estimate

### DIFF
--- a/packages/optimizer/src/lib.rs
+++ b/packages/optimizer/src/lib.rs
@@ -8,7 +8,6 @@ use wasm_bindgen::{prelude::wasm_bindgen, JsValue};
 type Bool = i32; // 0 or 1 (`wasm-bindgen` doesn't support `bool` well)
 
 type Vector = nalgebra::DVector<f64>;
-type Matrix = nalgebra::DMatrix<f64>;
 
 type Compiled =
     fn(inputs: *const f64, mask: *const Bool, gradient: *mut f64, secondary: *mut f64) -> f64;
@@ -563,15 +562,11 @@ fn aw_line_search(xs0: &[f64], f: FnCached, weight: f64, gradfxs0: &[f64], fxs0:
 // Approximate the inverse of the Hessian times the gradient
 // Only using the last `m` gradient/state difference vectors, not building the full h_k matrix (Nocedal p226)
 
+// "Nocedal" refers to the 1999 edition of "Numerical Optimization" by Nocedal and Wright
+// https://www.ime.unicamp.br/~pulino/MT404/TextosOnline/NocedalJ.pdf
+
 fn lbfgs_inner(grad_fx_k: &Vector, ss: &[Vector], ys: &[Vector]) -> Vector {
     // TODO: See if rewriting outside the functional style yields speedup (e.g. less copying of matrix objects -> less garbage collection)
-
-    // takes two column vectors (nx1), returns a square matrix (nxn)
-    fn estimate_hess(y_km1: &Vector, s_km1: &Vector) -> Matrix {
-        let gamma_k = s_km1.dot(y_km1) / (y_km1.dot(y_km1) + EPSD);
-        let n = y_km1.len();
-        Matrix::identity(n, n) * gamma_k
-    }
 
     // BACKWARD: for i = k-1 ... k-m
     // The length of any list should be the number of stored vectors
@@ -593,11 +588,13 @@ fn lbfgs_inner(grad_fx_k: &Vector, ss: &[Vector], ys: &[Vector]) -> Vector {
     }
     let q_k_minus_m = q_i;
 
-    let h_0_k = estimate_hess(&ys[0], &ss[0]); // nxn matrix, according to Nocedal p226, eqn 9.6
+    let y_km1 = &ys[0];
+    let s_km1 = &ss[0];
+    let gamma_k = s_km1.dot(y_km1) / (y_km1.dot(y_km1) + EPSD); // according to Nocedal p226, eqn 9.6
 
     // FORWARD: for i = k-m .. k-1
     // below: [nxn matrix * nx1 (col) vec] -> nx1 (col) vec
-    let r_k_minus_m = h_0_k * q_k_minus_m;
+    let r_k_minus_m = gamma_k * q_k_minus_m;
 
     // Note that rhos, alphas, ss, and ys are all in order from `k-1` to `k-m` so we just reverse all of them together to go from `k-m` to `k-1`
     let mut r_i = r_k_minus_m;

--- a/packages/optimizer/src/lib.rs
+++ b/packages/optimizer/src/lib.rs
@@ -593,7 +593,6 @@ fn lbfgs_inner(grad_fx_k: &Vector, ss: &[Vector], ys: &[Vector]) -> Vector {
     let gamma_k = s_km1.dot(y_km1) / (y_km1.dot(y_km1) + EPSD); // according to Nocedal p226, eqn 9.6
 
     // FORWARD: for i = k-m .. k-1
-    // below: [nxn matrix * nx1 (col) vec] -> nx1 (col) vec
     let r_k_minus_m = gamma_k * q_k_minus_m;
 
     // Note that rhos, alphas, ss, and ys are all in order from `k-1` to `k-m` so we just reverse all of them together to go from `k-m` to `k-1`


### PR DESCRIPTION
# Description

We use [L-BFGS](https://en.wikipedia.org/wiki/Limited-memory_BFGS) instead of [BFGS](https://en.wikipedia.org/wiki/Broyden%E2%80%93Fletcher%E2%80%93Goldfarb%E2%80%93Shanno_algorithm), so we shouldn't be materializing any $n \times n$ matrices in the optimizer. Previously we were doing so in one place, due to a naive interpretation of a diagonal matrix in the algorithm. This PR gets rid of the diagonal matrix by inlining its one usage. I also added a comment clarifying the source for some of the other reference comments.

# Checklist

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have reviewed any generated registry diagram changes