### PR TITLE
fix: use `Serializer::json_compatible()`

### DIFF
--- a/packages/optimizer/src/lib.rs
+++ b/packages/optimizer/src/lib.rs
@@ -780,7 +780,7 @@ fn contains_nan(number_list: &[f64]) -> bool {
 }
 
 fn to_js_value(value: &(impl Serialize + ?Sized)) -> Result<JsValue, serde_wasm_bindgen::Error> {
-    // ts-rs expects `Option::None` to become `null` instead of `undefined`
+    // ts-rs expects us to produce data that looks like JSON
     value.serialize(&serde_wasm_bindgen::Serializer::json_compatible())
 }
 

--- a/packages/optimizer/src/lib.rs
+++ b/packages/optimizer/src/lib.rs
@@ -781,7 +781,7 @@ fn contains_nan(number_list: &[f64]) -> bool {
 
 fn to_js_value(value: &(impl Serialize + ?Sized)) -> Result<JsValue, serde_wasm_bindgen::Error> {
     // ts-rs expects `Option::None` to become `null` instead of `undefined`
-    value.serialize(&serde_wasm_bindgen::Serializer::new().serialize_missing_as_null(true))
+    value.serialize(&serde_wasm_bindgen::Serializer::json_compatible())
 }
 
 #[wasm_bindgen]


### PR DESCRIPTION
# Description

I didn't know this [existed](https://docs.rs/serde-wasm-bindgen/0.4.5/serde_wasm_bindgen/struct.Serializer.html#method.json_compatible) until writing more in #1325 just now. As a followup to #1191, this allows us to use maps in our exported Rust types and have [ts-rs](https://github.com/Aleph-Alpha/ts-rs) type them properly. I don't think we currently have any plans to do that, but it'll be nice to eliminate this potential footgun in case we eventually do.

# Checklist

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have reviewed any generated registry diagram changes