### PR TITLE
fix: Diagram panel empty on iOS Chrome and iOS/macOS Safari

### DIFF
--- a/packages/editor/src/components/DiagramPanel.tsx
+++ b/packages/editor/src/components/DiagramPanel.tsx
@@ -306,6 +306,8 @@ export default function DiagramPanel() {
               (path) => pathResolver(path, rogerState, workspace),
               "diagramPanel"
             );
+        rendered.setAttribute("width", "100%");
+        rendered.setAttribute("height", "100%");
         if (cur.firstElementChild) {
           cur.replaceChild(rendered, cur.firstElementChild);
         } else {


### PR DESCRIPTION
# Description

The "Diagram" panel in `editor` is empty on Safari 15.2 and iOS 16.0.2 Chrome & Safari. Not sure which commit caused this, but adding `100%` as `width` and `height` of the SVG element seems to fix this. Perhaps it's a default value issue?
