### PR TITLE
feat: deduplication of mutated Substance programs in `edgeworth`

### DIFF
--- a/packages/edgeworth/src/analysis/SubstanceAnalysis.ts
+++ b/packages/edgeworth/src/analysis/SubstanceAnalysis.ts
@@ -613,12 +613,7 @@ export const dedupSynthesizedSubstances = (
     p1: SynthesizedSubstance,
     p2: SynthesizedSubstance
   ) => {
-    return (
-      p1.prog.statements.reduce<string>(
-        (acc, val) => acc + prettyStmt(val),
-        ""
-      ) ===
-      p2.prog.statements.reduce<string>((acc, val) => acc + prettyStmt(val), "")
+    return prettySubstance(p1.prog) === prettySubstance(p2.prog)
     );
   };
   // Remove duplicated programs

--- a/packages/edgeworth/src/analysis/SubstanceAnalysis.ts
+++ b/packages/edgeworth/src/analysis/SubstanceAnalysis.ts
@@ -34,6 +34,7 @@ import {
 import consola from "consola";
 import im from "immutable";
 import _ from "lodash";
+import { SynthesizedSubstance } from "../synthesis/Synthesizer";
 
 const log = consola
   .create({ level: (consola as any).LogLevel.Info })
@@ -598,6 +599,31 @@ export const dedupStmts = (prog: SubProg<A>): SubProg<A> => ({
     (s1: SubStmt<A>, s2: SubStmt<A>) => prettyStmt(s1) === prettyStmt(s2)
   ),
 });
+
+/**
+ * Remove duplicated SynthesizedSubstances.
+ * @param progs a list of SynthesizedSubstance programs
+ * @returns a list of SynthesizedSubstance programs without duplicates
+ */
+export const dedupSynthesizedSubstances = (
+  progs: SynthesizedSubstance[]
+): SynthesizedSubstance[] => {
+  // Find duplicated programs by comparing pretty-printed statements
+  const stmtsComparator = (
+    p1: SynthesizedSubstance,
+    p2: SynthesizedSubstance
+  ) => {
+    return (
+      p1.prog.statements.reduce<string>(
+        (acc, val) => acc + prettyStmt(val),
+        ""
+      ) ===
+      p2.prog.statements.reduce<string>((acc, val) => acc + prettyStmt(val), "")
+    );
+  };
+  // Remove duplicated programs
+  return _.uniqWith(progs, stmtsComparator);
+};
 
 // TODO: compare clean nodes instead?
 export const stmtExists = (stmt: SubStmt<A>, prog: SubProg<A>): boolean =>

--- a/packages/edgeworth/src/analysis/SubstanceAnalysis.ts
+++ b/packages/edgeworth/src/analysis/SubstanceAnalysis.ts
@@ -1,12 +1,15 @@
-import { prettyStmt } from "@penrose/core/dist/compiler/Substance";
+import {
+  prettyStmt,
+  prettySubstance,
+} from "@penrose/core/dist/compiler/Substance";
 import { dummyIdentifier } from "@penrose/core/dist/engine/EngineUtils";
 import {
   A,
   AbstractNode,
   C,
   Identifier,
-  metaProps,
   StringLit,
+  metaProps,
 } from "@penrose/core/dist/types/ast";
 import {
   ConstructorDecl,
@@ -613,8 +616,7 @@ export const dedupSynthesizedSubstances = (
     p1: SynthesizedSubstance,
     p2: SynthesizedSubstance
   ) => {
-    return prettySubstance(p1.prog) === prettySubstance(p2.prog)
-    );
+    return prettySubstance(p1.prog) === prettySubstance(p2.prog);
   };
   // Remove duplicated programs
   return _.uniqWith(progs, stmtsComparator);

--- a/packages/edgeworth/src/synthesis/Synthesizer.ts
+++ b/packages/edgeworth/src/synthesis/Synthesizer.ts
@@ -51,6 +51,7 @@ import {
   autoLabelStmt,
   cascadingDelete,
   dedupStmts,
+  dedupSynthesizedSubstances,
   desugarAutoLabel,
   domainToSubType,
   findDecl,
@@ -432,8 +433,8 @@ export class Synthesizer {
    * @param numProgs number of Substance programs to generate
    * @returns an array of Substance programs and some metadata (e.g. mutation operation record)
    */
-  generateSubstances = (numProgs: number): SynthesizedSubstance[] =>
-    _.times(numProgs, (n: number) => {
+  generateSubstances = (numProgs: number): SynthesizedSubstance[] => {
+    const iteratee = (n: number) => {
       const sub = this.generateSubstance();
       // DEBUG: report results
       log.info(
@@ -444,7 +445,20 @@ export class Synthesizer {
       // reset synthesizer after generating each Substance diagram
       this.reset();
       return sub;
-    });
+    };
+
+    let temp = dedupSynthesizedSubstances(_.times(numProgs, iteratee));
+
+    // Generate until there are numProgs unique Substance programs
+    while (temp.length < numProgs) {
+      const sub = iteratee(temp.length);
+      temp.push(sub);
+      temp = dedupSynthesizedSubstances(temp);
+    }
+
+    const substances = temp;
+    return substances;
+  };
 
   generateSubstance = (): SynthesizedSubstance => {
     const numStmts = this.random(...this.setting.mutationCount);

--- a/packages/edgeworth/src/synthesis/Synthesizer.ts
+++ b/packages/edgeworth/src/synthesis/Synthesizer.ts
@@ -434,7 +434,7 @@ export class Synthesizer {
    * @returns an array of Substance programs and some metadata (e.g. mutation operation record)
    */
   generateSubstances = (numProgs: number): SynthesizedSubstance[] => {
-    const oneSubstance = () => {
+    const oneSubstance = (n: number) => {
       const sub = this.generateSubstance();
       // DEBUG: report results
       log.info(
@@ -447,11 +447,13 @@ export class Synthesizer {
       return sub;
     };
 
-    let substances = dedupSynthesizedSubstances(_.times(numProgs, iteratee));
+    let substances = dedupSynthesizedSubstances(
+      _.times(numProgs, oneSubstance)
+    );
 
     // Generate until there are numProgs unique Substance programs
     while (substances.length < numProgs) {
-      const sub = oneSubstance(temp.length);
+      const sub = oneSubstance(substances.length);
       substances.push(sub);
       substances = dedupSynthesizedSubstances(substances);
     }

--- a/packages/edgeworth/src/synthesis/Synthesizer.ts
+++ b/packages/edgeworth/src/synthesis/Synthesizer.ts
@@ -434,7 +434,7 @@ export class Synthesizer {
    * @returns an array of Substance programs and some metadata (e.g. mutation operation record)
    */
   generateSubstances = (numProgs: number): SynthesizedSubstance[] => {
-    const iteratee = (n: number) => {
+    const oneSubstance = () => {
       const sub = this.generateSubstance();
       // DEBUG: report results
       log.info(
@@ -447,16 +447,14 @@ export class Synthesizer {
       return sub;
     };
 
-    let temp = dedupSynthesizedSubstances(_.times(numProgs, iteratee));
+    let substances = dedupSynthesizedSubstances(_.times(numProgs, iteratee));
 
     // Generate until there are numProgs unique Substance programs
-    while (temp.length < numProgs) {
-      const sub = iteratee(temp.length);
-      temp.push(sub);
-      temp = dedupSynthesizedSubstances(temp);
+    while (substances.length < numProgs) {
+      const sub = oneSubstance(temp.length);
+      substances.push(sub);
+      substances = dedupSynthesizedSubstances(substances);
     }
-
-    const substances = temp;
     return substances;
   };
 


### PR DESCRIPTION
# Description

Deduplication of program statements within a mutated Substance program exists in Edgeworth, but until now deduplication between mutated Substance programs themselves has not existed. This PR introduces such deduplication of programs themselves. 

# Implementation strategy and design decisions

We add a function `dedupSynthesizedSubstances` to [SubstanceAnalysis.ts](https://github.com/penrose/penrose/blob/main/packages/edgeworth/src/analysis/SubstanceAnalysis.ts), which `reduce`s together the prettyprint strings of each program statement, compares the concatenated strings of each program supplied to it, and removes duplicates. Then, in the `generateSubstances` function in [Synthesizer.ts](https://github.com/penrose/penrose/blob/main/packages/edgeworth/src/synthesis/Synthesizer.ts) we run `dedupSynthesizedSubstances` until the desired number of unique program mutations is reached. 

# Examples with steps to reproduce them

Using the Edgeworth tool, generate 10 diagram mutations under the `lewis_0` option. Checking the Substance programs of each of these mutations will show that none of the programs are duplicates, though some programs still produce visually duplicated SVGs while having different underlying Substance programs. Consider the example below:

<img width="367" alt="Screen Shot 2023-06-12 at 9 45 26 AM" src="https://github.com/penrose/penrose/assets/98900692/a4b166df-4e9c-4dcc-bc57-56b7ec824a98">

These SVGs look the same but as shown in the next image, they have different Substance programs/underlying mutations:

<img width="368" alt="Screen Shot 2023-06-12 at 9 45 49 AM" src="https://github.com/penrose/penrose/assets/98900692/2bc0500b-ca9d-4ba8-8037-628695acdbb0">

This PR therefore ensures the uniqueness of displayed mutated programs but not the uniqueness of their diagrams.

# Checklist

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have reviewed any generated registry diagram changes

# Open questions

This does not resolve the problem of mutated diagrams' SVGs appearing the same despite stemming from different, unique programs.
