### PR TITLE
ci: hash all `package.json` files for dep caching

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -25,12 +25,11 @@ runs:
           node_modules
           packages/*/node_modules
         # obviously we need to hash `yarn.lock` because that specifies all our
-        # external dependencies, but we also need to hash `package.json` because
-        # Yarn creates symlinks under `node_modules/@penrose/` for each of our
-        # packages, so we need to update those if any packages are added; note
-        # that this strategy means we cannot use wildcards in the `"packages"`
-        # list in `package.json`, and must instead list them all explicitly
-        key: ${{ runner.os }}-${{ hashFiles('package.json', 'yarn.lock') }}
+        # external dependencies, but we also need to hash all of our
+        # `package.json` files because Yarn creates symlinks under
+        # `node_modules/@penrose/` for each of our packages, so we need to
+        # update those if any packages are added
+        key: ${{ runner.os }}-${{ hashFiles('**/yarn.lock', '**/package.json') }}
     - if: steps.cache.outputs.cache-hit != 'true'
       name: Install packages
       run: yarn

--- a/package.json
+++ b/package.json
@@ -40,15 +40,7 @@
   },
   "workspaces": {
     "packages": [
-      "packages/components",
-      "packages/core",
-      "packages/docs-site",
-      "packages/edgeworth",
-      "packages/editor",
-      "packages/examples",
-      "packages/optimizer",
-      "packages/roger",
-      "packages/vscode"
+      "packages/*"
     ],
     "nohoist": [
       "**/@types/jest",


### PR DESCRIPTION
# Description

In #904 I realized that we need to invalidate our CI deps cache anytime we add a package, which I implemented by removing the wildcard from `"packages"` in `lerna.json`, meaning that now anyone adding a package needed to remember to also list it in that file. Then in #1081 I put back the wildcard in `lerna.json` and moved the explicit list to our root `package.json` instead. But now that #1412 is merged, I realized that we can get rid of this error-prone need to explicitly list our `packages/` by instead just hashing _all_ the `package.json` files in the repo, which will automatically detect when packages are added, removed, etc. This PR does that, so now adding a package doesn't have any necessary hidden steps beyond creating a new folder under `packages/`.

# Checklist

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have reviewed any generated registry diagram changes