### PR TITLE
Revert "chore: Revert "fix: Diagram panel empty on iOS Chrome and iOS/macOS Safari""

### DIFF
--- a/packages/editor/src/components/DiagramPanel.tsx
+++ b/packages/editor/src/components/DiagramPanel.tsx
@@ -306,6 +306,8 @@ export default function DiagramPanel() {
               (path) => pathResolver(path, rogerState, workspace),
               "diagramPanel"
             );
+        rendered.setAttribute("width", "100%");
+        rendered.setAttribute("height", "100%");
         if (cur.firstElementChild) {
           cur.replaceChild(rendered, cur.firstElementChild);
         } else {


### PR DESCRIPTION
Reverts penrose/penrose#1466