### PR TITLE
fix: async loading of solid examples in the registry

### DIFF
--- a/packages/examples/codegen.js
+++ b/packages/examples/codegen.js
@@ -92,7 +92,9 @@ for (const [k, v] of Object.entries(registry)) {
     if ("gallery" in v) lines.push(`    gallery: ${v.gallery},`);
   } else {
     lines.push(
-      `    f: (await import(${JSON.stringify(`./${k}.js`)})).default,`
+      `    f: async () => (await import(${JSON.stringify(
+        `./${k}.js`
+      )})).default(),`
     );
   }
   if ("name" in v) lines.push(`    name: ${JSON.stringify(v.name)},`);

--- a/packages/examples/src/registry.json
+++ b/packages/examples/src/registry.json
@@ -286,5 +286,8 @@
   "geometric-queries/ray-intersect/test": {
     "name": "Ray Intersection Tests",
     "gallery": false
-  }
+  },
+  "solid/eigenspace": { "trio": false },
+  "solid/triangles": { "trio": false },
+  "solid/vectors": { "trio": false }
 }


### PR DESCRIPTION
# Description

Resolves #1483.

Follows up on #1391 to re-introduce solid examples to the registry by fixing the generated imports. 

# Implementation strategy and design decisions

The old implementation imports solid examples no matter if the example is used. This PR wraps it around an async function to make sure it's only imported when `f` is invoked.

