### PR TITLE
feat: line wrap in error pane

### DIFF
--- a/packages/editor/src/components/DiagramPanel.tsx
+++ b/packages/editor/src/components/DiagramPanel.tsx
@@ -456,7 +456,9 @@ export default function DiagramPanel() {
             >
               error ({error.errorType})
             </span>
-            <pre>{showError(error).toString()}</pre>
+            <pre style={{ whiteSpace: "pre-wrap" }}>
+              {showError(error).toString()}
+            </pre>
           </div>
         )}
         <div


### PR DESCRIPTION
# Description

Resolves #1356.

Now the error pane looks like this:
![image](https://user-images.githubusercontent.com/16521252/236287079-f5dff94f-638c-4500-903c-7366debc9d7d.png)
