### PR TITLE
fix: dependency graph for paths with indices

### DIFF
--- a/packages/core/src/compiler/Style.test.ts
+++ b/packages/core/src/compiler/Style.test.ts
@@ -1336,16 +1336,21 @@ delete x.z.p }`,
       const sty =
         canvasPreamble +
         `
-forall T t {
-  t.xs = [1, 2, 3, 4, 5, 6]
-  t.index = 3
-  t.v = t.xs[t.index]
-}
+        forall T t {
+          t.vals = [1, 2, 3, 4, 5, 6]
+          t.val = t.vals[match_id]
+        
+          Circle {
+            r: t.val
+          }
+        }
       `;
 
+      // This problem would have failed compilation when indexing is not handled correctly
+      // And this would fail:
       const { graph } = await loadProgs({ dsl, sub, sty });
-      expect(graph.parents("`t`.v").sort()).toEqual(
-        ["`t`.xs", "`t`.index"].sort()
+      expect(graph.parents("`t`.val").sort()).toEqual(
+        ["`t`.vals", "1:0:match_id"].sort()
       );
     });
   });

--- a/packages/core/src/compiler/Style.test.ts
+++ b/packages/core/src/compiler/Style.test.ts
@@ -1328,4 +1328,25 @@ delete x.z.p }`,
       }
     });
   });
+
+  describe("gather dependencies", () => {
+    test("indexing", async () => {
+      const dsl = "type T";
+      const sub = "T t";
+      const sty =
+        canvasPreamble +
+        `
+forall T t {
+  t.xs = [1, 2, 3, 4, 5, 6]
+  t.index = 3
+  t.v = t.xs[t.index]
+}
+      `;
+
+      const { graph } = await loadProgs({ dsl, sub, sty });
+      expect(graph.parents("`t`.v").sort()).toEqual(
+        ["`t`.xs", "`t`.index"].sort()
+      );
+    });
+  });
 });

--- a/packages/core/src/compiler/Style.ts
+++ b/packages/core/src/compiler/Style.ts
@@ -2280,7 +2280,14 @@ const findPathsExpr = <T>(expr: Expr<T>, context: Context): Path<T>[] => {
       return expr.contents.flatMap((e) => findPathsExpr(e, context));
     }
     case "Path": {
-      return [expr];
+      // A `Path` (generally, `arr[index]`) expression depends on `arr` and `index` (if exists)
+      return [
+        {
+          ...expr,
+          indices: [],
+        },
+        ...expr.indices.flatMap((index) => findPathsExpr(index, context)),
+      ];
     }
     case "UOp": {
       return findPathsExpr(expr.arg, context);


### PR DESCRIPTION
# Description

This fixes a bug in the generation of the dependency graph when it sees `Path` expressions with indices.

# What broke?

Conceptually, the expression `arr[index]` depends on both `arr` and `index`. When handling the dependency graph for this expression, it only adds `arr`, not `index`. This sometimes result in `arr[index]` being evaluated before `index` even exists in the translation.

# The fix

In `findPathsExpr` we modify the case for `Path` to return the `arr` part and the `index` part:
```
      return [
        {
          ...expr,
          indices: [],
        }, // this is the `arr` part
        ...expr.indices.flatMap((index) => findPathsExpr(index, context)), // this is the `index` part
      ];
```

# Checklist

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have reviewed any generated registry diagram changes
