### PR TITLE
docs: add @rjainrjain and @ravenrothkopf to team page

### DIFF
--- a/packages/docs-site/docs/team.md
+++ b/packages/docs-site/docs/team.md
@@ -116,6 +116,24 @@ const members = [
     ],
   },
   {
+    name: "Rijul Jain",
+    title: "REUSE student",
+    avatar: "https://www.github.com/rjainrjain.png",
+    links: [
+      { icon: { svg: website }, link: "https://github.com/rjainrjain" },
+      { icon: "github", link: "https://github.com/rjainrjain" },
+    ],
+  },
+  {
+    name: "Raven Rothkopf",
+    title: "REUSE student",
+    avatar: "https://www.github.com/ravenrothkopf.png",
+    links: [
+      { icon: { svg: website }, link: "https://ravenrothkopf.github.io/" },
+      { icon: "github", link: "https://github.com/ravenrothkopf" },
+    ],
+  },
+  {
     name: "Josh Sunshine",
     title: "Professor @ CMU",
     avatar: "https://www.github.com/joshsunshine.png",


### PR DESCRIPTION
# Description

This PR adds @ravenrothkopf and @rjainrjain to the team page. Welcome!
