### PR TITLE
docs: homepage tweaks

### DIFF
--- a/packages/components/src/Demo.tsx
+++ b/packages/components/src/Demo.tsx
@@ -1,3 +1,4 @@
+import { PathResolver } from "@penrose/core";
 import { useEffect, useState } from "react";
 import { Simple } from "./Simple.js";
 
@@ -7,8 +8,9 @@ const Demo = (props: {
     sty: string;
     dsl: string;
     variation: string;
+    stepSize?: number;
+    imageResolver?: PathResolver;
   }[];
-  width: string;
   darkMode: boolean;
 }) => {
   const [index, setIndex] = useState(0);
@@ -24,17 +26,17 @@ const Demo = (props: {
   const example = props.examples[index];
 
   return (
-    <div style={{ width: props.width, height: props.width }}>
-      <Simple
-        name="demo"
-        substance={example.sub}
-        style={example.sty}
-        domain={example.dsl}
-        variation={example.variation}
-        interactive={false}
-        animate={true}
-      />
-    </div>
+    <Simple
+      name="demo"
+      substance={example.sub}
+      style={example.sty}
+      domain={example.dsl}
+      variation={example.variation}
+      interactive={false}
+      animate={true}
+      stepSize={example.stepSize}
+      imageResolver={example.imageResolver}
+    />
   );
 };
 

--- a/packages/components/src/Gallery.tsx
+++ b/packages/components/src/Gallery.tsx
@@ -11,13 +11,31 @@ const parser = new DOMParser();
 const serializer = new XMLSerializer();
 
 const Container = styled.div`
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  padding: 20px;
+  gap: 1em;
+`;
+
+const ExampleContainer = styled.div<{ dark?: boolean; shadow: string }>`
   width: 200px;
   height: 200px;
   padding: 1.5em;
-  box-shadow: 0px 3px 3px rgba(0, 0, 0, 0.1);
+  background-color: #fff;
+  border-radius: 10px;
+  box-shadow: ${(props) =>
+    props.dark ? "" : "0px 3px 3px rgba(0, 0, 0, 0.1)"};
   transition: 0.3s;
   &:hover {
-    box-shadow: 0px 20px 40px rgba(0, 0, 0, 0.2);
+    box-shadow: ${(props) =>
+      props.dark
+        ? `0px 1px 2px 0px ${props.shadow},
+          1px 2px 4px 0px ${props.shadow},
+          2px 4px 8px 0px ${props.shadow},
+          2px 4px 16px 0px ${props.shadow}`
+        : "0px 10px 10px rgba(0, 0, 0, 0.2)"};
+
     transform: scale(1.05, 1.05);
   }
 `;
@@ -25,8 +43,10 @@ const Container = styled.div`
 const Example = ({
   example,
   ideLink,
+  dark,
 }: {
   ideLink: string;
+  dark?: boolean;
   example: TrioWithPreview;
 }) => {
   const svgDoc = parser.parseFromString(example.preview!, "image/svg+xml");
@@ -38,15 +58,19 @@ const Example = ({
   const croppedPreview = serializer.serializeToString(svgNode);
   return (
     <a href={`${ideLink}?examples=${example.id}`} target="_blank">
-      <Container
+      <ExampleContainer
+        dark={dark}
+        shadow={"rgb(46, 154, 216, .7)"}
         dangerouslySetInnerHTML={{ __html: croppedPreview }}
-      ></Container>
+      ></ExampleContainer>
     </a>
   );
 };
 
-export default ({ ideLink }: { ideLink: string }) => {
+export default ({ ideLink, dark }: { ideLink: string; dark?: boolean }) => {
   let [examples, setExamples] = useState<TrioWithPreview[]>([]);
+  console.log(dark);
+
   useEffect(() => {
     const load = async () => {
       for (const [id, meta] of registry.entries()) {
@@ -66,10 +90,10 @@ export default ({ ideLink }: { ideLink: string }) => {
     load();
   }, []);
   return (
-    <div style={{ display: "flex", flexWrap: "wrap" }}>
+    <Container>
       {examples.map((e) => {
-        return <Example example={e} ideLink={ideLink}></Example>;
+        return <Example example={e} ideLink={ideLink} dark={dark}></Example>;
       })}
-    </div>
+    </Container>
   );
 };

--- a/packages/components/src/Gallery.tsx
+++ b/packages/components/src/Gallery.tsx
@@ -11,11 +11,12 @@ const parser = new DOMParser();
 const serializer = new XMLSerializer();
 
 const Container = styled.div`
-  display: flex;
-  flex-wrap: wrap;
-  justify-content: center;
-  padding: 20px;
-  gap: 1em;
+  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+  display: grid;
+  align-items: center;
+  justify-items: center;
+  padding: 2em;
+  grid-gap: 1.5em;
 `;
 
 const ExampleContainer = styled.div<{ dark?: boolean; shadow: string }>`
@@ -69,11 +70,10 @@ const Example = ({
 
 export default ({ ideLink, dark }: { ideLink: string; dark?: boolean }) => {
   let [examples, setExamples] = useState<TrioWithPreview[]>([]);
-  console.log(dark);
-
   useEffect(() => {
     const load = async () => {
-      for (const [id, meta] of registry.entries()) {
+      const entries = registry.entries();
+      for (const [id, meta] of entries) {
         if (meta.trio && meta.gallery) {
           const svg = await fetch(
             encodeURI(

--- a/packages/components/src/stories/Demo.stories.tsx
+++ b/packages/components/src/stories/Demo.stories.tsx
@@ -16,7 +16,7 @@ export default {
 
 // More on component templates: https://storybook.js.org/docs/react/writing-stories/introduction#using-args
 const Template: ComponentStory<typeof Demo> = (args) => (
-  <div style={{ width: "100%", height: "100%" }}>
+  <div style={{ width: "400px", height: "400px" }}>
     <Demo {...args} />
   </div>
 );
@@ -37,5 +37,4 @@ VectorExamples.args = {
       variation: vectorWedge.variation,
     },
   ],
-  width: "400px",
 };

--- a/packages/docs-site/.vitepress/config.ts
+++ b/packages/docs-site/.vitepress/config.ts
@@ -163,6 +163,7 @@ export default defineConfig({
       },
       { text: "Documentation", link: "/docs/ref", activeMatch: "/docs/ref" },
       { text: "Try Penrose", link: "pathname:///try/index.html" },
+      { text: "Join Discord", link: "https://discord.gg/Y3K2kHxp2b" },
       { text: "Team", link: "/docs/team" },
       {
         text: "News",
@@ -183,6 +184,7 @@ export default defineConfig({
     socialLinks: [
       { icon: "github", link: "https://github.com/penrose/penrose" },
       { icon: "twitter", link: "https://twitter.com/UsePenrose" },
+      { icon: "discord", link: "https://discord.gg/Y3K2kHxp2b" },
     ],
 
     sidebar: {
@@ -286,6 +288,10 @@ export default defineConfig({
       ],
     },
 
-    footer: { copyright: "made with ❤️ in Pittsburgh and abroad" },
+    footer: {
+      message:
+        'Released under the <a href="https://github.com/penrose/penrose/blob/main/LICENSE">MIT License</a>.',
+      copyright: "Copyright © 2017-present Penrose contributors",
+    },
   },
 });

--- a/packages/docs-site/docs/ref.md
+++ b/packages/docs-site/docs/ref.md
@@ -1,5 +1,7 @@
 # Penrose Overview
 
+For more information on any of the items summarized below, please use the navigation. More detailed documentation and example snippets for several aspects of Penrose (such as, types, shapes, and functions) can be found on the [wiki](https://github.com/penrose/penrose/wiki/).
+
 Penrose effortlessly creates beautiful diagrams using a 'trio':
 
 - A **Domain-specific Language (.domain) program**.  

--- a/packages/docs-site/index.md
+++ b/packages/docs-site/index.md
@@ -11,16 +11,14 @@ hero:
     - theme: sponsor
       text: Try
       link: pathname:///try/index.html
-    - theme: alt
-      text: Video
-      link: https://vimeo.com/416822487
+    # - theme: alt
+    #   text: Video
+    #   link: https://vimeo.com/416822487
 features:
   - title: Declarative
     details: Penrose is a platform that enables people to create beautiful diagrams just by typing mathematical notation in plain text.
   - title: Beautiful
-    details: The goal is to make it easy for non-experts to create and explore high-quality diagrams and provide deeper insight into challenging technical concepts.
+    details: Our goal is to make it easy for non-experts to create high-quality diagrams and provide deeper insight into challenging technical concepts.
   - title: Universal
     details: We aim to democratize the process of creating visual intuition.
-  - title: WIP
-    details: "Penrose is an early-stage system that is actively in development. Feel free to get in touch: penrose-team@cs.cmu.edu"
 ---

--- a/packages/docs-site/index.md
+++ b/packages/docs-site/index.md
@@ -16,7 +16,7 @@ hero:
       link: /docs/tutorial/welcome
 features:
   - title: Declarative
-    details: Penrose is a platform that enables people to create beautiful diagrams just by typing mathematical notation in plain text.
+    details: Penrose is a platform that enables people to create beautiful diagrams just by typing notation in plain text.
   - title: Beautiful
     details: Our goal is to make it easy for non-experts to create high-quality diagrams and provide deeper insight into challenging technical concepts.
   - title: Universal

--- a/packages/docs-site/index.md
+++ b/packages/docs-site/index.md
@@ -3,7 +3,7 @@ layout: home
 hero:
   name: Penrose
   text: Create beautiful diagrams
-  tagline: just by typing math notation in plain text.
+  tagline: just by typing notation in plain text.
   actions:
     - theme: brand
       text: Examples

--- a/packages/docs-site/index.md
+++ b/packages/docs-site/index.md
@@ -6,14 +6,14 @@ hero:
   tagline: just by typing math notation in plain text.
   actions:
     - theme: brand
-      text: Tutorial
-      link: /docs/tutorial/welcome
+      text: Examples
+      link: /examples
     - theme: sponsor
       text: Try
       link: pathname:///try/index.html
-    # - theme: alt
-    #   text: Video
-    #   link: https://vimeo.com/416822487
+    - theme: alt
+      text: Tutorial
+      link: /docs/tutorial/welcome
 features:
   - title: Declarative
     details: Penrose is a platform that enables people to create beautiful diagrams just by typing mathematical notation in plain text.

--- a/packages/docs-site/src/components/DemoWrapper.vue
+++ b/packages/docs-site/src/components/DemoWrapper.vue
@@ -1,7 +1,14 @@
 <script setup lang="ts">
 import { defineAsyncComponent } from "vue";
-import siggraphTeaser from "@penrose/examples/dist/geometry-domain/siggraph-teaser.trio";
-import treeVenn from "@penrose/examples/dist/set-theory-domain/tree-venn.trio";
+import siggraphTeaser from "@penrose/examples/dist/geometry-domain/siggraph-teaser.trio.js";
+import treeVenn from "@penrose/examples/dist/set-theory-domain/tree-venn-3d.trio.js";
+import hexagonal from "@penrose/examples/dist/spectral-graphs/examples/hexagonal-lattice.trio.js";
+import caffieine from "@penrose/examples/dist/structural-formula/molecules/caffeine.trio.js";
+
+import { useMediaQuery } from "@vueuse/core";
+
+const isVertical = useMediaQuery("(min-width: 960px)");
+const isMobile = useMediaQuery("(min-width: 640px)");
 
 const demo = [
   {
@@ -11,10 +18,26 @@ const demo = [
     variation: siggraphTeaser.variation,
   },
   {
+    sub: hexagonal.substance,
+    sty: hexagonal.style.map(({ contents }) => contents).join("\n"),
+    dsl: hexagonal.domain,
+    variation: hexagonal.variation,
+    stepSize: 10,
+  },
+  {
     sub: treeVenn.substance,
     sty: treeVenn.style.map(({ contents }) => contents).join("\n"),
     dsl: treeVenn.domain,
     variation: "PlumvilleCapybara104",
+    imageResolver: treeVenn.style[0].resolver,
+  },
+  {
+    sub: caffieine.substance,
+    sty: caffieine.style.map(({ contents }) => contents).join("\n"),
+    dsl: caffieine.domain,
+    variation: caffieine.variation,
+    stepSize: 1,
+    imageResolver: caffieine.style[0].resolver,
   },
 ];
 
@@ -28,14 +51,23 @@ const Demo = defineAsyncComponent(async () => {
 <template>
   <div
     style="
-      position: absolute;
-      top: 50%;
-      left: 50%;
-      transform: translate(-50%, -50%);
+      display: flex;
+      align-items: center;
+      justify-content: center;
       overflow: hidden;
+      width: 100%;
+      height: 100%;
     "
   >
     <!-- TODO: bad hardcoded width -->
-    <Demo :examples="demo" width="280px" />
+    <div
+      :style="`width: ${
+        isVertical.valueOf() ? 400 : isMobile.valueOf() ? 250 : 200
+      }px; height: ${
+        isVertical.valueOf() ? 400 : isMobile.valueOf() ? 250 : 200
+      }px;`"
+    >
+      <Demo :examples="demo" />
+    </div>
   </div>
 </template>

--- a/packages/docs-site/src/components/DemoWrapper.vue
+++ b/packages/docs-site/src/components/DemoWrapper.vue
@@ -5,11 +5,6 @@ import treeVenn from "@penrose/examples/dist/set-theory-domain/tree-venn-3d.trio
 import hexagonal from "@penrose/examples/dist/spectral-graphs/examples/hexagonal-lattice.trio.js";
 import caffieine from "@penrose/examples/dist/structural-formula/molecules/caffeine.trio.js";
 
-import { useMediaQuery } from "@vueuse/core";
-
-const isVertical = useMediaQuery("(min-width: 960px)");
-const isMobile = useMediaQuery("(min-width: 640px)");
-
 const demo = [
   {
     sub: siggraphTeaser.substance,
@@ -36,7 +31,7 @@ const demo = [
     sty: caffieine.style.map(({ contents }) => contents).join("\n"),
     dsl: caffieine.domain,
     variation: caffieine.variation,
-    stepSize: 1,
+    stepSize: 5,
     imageResolver: caffieine.style[0].resolver,
   },
 ];
@@ -47,6 +42,27 @@ const Demo = defineAsyncComponent(async () => {
   return applyPureReactInVue(Demo);
 });
 </script>
+
+<style scoped>
+.demo-container {
+  width: 200px;
+  height: 200px;
+}
+
+@media (min-width: 640px) {
+  .demo-container {
+    width: 250px;
+    height: 250px;
+  }
+}
+
+@media (min-width: 960px) {
+  .demo-container {
+    width: 400px;
+    height: 400px;
+  }
+}
+</style>
 
 <template>
   <div
@@ -59,14 +75,7 @@ const Demo = defineAsyncComponent(async () => {
       height: 100%;
     "
   >
-    <!-- TODO: bad hardcoded width -->
-    <div
-      :style="`width: ${
-        isVertical.valueOf() ? 400 : isMobile.valueOf() ? 250 : 200
-      }px; height: ${
-        isVertical.valueOf() ? 400 : isMobile.valueOf() ? 250 : 200
-      }px;`"
-    >
+    <div class="demo-container">
       <Demo :examples="demo" />
     </div>
   </div>

--- a/packages/docs-site/src/components/GalleryWrapper.vue
+++ b/packages/docs-site/src/components/GalleryWrapper.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { withBase } from "vitepress";
+import { withBase, useData } from "vitepress";
 import { defineAsyncComponent } from "vue";
 
 const Gallery = defineAsyncComponent(async () => {
@@ -11,5 +11,7 @@ const link = withBase(`/try/index.html`);
 </script>
 
 <template>
-  <div style="width: 100%"><Gallery :ideLink="link" /></div>
+  <div style="width: 100%">
+    <Gallery :ideLink="link" :dark="useData().isDark.value" />
+  </div>
 </template>

--- a/packages/examples/src/geometry-domain/euclidean-teaser.style
+++ b/packages/examples/src/geometry-domain/euclidean-teaser.style
@@ -3,7 +3,7 @@
 
 canvas {
   width = 800
-  height = 700
+  height = 800
 }
 
 Colors {
@@ -24,10 +24,10 @@ const {
     arrowheadSize = 0.65
     strokeWidth = 1.75
     textPadding = 7.0
-    textPadding2 = 25.0
+    textPadding2 = 40.0
     repelWeight = 0.7 -- TODO: Reverted from 0.0
     repelWeight2 = 0.5
-    fontSize = "25px"
+    fontSize = "35px"
     containPadding = 50.0
     rayLength = 100.0
     pointRadius = 4.0
@@ -44,8 +44,8 @@ const {
 
 --Plane
 forall Plane p {
-  width = canvas.width * .8
-  height = canvas.height * .8
+  width = canvas.width - 1 
+  height = canvas.height - 1
   p.text = Equation {
     center : ((width / 2.0) - const.textPadding2, (height / 2.0) - const.textPadding2)
     string : p.label

--- a/packages/examples/src/set-theory-domain/venn-3d.style
+++ b/packages/examples/src/set-theory-domain/venn-3d.style
@@ -1,6 +1,6 @@
 canvas {
   width = 800
-  height = 700
+  height = 800
 }
 
 forall Set x {

--- a/packages/examples/src/structural-formula/molecules/caffeine.trio.json
+++ b/packages/examples/src/structural-formula/molecules/caffeine.trio.json
@@ -2,5 +2,5 @@
   "substance": "./caffeine.substance",
   "style": ["../pseudo-3d.style"],
   "domain": "../structural-formula.domain",
-  "variation": "AmouretteEchidna3389"
+  "variation": "GreybeardChinchilla991"
 }

--- a/packages/examples/src/structural-formula/pseudo-3d.style
+++ b/packages/examples/src/structural-formula/pseudo-3d.style
@@ -1,6 +1,6 @@
 canvas {
    scalar width  = 800
-   scalar height = 600
+   scalar height = 800
 }
 
 global {

--- a/packages/examples/src/structural-formula/pseudo-3d.style
+++ b/packages/examples/src/structural-formula/pseudo-3d.style
@@ -299,7 +299,7 @@ where t has label
       string : t.label
       fillColor : Colors.black
       fontSize : "40px"
-      fontFamily: "Roboto Condensed, Impact, Franklin Gothic Bold, sans-serif"
+      fontFamily: "Roboto Condensed, Impact, Franklin Gothic Bold, Ubuntu Condensed, sans-serif"
       center : (?,?)
    }
    layer t.labelText above global.background


### PR DESCRIPTION
# Description

This PR makes a few changes to our homepage:

* Add discord server invitation
* Tweak landing page design
  * Better `Demo` component positioning and sizing
  * More demo examples: hexagonal graph, caffeine, 3D euler diagram
* Update footer to include copyright and license info   
* Gallery page: rounded corners and dark-mode shadow

# Checklist

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have reviewed any generated registry diagram changes

