### PR TITLE
ci: fix typo in delete branches workflow

### DIFF
--- a/.github/workflows/delete-branches.yml
+++ b/.github/workflows/delete-branches.yml
@@ -10,6 +10,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
-      - uses: Delete branches
+      - name: Delete branches
         # we use a colon instead of `--delete`, in case there are zero
         run: git push origin "$(git for-each-ref --format=':%(refname:lstrip=3)' 'refs/remotes/origin/ci/refs/pull/*/merge')"


### PR DESCRIPTION
# Description

After #1380 we're getting this error:

> a step cannot have both the `uses` and `run` keys

This PR fixes it.

# Checklist

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have reviewed any generated registry diagram changes