### PR TITLE
docs: give exact `wasm-bindgen` version command

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -47,7 +47,7 @@ Be sure you have these tools installed:
     rustup target add wasm32-unknown-unknown
     ```
 
-  - `wasm-bindgen` v0.2.84:
+  - `wasm-bindgen` CLI v0.2.84:
 
     ```sh
     cargo install --version=0.2.84 wasm-bindgen-cli

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -47,7 +47,7 @@ Be sure you have these tools installed:
     rustup target add wasm32-unknown-unknown
     ```
 
-  - `wasm-bindgen` v0.2.84
+  - `wasm-bindgen` v0.2.84:
 
     ```sh
     cargo install --version=0.2.84 wasm-bindgen-cli

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -47,7 +47,11 @@ Be sure you have these tools installed:
     rustup target add wasm32-unknown-unknown
     ```
 
-  - [`wasm-bindgen` CLI][] v0.2.84
+  - `wasm-bindgen` v0.2.84
+
+    ```sh
+    cargo install --version=0.2.84 wasm-bindgen-cli
+    ```
 
 Depending on your platform, here are some extra instructions:
 
@@ -441,7 +445,6 @@ Our repo uses [semantic versioning][] and maintains the same version number for 
 - Create a new [GitHub release][].
 - CI will run after the new release is created, automatically publishing packages to npm.
 
-[`wasm-bindgen` cli]: https://rustwasm.github.io/wasm-bindgen/reference/cli.html#installation
 [branch]: https://git-scm.com/book/en/v2/Git-Branching-Basic-Branching-and-Merging
 [ci]: https://docs.github.com/en/actions
 [clone]: https://docs.github.com/en/repositories/creating-and-managing-repositories/cloning-a-repository


### PR DESCRIPTION
# Description

[`wasm-bindgen` v0.2.85](https://github.com/rustwasm/wasm-bindgen/releases/tag/0.2.85) just released, so to follow up on the little doc change in #1338, this PR modifies the instructions in our `CONTRIBUTING.md` to give an exact command to specify our particular version of `wasm-bindgen-cli`.

# Checklist

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have reviewed any generated registry diagram changes