### PR TITLE
fix: `halfPlaneSDF` and padding

### DIFF
--- a/packages/core/src/contrib/ConstraintsUtils.ts
+++ b/packages/core/src/contrib/ConstraintsUtils.ts
@@ -214,7 +214,7 @@ export const containsPolygonCircle = (
   return containsPolygonPoints(
     s1.points.contents,
     s2.center.contents,
-    sub(padding, s2.r.contents)
+    add(padding, s2.r.contents)
   );
 };
 

--- a/packages/core/src/contrib/Minkowski.ts
+++ b/packages/core/src/contrib/Minkowski.ts
@@ -3,7 +3,6 @@ import { ops } from "../engine/Autodiff";
 import {
   absVal,
   add,
-  addN,
   div,
   eq,
   ifCond,
@@ -87,7 +86,7 @@ export const halfPlaneSDF = (
   const normal = outwardUnitNormal(lineSegment, insidePoint);
   const alpha = ops.vdot(normal, lineSegment[0]);
   const alphaOther = maxN(otherPoints.map((p) => ops.vdot(normal, p)));
-  return neg(addN([alpha, alphaOther, padding]));
+  return add(neg(add(alpha, alphaOther)), padding);
 };
 
 /**
@@ -228,7 +227,7 @@ export const rectangleSignedDistance = (
  * @param point Testing point.
  * @param padding Padding applied to the polygon.
  */
-const containsConvexPolygonPoints = (
+export const containsConvexPolygonPoints = (
   p1: ad.Num[][],
   p2: ad.Num[],
   padding: ad.Num

--- a/packages/core/src/contrib/__tests__/Minkowski.test.ts
+++ b/packages/core/src/contrib/__tests__/Minkowski.test.ts
@@ -1,11 +1,36 @@
 import * as BBox from "../../engine/BBox";
 import * as ad from "../../types/ad";
 import {
+  containsConvexPolygonPoints,
   convexPartitions,
   halfPlaneSDF,
   rectangleDifference,
 } from "../Minkowski";
 import { numsOf } from "../Utils";
+
+describe("containsConvexPolygonPoints", () => {
+  test("test", () => {
+    const poly = [
+      [0, 0],
+      [1, 0],
+      [1, 1],
+      [0, 1],
+    ];
+    const pt = [0.25, 0.25];
+
+    expect(
+      numsOf([containsConvexPolygonPoints(poly, pt, 0)])[0]
+    ).toBeLessThanOrEqual(0);
+
+    expect(
+      numsOf([containsConvexPolygonPoints(poly, pt, 0.1)])[0]
+    ).toBeLessThanOrEqual(0);
+
+    expect(
+      numsOf([containsConvexPolygonPoints(poly, pt, 0.26)])[0]
+    ).toBeGreaterThan(0);
+  });
+});
 
 describe("rectangleDifference", () => {
   const expectRectDiff = (
@@ -74,7 +99,7 @@ describe("halfPlaneSDF", () => {
 
   test("with padding", async () => {
     let result = halfPlaneSDF([point2, point3], [point2, point4], point5, 10);
-    expect(numsOf([result])[0]).toBeCloseTo(-13, 4);
+    expect(numsOf([result])[0]).toBeCloseTo(7, 4);
   });
 
   test("zero outside", async () => {


### PR DESCRIPTION
# Description

Resolves #1359.

This is an attempt to resolve the issue using the fix I talked about in the comment. It _might_ not be correct.

# Implementation strategy and design decisions
* Now, `halfPlaneSDF` has the effect of adding `padding` instead of subtracting.
* With this, a broken test case has been fixed. (Detailed below)
* Also, `containsPolygonCircle` now calls `containsPolygonPoins` with `add(padding, s2.r.contents)`. (Detailed below)

# Broken Test Case

The bad test case involved is as follows:
```
  let point1 = [2, 3];
  let point2 = [1, 2];
  let point3 = [1, 4];
  let point4 = [2, 2];
  let point5 = [0, 0];
  // ...
  test("with padding", async () => {
    let result = halfPlaneSDF([point2, point3], [point2, point4], point5, 10);
    expect(numsOf([result])[0]).toBeCloseTo(-13, 4);
  });
```

Under the prescribed changes, the `halfPlaneSDF` function should output `7` instead of `-13`.

As far as I understand it, checking whether or not a point `p` is within the halfplane defined with `lineSegment` and interior vector `center` is essentially checking whether or not
```
halfPlaneSDF(lineSegment, -p, center, padding) // note the minus sign before `p`
```

So, calling
```
halfPlaneSDF([point2, point3], [point2, point4], point5, 10)
```
is essentially checking whether or not points `[-point2, -point4]` is within the half-plane defined using line segment `[point2, point3]` with interior point `point5`, under padding 10.

Graphing it out,


# Checklist

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have reviewed any generated registry diagram changes

# Open questions

Questions that require more discussion or to be addressed in future development:
