### PR TITLE
ci: fix CI branch deletion commands

### DIFF
--- a/.github/workflows/delete-branches.yml
+++ b/.github/workflows/delete-branches.yml
@@ -10,6 +10,12 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
-      - name: Delete branches
+      # https://stackoverflow.com/a/27393574
+      - name: Track CI branches
+        run: git remote set-branches origin 'ci/refs/pull/*/merge'
+      - name: Checkout CI branches
+        run: git fetch --depth=1
+      # https://stackoverflow.com/q/3670355
+      - name: Delete CI branches
         # we use a colon instead of `--delete`, in case there are zero
-        run: git push origin "$(git for-each-ref --format=':%(refname:lstrip=3)' 'refs/remotes/origin/ci/refs/pull/*/merge')"
+        run: git for-each-ref --format=':%(refname:lstrip=3)' 'refs/remotes/origin/ci/refs/pull/*/merge' | xargs -d '\n' git push origin


### PR DESCRIPTION
# Description

Still broken after #1382, now getting this error:

```
fatal: invalid refspec ''
```

That error means both that the `git for-each-ref` command is returning zero branch names and that the list of branch names is being passed as a single arg to `git push`. This PR fixes both issues by using `git remote set-branches`, `git fetch`, and `xargs`.

# Checklist

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have reviewed any generated registry diagram changes