### PR TITLE
ci: delete CI-generated branches

### DIFF
--- a/.github/workflows/delete-branches.yml
+++ b/.github/workflows/delete-branches.yml
@@ -1,0 +1,14 @@
+name: Delete branches
+on:
+  schedule:
+    - cron: "0 0 * * *"
+
+jobs:
+  ci:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: dawidd6/action-delete-branch@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          prefix: ci/refs/pull/
+          suffix: /merge


### PR DESCRIPTION
# Description

This PR adds a daily cron job using https://github.com/dawidd6/action-delete-branch to automatically delete the `ci/refs/pull/*/merge` branches created by #988, now that the autogenerated PR comment links to commits instead of branches as of #1313.

# Checklist

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have reviewed any generated registry diagram changes