### PR TITLE
fix: list whitespace parsing in Style

### DIFF
--- a/packages/core/src/parser/Style.ne
+++ b/packages/core/src/parser/Style.ne
@@ -545,7 +545,7 @@ expr_literal
   # |  transformExpr 
 
 list -> "[" expr_list "]" {% 
-  ([lbracket, , exprs, , rbracket]): List<C> => ({
+  ([lbracket, exprs, rbracket]): List<C> => ({
     ...nodeData,
     ...rangeBetween(lbracket, rbracket),
     tag: 'List',

--- a/packages/core/src/parser/Style.ne
+++ b/packages/core/src/parser/Style.ne
@@ -544,7 +544,7 @@ expr_literal
   # TODO: 
   # |  transformExpr 
 
-list -> "[" _ expr_list _ "]" {% 
+list -> "[" expr_list "]" {% 
   ([lbracket, , exprs, , rbracket]): List<C> => ({
     ...nodeData,
     ...rangeBetween(lbracket, rbracket),

--- a/packages/core/src/parser/StyleParser.test.ts
+++ b/packages/core/src/parser/StyleParser.test.ts
@@ -512,6 +512,17 @@ const {
     sameASTs(results);
   });
 
+  test("list expr", () => {
+    const prog = `
+testing {
+  a = [1]
+  a = [1  ]
+  a = ["a", 1, 2,3,4    ,5  ]
+}`;
+    const { results } = parser.feed(prog);
+    sameASTs(results);
+  });
+
   test("tuple expr", () => {
     const prog = `
 testing {


### PR DESCRIPTION
# Description

Resolves #1454.

The `list` rule in the parser handles whitespaces around list elements incorrectly: `expr_list` consumes all the whitespaces already, and the rule ambiguously consumes extra whitespaces, leading to a blowup of ambiguous parses.

Although #1454 observes this only when the comments are present. The number of parsed trees exceeds 4000 with or without them. 

# Checklist

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have reviewed any generated registry diagram changes

