### PR TITLE
feat: error and warning markings in IDE editor

### DIFF
--- a/packages/components/src/editing/EditorPane.tsx
+++ b/packages/components/src/editing/EditorPane.tsx
@@ -1,7 +1,16 @@
 import MonacoEditor, { useMonaco } from "@monaco-editor/react";
-import { Env } from "@penrose/core";
-import { editor } from "monaco-editor";
-import { initVimMode, VimMode } from "monaco-vim";
+import { Env, errLocs, showError } from "@penrose/core";
+import {
+  DomainError,
+  RuntimeError,
+  StyleError,
+  StyleErrorList,
+  StyleWarning,
+  SubstanceError,
+} from "@penrose/core/dist/types/errors.js";
+import { ErrorLoc } from "@penrose/core/dist/utils/Util.js";
+import { MarkerSeverity, editor } from "monaco-editor";
+import { VimMode, initVimMode } from "monaco-vim";
 import { useEffect, useRef } from "react";
 import { SetupDomainMonaco } from "./languages/DomainConfig.js";
 import { SetupStyleMonaco } from "./languages/StyleConfig.js";
@@ -18,7 +27,30 @@ const monacoOptions = (
   copyWithSyntaxHighlighting: true,
   glyphMargin: false,
   cursorStyle: vimMode ? "block" : "line",
+  fixedOverflowWidgets: true,
 });
+
+type IndividualError = Exclude<
+  StyleError | DomainError | SubstanceError | RuntimeError | StyleWarning,
+  StyleErrorList
+>;
+
+type ErrLocPair = {
+  err: IndividualError;
+  loc: ErrorLoc;
+};
+
+const errLocPairs = (
+  err: StyleError | DomainError | SubstanceError | RuntimeError | StyleWarning
+): ErrLocPair[] => {
+  if (err.tag === "StyleErrorList") {
+    const pairs = err.errors.map(errLocPairs);
+    return pairs.flat(1);
+  } else {
+    const locs = errLocs(err);
+    return locs.length > 0 ? [{ err, loc: locs[0] }] : [];
+  }
+};
 
 export default function EditorPane({
   value,
@@ -28,6 +60,8 @@ export default function EditorPane({
   domainCache,
   readOnly,
   onWrite,
+  error,
+  warnings,
 }: {
   value: string;
   vimMode: boolean;
@@ -37,6 +71,8 @@ export default function EditorPane({
   readOnly?: boolean;
   /// In vim mode, this is called when the user calls :w
   onWrite?: () => void;
+  error: StyleError | DomainError | SubstanceError | RuntimeError | null;
+  warnings: StyleWarning[];
 }) {
   const monaco = useMonaco();
   const editorRef = useRef<editor.IStandaloneCodeEditor | null>(null);
@@ -83,6 +119,36 @@ export default function EditorPane({
   const onEditorMount = (editorArg: editor.IStandaloneCodeEditor) => {
     editorRef.current = editorArg;
   };
+
+  useEffect(() => {
+    const errPairs = error === null ? [] : errLocPairs(error);
+    const warningPairs = warnings.map(errLocPairs).flat(1);
+    const errMarkers: editor.IMarkerData[] = errPairs
+      .filter(({ loc }) => loc.type.toLowerCase() === languageType)
+      .map(({ loc, err }) => ({
+        startLineNumber: loc.range.start.line,
+        startColumn: loc.range.start.col + 1,
+        endLineNumber: loc.range.end.line,
+        endColumn: loc.range.end.col + 1,
+        message: showError(err),
+        severity: MarkerSeverity.Error,
+      }));
+    const warningMarkers: editor.IMarkerData[] = warningPairs
+      .filter(({ loc }) => loc.type.toLowerCase() === languageType)
+      .map(({ loc, err: warn }) => ({
+        startLineNumber: loc.range.start.line,
+        startColumn: loc.range.start.col + 1,
+        endLineNumber: loc.range.end.line,
+        endColumn: loc.range.end.col + 1,
+        message: showError(warn),
+        severity: MarkerSeverity.Warning,
+      }));
+
+    const markers = [...errMarkers, ...warningMarkers];
+    if (monaco && editorRef.current) {
+      monaco.editor.setModelMarkers(editorRef.current.getModel()!, "", markers);
+    }
+  }, [monaco, editorRef.current, languageType, error, warnings, value]);
 
   return (
     <div style={{ width: "100%", height: "100%", position: "relative" }}>

--- a/packages/core/src/compiler/Domain.ts
+++ b/packages/core/src/compiler/Domain.ts
@@ -54,10 +54,12 @@ export const parseDomain = (
       const ast: DomainProg<C> = results[0];
       return ok(ast);
     } else {
-      return err(parseError(`Unexpected end of input`, lastLocation(parser)));
+      return err(
+        parseError(`Unexpected end of input`, lastLocation(parser), "Domain")
+      );
     }
   } catch (e) {
-    return err(parseError(prettyParseError(e), lastLocation(parser)));
+    return err(parseError(prettyParseError(e), lastLocation(parser), "Domain"));
   }
 };
 

--- a/packages/core/src/compiler/Style.ts
+++ b/packages/core/src/compiler/Style.ts
@@ -3708,7 +3708,9 @@ export const parseStyle = (p: string): Result<StyProg<C>, ParseError> => {
       const ast: StyProg<C> = results[0] as StyProg<C>;
       return ok(ast);
     } else {
-      return err(parseError(`Unexpected end of input`, lastLocation(parser), "Style"));
+      return err(
+        parseError(`Unexpected end of input`, lastLocation(parser), "Style")
+      );
     }
   } catch (e) {
     return err(parseError(prettyParseError(e), lastLocation(parser), "Style"));

--- a/packages/core/src/compiler/Style.ts
+++ b/packages/core/src/compiler/Style.ts
@@ -3708,10 +3708,10 @@ export const parseStyle = (p: string): Result<StyProg<C>, ParseError> => {
       const ast: StyProg<C> = results[0] as StyProg<C>;
       return ok(ast);
     } else {
-      return err(parseError(`Unexpected end of input`, lastLocation(parser)));
+      return err(parseError(`Unexpected end of input`, lastLocation(parser), "Style"));
     }
   } catch (e) {
-    return err(parseError(prettyParseError(e), lastLocation(parser)));
+    return err(parseError(prettyParseError(e), lastLocation(parser), "Style"));
   }
 };
 

--- a/packages/core/src/compiler/Substance.ts
+++ b/packages/core/src/compiler/Substance.ts
@@ -71,10 +71,14 @@ export const parseSubstance = (
       const ast: SubProg<C> = results[0];
       return ok(ast);
     } else {
-      return err(parseError(`Unexpected end of input`, lastLocation(parser)));
+      return err(
+        parseError(`Unexpected end of input`, lastLocation(parser), "Substance")
+      );
     }
   } catch (e) {
-    return err(parseError(prettyParseError(e), lastLocation(parser)));
+    return err(
+      parseError(prettyParseError(e), lastLocation(parser), "Substance")
+    );
   }
 };
 

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -360,7 +360,7 @@ export type {
 export type { CompFunc } from "./types/functions.js";
 export type { SubProg } from "./types/substance.js";
 export * as Value from "./types/value.js";
-export { showError } from "./utils/Error.js";
+export { errLocs, showError } from "./utils/Error.js";
 export type { Result } from "./utils/Error.js";
 export {
   describeType,

--- a/packages/core/src/types/errors.ts
+++ b/packages/core/src/types/errors.ts
@@ -5,6 +5,7 @@ import {
   AbstractNode,
   C,
   Identifier,
+  NodeType,
   SourceLoc,
   SourceRange,
 } from "./ast.js";
@@ -271,6 +272,7 @@ export interface ParseError {
   tag: "ParseError";
   message: string;
   location?: SourceLoc;
+  fileType?: NodeType;
 }
 
 export interface InvalidColorLiteral {

--- a/packages/core/src/utils/Error.ts
+++ b/packages/core/src/utils/Error.ts
@@ -624,7 +624,6 @@ export const errLocs = (
       return [];
     }
     case "ParseError":
-      // Don't know in Style, Substance, or Domain
       if (e.fileType === undefined || e.location === undefined) {
         return [];
       } else {

--- a/packages/core/src/utils/Error.ts
+++ b/packages/core/src/utils/Error.ts
@@ -31,6 +31,7 @@ import {
   RuntimeError,
   SelectorFieldNotSupported,
   StyleError,
+  StyleErrorList,
   StyleWarning,
   SubstanceError,
   SymmetricArgLengthMismatch,
@@ -54,9 +55,12 @@ import { BindingForm, ColorLit } from "../types/style.js";
 import { Deconstructor, SubExpr } from "../types/substance.js";
 import { ArgVal, ArgValWithSourceLoc, ShapeVal, Val } from "../types/value.js";
 import {
+  ErrorLoc,
   describeType,
+  locOrNone,
   prettyPrintPath,
   prettyPrintResolvedPath,
+  toErrorLoc,
 } from "./Util.js";
 const {
   or,
@@ -608,6 +612,247 @@ canvas {
   }
 };
 
+export const errLocs = (
+  e: Exclude<
+    DomainError | SubstanceError | StyleError | StyleWarning | RuntimeError,
+    StyleErrorList
+  >
+): ErrorLoc[] => {
+  switch (e.tag) {
+    case "RuntimeError":
+    case "NaNError": {
+      return [];
+    }
+    case "ParseError":
+      // Don't know in Style, Substance, or Domain
+      if (e.fileType === undefined || e.location === undefined) {
+        return [];
+      } else {
+        return [
+          {
+            type: e.fileType,
+            range: {
+              start: e.location,
+              end: e.location,
+            },
+          },
+        ];
+      }
+    case "InvalidColorLiteral":
+      return [toErrorLoc(e.color)];
+    case "TypeDeclared": {
+      return locOrNone(e.typeName);
+    }
+    // TODO: abstract out this pattern if it becomes more common
+    case "VarNotFound": {
+      return locOrNone(e.variable);
+    }
+    case "TypeNotFound": {
+      return locOrNone(e.typeName);
+    }
+    case "TypeVarNotFound": {
+      return locOrNone(e.typeVar);
+    }
+    case "DuplicateName": {
+      return locOrNone(e.name);
+    }
+    case "CyclicSubtypes": {
+      return [];
+    }
+    case "SymmetricTypeMismatch":
+    case "SymmetricArgLengthMismatch":
+    case "TypeMismatch":
+    case "TypeArgLengthMismatch":
+    case "ArgLengthMismatch":
+    case "UnexpectedExprForNestedPred": {
+      return locOrNone(e.sourceExpr);
+    }
+    case "DeconstructNonconstructor": {
+      return locOrNone(e.deconstructor);
+    }
+
+    // ---- BEGIN STYLE ERRORS
+    // COMBAK suggest improvements after reporting errors
+
+    case "GenericStyleError": {
+      return [];
+    }
+
+    case "SelectorVarMultipleDecl": {
+      return locOrNone(e.varName);
+    }
+
+    case "SelectorFieldNotSupported": {
+      return locOrNone(e.field);
+    }
+
+    case "SelectorDeclTypeMismatch": {
+      // COMBAK: Add code for prettyprinting types
+      return locOrNone(e.styType);
+    }
+
+    case "SelectorRelTypeMismatch": {
+      // COMBAK: Add code for prettyprinting types
+      return locOrNone(e.exprType);
+    }
+
+    case "TaggedSubstanceError": {
+      switch (e.error.tag) {
+        // special handling for VarNotFound
+        case "VarNotFound":
+          return locOrNone(e.error.variable);
+        default:
+          return errLocs(e.error);
+      }
+    }
+
+    case "SelectorAliasNamingError": {
+      return locOrNone(e.alias);
+    }
+
+    case "MultipleLayoutError": {
+      return e.decls.map(locOrNone).flat();
+    }
+    // --- BEGIN BLOCK STATIC ERRORS
+    case "InvalidGPIPropertyError": {
+      return [];
+    }
+    case "InvalidGPITypeError": {
+      return locOrNone(e.givenType);
+    }
+    case "InvalidFunctionNameError":
+    case "InvalidObjectiveNameError":
+    case "InvalidConstraintNameError": {
+      return locOrNone(e.givenName);
+    }
+
+    // --- END BLOCK STATIC ERRORS
+
+    // --- BEGIN COMPILATION ERRORS
+
+    case "AssignAccessError": {
+      return locOrNone(e.path);
+    }
+
+    case "BadElementError": {
+      return locOrNone(e.coll);
+    }
+
+    case "BadIndexError":
+    case "BinOpTypeError": {
+      return locOrNone(e.expr);
+    }
+
+    case "CanvasNonexistentDimsError": {
+      return [];
+    }
+
+    case "CyclicAssignmentError": {
+      const cycleLocs = e.cycles
+        .map((c) =>
+          c
+            .map(({ id, src }) =>
+              src === undefined ? [] : toErrorLoc({ ...src, nodeType: "Style" })
+            )
+            .flat()
+        )
+        .flat();
+      return cycleLocs;
+    }
+
+    case "DeleteGlobalError":
+    case "DeleteSubstanceError":
+    case "MissingPathError":
+    case "MissingShapeError":
+    case "NotShapeError":
+    case "PropertyMemberError":
+    case "AssignGlobalError":
+    case "AssignSubstanceError": {
+      return locOrNone({ ...e.path, nodeType: "Style" });
+    }
+
+    case "NestedShapeError":
+    case "NotCollError":
+    case "IndexIntoShapeListError":
+    case "NotValueError":
+    case "OutOfBoundsError":
+    case "UOpTypeError": {
+      return locOrNone(e.expr);
+    }
+
+    case "BadShapeParamTypeError": {
+      // TODO: incorporate location information in shape parameter errors
+      return [];
+    }
+
+    case "BadArgumentTypeError": {
+      return [
+        toErrorLoc({
+          nodeType: "Style",
+          start: e.provided.start,
+          end: e.provided.end,
+        }),
+      ];
+    }
+
+    case "MissingArgumentError": {
+      return [
+        toErrorLoc({
+          ...e.funcLocation,
+          nodeType: "Style",
+        }),
+      ];
+    }
+
+    case "TooManyArgumentsError": {
+      return [
+        toErrorLoc({
+          ...e.funcLocation,
+          nodeType: "Style",
+        }),
+      ];
+    }
+
+    case "FunctionInternalError":
+    case "RedeclareNamespaceError":
+    case "UnexpectedCollectionAccessError": {
+      return [
+        toErrorLoc({
+          ...e.location,
+          nodeType: "Style",
+        }),
+      ];
+    }
+    // --- END COMPILATION ERRORS
+
+    // TODO(errors): use identifiers here
+    case "RuntimeValueTypeError": {
+      return locOrNone({ ...e.path, nodeType: "Style" });
+    }
+
+    // ----- END STYLE ERRORS
+
+    // ---- BEGIN STYLE WARNINGS
+
+    case "ImplicitOverrideWarning":
+    case "NoopDeleteWarning": {
+      return locOrNone({ ...e.path, nodeType: "Style" });
+    }
+
+    case "LayerCycleWarning":
+    case "ShapeBelongsToMultipleGroups":
+    case "GroupCycleWarning": {
+      return [];
+    }
+
+    // ----- END STYLE WARNINGS
+
+    case "Fatal": {
+      return [];
+    }
+  }
+};
+
 const showCycles = (cycles: string[][]) => {
   // repeats the cycle start again
   const pathString = (path: string[]) => [...path, path[0]].join(" -> ");
@@ -738,11 +983,13 @@ export const fatalError = (message: string): FatalError => ({
 
 export const parseError = (
   message: string,
-  location?: SourceLoc
+  location?: SourceLoc,
+  fileType?: NodeType
 ): ParseError => ({
   tag: "ParseError",
   message,
   location,
+  fileType,
 });
 
 export const invalidColorLiteral = (

--- a/packages/core/src/utils/Util.ts
+++ b/packages/core/src/utils/Util.ts
@@ -1,9 +1,10 @@
 import _ from "lodash";
 import seedrandom from "seedrandom";
+import { isConcrete } from "../engine/EngineUtils.js";
 import { LineProps } from "../shapes/Line.js";
 import { Shape, ShapeType } from "../shapes/Shapes.js";
 import * as ad from "../types/ad.js";
-import { A } from "../types/ast.js";
+import { A, ASTNode, NodeType, SourceLoc, SourceRange } from "../types/ast.js";
 import { Either, Left, Right } from "../types/common.js";
 import { Fn } from "../types/state.js";
 import { BindingForm, Expr, Path } from "../types/style.js";
@@ -1018,6 +1019,35 @@ export const getAdValueAsString = (
 export const getValueAsShapeList = <T>(val: Value<T>): Shape<T>[] => {
   if (val.tag === "ShapeListV") return val.contents;
   throw new Error("Not a list of shapes");
+};
+
+//#endregion
+
+//#region AST
+
+export type ErrorLoc = {
+  type: NodeType;
+  range: SourceRange;
+};
+
+export const toErrorLoc = (node: {
+  nodeType: NodeType;
+  start: SourceLoc;
+  end: SourceLoc;
+}): ErrorLoc => {
+  return {
+    type: node.nodeType,
+    range: {
+      start: node.start,
+      end: node.end,
+    },
+  };
+};
+
+export const locOrNone = (node: ASTNode<A>): ErrorLoc[] => {
+  if (isConcrete(node)) {
+    return [toErrorLoc(node)];
+  } else return [];
 };
 
 //#endregion

--- a/packages/editor/src/components/ProgramEditor.tsx
+++ b/packages/editor/src/components/ProgramEditor.tsx
@@ -3,6 +3,7 @@ import { useCallback } from "react";
 import { useRecoilState, useRecoilValue, useRecoilValueLoadable } from "recoil";
 import {
   ProgramType,
+  diagramState,
   domainCacheState,
   fileContentsSelector,
   settingsState,
@@ -17,6 +18,8 @@ export default function ProgramEditor({ kind }: { kind: ProgramType }) {
   const domainCache = useRecoilValue(domainCacheState);
   const compileDiagram = useCompileDiagram();
   const settings = useRecoilValueLoadable(settingsState);
+  const [diagram] = useRecoilState(diagramState);
+  const { error, warnings } = diagram;
   const onChange = useCallback(
     (v: string) => {
       setProgramState((state) => ({ ...state, contents: v }));
@@ -35,6 +38,8 @@ export default function ProgramEditor({ kind }: { kind: ProgramType }) {
       onChange={onChange}
       readOnly={workspaceMetadata.location.kind === "roger"}
       onWrite={compileDiagram}
+      error={error}
+      warnings={warnings}
     />
   );
 }


### PR DESCRIPTION
# Description

Since many types of warnings and errors include source location information, we can utilize these information to mark them in the IDE editor.

# Implementation strategy and design decisions

1. We write a function, `errLocs`, that extracts the location information (which file, which row, which column) from each error and warning, _except `StyleErrorList`_. `StyleErrorList` essentially stores multiple Style errors, so we handle them specially.
2. For errors and warnings with location information, the IDE editor now draws red squiggly lines at places for errors, and yellow squiggly lines at places for warnings.
3. These squiggly lines update after every time the "compile" button is pressed.

# Checklist

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have reviewed any generated registry diagram changes

