### PR TITLE
fix: query string for examples in `editor`

### DIFF
--- a/packages/editor/src/components/ExamplesBrowser.tsx
+++ b/packages/editor/src/components/ExamplesBrowser.tsx
@@ -46,7 +46,7 @@ const Example = ({
             examples: example.id,
           });
           // https://stackoverflow.com/questions/32828160/appending-parameter-to-url-without-refresh
-          window.history.replaceState(null, "", query);
+          window.history.replaceState(null, "", `?${query}`);
         }}
       >
         <ExampleTab key={`example-tab-${k}`}>


### PR DESCRIPTION
# Description

Following up on #1464. There's a bug in https://github.com/penrose/penrose/pull/1464/commits/843728a3b6783589c12be03bed71fd802ca9ebfb that causes 404 when a user loads an example from the example browser and then refresh the page. This PR prepends the query string with `?` to make sure the link is valid. 