### PR TITLE
chore: enable example panel on `editor` startup

### DIFF
--- a/packages/editor/src/App.tsx
+++ b/packages/editor/src/App.tsx
@@ -1,6 +1,7 @@
 import {
   Action,
   Actions,
+  DockLocation,
   IJsonRowNode,
   Layout,
   Model,
@@ -43,6 +44,7 @@ const mainRowLayout: IJsonRowNode = {
   children: [
     {
       type: "tabset",
+      id: "mainEditor",
       weight: process.env.NODE_ENV === "development" ? 25 : 50,
       children: [
         ...(process.env.NODE_ENV === "development"
@@ -121,6 +123,7 @@ export const layoutModel = Model.fromJson({
         {
           type: "tab",
           name: "examples",
+          id: "examples",
           component: "examplesPanel",
         },
         {
@@ -308,6 +311,11 @@ function App() {
         rootOrientationVertical: isTabletOrMobile && isPortrait,
       })
     );
+    if (isTabletOrMobile && isPortrait) {
+      layoutModel.doAction(
+        Actions.moveNode("examples", "mainEditor", DockLocation.CENTER, 0)
+      );
+    }
   }, [isTabletOrMobile, isPortrait]);
 
   const checkURL = useCheckURL();

--- a/packages/editor/src/App.tsx
+++ b/packages/editor/src/App.tsx
@@ -112,8 +112,7 @@ export const layoutModel = Model.fromJson({
       type: "border",
       location: "left",
       // auto-expand examples tab on start
-      // selected: process.env.NODE_ENV === "development" ? -1 : 1,
-      selected: 1,
+      selected: process.env.NODE_ENV === "development" ? -1 : 1,
       children: [
         {
           type: "tab",

--- a/packages/editor/src/App.tsx
+++ b/packages/editor/src/App.tsx
@@ -311,6 +311,7 @@ function App() {
         rootOrientationVertical: isTabletOrMobile && isPortrait,
       })
     );
+    // on mobile, move example browser to the center panel
     if (isTabletOrMobile && isPortrait) {
       layoutModel.doAction(
         Actions.moveNode("examples", "mainEditor", DockLocation.CENTER, 0)

--- a/packages/editor/src/App.tsx
+++ b/packages/editor/src/App.tsx
@@ -109,6 +109,9 @@ export const layoutModel = Model.fromJson({
     {
       type: "border",
       location: "left",
+      // auto-expand examples tab on start
+      // selected: process.env.NODE_ENV === "development" ? -1 : 1,
+      selected: 1,
       children: [
         {
           type: "tab",

--- a/packages/editor/src/components/ExamplesBrowser.tsx
+++ b/packages/editor/src/components/ExamplesBrowser.tsx
@@ -1,11 +1,18 @@
 import queryString from "query-string";
 import { useRecoilValueLoadable } from "recoil";
+import styled from "styled-components";
 import { TrioWithPreview, exampleTriosState } from "../state/atoms.js";
 import { useLoadExampleWorkspace } from "../state/callbacks.js";
 import FileButton from "./FileButton.js";
 
 const parser = new DOMParser();
 const serializer = new XMLSerializer();
+
+const ExampleTab = styled.div`
+  display: flex;
+  justify-content: space-between;
+  gap: 10px;
+`;
 
 const Example = ({
   example,
@@ -38,15 +45,13 @@ const Example = ({
           window.history.replaceState(null, "", query);
         }}
       >
-        <div style={{ display: "flex", justifyContent: "space-between" }}>
-          {
-            <div
-              style={{ width: 50, height: 50 }}
-              dangerouslySetInnerHTML={{ __html: croppedPreview }}
-            ></div>
-          }
+        <ExampleTab key={`example-tab-${k}`}>
+          <div
+            style={{ width: "50px", flexShrink: 0 }}
+            dangerouslySetInnerHTML={{ __html: croppedPreview }}
+          ></div>
           {example.name}
-        </div>
+        </ExampleTab>
       </FileButton>
     </div>
   );
@@ -62,7 +67,12 @@ export default function ExamplesBrowser() {
   return (
     <div>
       {examples.contents.map((example, k) => (
-        <Example example={example} loadExample={loadExample} k={k}></Example>
+        <Example
+          example={example}
+          loadExample={loadExample}
+          k={k}
+          key={`example-${k}`}
+        ></Example>
       ))}
     </div>
   );

--- a/packages/editor/src/components/ExamplesBrowser.tsx
+++ b/packages/editor/src/components/ExamplesBrowser.tsx
@@ -8,6 +8,10 @@ import FileButton from "./FileButton.js";
 const parser = new DOMParser();
 const serializer = new XMLSerializer();
 
+const ExampleContainer = styled.div`
+  margin: 0;
+`;
+
 const ExampleTab = styled.div`
   display: flex;
   justify-content: space-between;
@@ -65,7 +69,7 @@ export default function ExamplesBrowser() {
   }
 
   return (
-    <div>
+    <ExampleContainer>
       {examples.contents.map((example, k) => (
         <Example
           example={example}
@@ -74,6 +78,6 @@ export default function ExamplesBrowser() {
           key={`example-${k}`}
         ></Example>
       ))}
-    </div>
+    </ExampleContainer>
   );
 }

--- a/packages/editor/src/components/FileButton.tsx
+++ b/packages/editor/src/components/FileButton.tsx
@@ -11,7 +11,6 @@ const _FileButton = styled.button<{ isFocused: boolean }>`
   border: 0;
   text-align: left;
   font-size: 15px;
-  margin: 3px;
   padding: 10px;
   transition: 0.2s;
   cursor: pointer;


### PR DESCRIPTION
# Description

This PR enables the example panel on `editor` startup and fixes the layout of `ExampleBrowser` so things are aligned properly and horizontal overflow is removed.

# Implementation strategy and design decisions

* Make sure preview icon doesn't shrink in the container
* Introduce a small gap between preview icon and text
* Remove `margin` of `FileButton` to avoid overflowing
* For mobile layout, move `ExampleBrowser` to the center tab group so it's visible

# Examples with steps to reproduce them

Mobile layout:
![image](https://github.com/penrose/penrose/assets/11740102/06fee76a-4815-4fc6-8b65-65049c720a2a)

# Checklist

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have reviewed any generated registry diagram changes

# Open questions

Questions that require more discussion or to be addressed in future development:
