### PR TITLE
fix: type exports in core API

### DIFF
--- a/packages/core/src/api.ts
+++ b/packages/core/src/api.ts
@@ -63,8 +63,9 @@ export const lessThan = (x: ad.Num, y: ad.Num): ad.Num => sub(x, y);
 export { convexPolygonMinkowskiSDF } from "./contrib/Minkowski.js";
 export { compile, ops, problem } from "./engine/Autodiff.js";
 export * from "./engine/AutodiffFunctions.js";
-export { BBox, corners } from "./engine/BBox.js";
-export {
+export { corners } from "./engine/BBox.js";
+export type { BBox } from "./engine/BBox.js";
+export type {
   Binary,
   Bool,
   Comp,


### PR DESCRIPTION
# Description

`api.ts` mixes type and value exports, which causes an error when clients try to import `core` functions:

```
api.ts:66 Uncaught SyntaxError: The requested module '/try/@fs/Users/nimo/Code/penrose/packages/core/src/engine/BBox.ts' does not provide an export named 'BBox' (at api.ts:66:10)
```

This PR separates exported types and values in `api.ts`.