### PR TITLE
build: pass `--verbose` to `yarn start`

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "build:roger": "nx run roger:build",
     "build:docs-site": "nx run docs-site:build",
     "start:docs-site": "nx run docs-site:dev",
-    "start": "nx run editor:watch",
+    "start": "nx run editor:watch --verbose",
     "build:ide": "nx run editor:build",
     "test": "nx run-many --target=test --verbose",
     "coverage": "nx run core:coverage",


### PR DESCRIPTION
# Description

We've been meaning to do this for a while, since #1142.

# Examples with steps to reproduce them

Now the whole build log gets printed when you run `yarn start`.

# Checklist

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have reviewed any generated registry diagram changes