### PR TITLE
feat: allow namespace updates in Style

### DIFF
--- a/packages/core/src/compiler/Style.test.ts
+++ b/packages/core/src/compiler/Style.test.ts
@@ -66,7 +66,7 @@ export const loadProgs = async ({
   ).unwrapOrElse(throwErr);
 };
 
-const canvasPreamble = `canvas {
+const canvasPreamble = ` canvas {
   width = 800
   height = 700
 }
@@ -500,10 +500,6 @@ describe("Compiler", () => {
        o.f = (?, ?)
        -- o.f[0] = 0.
        o.shape = Circle {}
-}`,
-      `canvas {
-  width = 500.0
-  height = 400.0
 }`,
       `forall Object o {
         o.a = ?

--- a/packages/core/src/compiler/Style.ts
+++ b/packages/core/src/compiler/Style.ts
@@ -2035,7 +2035,7 @@ const processBlock = (
     const block = blockId(blockIndex, substIndex, hb.header);
     const withLocals: BlockAssignment = { ...assignment, locals: im.Map() };
     if (block.tag === "NamespaceId") {
-      if (withLocals.globals.get(block.contents)) {
+      if (withLocals.globals.has(block.contents)) {
         // if the namespace exists, throw an error
         withLocals.diagnostics.errors = errors.push(
           redeclareNamespaceError(block.contents, {

--- a/packages/core/src/types/errors.ts
+++ b/packages/core/src/types/errors.ts
@@ -208,6 +208,7 @@ export type StyleError =
   | MissingArgumentError
   | TooManyArgumentsError
   | FunctionInternalError
+  | RedeclareNamespaceError
   // Runtime errors
   | RuntimeValueTypeError;
 
@@ -486,6 +487,12 @@ export interface FunctionInternalError {
   func: CompFunc | ObjFunc | ConstrFunc;
   location: SourceRange;
   message: string;
+}
+
+export interface RedeclareNamespaceError {
+  tag: "RedeclareNamespaceError";
+  existingNamespace: string;
+  location: SourceRange; // location of the duplicated declaration
 }
 
 //#endregion

--- a/packages/core/src/types/styleSemantics.ts
+++ b/packages/core/src/types/styleSemantics.ts
@@ -109,13 +109,13 @@ export interface OtherSource {
 
 export type FieldSource = ShapeSource | OtherSource;
 
-export type Fielded = im.Map<Field, FieldSource>;
+export type FieldDict = im.Map<Field, FieldSource>;
 
 export interface Assignment {
   diagnostics: StyleDiagnostics;
-  globals: im.Map<StyleName, Fielded>;
-  unnamed: im.Map<im.List<number>, Fielded>; // indexed by block/subst indices
-  substances: im.Map<SubstanceName, Fielded>;
+  globals: im.Map<StyleName, FieldDict>;
+  unnamed: im.Map<im.List<number>, FieldDict>; // indexed by block/subst indices
+  substances: im.Map<SubstanceName, FieldDict>;
 }
 
 export interface Locals {

--- a/packages/core/src/utils/Error.ts
+++ b/packages/core/src/utils/Error.ts
@@ -27,6 +27,7 @@ import {
   NaNError,
   ParseError,
   PenroseError,
+  RedeclareNamespaceError,
   RuntimeError,
   SelectorFieldNotSupported,
   StyleError,
@@ -511,6 +512,12 @@ canvas {
       const locStr = locc("Style", location);
       return `Function \`${func.name}\` (at ${locStr}) failed with message: ${message}`;
     }
+    case "RedeclareNamespaceError": {
+      return `Namespace ${
+        error.existingNamespace
+      } already exists and is redeclared in ${locc("Style", error.location)}.`;
+    }
+
     // --- END COMPILATION ERRORS
 
     // TODO(errors): use identifiers here
@@ -767,6 +774,15 @@ export const functionInternalError = (
   func,
   location,
   message,
+});
+
+export const redeclareNamespaceError = (
+  existingNamespace: string,
+  location: SourceRange
+): RedeclareNamespaceError => ({
+  tag: "RedeclareNamespaceError",
+  existingNamespace,
+  location,
 });
 
 export const nanError = (message: string, lastState: State): NaNError => ({

--- a/packages/examples/src/geometry-domain/euclidean-teaser.style
+++ b/packages/examples/src/geometry-domain/euclidean-teaser.style
@@ -102,8 +102,8 @@ with Plane P
 where In(p, P) {
   -- TODO: the problem is that this ensures the padding is const? Or is > padding okay?
   -- There's a choice of whether to put padding on the point or the text for containment
-  p.iconOnPlane = ensure contains(P.icon, p.icon, const.containPadding)
-  p.textOnPlane = ensure contains(P.icon, p.text, 0.0)
+  override p.iconOnPlane = ensure contains(P.icon, p.icon, const.containPadding)
+  override p.textOnPlane = ensure contains(P.icon, p.text, 0.0)
 
   p.icon above P.icon
   p.text above P.icon
@@ -241,7 +241,7 @@ where Parallel(l1, l2) {
 forall Segment e
 where e := MkSegment(p, q)
 with Point p; Point q {
-  override e.vec = [q.x - p.x, q.y - p.y]
+  e.vec = [q.x - p.x, q.y - p.y]
   e.start = p.vec
   e.end = q.vec
 
@@ -897,7 +897,7 @@ forall Plane p {
   dim = 700.0
   override p.text.center = ((dim / 2.0) - const.textPadding2, (dim / 2.0) - const.textPadding2)
   -- inner: 
-  p.icon = Rectangle {
+  override p.icon = Rectangle {
     fillColor : #f3f4f9
     strokeColor : #8e93c4
     strokeWidth : 2.0
@@ -913,22 +913,22 @@ forall Triangle t
 where t := MkTriangle(p, q, r)
 with Point p; Point q; Point r {
   t.strokeWidth = 0.0
-  t.PQ = Line {
+  override t.PQ = Line {
     start : p.icon.center
     end : q.icon.center
     strokeWidth : t.strokeWidth
   }
-  t.QR = Line {
+  override t.QR = Line {
     start : q.icon.center
     end : r.icon.center
     strokeWidth : t.strokeWidth
   }
-  t.RP = Line {
+  override t.RP = Line {
     start : r.icon.center
     end : p.icon.center
     strokeWidth : t.strokeWidth
   }
-  t.icon = Path {
+  override t.icon = Path {
     d : pathFromPoints("closed", [p.icon.center, r.icon.center, q.icon.center])
     fillColor: Colors.purple2
     strokeWidth: 0
@@ -951,16 +951,16 @@ with Point p; Point q; Point r {
 forall Angle theta
 where theta := InteriorAngle(p, q, r)
 with Point p; Point q; Point r {
-  theta.p = p.vec
-  theta.q = q.vec
-  theta.r = r.vec
+  override theta.p = p.vec
+  override theta.q = q.vec
+  override theta.r = r.vec
 
-  theta.radius = const.thetaRadius
+  override theta.radius = const.thetaRadius
   encourage nonDegenerateAngle(p.icon, q.icon, r.icon)
   startA = ptOnLine(theta.q, theta.p, theta.radius)
   endA = ptOnLine(theta.q, theta.r, theta.radius)
   sweepA = arcSweepFlag(theta.q, startA, endA)
-  override theta.mark = Path {
+  theta.mark = Path {
     d : arc("open", startA, endA, (theta.radius, theta.radius), 0, 0, sweepA)
     strokeWidth : 2.0
     strokeColor : Colors.darkpurple
@@ -984,7 +984,7 @@ with Segment s2; Point p {
   sweepA = arcSweepFlag(s.icon.end, startA, endA)
 
   markSize = 10
-  s.mark = Path {
+  override s.mark = Path {
     d : pathFromPoints("open", [ptOnLine(s.icon.end, s.icon.start, markSize), innerPointOffset(s.icon.end, s.icon.start, s2.icon.end, markSize), ptOnLine(s.icon.end, s2.icon.end, markSize)])
     strokeWidth : 2.0
     strokeColor : Colors.black


### PR DESCRIPTION
# Description

Resolves #776 

This PR allows updates to global namespaces Style. The current semantics do not allow users to insert/delete/override values in global namespaces (e.g. `Colors`). For example:
```

Colors {
   color red = rgba(1.,0.,0.,1.)
   color green = rgba(0.,1.,0.,1.)
}

Colors {
  red = #e00 -- updates the definition of Colors.red
  -- also removes Colors.green because the entire block is re-declared
}

OverrideColors {
   Colors.red = #e00 -- throws `AssignGlobalError`
}
```
This is an arbitrary decision we made, but now it seems to be useful to allow namespace updates for Style modules (#776). 

This PR allows updates to global namespaces, but disallows re-declaration of global namespaces to prevent multiple definitions scattered in one or multiple Style files. For instance:

```
Colors {
   color red = rgba(1.,0.,0.,1.)
   color green = rgba(0.,1.,0.,1.)
}

-- cannot redeclare `Colors` and will throw a `RedeclareNamespaceError`
Colors {
  red = #e00 -- updates the definition of Colors.red
}

-- this is allowed. `Colors.green` still exists and `Colors.red` has a value of `#e00` now.
OverrideColors {
   Colors.red = #e00 -- throws `AssignGlobalError`
}
```

# Implementation strategy and design decisions

* Change `updateExpr` to allow the global update behavior
* Catch namespace redeclaration in the assignment stage of the Style compiler.
* `Fielded` is renamed to `FieldDict`

# Examples with steps to reproduce them

# Checklist

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have reviewed any generated registry diagram changes

# Open questions

Questions that require more discussion or to be addressed in future development:
