### PR TITLE
fix: repeated state updates in `Gridbox` of `components`

### DIFF
--- a/packages/components/src/Gridbox.tsx
+++ b/packages/components/src/Gridbox.tsx
@@ -154,16 +154,6 @@ export class Gridbox extends React.Component<GridboxProps, GridboxState> {
       variation: props.variation,
     };
   }
-
-  componentDidUpdate(
-    prevProps: Readonly<GridboxProps>,
-    prevState: Readonly<GridboxState>
-  ): void {
-    if (this.props.selected !== prevState.isSelected) {
-      this.setState({ isSelected: this.props.selected ?? false });
-    }
-  }
-
   toggleView = () => {
     this.setState({ showDiagramInfo: !this.state.showDiagramInfo });
   };
@@ -234,9 +224,11 @@ export class Gridbox extends React.Component<GridboxProps, GridboxState> {
             name={`gridbox-${this.props.gridIndex}`}
             interactive={false}
             onFrame={(state: PenroseState) => {
-              this.setState({ currentState: state });
-              if (onStateUpdate) {
-                onStateUpdate(this.props.gridIndex, state);
+              if (stateful) {
+                this.setState({ currentState: state });
+                if (onStateUpdate !== undefined) {
+                  onStateUpdate(this.props.gridIndex, state);
+                }
               }
             }}
           />


### PR DESCRIPTION
# Description

#1344 accidentally merged an old `componentDidUpdate` function in `Gridbox`, which causes all `Grid` components to break due to repeated state updates. This PR moves the function and restores the grids in `edgeworth` and `editor`.
