### PR TITLE
feat: saving `variation` in local and Gist workspace

### DIFF
--- a/packages/editor/src/state/atoms.ts
+++ b/packages/editor/src/state/atoms.ts
@@ -5,7 +5,7 @@ import {
   PenroseState,
   PenroseWarning,
 } from "@penrose/core";
-import { PathResolver, Trio, TrioMeta } from "@penrose/examples/dist";
+import { PathResolver, Trio, TrioMeta } from "@penrose/examples/dist/";
 import registry from "@penrose/examples/dist/registry.js";
 import { Actions, BorderNode, TabNode } from "flexlayout-react";
 import localforage from "localforage";
@@ -63,6 +63,8 @@ export type WorkspaceMetadata = {
   forkedFromGist: string | null;
   editorVersion: number;
   location: WorkspaceLocation;
+  // Diagram-specific
+  variation?: string;
 };
 
 export type ProgramFile = {
@@ -146,6 +148,7 @@ const saveWorkspaceEffect: AtomEffect<Workspace> = ({ onSet, setSelf }) => {
                 newValue.metadata.location.kind === "gist"
                   ? newValue.metadata.location.id
                   : null,
+              variation: newValue.metadata.variation,
             } as WorkspaceMetadata,
           };
         });
@@ -426,6 +429,7 @@ export type GistMetadata = {
     style: string;
     domain: string;
   };
+  variation?: string;
 };
 
 export type Settings = {

--- a/packages/editor/src/state/atoms.ts
+++ b/packages/editor/src/state/atoms.ts
@@ -150,6 +150,7 @@ const saveWorkspaceEffect: AtomEffect<Workspace> = ({ onSet, setSelf }) => {
                   ? newValue.metadata.location.id
                   : null,
               variation: newValue.metadata.variation,
+              excludeWarnings: newValue.metadata.excludeWarnings,
             } as WorkspaceMetadata,
           };
         });

--- a/packages/editor/src/state/callbacks.ts
+++ b/packages/editor/src/state/callbacks.ts
@@ -165,6 +165,10 @@ export const useResampleDiagram = () =>
       metadata: { ...state.metadata, variation },
       state: resampled,
     }));
+    set(currentWorkspaceState, (state) => ({
+      ...state,
+      metadata: { ...state.metadata, variation },
+    }));
     // update grid state too
     set(diagramGridState, ({ gridSize }) => ({
       variations: range(gridSize).map((i) =>


### PR DESCRIPTION
# Description

Some diagram-related fields aren't saved in the IDE's local or Gist workspaces. An example that currently exists is `variation` - whenever we refresh the page, the `variation` of a diagram stored in local or Gist workspace is gone. Another example that is `excludeWarnings`.

This is because `variation` and `excludeWarnings` are parts of `DiagramMetadata`, whereas we only save things from `WorkspaceMetadata` into local or Gist workspace.

# Implementation strategy and design decisions

The solution is to also add `variation` and `excludeWarnings` into `WorkspaceMetadata` so that they can be saved alongside other Workspace-related information. We keep the versions of `variation` and `excludeWarnings` in `DiagramMetadata` and `WorkspaceMetadata` in sync. In order to support loading `variation` and `excludeWarnings` from Gist, we also add these fields into `GistMetadata`. These `GistMetadata` fields will, however, be optional in order to not break any previous diagrams saved to Gist.

# Checklist

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have reviewed any generated registry diagram changes
