### PR TITLE
fix: passthrough auto fill

### DIFF
--- a/packages/core/src/renderer/AttrHelper.ts
+++ b/packages/core/src/renderer/AttrHelper.ts
@@ -77,20 +77,18 @@ export const attrAutoFillSvg = (
       const mappedPropKey: string = attrMapSvg[propKey];
       if (!elem.hasAttribute(mappedPropKey)) {
         elem.setAttribute(mappedPropKey, propVal.contents.toString());
-      } else if (propKey === "style") {
-        const style = elem.getAttribute(propKey);
-        if (style === null) {
-          elem.setAttribute(propKey, propVal.contents.toString());
-        } else {
-          elem.setAttribute(propKey, `${style}${propVal.contents.toString()}`);
-        }
+      }
+    } else if (propKey === "style" && propVal.contents !== "") {
+      const style = elem.getAttribute(propKey);
+      if (style === null) {
+        elem.setAttribute(propKey, propVal.contents.toString());
       } else {
-        if (!elem.hasAttribute(propKey)) {
-          elem.setAttribute(propKey, propVal.contents.toString());
-        }
+        elem.setAttribute(propKey, `${style}${propVal.contents.toString()}`);
       }
     } else {
-      elem.setAttribute(propKey, propVal.contents.toString());
+      if (!elem.hasAttribute(propKey)) {
+        elem.setAttribute(propKey, propVal.contents.toString());
+      }
     }
   }
 };


### PR DESCRIPTION
# Description

In #1337, while adapting the passthrough auto-fill feature to work with the consolidated shape types, I introduced a bug where the `style` would not correctly map.

This PR fixes it by reverting the logic of the `attrAutoFilSvg` to the version before #1337.