### PR TITLE
feat: show warnings in `editor`

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -383,7 +383,7 @@ export type { Canvas } from "./shapes/Samplers";
 export { sampleShape, shapeTypes } from "./shapes/Shapes";
 export type { ShapeType } from "./shapes/Shapes";
 export type { Env } from "./types/domain";
-export type { PenroseError } from "./types/errors";
+export type { PenroseError, Warning as PenroseWarning } from "./types/errors";
 export type { Trio } from "./types/io";
 export type { SubProg } from "./types/substance";
 export * as Value from "./types/value";

--- a/packages/core/src/types/errors.ts
+++ b/packages/core/src/types/errors.ts
@@ -20,10 +20,6 @@ import { ArgValWithSourceLoc, ShapeVal, Val, Value } from "./value";
 
 //#region ErrorTypes
 
-// type PenroseError = LanguageError | RuntimeError;
-// type LanguageError = DomainError | SubstanceError | StyleError | PluginError;
-// type RuntimeError = OptimizerError | EvaluatorError;
-// type StyleError = StyleParseError | StyleCheckError | TranslationError;
 export type PenroseError =
   | (DomainError & { errorType: "DomainError" })
   | (SubstanceError & { errorType: "SubstanceError" })

--- a/packages/core/src/types/errors.ts
+++ b/packages/core/src/types/errors.ts
@@ -38,7 +38,7 @@ export interface NaNError {
   lastState: State;
 }
 
-export type Warning = StyleError;
+export type Warning = StyleWarning;
 
 // TODO: does type var ever appear in Substance? If not, can we encode that at the type level?
 export type SubstanceError =

--- a/packages/editor/src/components/DiagramPanel.tsx
+++ b/packages/editor/src/components/DiagramPanel.tsx
@@ -271,7 +271,7 @@ export const DownloadPNG = (
 export default function DiagramPanel() {
   const canvasRef = useRef<HTMLDivElement>(null);
   const [diagram, setDiagram] = useRecoilState(diagramState);
-  const { state, error, metadata } = diagram;
+  const { state, error, warnings, metadata } = diagram;
   const [showEasterEgg, setShowEasterEgg] = useState(false);
   const { interactive } = useRecoilValue(diagramMetadataSelector);
   const workspace = useRecoilValue(workspaceMetadataSelector);
@@ -458,6 +458,29 @@ export default function DiagramPanel() {
             </span>
             <pre style={{ whiteSpace: "pre-wrap" }}>
               {showError(error).toString()}
+            </pre>
+          </div>
+        )}
+        {warnings.length > 0 && (
+          <div
+            style={{
+              bottom: 0,
+              backgroundColor: "#FFF2C5",
+              maxHeight: "100%",
+              maxWidth: "100%",
+              minHeight: "100px",
+              overflow: "auto",
+              padding: "10px",
+              boxSizing: "border-box",
+            }}
+          >
+            <span
+              style={{ fontWeight: "bold", color: "#F0C324", fontSize: 14 }}
+            >
+              warnings
+            </span>
+            <pre style={{ whiteSpace: "pre-wrap" }}>
+              {warnings.map((w) => showError(w).toString()).join("\n")}
             </pre>
           </div>
         )}

--- a/packages/editor/src/state/atoms.ts
+++ b/packages/editor/src/state/atoms.ts
@@ -3,6 +3,7 @@ import {
   Env,
   PenroseError,
   PenroseState,
+  PenroseWarning,
   readRegistry,
   Trio,
 } from "@penrose/core";
@@ -276,6 +277,7 @@ export type DiagramMetadata = {
 export type Diagram = {
   state: PenroseState | null;
   error: PenroseError | null;
+  warnings: PenroseWarning[];
   metadata: DiagramMetadata;
 };
 
@@ -284,6 +286,7 @@ export const diagramState = atom<Diagram>({
   default: {
     state: null,
     error: null,
+    warnings: [],
     metadata: {
       variation: generateVariation(),
       stepSize: 10000,

--- a/packages/editor/src/state/callbacks.ts
+++ b/packages/editor/src/state/callbacks.ts
@@ -61,11 +61,13 @@ const _compileDiagram = async (
     return;
   }
   const initialState = await prepareState(compileResult.value);
+
   set(
     diagramState,
     (state: Diagram): Diagram => ({
       ...state,
       error: null,
+      warnings: initialState.warnings,
       metadata: {
         ...state.metadata,
         variation,

--- a/packages/examples/src/geometry-domain/euclidean-teaser.style
+++ b/packages/examples/src/geometry-domain/euclidean-teaser.style
@@ -102,8 +102,8 @@ with Plane P
 where In(p, P) {
   -- TODO: the problem is that this ensures the padding is const? Or is > padding okay?
   -- There's a choice of whether to put padding on the point or the text for containment
-  p.iconOnPlane = ensure contains(P.icon, p.icon, const.containPadding)
-  p.textOnPlane = ensure contains(P.icon, p.text, 0.0)
+  override p.iconOnPlane = ensure contains(P.icon, p.icon, const.containPadding)
+  override p.textOnPlane = ensure contains(P.icon, p.text, 0.0)
 
   p.icon above P.icon
   p.text above P.icon
@@ -241,7 +241,7 @@ where Parallel(l1, l2) {
 forall Segment e
 where e := MkSegment(p, q)
 with Point p; Point q {
-  override e.vec = [q.x - p.x, q.y - p.y]
+  e.vec = [q.x - p.x, q.y - p.y]
   e.start = p.vec
   e.end = q.vec
 
@@ -897,7 +897,7 @@ forall Plane p {
   dim = 700.0
   override p.text.center = ((dim / 2.0) - const.textPadding2, (dim / 2.0) - const.textPadding2)
   -- inner: 
-  p.icon = Rectangle {
+  override p.icon = Rectangle {
     fillColor : #f3f4f9
     strokeColor : #8e93c4
     strokeWidth : 2.0
@@ -913,22 +913,22 @@ forall Triangle t
 where t := MkTriangle(p, q, r)
 with Point p; Point q; Point r {
   t.strokeWidth = 0.0
-  t.PQ = Line {
+  override t.PQ = Line {
     start : p.icon.center
     end : q.icon.center
     strokeWidth : t.strokeWidth
   }
-  t.QR = Line {
+  override t.QR = Line {
     start : q.icon.center
     end : r.icon.center
     strokeWidth : t.strokeWidth
   }
-  t.RP = Line {
+  override t.RP = Line {
     start : r.icon.center
     end : p.icon.center
     strokeWidth : t.strokeWidth
   }
-  t.icon = Path {
+  override t.icon = Path {
     d : pathFromPoints("closed", [p.icon.center, r.icon.center, q.icon.center])
     fillColor: Colors.purple2
     strokeWidth: 0
@@ -951,16 +951,16 @@ with Point p; Point q; Point r {
 forall Angle theta
 where theta := InteriorAngle(p, q, r)
 with Point p; Point q; Point r {
-  theta.p = p.vec
-  theta.q = q.vec
-  theta.r = r.vec
+  override theta.p = p.vec
+  override theta.q = q.vec
+  override theta.r = r.vec
 
-  theta.radius = const.thetaRadius
+  override theta.radius = const.thetaRadius
   encourage nonDegenerateAngle(p.icon, q.icon, r.icon)
   startA = ptOnLine(theta.q, theta.p, theta.radius)
   endA = ptOnLine(theta.q, theta.r, theta.radius)
   sweepA = arcSweepFlag(theta.q, startA, endA)
-  override theta.mark = Path {
+  theta.mark = Path {
     d : arc("open", startA, endA, (theta.radius, theta.radius), 0, 0, sweepA)
     strokeWidth : 2.0
     strokeColor : Colors.darkpurple
@@ -984,7 +984,7 @@ with Segment s2; Point p {
   sweepA = arcSweepFlag(s.icon.end, startA, endA)
 
   markSize = 10
-  s.mark = Path {
+  override s.mark = Path {
     d : pathFromPoints("open", [ptOnLine(s.icon.end, s.icon.start, markSize), innerPointOffset(s.icon.end, s.icon.start, s2.icon.end, markSize), ptOnLine(s.icon.end, s2.icon.end, markSize)])
     strokeWidth : 2.0
     strokeColor : Colors.black

--- a/packages/examples/src/geometry-domain/euclidean.style
+++ b/packages/examples/src/geometry-domain/euclidean.style
@@ -99,8 +99,8 @@ with Plane P
 where In(p, P) {
   -- TODO: the problem is that this ensures the padding is const? Or is > padding okay?
   -- There's a choice of whether to put padding on the point or the text for containment
-  p.iconOnPlane = ensure contains(P.icon, p.icon, const.containPadding)
-  p.textOnPlane = ensure contains(P.icon, p.text) in label
+  override p.iconOnPlane = ensure contains(P.icon, p.icon, const.containPadding)
+  override p.textOnPlane = ensure contains(P.icon, p.text) in label
 
   p.icon above P.icon
   p.text above P.icon
@@ -233,7 +233,7 @@ where Parallel(l1, l2) {
 forall Segment e
 where e := MkSegment(p, q)
 with Point p; Point q {
-  override e.vec = [q.x - p.x, q.y - p.y]
+  e.vec = [q.x - p.x, q.y - p.y]
   e.start = p.vec
   e.end = q.vec
 
@@ -446,7 +446,7 @@ forall Angle a
 where RightMarked(a) {
   --render half square path of size a.radius
   markSize = 10
-  override a.mark = Path {
+  a.mark = Path {
     d : pathFromPoints("open", [ptOnLine(a.q, a.p, markSize), innerPointOffset(a.q, a.p, a.r, markSize), ptOnLine(a.q, a.r, markSize)])
     strokeWidth : 2.0
     strokeColor : #000

--- a/packages/examples/src/group-theory/CayleyGraph.style
+++ b/packages/examples/src/group-theory/CayleyGraph.style
@@ -1,7 +1,7 @@
 -- Draws a Cayley graph for a group G, assuming that
 --   (i) all elements g of G have been declared as an Element,
 --   (ii) all generator s of G have been tagged, via IsGenerator(), and
---   (iii) the group multiplication table has been s7pecified, via IsProduct.
+--   (iii) the group multiplication table has been specified, via IsProduct.
 -- For drawing the Cayley graph, it is not strictly necessary to specify the
 -- entire multiplication table: one can instead just specify the subset of
 -- the table corresponding to right-multiplication by any generator.  However,

--- a/packages/examples/src/group-theory/CayleyGraph.style
+++ b/packages/examples/src/group-theory/CayleyGraph.style
@@ -1,7 +1,7 @@
 -- Draws a Cayley graph for a group G, assuming that
 --   (i) all elements g of G have been declared as an Element,
 --   (ii) all generator s of G have been tagged, via IsGenerator(), and
---   (iii) the group multiplication table has been specified, via IsProduct.
+--   (iii) the group multiplication table has been s7pecified, via IsProduct.
 -- For drawing the Cayley graph, it is not strictly necessary to specify the
 -- entire multiplication table: one can instead just specify the subset of
 -- the table corresponding to right-multiplication by any generator.  However,
@@ -67,9 +67,9 @@ where IsIdentity(e)
     ensure inRange(g,.25,1.0)
     ensure inRange(b,.25,1.0)
 
-    s.icon.fillColor = rgba(r,g,b,1.0)
-    s.icon.strokeColor = rgba(.7*r,.7*g,.7*b,1.0)
-    s.labelText.fillColor = s.icon.strokeColor
+    override s.icon.fillColor = rgba(r,g,b,1.0)
+    override s.icon.strokeColor = rgba(.7*r,.7*g,.7*b,1.0)
+    override s.labelText.fillColor = s.icon.strokeColor
  }
 
 -- encourage all nodes to avoid each other
@@ -117,7 +117,6 @@ where IsGenerator(s); IsProduct( g2, g1, s )
 
    -- encourage these nodes to be close together, by minimizing a spring energy
    vec2 x1 = g1.icon.center
-   vec2 x2 = g2.icon.center
    scalar d = norm( x1 - x2 )
    scalar k = 1. -- spring stiffness
    scalar L = global.targetEdgeLength -- rest length
@@ -155,7 +154,6 @@ where IsGenerator(s); IsProduct( s, e, s )
 
    -- encourage these nodes to be close together, by minimizing a spring energy
    vec2 x1 = e.icon.center
-   vec2 x2 = s.icon.center
    scalar d = norm( x1 - x2 )
    scalar k = 1. -- spring stiffness
    scalar L = global.targetEdgeLength -- rest length
@@ -193,7 +191,6 @@ where IsGenerator(s); IsProduct( g, s, s )
 
    -- encourage these nodes to be close together, by minimizing a spring energy
    vec2 x1 = s.icon.center
-   vec2 x2 = g.icon.center
    scalar d = norm( x1 - x2 )
    scalar k = 1. -- spring stiffness
    scalar L = global.targetEdgeLength -- rest length

--- a/packages/examples/src/molecules/lewis.style
+++ b/packages/examples/src/molecules/lewis.style
@@ -611,7 +611,7 @@ forall Atom x {
 -- Bonds
 
 forall Bond b {
-  b.icon = Circle { fillColor: #0000 }
+  shape b.icon = Circle { fillColor: #0000 }
 }
 
 forall Bond b
@@ -620,7 +620,7 @@ with Atom x; Atom y {
     vec2 b.vec = y.icon.center - x.icon.center
     vec2 b.dir = normalize(b.vec)
     vec2 paddingVec = b.dir * const.atomSize/2
-    shape b.icon = Line {
+    override b.icon = Line {
         start : x.icon.center + paddingVec
         end : y.icon.center - paddingVec
         strokeColor : rgba(0.0, 0.0, 0.0, 1.0)
@@ -636,7 +636,7 @@ with Atom x; Atom y {
     vec2 b.vec = y.icon.center - x.icon.center
     vec2 b.dir = normalize(b.vec)
     vec2 paddingVec = b.dir * const.atomSize/2
-    shape b.icon = Line {
+    override b.icon = Line {
         start : x.icon.center + paddingVec
         end : y.icon.center - paddingVec
         strokeColor : rgba(0.0, 0.0, 0.0, 1.0)
@@ -658,7 +658,7 @@ with Atom x; Atom y {
     vec2 b.vec = y.icon.center - x.icon.center
     vec2 b.dir = normalize(b.vec)
     vec2 paddingVec = b.dir * const.atomSize/2
-    shape b.icon = Line {
+    override b.icon = Line {
         start : x.icon.center + paddingVec
         end : y.icon.center - paddingVec
         strokeColor : #000


### PR DESCRIPTION
# Description

Resolves #1305.

This PR displays warnings in `editor`. The current implementation simply shows them in the diagram panel, just like errors but in a different color:

![image](https://github.com/penrose/penrose/assets/11740102/04b0af6b-faac-4546-8653-1836b4fad145)

Like shown in the screenshot, some of our gallery diagrams contain warnings (mostly `ImplicitOverrideWarning`). 

# Implementation strategy and design decisions

Basically copied the implementation for the error UI.

# Checklist

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have reviewed any generated registry diagram changes
