### PR TITLE
style: bump Prettier version from 2.2.1 to 2.8.8

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "lerna": "^3.22.1",
     "markdown-toc": "^1.2.0",
     "nx": "^15.0.13",
-    "prettier": "2.2.1",
+    "prettier": "2.8.8",
     "prettier-plugin-organize-imports": "^3.2.1",
     "pretty-quick": "^3.1.0",
     "rimraf": "^3.0.2",

--- a/packages/components/src/Grid.tsx
+++ b/packages/components/src/Grid.tsx
@@ -15,9 +15,7 @@ type DiagramSource = {
 
 export interface GridProps {
   diagrams: DiagramSource[];
-  metadata: (
-    i: number
-  ) => {
+  metadata: (i: number) => {
     name: string;
     data: string;
   }[];

--- a/packages/components/src/Listing.tsx
+++ b/packages/components/src/Listing.tsx
@@ -4,18 +4,19 @@ import { editor } from "monaco-editor";
 import { useEffect } from "react";
 import { SetupSubstanceMonaco } from "./editing/languages/SubstanceConfig";
 
-export const defaultMonacoOptions: editor.IStandaloneEditorConstructionOptions = {
-  automaticLayout: true,
-  minimap: { enabled: false },
-  wordWrap: "on",
-  lineNumbers: "off",
-  fontSize: 16,
-  scrollbar: {
-    handleMouseWheel: true,
-  },
-  scrollBeyondLastLine: false,
-  renderLineHighlight: "none",
-};
+export const defaultMonacoOptions: editor.IStandaloneEditorConstructionOptions =
+  {
+    automaticLayout: true,
+    minimap: { enabled: false },
+    wordWrap: "on",
+    lineNumbers: "off",
+    fontSize: 16,
+    scrollbar: {
+      handleMouseWheel: true,
+    },
+    scrollBeyondLastLine: false,
+    renderLineHighlight: "none",
+  };
 
 const Listing = ({
   domain,

--- a/packages/components/src/editing/languages/SubstanceConfig.ts
+++ b/packages/components/src/editing/languages/SubstanceConfig.ts
@@ -119,42 +119,41 @@ export const SubstanceCompletions = (
   return [...types, ...fns, ...predicates, ...constructors, ...labeling];
 };
 
-export const SetupSubstanceMonaco = (domainCache: Env | null) => (
-  monaco: Monaco
-) => {
-  monaco.languages.register({ id: "substance" });
-  monaco.languages.setLanguageConfiguration("substance", SubstanceConfig);
-  if (domainCache) {
-    const provideCompletion = (
-      model: editor.ITextModel,
-      position: Position
-    ) => {
-      const word = model.getWordUntilPosition(position);
-      const range: IRange = {
-        startLineNumber: position.lineNumber,
-        endLineNumber: position.lineNumber,
-        startColumn: word.startColumn,
-        endColumn: word.endColumn,
+export const SetupSubstanceMonaco =
+  (domainCache: Env | null) => (monaco: Monaco) => {
+    monaco.languages.register({ id: "substance" });
+    monaco.languages.setLanguageConfiguration("substance", SubstanceConfig);
+    if (domainCache) {
+      const provideCompletion = (
+        model: editor.ITextModel,
+        position: Position
+      ) => {
+        const word = model.getWordUntilPosition(position);
+        const range: IRange = {
+          startLineNumber: position.lineNumber,
+          endLineNumber: position.lineNumber,
+          startColumn: word.startColumn,
+          endColumn: word.endColumn,
+        };
+        return { suggestions: SubstanceCompletions(range, domainCache) };
       };
-      return { suggestions: SubstanceCompletions(range, domainCache) };
-    };
 
-    monaco.languages.setMonarchTokensProvider(
-      "substance",
-      SubstanceLanguageTokens(domainCache)
-    );
-    const dispose = monaco.languages.registerCompletionItemProvider(
-      "substance",
-      {
-        provideCompletionItems: provideCompletion,
-      } as any
-    );
-    // HACK ^
-    return () => {
-      // prevents duplicates
-      dispose.dispose();
-    };
-  } else {
-    return () => {};
-  }
-};
+      monaco.languages.setMonarchTokensProvider(
+        "substance",
+        SubstanceLanguageTokens(domainCache)
+      );
+      const dispose = monaco.languages.registerCompletionItemProvider(
+        "substance",
+        {
+          provideCompletionItems: provideCompletion,
+        } as any
+      );
+      // HACK ^
+      return () => {
+        // prevents duplicates
+        dispose.dispose();
+      };
+    } else {
+      return () => {};
+    }
+  };

--- a/packages/core/src/compiler/Style.ts
+++ b/packages/core/src/compiler/Style.ts
@@ -1524,9 +1524,8 @@ const makeListRSubstsForStyleRels = (
   subProg: SubProg<A>
 ): [im.Set<string>, im.List<im.List<[Subst, im.Set<SubStmt<A>>]>>] => {
   const initUsedStyVars: im.Set<string> = im.Set();
-  const initListRSubsts: im.List<
-    im.List<[Subst, im.Set<SubStmt<A>>]>
-  > = im.List();
+  const initListRSubsts: im.List<im.List<[Subst, im.Set<SubStmt<A>>]>> =
+    im.List();
 
   const [newUsedStyVars, newListRSubsts] = rels.reduce(
     ([usedStyVars, listRSubsts], rel) => {
@@ -2064,17 +2063,12 @@ const processBlock = (
       .concat(hb.block.statements);
 
     // Translate each statement in the block
-    const {
-      diagnostics,
-      globals,
-      unnamed,
-      substances,
-      locals,
-    } = augmentedStatements.reduce(
-      (assignment, stmt, stmtIndex) =>
-        processStmt({ block, subst }, stmtIndex, stmt, assignment),
-      withLocals
-    );
+    const { diagnostics, globals, unnamed, substances, locals } =
+      augmentedStatements.reduce(
+        (assignment, stmt, stmtIndex) =>
+          processStmt({ block, subst }, stmtIndex, stmt, assignment),
+        withLocals
+      );
 
     switch (block.tag) {
       case "LocalVarId": {
@@ -2307,18 +2301,16 @@ const evalVals = (
 ): Result<Value<ad.Num>[], StyleDiagnostics> =>
   evalExprs(mut, canvas, stages, context, args, trans).andThen((argVals) =>
     all(
-      argVals.map(
-        (argVal, i): Result<Value<ad.Num>, StyleDiagnostics> => {
-          switch (argVal.tag) {
-            case "ShapeVal": {
-              return err(oneErr({ tag: "NotValueError", expr: args[i] }));
-            }
-            case "Val": {
-              return ok(argVal.contents);
-            }
+      argVals.map((argVal, i): Result<Value<ad.Num>, StyleDiagnostics> => {
+        switch (argVal.tag) {
+          case "ShapeVal": {
+            return err(oneErr({ tag: "NotValueError", expr: args[i] }));
+          }
+          case "Val": {
+            return ok(argVal.contents);
           }
         }
-      )
+      })
     ).mapErr(flatErrs)
   );
 
@@ -3713,14 +3705,12 @@ export const compileStyleHelper = async (
 
   const groupWarnings = checkGroupGraph(groupGraph);
 
-  const {
-    shapeOrdering: layerOrdering,
-    warning: layeringWarning,
-  } = computeLayerOrdering(
-    [...graph.nodes().filter((p) => typeof graph.node(p) === "string")],
-    [...translation.layering],
-    groupGraph
-  );
+  const { shapeOrdering: layerOrdering, warning: layeringWarning } =
+    computeLayerOrdering(
+      [...graph.nodes().filter((p) => typeof graph.node(p) === "string")],
+      [...translation.layering],
+      groupGraph
+    );
 
   // Fix the ordering between nodes of the group graph
   for (let i = 0; i < layerOrdering.length; i++) {

--- a/packages/core/src/compiler/Substance.ts
+++ b/packages/core/src/compiler/Substance.ts
@@ -633,13 +633,12 @@ const checkFunc = (
         ([expr, arg], { substEnv: cxt, env: e }) => matchArg(expr, arg, cxt, e),
         ok({ substEnv: substContext, env, contents: func.args[0] })
       );
-      const outputOk: ResultWithType<
-        ApplyConstructor<A> | ApplyFunction<A>
-      > = andThen(
-        ({ substEnv, env }) =>
-          withType(env, applySubstitution(output.type, substEnv), consOrFunc),
-        argsOk
-      );
+      const outputOk: ResultWithType<ApplyConstructor<A> | ApplyFunction<A>> =
+        andThen(
+          ({ substEnv, env }) =>
+            withType(env, applySubstitution(output.type, substEnv), consOrFunc),
+          argsOk
+        );
       // if the func is a constructor and bounded by a variable, cache the binding to env
       if (
         variable &&

--- a/packages/core/src/engine/AutodiffFunctions.ts
+++ b/packages/core/src/engine/AutodiffFunctions.ts
@@ -1,32 +1,31 @@
 import * as ad from "../types/ad";
 
-const binary = (binop: ad.Binary["binop"]) => (
-  v: ad.Num,
-  w: ad.Num
-): ad.Binary => ({
-  tag: "Binary",
-  binop,
-  left: v,
-  right: w,
-});
+const binary =
+  (binop: ad.Binary["binop"]) =>
+  (v: ad.Num, w: ad.Num): ad.Binary => ({
+    tag: "Binary",
+    binop,
+    left: v,
+    right: w,
+  });
 
-const nary = (op: ad.Nary["op"], bin: (v: ad.Num, w: ad.Num) => ad.Binary) => (
-  xs: ad.Num[]
-): ad.Num => {
-  // interestingly, special-casing 1 and 2 args like this actually affects the
-  // gradient by a nontrivial amount in some cases
-  switch (xs.length) {
-    case 1: {
-      return xs[0];
+const nary =
+  (op: ad.Nary["op"], bin: (v: ad.Num, w: ad.Num) => ad.Binary) =>
+  (xs: ad.Num[]): ad.Num => {
+    // interestingly, special-casing 1 and 2 args like this actually affects the
+    // gradient by a nontrivial amount in some cases
+    switch (xs.length) {
+      case 1: {
+        return xs[0];
+      }
+      case 2: {
+        return bin(xs[0], xs[1]);
+      }
+      default: {
+        return { tag: "Nary", op, params: xs };
+      }
     }
-    case 2: {
-      return bin(xs[0], xs[1]);
-    }
-    default: {
-      return { tag: "Nary", op, params: xs };
-    }
-  }
-};
+  };
 
 /**
  * Return `v + w`.
@@ -92,11 +91,13 @@ export const pow = binary("pow");
 
 // --- Unary ops
 
-const unary = (unop: ad.Unary["unop"]) => (v: ad.Num): ad.Unary => ({
-  tag: "Unary",
-  unop,
-  param: v,
-});
+const unary =
+  (unop: ad.Unary["unop"]) =>
+  (v: ad.Num): ad.Unary => ({
+    tag: "Unary",
+    unop,
+    param: v,
+  });
 
 /**
  * Return `-v`.
@@ -245,12 +246,14 @@ export const trunc = unary("trunc");
 
 // ------- Discontinuous / noGrad ops
 
-const comp = (binop: ad.Comp["binop"]) => (v: ad.Num, w: ad.Num): ad.Comp => ({
-  tag: "Comp",
-  binop,
-  left: v,
-  right: w,
-});
+const comp =
+  (binop: ad.Comp["binop"]) =>
+  (v: ad.Num, w: ad.Num): ad.Comp => ({
+    tag: "Comp",
+    binop,
+    left: v,
+    right: w,
+  });
 
 /**
  * Return a conditional `v > w`.
@@ -277,15 +280,14 @@ export const lte = comp("<=");
  */
 export const eq = comp("===");
 
-const logic = (binop: ad.Logic["binop"]) => (
-  v: ad.Bool,
-  w: ad.Bool
-): ad.Logic => ({
-  tag: "Logic",
-  binop,
-  left: v,
-  right: w,
-});
+const logic =
+  (binop: ad.Logic["binop"]) =>
+  (v: ad.Bool, w: ad.Bool): ad.Logic => ({
+    tag: "Logic",
+    binop,
+    left: v,
+    right: w,
+  });
 
 /**
  * Return a boolean `v && w`

--- a/packages/core/src/engine/EngineUtils.ts
+++ b/packages/core/src/engine/EngineUtils.ts
@@ -150,14 +150,12 @@ function mapPathData<T, S>(f: (arg: T) => S, v: PathDataV<T>): PathDataV<S> {
     contents: v.contents.map((pathCmd: PathCmd<T>) => {
       return {
         cmd: pathCmd.cmd,
-        contents: pathCmd.contents.map(
-          (subCmd: SubPath<T>): SubPath<S> => {
-            return {
-              tag: subCmd.tag,
-              contents: mapTuple(f, subCmd.contents),
-            };
-          }
-        ),
+        contents: pathCmd.contents.map((subCmd: SubPath<T>): SubPath<S> => {
+          return {
+            tag: subCmd.tag,
+            contents: mapTuple(f, subCmd.contents),
+          };
+        }),
       };
     }),
   };
@@ -488,8 +486,9 @@ export const compileCompGraph = async (
   const compGraph: ad.Graph = secondaryGraph(vars);
   const evalFn = await genCode(compGraph);
   return (xs: number[]): Shape<number>[] => {
-    const numbers = evalFn((x) => xs[safe(indices.get(x), "input not found")])
-      .secondary;
+    const numbers = evalFn(
+      (x) => xs[safe(indices.get(x), "input not found")]
+    ).secondary;
     const m = new Map(compGraph.secondary.map((id, i) => [id, numbers[i]]));
     return shapes.map((s: Shape<ad.Num>) =>
       mapShape(

--- a/packages/core/src/overall.test.ts
+++ b/packages/core/src/overall.test.ts
@@ -248,12 +248,10 @@ describe("Run individual functions", () => {
       // console.log("# constraints", stateEvaled.constrFns.length);
 
       // Test objectives
-      const { constrEngs: initEngsConstr, objEngs: initEngsObj } = evalFns(
-        stateEvaled
-      );
-      const { constrEngs: optedEngsConstr, objEngs: optedEngsObj } = evalFns(
-        stateOptimizedValue
-      );
+      const { constrEngs: initEngsConstr, objEngs: initEngsObj } =
+        evalFns(stateEvaled);
+      const { constrEngs: optedEngsConstr, objEngs: optedEngsObj } =
+        evalFns(stateOptimizedValue);
 
       for (let i = 0; i < initEngsObj.length; i++) {
         expect(initEngsObj[i]).toBeGreaterThanOrEqual(optedEngsObj[i]);

--- a/packages/core/src/parser/ParserUtil.ts
+++ b/packages/core/src/parser/ParserUtil.ts
@@ -26,7 +26,8 @@ export const basicSymbols: moo.Rules = {
     match: /"(?:[^\n"]|\\["\\ntbfr])*"/,
     value: (s: string): string => s.slice(1, -1),
   },
-  float_literal: /[+-]?(?:\d+(?:[.]\d*)?(?:[eE][+-]?\d+)?|[.]\d+(?:[eE][+-]?\d+)?)/,
+  float_literal:
+    /[+-]?(?:\d+(?:[.]\d*)?(?:[eE][+-]?\d+)?|[.]\d+(?:[eE][+-]?\d+)?)/,
   comment: /--.*?$/,
   multiline_comment: {
     match: /\/\*(?:[\s\S]*?)\*\//,

--- a/packages/core/src/parser/StyleParser.test.ts
+++ b/packages/core/src/parser/StyleParser.test.ts
@@ -161,7 +161,8 @@ where IsSubset(A, B) as foo; IsSubset(B,C) as bar; Union(C,D) as yeet;
     sameASTs(results);
   });
   test("alias general test", () => {
-    const prog = "\
+    const prog =
+      "\
   forall Atom a1; Atom a2 \
   where Bond(a1, a2) as b {}";
     const { results } = parser.feed(prog);

--- a/packages/core/src/renderer/Line.ts
+++ b/packages/core/src/renderer/Line.ts
@@ -128,10 +128,8 @@ const RenderLine = (
 ): SVGGElement => {
   const startArrowhead = getArrowhead(shape.startArrowhead.contents);
   const endArrowhead = getArrowhead(shape.endArrowhead.contents);
-  const [
-    [[arrowSX, arrowSY], [arrowEX, arrowEY]],
-    attrToNotAutoMap,
-  ] = makeRoomForArrows(shape, startArrowhead, endArrowhead);
+  const [[[arrowSX, arrowSY], [arrowEX, arrowEY]], attrToNotAutoMap] =
+    makeRoomForArrows(shape, startArrowhead, endArrowhead);
   const [sx, sy] = toScreen([arrowSX, arrowSY], canvasSize);
   const [ex, ey] = toScreen([arrowEX, arrowEY], canvasSize);
 

--- a/packages/core/src/shapes/Samplers.ts
+++ b/packages/core/src/shapes/Samplers.ts
@@ -66,9 +66,10 @@ export const simpleContext = (variation: string): Context => {
   };
 };
 
-export const uniform = (min: number, max: number): Sampler => (
-  rng: seedrandom.prng
-) => randFloat(rng, min, max);
+export const uniform =
+  (min: number, max: number): Sampler =>
+  (rng: seedrandom.prng) =>
+    randFloat(rng, min, max);
 
 export const sampleVector = (
   { makeInput }: Context,

--- a/packages/core/src/utils/Util.ts
+++ b/packages/core/src/utils/Util.ts
@@ -233,8 +233,7 @@ export const arrowheads: ArrowheadMap = {
     viewbox: "0 0 12.5 14",
     refX: 5,
     refY: 7,
-    path:
-      "M 7 7 a -6 6.75 0 0 1 -6 -6 M 7 7 a -6 6.75 0 0 0 -6 6 M 12 7 a -6 6.75 0 0 1 -6 -6 M 7 7 L 12 7 M 12 7 a -6 6.75 0 0 0 -6 6",
+    path: "M 7 7 a -6 6.75 0 0 1 -6 -6 M 7 7 a -6 6.75 0 0 0 -6 6 M 12 7 a -6 6.75 0 0 1 -6 -6 M 7 7 L 12 7 M 12 7 a -6 6.75 0 0 0 -6 6",
     fillKind: "stroke",
     style: {
       "stroke-linecap": "round",

--- a/packages/docs-site/.vitepress/config.ts
+++ b/packages/docs-site/.vitepress/config.ts
@@ -105,8 +105,7 @@ export default defineConfig({
       "link",
       {
         rel: "stylesheet",
-        href:
-          "https://cdnjs.cloudflare.com/ajax/libs/KaTeX/0.6.0/katex.min.css",
+        href: "https://cdnjs.cloudflare.com/ajax/libs/KaTeX/0.6.0/katex.min.css",
       },
     ],
   ],
@@ -142,13 +141,11 @@ export default defineConfig({
           { text: "SIGGRAPH'20 paper", link: "pathname:///siggraph20.html" },
           {
             text: "CHI'20 paper",
-            link:
-              "https://www.cs.cmu.edu/~woden/assets/chi-20-natural-diagramming.pdf",
+            link: "https://www.cs.cmu.edu/~woden/assets/chi-20-natural-diagramming.pdf",
           },
           {
             text: "Popular Mechanics",
-            link:
-              "https://www.popularmechanics.com/science/math/a32743509/cmu-penrose-math-equations-into-pictures/",
+            link: "https://www.popularmechanics.com/science/math/a32743509/cmu-penrose-math-equations-into-pictures/",
           },
         ],
       },

--- a/packages/edgeworth/src/analysis/SubstanceAnalysis.ts
+++ b/packages/edgeworth/src/analysis/SubstanceAnalysis.ts
@@ -327,7 +327,7 @@ export const cascadingDelete = <T>(
     const toDelete = prog.statements.filter((s): boolean => {
       switch (s.tag) {
         case "Bind": {
-          const expr = (s.expr as unknown) as ApplyPredicate<T>;
+          const expr = s.expr as unknown as ApplyPredicate<T>;
           const willDelete = findArg(expr, id);
           // push its return value IF bind will be deleted
           if (willDelete) ids.push(s.variable);

--- a/packages/edgeworth/src/components/Content.tsx
+++ b/packages/edgeworth/src/components/Content.tsx
@@ -127,47 +127,49 @@ export class Content extends React.Component<ContentProps, ContentState> {
 
   onPrompt = (prompt: string) => this.setState({ prompt });
 
-  generateProgs = () => (
-    setting: SynthesizerSetting,
-    seed: string,
-    numPrograms: number,
-    dsl: string,
-    sub: string,
-    sty: string
-  ) => {
-    const envOrError = compileDomain(dsl);
+  generateProgs =
+    () =>
+    (
+      setting: SynthesizerSetting,
+      seed: string,
+      numPrograms: number,
+      dsl: string,
+      sub: string,
+      sty: string
+    ) => {
+      const envOrError = compileDomain(dsl);
 
-    // initialize synthesizer
-    if (envOrError.isOk()) {
-      const env = envOrError.value;
-      let subResult;
-      if (sub.length > 0) {
-        const subRes = compileSubstance(sub, env);
-        if (subRes.isOk()) {
-          subResult = subRes.value;
-        } else {
-          console.log(
-            `Error when compiling the template Substance program: ${showError(
-              subRes.error
-            )}`
-          );
+      // initialize synthesizer
+      if (envOrError.isOk()) {
+        const env = envOrError.value;
+        let subResult;
+        if (sub.length > 0) {
+          const subRes = compileSubstance(sub, env);
+          if (subRes.isOk()) {
+            subResult = subRes.value;
+          } else {
+            console.log(
+              `Error when compiling the template Substance program: ${showError(
+                subRes.error
+              )}`
+            );
+          }
+        }
+        const synth = new Synthesizer(env, setting, subResult, seed);
+        let progs = synth.generateSubstances(numPrograms);
+        const template: SubProg<A> | undefined = synth.getTemplate();
+
+        if (template) {
+          this.setState({
+            progs: [{ prog: template, ops: [] }, ...progs],
+            staged: [],
+            domain: dsl,
+            style: sty,
+            layoutDone: false,
+          });
         }
       }
-      const synth = new Synthesizer(env, setting, subResult, seed);
-      let progs = synth.generateSubstances(numPrograms);
-      const template: SubProg<A> | undefined = synth.getTemplate();
-
-      if (template) {
-        this.setState({
-          progs: [{ prog: template, ops: [] }, ...progs],
-          staged: [],
-          domain: dsl,
-          style: sty,
-          layoutDone: false,
-        });
-      }
-    }
-  };
+    };
 
   exportDiagrams = async (indices: number[]) => {
     const zip = JSZip();

--- a/packages/edgeworth/src/components/Settings.tsx
+++ b/packages/edgeworth/src/components/Settings.tsx
@@ -238,58 +238,57 @@ export class Settings extends React.Component<SettingsProps, SettingState> {
     this.setState({ numPrograms: newValue as number });
   };
 
-  onChangeMultiselect = (op: string, stmtType: string) => (
-    selected: string[]
-  ) => {
-    const typeSelect = (
-      stmtType: string,
-      op: DeclTypes,
-      arr: string[]
-    ): DeclTypes => {
-      let newMatchSetting: MatchSetting = "*";
-      if (!arr.includes(wildcardType)) {
-        newMatchSetting = arr;
-      }
-      switch (stmtType) {
-        case "Type":
-          return { ...op, type: newMatchSetting };
-        case "Constructor":
-          return { ...op, constructor: newMatchSetting };
-        case "Function":
-          return { ...op, function: newMatchSetting };
-        case "Predicate":
-          return { ...op, predicate: newMatchSetting };
-        default:
-          return op;
+  onChangeMultiselect =
+    (op: string, stmtType: string) => (selected: string[]) => {
+      const typeSelect = (
+        stmtType: string,
+        op: DeclTypes,
+        arr: string[]
+      ): DeclTypes => {
+        let newMatchSetting: MatchSetting = "*";
+        if (!arr.includes(wildcardType)) {
+          newMatchSetting = arr;
+        }
+        switch (stmtType) {
+          case "Type":
+            return { ...op, type: newMatchSetting };
+          case "Constructor":
+            return { ...op, constructor: newMatchSetting };
+          case "Function":
+            return { ...op, function: newMatchSetting };
+          case "Predicate":
+            return { ...op, predicate: newMatchSetting };
+          default:
+            return op;
+        }
+      };
+      let newSetting = this.state.setting;
+      if (newSetting) {
+        switch (op) {
+          case "Add":
+            newSetting = {
+              ...newSetting,
+              add: typeSelect(stmtType, newSetting.add, selected),
+            };
+            break;
+          case "Delete":
+            newSetting = {
+              ...newSetting,
+              delete: typeSelect(stmtType, newSetting.delete, selected),
+            };
+            break;
+          case "Edit":
+            newSetting = {
+              ...newSetting,
+              edit: typeSelect(stmtType, newSetting.edit, selected),
+            };
+            break;
+          default:
+            break;
+        }
+        this.setState({ setting: newSetting });
       }
     };
-    let newSetting = this.state.setting;
-    if (newSetting) {
-      switch (op) {
-        case "Add":
-          newSetting = {
-            ...newSetting,
-            add: typeSelect(stmtType, newSetting.add, selected),
-          };
-          break;
-        case "Delete":
-          newSetting = {
-            ...newSetting,
-            delete: typeSelect(stmtType, newSetting.delete, selected),
-          };
-          break;
-        case "Edit":
-          newSetting = {
-            ...newSetting,
-            edit: typeSelect(stmtType, newSetting.edit, selected),
-          };
-          break;
-        default:
-          break;
-      }
-      this.setState({ setting: newSetting });
-    }
-  };
 
   getDefaults = (mutationType: string, stmtType: string): string[] => {
     let defaults: string[] = [];

--- a/packages/edgeworth/src/synthesis/Mutation.ts
+++ b/packages/edgeworth/src/synthesis/Mutation.ts
@@ -763,11 +763,11 @@ export const enumChangeExprType = (
     ) {
       const options = argMatches(stmt, cxt.env);
       return options.map((decl: ArgStmtDecl<A>) => {
-        const { res, stmts, ctx: newCtx } = generateArgStmt(
-          decl,
-          cxt,
-          expr.args
-        );
+        const {
+          res,
+          stmts,
+          ctx: newCtx,
+        } = generateArgStmt(decl, cxt, expr.args);
         let toDelete: SubStmt<A>[];
         // remove old statement
         if (res.tag === "Bind" && res.variable.type !== stmt.variable.type) {

--- a/packages/edgeworth/src/synthesis/Search.ts
+++ b/packages/edgeworth/src/synthesis/Search.ts
@@ -575,10 +575,8 @@ export const enumerateMutationPaths = (
             cxt
           );
           // execute all mutations and get resulting programs
-          const resultProgs: WithContext<
-            SubProg<A>
-          >[] = possibleMutations.map((m) =>
-            executeMutation(m, progToGrow, cxt)
+          const resultProgs: WithContext<SubProg<A>>[] = possibleMutations.map(
+            (m) => executeMutation(m, progToGrow, cxt)
           );
           // pack the resulting programs with their updated mutation path
           return _.zipWith(

--- a/packages/edgeworth/src/synthesis/Synthesizer.ts
+++ b/packages/edgeworth/src/synthesis/Synthesizer.ts
@@ -619,11 +619,11 @@ export class Synthesizer {
           const options = argMatches(oldStmt, ctx.env);
           if (options.length > 0) {
             const pick = this.choice(options);
-            const { res, stmts, ctx: newCtx } = generateArgStmt(
-              pick,
-              ctx,
-              oldStmt.args
-            );
+            const {
+              res,
+              stmts,
+              ctx: newCtx,
+            } = generateArgStmt(pick, ctx, oldStmt.args);
             const deleteOp: Delete = deleteMutation(oldStmt, newCtx);
             const addOps: Add[] = stmts.map((s) => addMutation(s, newCtx));
             return {
@@ -640,11 +640,11 @@ export class Synthesizer {
           const options = argMatches(oldStmt, ctx.env);
           if (options.length > 0) {
             const pick = this.choice(options);
-            const { res, stmts, ctx: newCtx } = generateArgStmt(
-              pick,
-              ctx,
-              oldExpr.args
-            );
+            const {
+              res,
+              stmts,
+              ctx: newCtx,
+            } = generateArgStmt(pick, ctx, oldExpr.args);
             let toDelete: SubStmt<A>[];
             // remove old statement if (1) the new stmt becomes a predicate OR (2) the return type of the new stmt is different from the old stmt
             if (
@@ -686,9 +686,9 @@ export class Synthesizer {
     const mutations = this.currentProg.statements.map((stmt) => {
       const mutations = this.findMutations(stmt, ctx);
       log.debug(
-        `Possible update mutations for ${prettyStmt(
-          stmt
-        )} are:\n${mutations.map(showMutations).join("\n")}`
+        `Possible update mutations for ${prettyStmt(stmt)} are:\n${mutations
+          .map(showMutations)
+          .join("\n")}`
       );
       return mutations;
     });

--- a/packages/editor/src/App.tsx
+++ b/packages/editor/src/App.tsx
@@ -156,9 +156,8 @@ function App() {
   const compileDiagram = useCompileDiagram();
 
   const ws = useRef<WebSocket | null>(null);
-  const [rogerState, setRogerState] = useRecoilState<RogerState>(
-    currentRogerState
-  );
+  const [rogerState, setRogerState] =
+    useRecoilState<RogerState>(currentRogerState);
 
   const panelFactory = useCallback(
     (node: TabNode) => {
@@ -191,43 +190,46 @@ function App() {
     [rogerState]
   );
   const onAction = useRecoilCallback(
-    ({ set, snapshot }) => (action: Action) => {
-      if (action.type === Actions.RENAME_TAB) {
-        const node = layoutModel.getNodeById(action.data.node) as TabNode;
-        const { kind } = node.getConfig();
-        const program = snapshot.getLoadable(fileContentsSelector(kind))
-          .contents;
-        set(fileContentsSelector(kind), {
-          ...program,
-          name: action.data.text,
-        });
-      }
-      return action;
-    },
+    ({ set, snapshot }) =>
+      (action: Action) => {
+        if (action.type === Actions.RENAME_TAB) {
+          const node = layoutModel.getNodeById(action.data.node) as TabNode;
+          const { kind } = node.getConfig();
+          const program = snapshot.getLoadable(
+            fileContentsSelector(kind)
+          ).contents;
+          set(fileContentsSelector(kind), {
+            ...program,
+            name: action.data.text,
+          });
+        }
+        return action;
+      },
     []
   );
   const updatedFile = useRecoilCallback(
-    ({ snapshot, set }) => async (fileName: string, contents: string) => {
-      const workspace = await snapshot.getPromise(currentWorkspaceState);
-      if (fileName === workspace.files.domain.name) {
-        set(fileContentsSelector("domain"), (file) => {
-          return {
+    ({ snapshot, set }) =>
+      async (fileName: string, contents: string) => {
+        const workspace = await snapshot.getPromise(currentWorkspaceState);
+        if (fileName === workspace.files.domain.name) {
+          set(fileContentsSelector("domain"), (file) => {
+            return {
+              ...file,
+              contents,
+            };
+          });
+          await compileDiagram();
+        } else if (fileName === workspace.files.style.name) {
+          set(fileContentsSelector("style"), (file) => ({ ...file, contents }));
+          await compileDiagram();
+        } else if (fileName === workspace.files.substance.name) {
+          set(fileContentsSelector("substance"), (file) => ({
             ...file,
             contents,
-          };
-        });
-        await compileDiagram();
-      } else if (fileName === workspace.files.style.name) {
-        set(fileContentsSelector("style"), (file) => ({ ...file, contents }));
-        await compileDiagram();
-      } else if (fileName === workspace.files.substance.name) {
-        set(fileContentsSelector("substance"), (file) => ({
-          ...file,
-          contents,
-        }));
-        await compileDiagram();
-      }
-    },
+          }));
+          await compileDiagram();
+        }
+      },
     []
   );
 

--- a/packages/editor/src/components/DiagramPanel.tsx
+++ b/packages/editor/src/components/DiagramPanel.tsx
@@ -389,32 +389,33 @@ export default function DiagramPanel() {
   });
 
   const downloadPdf = useRecoilCallback(
-    ({ snapshot }) => () => {
-      if (canvasRef.current !== null) {
-        const svg = canvasRef.current.firstElementChild as SVGSVGElement;
-        if (svg !== null && state) {
-          const metadata = snapshot.getLoadable(workspaceMetadataSelector)
-            .contents as WorkspaceMetadata;
-          const openedWindow = window.open(
-            "",
-            "PRINT",
-            `height=${state.canvas.height},width=${state.canvas.width}`
-          );
-          if (openedWindow === null) {
-            toast.error("Couldn't open popup to print");
-            return;
+    ({ snapshot }) =>
+      () => {
+        if (canvasRef.current !== null) {
+          const svg = canvasRef.current.firstElementChild as SVGSVGElement;
+          if (svg !== null && state) {
+            const metadata = snapshot.getLoadable(workspaceMetadataSelector)
+              .contents as WorkspaceMetadata;
+            const openedWindow = window.open(
+              "",
+              "PRINT",
+              `height=${state.canvas.height},width=${state.canvas.width}`
+            );
+            if (openedWindow === null) {
+              toast.error("Couldn't open popup to print");
+              return;
+            }
+            openedWindow.document.write(
+              `<!DOCTYPE html><head><title>${metadata.name}</title></head><body>`
+            );
+            openedWindow.document.write(svg.outerHTML);
+            openedWindow.document.write("</body></html>");
+            openedWindow.document.close();
+            openedWindow.focus();
+            openedWindow.print();
           }
-          openedWindow.document.write(
-            `<!DOCTYPE html><head><title>${metadata.name}</title></head><body>`
-          );
-          openedWindow.document.write(svg.outerHTML);
-          openedWindow.document.write("</body></html>");
-          openedWindow.document.close();
-          openedWindow.focus();
-          openedWindow.print();
         }
-      }
-    },
+      },
     [state]
   );
 

--- a/packages/editor/src/components/Opt.tsx
+++ b/packages/editor/src/components/Opt.tsx
@@ -15,13 +15,8 @@ export default function Opt() {
     );
   }
 
-  const {
-    constraintSets,
-    optStages,
-    currentStageIndex,
-    constrFns,
-    objFns,
-  } = state;
+  const { constraintSets, optStages, currentStageIndex, constrFns, objFns } =
+    state;
   const { objMask, constrMask } = constraintSets.get(
     optStages[currentStageIndex]
   )!;

--- a/packages/editor/src/components/RogerPanel.tsx
+++ b/packages/editor/src/components/RogerPanel.tsx
@@ -14,52 +14,53 @@ export default function RogerPanel({
   const workspace = useRecoilValue(currentWorkspaceState);
   const { substance, style, domain } = workspace.files;
   const onSelection = useRecoilCallback(
-    ({ set }) => (val: string, key: ProgramType) => {
-      set(currentWorkspaceState, (state) => {
-        const files = {
-          ...state.files,
-          [key]: { ...state.files[key], name: val },
-        };
-        localforage.setItem("selected_roger_files", {
-          substance: files.substance.name,
-          style: files.style.name,
-          domain: files.domain.name,
-        });
-        const { location } = state.metadata;
+    ({ set }) =>
+      (val: string, key: ProgramType) => {
+        set(currentWorkspaceState, (state) => {
+          const files = {
+            ...state.files,
+            [key]: { ...state.files[key], name: val },
+          };
+          localforage.setItem("selected_roger_files", {
+            substance: files.substance.name,
+            style: files.style.name,
+            domain: files.domain.name,
+          });
+          const { location } = state.metadata;
 
-        const fileLocations =
-          location.kind === "roger"
-            ? { ...location, [key]: val }
-            : {
-                substance: undefined,
-                style: undefined,
-                domain: undefined,
-              };
+          const fileLocations =
+            location.kind === "roger"
+              ? { ...location, [key]: val }
+              : {
+                  substance: undefined,
+                  style: undefined,
+                  domain: undefined,
+                };
 
-        return {
-          ...state,
-          metadata: {
-            ...state.metadata,
-            location: {
-              kind: "roger" as const,
-              // TODO: only set the root of the location if a style file is selected
-              // TODO: do path processing in a more principled way
-              ...fileLocations,
+          return {
+            ...state,
+            metadata: {
+              ...state.metadata,
+              location: {
+                kind: "roger" as const,
+                // TODO: only set the root of the location if a style file is selected
+                // TODO: do path processing in a more principled way
+                ...fileLocations,
+              },
+              id: uuid(),
             },
-            id: uuid(),
-          },
-          files,
-        };
-      });
-      if (ws !== null) {
-        ws.send(
-          JSON.stringify({
-            kind: "retrieve_file",
-            fileName: val,
-          })
-        );
+            files,
+          };
+        });
+        if (ws !== null) {
+          ws.send(
+            JSON.stringify({
+              kind: "retrieve_file",
+              fileName: val,
+            })
+          );
+        }
       }
-    }
   );
   useEffect(() => {
     if (rogerState.kind === "connected") {

--- a/packages/editor/src/components/TopBar.tsx
+++ b/packages/editor/src/components/TopBar.tsx
@@ -53,17 +53,18 @@ function EditableTitle() {
   const workspaceMetadata = useRecoilValue(workspaceMetadataSelector);
   const saveLocally = useSaveLocally();
   const onChange = useRecoilCallback(
-    ({ set, snapshot }) => (e: React.ChangeEvent<HTMLInputElement>) => {
-      set(workspaceMetadataSelector, (state) => ({
-        ...state,
-        name: e.target.value,
-      }));
-      const metadata = snapshot.getLoadable(workspaceMetadataSelector)
-        .contents as WorkspaceMetadata;
-      if (metadata.location.kind !== "local" || !metadata.location.saved) {
-        saveLocally();
+    ({ set, snapshot }) =>
+      (e: React.ChangeEvent<HTMLInputElement>) => {
+        set(workspaceMetadataSelector, (state) => ({
+          ...state,
+          name: e.target.value,
+        }));
+        const metadata = snapshot.getLoadable(workspaceMetadataSelector)
+          .contents as WorkspaceMetadata;
+        if (metadata.location.kind !== "local" || !metadata.location.saved) {
+          saveLocally();
+        }
       }
-    }
   );
   const onKey = useCallback((e: React.KeyboardEvent) => {
     if (e.key === "Enter" || e.key === "Escape") {

--- a/packages/editor/src/state/atoms.ts
+++ b/packages/editor/src/state/atoms.ts
@@ -214,15 +214,19 @@ export const currentRogerState = atom<RogerState>({
  */
 export const fileContentsSelector = selectorFamily<ProgramFile, ProgramType>({
   key: "fileContents",
-  get: (programType: ProgramType) => ({ get }) => {
-    return get(currentWorkspaceState).files[programType];
-  },
-  set: (programType: ProgramType) => ({ set }, newValue) => {
-    set(currentWorkspaceState, (state) => ({
-      ...state,
-      files: { ...state.files, [programType]: newValue },
-    }));
-  },
+  get:
+    (programType: ProgramType) =>
+    ({ get }) => {
+      return get(currentWorkspaceState).files[programType];
+    },
+  set:
+    (programType: ProgramType) =>
+    ({ set }, newValue) => {
+      set(currentWorkspaceState, (state) => ({
+        ...state,
+        files: { ...state.files, [programType]: newValue },
+      }));
+    },
 });
 
 /**

--- a/packages/editor/src/state/callbacks.ts
+++ b/packages/editor/src/state/callbacks.ts
@@ -90,31 +90,35 @@ const _compileDiagram = async (
 };
 
 export const useStepDiagram = () =>
-  useRecoilCallback(({ set }) => () =>
-    set(diagramState, (diagram: Diagram) => {
-      if (diagram.state === null) {
-        toast.error(`No diagram`);
-        return diagram;
-      }
-      return {
-        ...diagram,
-        state: stepState(diagram.state, diagram.metadata.stepSize),
-      };
-    })
+  useRecoilCallback(
+    ({ set }) =>
+      () =>
+        set(diagramState, (diagram: Diagram) => {
+          if (diagram.state === null) {
+            toast.error(`No diagram`);
+            return diagram;
+          }
+          return {
+            ...diagram,
+            state: stepState(diagram.state, diagram.metadata.stepSize),
+          };
+        })
   );
 
 export const useStepStage = () =>
-  useRecoilCallback(({ set }) => () =>
-    set(diagramState, (diagram: Diagram) => {
-      if (diagram.state === null) {
-        toast.error(`No diagram`);
-        return diagram;
-      }
-      return {
-        ...diagram,
-        state: stepNextStage(diagram.state, diagram.metadata.stepSize),
-      };
-    })
+  useRecoilCallback(
+    ({ set }) =>
+      () =>
+        set(diagramState, (diagram: Diagram) => {
+          if (diagram.state === null) {
+            toast.error(`No diagram`);
+            return diagram;
+          }
+          return {
+            ...diagram,
+            state: stepNextStage(diagram.state, diagram.metadata.stepSize),
+          };
+        })
   );
 
 export const useCompileDiagram = () =>
@@ -223,8 +227,9 @@ export const useLoadLocalWorkspace = () =>
 
 export const useLoadExampleWorkspace = () =>
   useRecoilCallback(({ set, reset, snapshot }) => async (trio: Trio) => {
-    const currentWorkspace = snapshot.getLoadable(currentWorkspaceState)
-      .contents;
+    const currentWorkspace = snapshot.getLoadable(
+      currentWorkspaceState
+    ).contents;
     if (!_confirmDirtyWorkspace(currentWorkspace)) {
       return;
     }
@@ -459,25 +464,25 @@ export const useSignIn = () =>
 
 export const useDeleteLocalFile = () =>
   useRecoilCallback(
-    ({ set, snapshot, reset }) => async (
-      workspaceMetadata: WorkspaceMetadata
-    ) => {
-      const { id, name } = workspaceMetadata;
-      const shouldDelete = confirm(`Delete ${name}?`);
-      if (!shouldDelete) {
-        return;
+    ({ set, snapshot, reset }) =>
+      async (workspaceMetadata: WorkspaceMetadata) => {
+        const { id, name } = workspaceMetadata;
+        const shouldDelete = confirm(`Delete ${name}?`);
+        if (!shouldDelete) {
+          return;
+        }
+        const currentWorkspace = snapshot.getLoadable(
+          currentWorkspaceState
+        ).contents;
+        // removes from index
+        set(localFilesState, (localFiles) => {
+          const { [id]: removedFile, ...newFiles } = localFiles;
+          return newFiles;
+        });
+        await localforage.removeItem(id);
+        if (currentWorkspace.metadata.id === id) {
+          reset(currentWorkspaceState);
+        }
+        toast.success(`Removed ${name}`);
       }
-      const currentWorkspace = snapshot.getLoadable(currentWorkspaceState)
-        .contents;
-      // removes from index
-      set(localFilesState, (localFiles) => {
-        const { [id]: removedFile, ...newFiles } = localFiles;
-        return newFiles;
-      });
-      await localforage.removeItem(id);
-      if (currentWorkspace.metadata.id === id) {
-        reset(currentWorkspaceState);
-      }
-      toast.success(`Removed ${name}`);
-    }
   );

--- a/packages/roger/index.ts
+++ b/packages/roger/index.ts
@@ -125,26 +125,25 @@ const render = async (
 };
 
 // set up path resolution
-const resolvePath = (prefix: string, stylePath: string) => async (
-  filePath: string
-) => {
-  // Handle absolute URLs
-  if (/^(http|https):\/\/[^ "]+$/.test(filePath)) {
-    const fileURL = new URL(filePath).href;
-    try {
-      const fileReq = await fetch(fileURL);
-      return fileReq.text();
-    } catch (e) {
-      console.error(`Failed to resolve path: ${e}`);
-      return undefined;
+const resolvePath =
+  (prefix: string, stylePath: string) => async (filePath: string) => {
+    // Handle absolute URLs
+    if (/^(http|https):\/\/[^ "]+$/.test(filePath)) {
+      const fileURL = new URL(filePath).href;
+      try {
+        const fileReq = await fetch(fileURL);
+        return fileReq.text();
+      } catch (e) {
+        console.error(`Failed to resolve path: ${e}`);
+        return undefined;
+      }
     }
-  }
 
-  // Relative paths
-  const parentDir = parse(join(prefix, stylePath)).dir;
-  const joined = resolve(parentDir, filePath);
-  return fs.readFileSync(joined, "utf8").toString();
-};
+    // Relative paths
+    const parentDir = parse(join(prefix, stylePath)).dir;
+    const joined = resolve(parentDir, filePath);
+    return fs.readFileSync(joined, "utf8").toString();
+  };
 
 const readTrio = (sub: string, sty: string[], dsl: string, prefix: string) => {
   // Fetch Substance, Style, and Domain files
@@ -367,8 +366,7 @@ yargs(hideBin(process.argv))
     (yargs) =>
       yargs
         .options("trio", {
-          desc:
-            "Three files pointing to a Penrose trio or a JSON file that links to them.",
+          desc: "Three files pointing to a Penrose trio or a JSON file that links to them.",
           type: "array",
           demandOption: true,
         })
@@ -457,8 +455,7 @@ yargs(hideBin(process.argv))
         })
         .option("path", {
           alias: "p",
-          desc:
-            "Path prefix for both the registry file itself and all paths to trios in the registry.",
+          desc: "Path prefix for both the registry file itself and all paths to trios in the registry.",
           default: ".",
         }),
     async (options) => {

--- a/packages/roger/package.json
+++ b/packages/roger/package.json
@@ -34,7 +34,7 @@
     "global-jsdom": "^8.8.0",
     "jsdom": "^22.0.0",
     "node-fetch": "^3.3.1",
-    "prettier": "2.2.1",
+    "prettier": "2.8.8",
     "regenerator-runtime": "^0.13.11",
     "true-myth": "^4.1.1",
     "tsx": "^3.12.7",

--- a/yarn.lock
+++ b/yarn.lock
@@ -14747,10 +14747,10 @@ prettier-plugin-organize-imports@^3.2.1:
   resolved "https://registry.yarnpkg.com/prettier-plugin-organize-imports/-/prettier-plugin-organize-imports-3.2.1.tgz#7e0e0a18457e0166e740daaff1aed1c08069fcb9"
   integrity sha512-bty7C2Ecard5EOXirtzeCAqj4FU4epeuWrQt/Z+sh8UVEpBlBZ3m3KNPz2kFu7KgRTQx/C9o4/TdquPD1jOqjQ==
 
-prettier@2.2.1:
-  version "2.2.1"
-  resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.2.1.tgz#795a1a78dd52f073da0cd42b21f9c91381923ff5"
-  integrity sha512-PqyhM2yCjg/oKkFPtTGUojv7gnZAoG80ttl45O6x2Ug/rMJw4wcc9k6aaf2hibP7BGVCCM33gZoGjyvt9mm16Q==
+prettier@2.8.8:
+  version "2.8.8"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.8.8.tgz#e8c5d7e98a4305ffe3de2e1fc4aca1a71c28b1da"
+  integrity sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q==
 
 "prettier@>=2.2.1 <=2.3.0":
   version "2.3.0"


### PR DESCRIPTION
# Description

[TypeScript 5.0 added `const` type parameters](https://devblogs.microsoft.com/typescript/announcing-typescript-5-0-beta/#const-type-parameters), which I want to use in #1393. This new syntax wasn't supported until [Prettier 2.8.5](https://github.com/prettier/prettier/releases/tag/2.8.5), though, so we need to upgrade our Prettier version. This PR bumps Prettier to 2.8.8 and runs `yarn format`.

# Checklist

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have reviewed any generated registry diagram changes