### PR TITLE
feat: export SVGs with plain TeX labels

### DIFF
--- a/packages/core/src/renderer/Equation.ts
+++ b/packages/core/src/renderer/Equation.ts
@@ -1,4 +1,8 @@
+import seedrandom from "seedrandom";
+import { input } from "../engine/Autodiff.js";
+import { makeCanvas } from "../index.js";
 import { Equation } from "../shapes/Equation.js";
+import { sampleText } from "../shapes/Text.js";
 import { getAdValueAsString } from "../utils/Util.js";
 import {
   attrAutoFillSvg,
@@ -9,11 +13,38 @@ import {
   attrWH,
 } from "./AttrHelper.js";
 import { RenderProps } from "./Renderer.js";
+import RenderText from "./Text.js";
 
 const RenderEquation = (
   shape: Equation<number>,
-  { canvasSize, labels }: RenderProps
+  renderOptions: RenderProps
 ): SVGGElement => {
+  const { canvasSize, labels, texLabels, variation } = renderOptions;
+  if (texLabels) {
+    const rng = seedrandom(variation);
+    return RenderText(
+      {
+        ...sampleText(
+          {
+            makeInput: (meta) =>
+              input(
+                meta.init.tag === "Sampled"
+                  ? meta.init.sampler(rng)
+                  : meta.init.pending
+              ),
+          },
+          makeCanvas(canvasSize[0], canvasSize[1])
+        ),
+        ...shape,
+        shapeType: "Text",
+        string: {
+          tag: "StrV",
+          contents: `$${shape.string.contents}$`,
+        },
+      } as any,
+      renderOptions
+    );
+  }
   const elem = document.createElementNS("http://www.w3.org/2000/svg", "g");
 
   // Keep track of which input properties we programatically mapped

--- a/packages/core/src/renderer/Equation.ts
+++ b/packages/core/src/renderer/Equation.ts
@@ -1,5 +1,5 @@
 import { Equation } from "../shapes/Equation.js";
-import { getAdValueAsString } from "../utils/Util.js";
+import { getAdValueAsString, toScreen } from "../utils/Util.js";
 import {
   attrAutoFillSvg,
   attrFill,
@@ -16,10 +16,17 @@ const placeholderString = (
   shape: Equation<number>
 ): SVGGElement => {
   const txt = document.createElementNS("http://www.w3.org/2000/svg", "text");
+  // fake font
   txt.textContent = label;
   attrFill(shape, txt);
   attrWH(shape, txt);
-  attrTransformCoords(shape, canvasSize, txt);
+  const { center } = shape;
+  const [x, y] = toScreen([center.contents[0], center.contents[1]], canvasSize);
+  txt.setAttribute("x", `${x}`);
+  txt.setAttribute("y", `${y}`);
+  txt.setAttribute("alignment-baseline", "alphabetic");
+  txt.setAttribute("dominant-baseline", "alphabetic");
+  txt.setAttribute("text-anchor", "middle");
   return txt;
 };
 

--- a/packages/core/src/renderer/Renderer.ts
+++ b/packages/core/src/renderer/Renderer.ts
@@ -33,6 +33,7 @@ export interface RenderProps {
   namespace: string;
   variation: string;
   labels: LabelCache;
+  texLabels: boolean;
   canvasSize: [number, number];
   pathResolver: PathResolver;
 }
@@ -91,6 +92,7 @@ export const RenderInteractive = async (
       canvasSize: state.canvas.size,
       variation: state.variation,
       namespace,
+      texLabels: false,
       pathResolver,
     },
     {
@@ -109,7 +111,8 @@ export const RenderInteractive = async (
 export const RenderStatic = async (
   state: State,
   pathResolver: PathResolver,
-  namespace: string
+  namespace: string,
+  texLabels = false
 ): Promise<SVGSVGElement> => {
   const {
     varyingValues,
@@ -132,6 +135,7 @@ export const RenderStatic = async (
       canvasSize: canvas.size,
       variation,
       namespace,
+      texLabels,
       pathResolver,
     },
     undefined
@@ -141,13 +145,7 @@ export const RenderStatic = async (
 
 const RenderGroup = async (
   groupShape: Group<number>,
-  shapeProps: {
-    labels: LabelCache;
-    canvasSize: [number, number];
-    variation: string;
-    namespace: string;
-    pathResolver: PathResolver;
-  },
+  shapeProps: RenderProps,
   interactiveProp?: InteractiveProps
 ): Promise<SVGGElement> => {
   const elem = document.createElementNS("http://www.w3.org/2000/svg", "g");

--- a/packages/core/src/utils/CollectLabels.ts
+++ b/packages/core/src/utils/CollectLabels.ts
@@ -90,7 +90,6 @@ const tex2svg = async (
           `Label 'string' and 'fontSize' must be non-empty and non-optimized for ${properties.name.contents}`
         )
       );
-      return;
     }
 
     // Render the label

--- a/packages/editor/src/components/DiagramPanel.tsx
+++ b/packages/editor/src/components/DiagramPanel.tsx
@@ -12,6 +12,7 @@ import toast from "react-hot-toast";
 import { useRecoilCallback, useRecoilState, useRecoilValue } from "recoil";
 import { v4 as uuid } from "uuid";
 import {
+  Diagram,
   DiagramMetadata,
   ProgramFile,
   RogerState,
@@ -366,6 +367,41 @@ export default function DiagramPanel() {
     }
   });
 
+  // download an svg with raw TeX labels
+  const downloadSvgTex = useRecoilCallback(({ snapshot }) => async () => {
+    if (canvasRef.current !== null) {
+      const { state } = snapshot.getLoadable(diagramState).contents as Diagram;
+      if (state !== null) {
+        const svg = await RenderStatic(
+          state,
+          (path) => pathResolver(path, rogerState, workspace),
+          "diagramPanel",
+          true
+        );
+        const metadata = snapshot.getLoadable(workspaceMetadataSelector)
+          .contents as WorkspaceMetadata;
+        const diagram = snapshot.getLoadable(diagramMetadataSelector)
+          .contents as DiagramMetadata;
+        const domain = snapshot.getLoadable(fileContentsSelector("domain"))
+          .contents as ProgramFile;
+        const substance = snapshot.getLoadable(
+          fileContentsSelector("substance")
+        ).contents as ProgramFile;
+        const style = snapshot.getLoadable(fileContentsSelector("style"))
+          .contents as ProgramFile;
+        DownloadSVG(
+          svg,
+          metadata.name,
+          domain.contents,
+          substance.contents,
+          style.contents,
+          metadata.editorVersion.toString(),
+          diagram.variation
+        );
+      }
+    }
+  });
+
   const downloadPng = useRecoilCallback(({ snapshot }) => async () => {
     if (canvasRef.current !== null) {
       const svg = canvasRef.current.firstElementChild as SVGSVGElement;
@@ -431,6 +467,7 @@ export default function DiagramPanel() {
         {state && (
           <div style={{ display: "flex" }}>
             <BlueButton onClick={downloadSvg}>SVG</BlueButton>
+            <BlueButton onClick={downloadSvgTex}>SVG (TeX)</BlueButton>
             <BlueButton onClick={downloadPng}>PNG</BlueButton>
             <BlueButton onClick={downloadPdf}>PDF</BlueButton>
           </div>

--- a/packages/roger/index.ts
+++ b/packages/roger/index.ts
@@ -40,6 +40,7 @@ const render = async (
   style: string,
   domain: string,
   resolvePath: (filePath: string) => Promise<string | undefined>,
+  texLabels: boolean,
   verbose: boolean,
   meta: {
     substanceName: string;
@@ -89,8 +90,9 @@ const render = async (
   const convergeEnd = process.hrtime(convergeStart);
   const reactRenderStart = process.hrtime();
 
-  const canvas = (await RenderStatic(optimizedState, resolvePath, "roger"))
-    .outerHTML;
+  const canvas = (
+    await RenderStatic(optimizedState, resolvePath, "roger", texLabels)
+  ).outerHTML;
 
   const reactRenderEnd = process.hrtime(reactRenderStart);
   const overallEnd = process.hrtime(overallStart);
@@ -269,6 +271,11 @@ yargs(hideBin(process.argv))
           desc: "A common path prefix for the trio files",
           default: ".",
         })
+        .option("tex-labels", {
+          desc: "Render Equation shapes as plain TeX strings in the output SVG",
+          type: "boolean",
+          default: false,
+        })
         .option("variation", {
           alias: "v",
           desc: "Variation for the Penrose diagram",
@@ -277,6 +284,7 @@ yargs(hideBin(process.argv))
     async (options) => {
       let sub: string, sty: string[], dom: string;
       let prefix = options.path;
+      const texLabels = options.texLabels;
       let variation = options.variation as string | undefined;
       if (options.trio.length === 1) {
         console.log();
@@ -304,6 +312,7 @@ yargs(hideBin(process.argv))
         style,
         domain,
         resolvePath(prefix, sty),
+        texLabels,
         false,
         {
           substanceName: sub,


### PR DESCRIPTION
# Description

Resolves #303.

This PR implements a version of option (1) in #303 :

> Automatically convert all Equation shapes to Text shapes, replacing the string S with the string $S$ so that it gets typeset as math when imported into TeX. (Note that with this conversion, existing Text shapes are unaffected will still get rendered properly within TeX.)

# Implementation strategy and design decisions

The implementation strategy is simpler than the proposal: we allow an additional flag (`texLabels`) to `RenderStatic` to indicate if we want to render TeX strings. This flag is then passed to the `Equation` renderer, which will render the equation as a plain `<text>` element with surrounding `$`s so that they can be rendered by an external TeX engine like the `svg` package mentioned in #303. We explicitly forward the following properties to this `<text>` object:

* fillColor
* fillOpacity
* width
* height

# Examples with steps to reproduce them

Try to export SVGs with plain TeX labels either in the IDE or `roger`. In the IDE, click "SVG (TeX)" button. In `roger`, run the following in `packages/examples`:

```
roger trio src/set-theory-domain/tree-venn-3d.trio.json --tex-labels > out.svg
```
Either outputs should have plain TeX strings in the raw SVG, which will be rendered in TeX if imported through `\includesvg{}`.

# Checklist

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have reviewed any generated registry diagram changes

# Open questions

* TODO: docs in `docs-site` about TeX import support