### PR TITLE
feat: `appendShape` function

### DIFF
--- a/packages/core/src/compiler/Style.ts
+++ b/packages/core/src/compiler/Style.ts
@@ -2884,7 +2884,9 @@ const evalExpr = (
           oneErr({ tag: "InvalidFunctionNameError", givenName: name })
         );
       }
-      const f = compDict[name.value] ? compDict[name.value] : impDict[name.value];
+      const f = compDict[name.value]
+        ? compDict[name.value]
+        : impDict[name.value];
       const x = callCompFunc(f, { start, end }, mut, argsWithSourceLoc);
       if (x.isErr()) return err(oneErr(x.error));
       return ok(val(x.value));

--- a/packages/core/src/contrib/Functions.ts
+++ b/packages/core/src/contrib/Functions.ts
@@ -2807,29 +2807,6 @@ export const compDict = {
     },
     returns: valueT("Real"),
   },
-
-  appendShape: {
-    name: "appendShape",
-    description:
-      "Appends a shape into a list of shapes in-place and returns the resultant list",
-    params: [
-      {
-        name: "shapes",
-        type: valueT("ShapeList"),
-        description: "A list of shapes",
-      },
-      { name: "shape", type: shapeT("AnyShape"), description: "A shape" },
-    ],
-    body: (
-      _context: Context,
-      shapes: Shape<ad.Num>[],
-      shape: Shape<ad.Num>
-    ): ShapeListV<ad.Num> => {
-      shapes.push(shape);
-      return shapeListV(shapes);
-    },
-    returns: valueT("ShapeList"),
-  },
 };
 
 // `_compDictVals` causes TypeScript to enforce that every function in

--- a/packages/core/src/contrib/Functions.ts
+++ b/packages/core/src/contrib/Functions.ts
@@ -66,7 +66,6 @@ import {
   MatrixV,
   PathDataV,
   PtListV,
-  ShapeListV,
   TupV,
   VectorV,
 } from "../types/value";
@@ -88,7 +87,6 @@ import {
   realNT,
   realT,
   rectlikeT,
-  shapeListV,
   shapeT,
   stringT,
   unionT,

--- a/packages/core/src/contrib/Functions.ts
+++ b/packages/core/src/contrib/Functions.ts
@@ -2806,24 +2806,29 @@ export const compDict = {
       return { tag: "FloatV", contents: totalCurvature(points, closed) };
     },
     returns: valueT("Real"),
+  },
 
-    appendShape: {
-      name: "appendShape",
-      description: "Appends a shape into a list of shapes in-place and returns the resultant list",
-      params: [
-        { name: "shapes", type: valueT("ShapeList"), description: "A list of shapes" },
-        { name: "shape", type: shapeT("AnyShape"), description: "A shape" },
-      ],
-      body: (
-        _context: Context,
-        shapes: Shape<ad.Num>[],
-        shape: Shape<ad.Num>
-      ): ShapeListV<ad.Num> => {
-        shapes.push(shape);
-        return shapeListV(shapes);
+  appendShape: {
+    name: "appendShape",
+    description:
+      "Appends a shape into a list of shapes in-place and returns the resultant list",
+    params: [
+      {
+        name: "shapes",
+        type: valueT("ShapeList"),
+        description: "A list of shapes",
       },
-      returns: valueT("ShapeList"),
+      { name: "shape", type: shapeT("AnyShape"), description: "A shape" },
+    ],
+    body: (
+      _context: Context,
+      shapes: Shape<ad.Num>[],
+      shape: Shape<ad.Num>
+    ): ShapeListV<ad.Num> => {
+      shapes.push(shape);
+      return shapeListV(shapes);
     },
+    returns: valueT("ShapeList"),
   },
 };
 

--- a/packages/core/src/contrib/Functions.ts
+++ b/packages/core/src/contrib/Functions.ts
@@ -66,6 +66,7 @@ import {
   MatrixV,
   PathDataV,
   PtListV,
+  ShapeListV,
   TupV,
   VectorV,
 } from "../types/value";
@@ -87,6 +88,7 @@ import {
   realNT,
   realT,
   rectlikeT,
+  shapeListV,
   shapeT,
   stringT,
   unionT,
@@ -2804,6 +2806,24 @@ export const compDict = {
       return { tag: "FloatV", contents: totalCurvature(points, closed) };
     },
     returns: valueT("Real"),
+
+    appendShape: {
+      name: "appendShape",
+      description: "Appends a shape into a list of shapes in-place and returns the resultant list",
+      params: [
+        { name: "shapes", type: valueT("ShapeList"), description: "A list of shapes" },
+        { name: "shape", type: shapeT("AnyShape"), description: "A shape" },
+      ],
+      body: (
+        _context: Context,
+        shapes: Shape<ad.Num>[],
+        shape: Shape<ad.Num>
+      ): ShapeListV<ad.Num> => {
+        shapes.push(shape);
+        return shapeListV(shapes);
+      },
+      returns: valueT("ShapeList"),
+    },
   },
 };
 

--- a/packages/core/src/contrib/ImpFunctions.ts
+++ b/packages/core/src/contrib/ImpFunctions.ts
@@ -1,0 +1,35 @@
+import { Context } from "../shapes/Samplers";
+import { Shape } from "../shapes/Shapes";
+import * as ad from "../types/ad";
+import { CompFunc } from "../types/functions";
+import { ShapeListV } from "../types/value";
+import { shapeListV, shapeT, valueT } from "../utils/Util";
+
+export const impDict = {
+  appendShape: {
+    name: "appendShape",
+    description:
+      "Appends a shape into a list of shapes in-place and returns the resultant list",
+    params: [
+      {
+        name: "shapes",
+        type: valueT("ShapeList"),
+        description: "A list of shapes",
+      },
+      { name: "shape", type: shapeT("AnyShape"), description: "A shape" },
+    ],
+    body: (
+      _context: Context,
+      shapes: Shape<ad.Num>[],
+      shape: Shape<ad.Num>
+    ): ShapeListV<ad.Num> => {
+      shapes.push(shape);
+      return shapeListV(shapes);
+    },
+    returns: valueT("ShapeList"),
+  },
+};
+
+// `_impDictVals` causes TypeScript to enforce that every function in
+// `impDict` actually has type `CompFunc` with the right function signature, etc.
+const _impDictVals: CompFunc[] = Object.values(impDict);

--- a/packages/core/src/parser/Style.ne
+++ b/packages/core/src/parser/Style.ne
@@ -415,6 +415,7 @@ anonymous_expr
   |  objective {% id %}
   |  constraint {% id %}
   |  gpi_decl {% id %}
+  |  computation_function {% id %}
 
 # NOTE: inline computations on expr_literal (including expr_literal)
 expr -> arithmeticExpr {% id %}

--- a/packages/core/src/types/errors.ts
+++ b/packages/core/src/types/errors.ts
@@ -208,6 +208,7 @@ export type StyleError =
   | MissingArgumentError
   | TooManyArgumentsError
   | FunctionInternalError
+  | InvalidTopLevelFunctionError
   // Runtime errors
   | RuntimeValueTypeError;
 
@@ -486,6 +487,12 @@ export interface FunctionInternalError {
   func: CompFunc | ObjFunc | ConstrFunc;
   location: SourceRange;
   message: string;
+}
+
+export interface InvalidTopLevelFunctionError {
+  tag: "InvalidTopLevelFunctionError";
+  name: string;
+  location: SourceRange;
 }
 
 //#endregion

--- a/packages/core/src/utils/Error.ts
+++ b/packages/core/src/utils/Error.ts
@@ -511,6 +511,12 @@ canvas {
       const locStr = locc("Style", location);
       return `Function \`${func.name}\` (at ${locStr}) failed with message: ${message}`;
     }
+
+    case "InvalidTopLevelFunctionError": {
+      const { name, location } = error;
+      const locStr = locc("Style", location);
+      return `Function \`${name}\` (at ${locStr}) cannot be called in top-level. Either the function does not exist, or the return value must be assigned to another variable.`;
+    }
     // --- END COMPILATION ERRORS
 
     // TODO(errors): use identifiers here


### PR DESCRIPTION
# Description

Resolves #1372 .

We implement a function called `appendShape` that takes a list of shapes, and appends a shape into the list of shapes imperatively (in-place).

# Implementation strategy and design decisions

Given that there now exists Style computation functions that have side-effects, we add another dictionary full of imperative computational functions, `impDict`.

We also allow top-level function calls for functions in `impDict`, since, many times, we only want the imperative behavior. If a function is not in `impDict`, we do not allow top-level function call.

# Examples with steps to reproduce them

https://appendshape.penrose-72l.pages.dev/try/?gist=2f26b6d92c64332ca92a80afcb40d54b

# Checklist

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have reviewed any generated registry diagram changes
