### PR TITLE
fix: remove width and height attributes in `editor` SVG export

### DIFF
--- a/packages/components/src/Simple.tsx
+++ b/packages/components/src/Simple.tsx
@@ -155,9 +155,6 @@ class Simple extends React.Component<SimpleProps, SimpleState> {
               this.props.imageResolver ?? fetchResolver,
               this.props.name ?? ""
             ));
-        // to avoid overflowing the parent div, force the height and width to be 100%
-        renderedState.setAttribute("height", "100%");
-        renderedState.setAttribute("width", "100%");
         if (node.firstChild !== null) {
           node.replaceChild(renderedState, node.firstChild);
         } else {

--- a/packages/core/src/renderer/Renderer.ts
+++ b/packages/core/src/renderer/Renderer.ts
@@ -74,8 +74,6 @@ export const RenderInteractive = async (
 ): Promise<SVGSVGElement> => {
   const svg = document.createElementNS("http://www.w3.org/2000/svg", "svg");
   svg.setAttribute("xmlns", "http://www.w3.org/2000/svg");
-  svg.setAttribute("width", "100%");
-  svg.setAttribute("height", "100%");
   svg.setAttribute("version", "1.2");
   svg.setAttribute(
     "viewBox",

--- a/packages/editor/src/components/DiagramPanel.tsx
+++ b/packages/editor/src/components/DiagramPanel.tsx
@@ -137,9 +137,6 @@ export const DownloadSVG = (
   variationStr: string
 ): void => {
   SVGaddCode(svg, dslStr, subStr, styleStr, versionStr, variationStr);
-  // remove `width` and `height` for tool compatibility
-  svg.setAttribute("width", "");
-  svg.setAttribute("height", "");
   const blob = new Blob([svg.outerHTML], {
     type: "image/svg+xml;charset=utf-8",
   });
@@ -307,8 +304,6 @@ export default function DiagramPanel() {
               (path) => pathResolver(path, rogerState, workspace),
               "diagramPanel"
             );
-        rendered.setAttribute("width", "100%");
-        rendered.setAttribute("height", "100%");
         if (cur.firstElementChild) {
           cur.replaceChild(rendered, cur.firstElementChild);
         } else {

--- a/packages/editor/src/components/DiagramPanel.tsx
+++ b/packages/editor/src/components/DiagramPanel.tsx
@@ -137,6 +137,9 @@ export const DownloadSVG = (
   variationStr: string
 ): void => {
   SVGaddCode(svg, dslStr, subStr, styleStr, versionStr, variationStr);
+  // remove `width` and `height` for tool compatibility
+  svg.setAttribute("width", "");
+  svg.setAttribute("height", "");
   const blob = new Blob([svg.outerHTML], {
     type: "image/svg+xml;charset=utf-8",
   });


### PR DESCRIPTION
# Description

In the renderer, we set the `width` and `height` of the rendered SVG element to be `100%` for best browser compatibility and responsiveness (#1105). However, tools like Figma and Adobe Illustrator have their own interpretation of these fields and resize their imports. To make sure they use the width and height defined in Penrose, this PR leaves the dimensions in `viewport` and removes `width` and `height` from downloaded SVGs in `editor` for compatibility with external tools.

# Checklist

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have reviewed any generated registry diagram changes

