### PR TITLE
build: update VitePress `cleanUrls` setting

### DIFF
--- a/packages/docs-site/.vitepress/config.ts
+++ b/packages/docs-site/.vitepress/config.ts
@@ -95,7 +95,7 @@ export default defineConfig({
   description:
     "Create beautiful diagrams just by typing math notation in plain text.",
 
-  cleanUrls: "without-subfolders",
+  cleanUrls: true,
   ignoreDeadLinks: true,
   outDir: "build",
 


### PR DESCRIPTION
# Description

Since we updated our VitePress dependency version from 1.0.0-alpha.35 to 1.0.0-beta.1 in #1427, we've had a type error in `packages/docs-site/.vitepress/config.ts`, since [`cleanUrls` is now a `boolean`](https://vitepress.dev/reference/site-config#cleanurls). This PR fixes that.

# Examples with steps to reproduce them

Open `packages/docs-site/.vitepress/config.ts` in VS Code before vs after this PR.

# Checklist

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have reviewed any generated registry diagram changes