### PR TITLE
chore: Revert "fix: Diagram panel empty on iOS Chrome and iOS/macOS Safari"

### DIFF
--- a/packages/editor/src/components/DiagramPanel.tsx
+++ b/packages/editor/src/components/DiagramPanel.tsx
@@ -306,8 +306,6 @@ export default function DiagramPanel() {
               (path) => pathResolver(path, rogerState, workspace),
               "diagramPanel"
             );
-        rendered.setAttribute("width", "100%");
-        rendered.setAttribute("height", "100%");
         if (cur.firstElementChild) {
           cur.replaceChild(rendered, cur.firstElementChild);
         } else {


### PR DESCRIPTION
Reverts penrose/penrose#1465

This PR caused display issues in our gallery (SVG gradients not rendering properly).

Since it's a minor change, and the most recent one, I'm rolling it back until we have a fix.