### PR TITLE
docs: show default values of function parameters

### DIFF
--- a/packages/docs-site/src/components/Function.vue
+++ b/packages/docs-site/src/components/Function.vue
@@ -2,6 +2,7 @@
 import { defineComponent } from "vue";
 import Markdown from "markdown-it";
 import { describeType } from "@penrose/core";
+import { FuncParam } from "@penrose/core/dist/types/functions";
 const md = new Markdown();
 export default defineComponent({
   props: ["name", "description", "params", "returns"],
@@ -33,6 +34,7 @@ export default defineComponent({
           <th>Type</th>
           <th>Type Description</th>
           <th>Description</th>
+          <th v-if="parameters.filter((p: FuncParam) => p.default).length > 0">Default Value</th>
         </tr>
       </thead>
       <tbody>
@@ -43,6 +45,7 @@ export default defineComponent({
           <td>{{ param.type.symbol }}</td>
           <td>{{ param.type.description }}</td>
           <td>{{ param.description }}</td>
+          <td v-if="parameters.filter((p: FuncParam) => p.default).length > 0">{{ param.default ?? "" }}</td>
         </tr>
       </tbody>
     </table>

--- a/packages/docs-site/src/components/Function.vue
+++ b/packages/docs-site/src/components/Function.vue
@@ -34,7 +34,9 @@ export default defineComponent({
           <th>Type</th>
           <th>Type Description</th>
           <th>Description</th>
-          <th v-if="parameters.filter((p: FuncParam) => p.default).length > 0">Default Value</th>
+          <th v-if="parameters.filter((p: FuncParam) => p.default).length > 0">
+            Default Value
+          </th>
         </tr>
       </thead>
       <tbody>
@@ -45,7 +47,9 @@ export default defineComponent({
           <td>{{ param.type.symbol }}</td>
           <td>{{ param.type.description }}</td>
           <td>{{ param.description }}</td>
-          <td v-if="parameters.filter((p: FuncParam) => p.default).length > 0">{{ param.default ?? "" }}</td>
+          <td v-if="parameters.filter((p: FuncParam) => p.default).length > 0">
+            {{ param.default ?? "" }}
+          </td>
         </tr>
       </tbody>
     </table>


### PR DESCRIPTION
# Description

Following up on #1427, this PR adds a "Default Value" column to the function documentation page when any of the parameters have a default.  

# Implementation strategy and design decisions

* The conditional rendering is repeated for both table header and each row to avoid incomplete tables.

# Examples with steps to reproduce them

https://fix-fn-docs.penrose-72l.pages.dev/docs/ref/style/functions

# Checklist

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have reviewed any generated registry diagram changes

