### PR TITLE
feat: cropping picks smaller viewbox in gallery and `editor`

### DIFF
--- a/packages/components/src/Gallery.tsx
+++ b/packages/components/src/Gallery.tsx
@@ -30,11 +30,28 @@ const Example = ({
   ideLink: string;
   example: TrioWithPreview;
 }) => {
+  // determine whether to crop the SVG
   const svgDoc = parser.parseFromString(example.preview!, "image/svg+xml");
   const cropped = svgDoc.querySelector("croppedViewBox")?.innerHTML;
   const svgNode = svgDoc.querySelector("svg")!;
-  if (cropped !== undefined) {
-    svgNode.setAttribute("viewBox", cropped!);
+  const viewBox = svgNode.getAttribute("viewBox");
+  if (cropped && viewBox) {
+    const viewBoxNums = svgNode.viewBox.baseVal;
+    const croppedNums = cropped.split(/\s+|,/);
+
+    const croppedWidth = parseFloat(croppedNums[3]);
+    const croppedHeight = parseFloat(croppedNums[4]);
+    const viewBoxWidth = viewBoxNums.width;
+    const viewBoxHeight = viewBoxNums.height;
+
+    // if area of cropped view box is leq area of current view box
+    // then set the view box to the cropped view box
+    if (
+      Math.abs(croppedWidth * croppedHeight) <
+      Math.abs(viewBoxWidth * viewBoxHeight)
+    ) {
+      svgNode.setAttribute("viewBox", cropped);
+    }
   }
   const croppedPreview = serializer.serializeToString(svgNode);
   return (
@@ -60,12 +77,28 @@ export default ({ ideLink }: { ideLink: string }) => {
           if (svg.ok) {
             const preview = await svg.text();
 
-            // crop the SVG
+            // determine whether to crop the SVG
             const svgDoc = parser.parseFromString(preview, "image/svg+xml");
             const cropped = svgDoc.querySelector("croppedViewBox")?.innerHTML;
             const svgNode = svgDoc.querySelector("svg")!;
-            if (cropped !== undefined) {
-              svgNode.setAttribute("viewBox", cropped!);
+            const viewBox = svgNode.getAttribute("viewBox");
+            if (cropped && viewBox) {
+              const viewBoxNums = svgNode.viewBox.baseVal;
+              const croppedNums = cropped.split(/\s+|,/);
+
+              const croppedWidth = parseFloat(croppedNums[3]);
+              const croppedHeight = parseFloat(croppedNums[4]);
+              const viewBoxWidth = viewBoxNums.width;
+              const viewBoxHeight = viewBoxNums.height;
+
+              // if area of cropped view box is leq area of current view box
+              // then set the view box to the cropped view box
+              if (
+                Math.abs(croppedWidth * croppedHeight) <
+                Math.abs(viewBoxWidth * viewBoxHeight)
+              ) {
+                svgNode.setAttribute("viewBox", cropped);
+              }
             }
             const croppedPreview = serializer.serializeToString(svgNode);
 

--- a/packages/editor/src/components/ExamplesBrowser.tsx
+++ b/packages/editor/src/components/ExamplesBrowser.tsx
@@ -27,11 +27,28 @@ const Example = ({
   loadExample: (t: TrioWithPreview) => Promise<void>;
   k: number;
 }) => {
+  // determine whether to crop the SVG
   const svgDoc = parser.parseFromString(example.preview!, "image/svg+xml");
   const cropped = svgDoc.querySelector("croppedViewBox")?.innerHTML;
   const svgNode = svgDoc.querySelector("svg")!;
-  if (cropped !== undefined) {
-    svgNode.setAttribute("viewBox", cropped!);
+  const viewBox = svgNode.getAttribute("viewBox");
+  if (cropped && viewBox) {
+    const viewBoxNums = svgNode.viewBox.baseVal;
+    const croppedNums = cropped.split(/\s+|,/);
+
+    const croppedWidth = parseFloat(croppedNums[3]);
+    const croppedHeight = parseFloat(croppedNums[4]);
+    const viewBoxWidth = viewBoxNums.width;
+    const viewBoxHeight = viewBoxNums.height;
+
+    // if area of cropped view box is leq area of current view box
+    // then set the view box to the cropped view box
+    if (
+      Math.abs(croppedWidth * croppedHeight) <
+      Math.abs(viewBoxWidth * viewBoxHeight)
+    ) {
+      svgNode.setAttribute("viewBox", cropped);
+    }
   }
   const croppedPreview = serializer.serializeToString(svgNode);
 


### PR DESCRIPTION
# Description

This PR resolves the problem of diagram previews being cropped to the tightest bounding box even when the intended view box is zoomed in on a portion of the total shapes, which makes some previews look wholly unlike the actual diagrams in the gallery and the editor.

We introduce a check to compare the areas of (1) the existing view box and (2) the tightest bounding box of all shapes, and set the SVG `viewBox` to the smaller of the two.

# Implementation strategy and design decisions

Since this is done after the SVGs have been produced, we parse the widths and heights of the `viewBox` and `croppedViewBox` strings from these SVGs to calculate the area. We only set the `viewBox` to the values in `croppedViewBox` if the area of the latter is smaller than the former. 

# Examples with steps to reproduce them

Here is a screenshot of the previously badly cropped diagram in the gallery (Brownian Motion Absorbed at Boundary), which is now fixed:
<img width="1434" alt="Screen Shot 2023-06-29 at 10 34 54 AM" src="https://github.com/penrose/penrose/assets/98900692/c8884280-b3f9-4909-ba2a-072fadc531e6">
And here it is in the editor:
<img width="251" alt="Screen Shot 2023-06-29 at 10 35 11 AM" src="https://github.com/penrose/penrose/assets/98900692/45fdc113-b40a-4d18-89f7-fac5448dece2">


# Checklist

- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have reviewed any generated registry diagram changes
