### PR TITLE
fix: warnings in example diagrams

### DIFF
--- a/packages/examples/src/curve-examples/catmull-rom/catmull-rom.trio.json
+++ b/packages/examples/src/curve-examples/catmull-rom/catmull-rom.trio.json
@@ -2,5 +2,6 @@
   "substance": "./test.substance",
   "style": ["./catmull-rom.style"],
   "domain": "./catmull-rom.domain",
-  "variation": "UranusYak398"
+  "variation": "UranusYak398",
+  "excludeWarnings": ["BBoxApproximationWarning"]
 }

--- a/packages/examples/src/exterior-algebra/vector-wedge.trio.json
+++ b/packages/examples/src/exterior-algebra/vector-wedge.trio.json
@@ -2,5 +2,6 @@
   "substance": "./vector-wedge.substance",
   "style": ["./exterior-algebra.style"],
   "domain": "./exterior-algebra.domain",
-  "variation": "SnorlaxIbis743"
+  "variation": "SnorlaxIbis743",
+  "excludeWarnings": ["BBoxApproximationWarning"]
 }

--- a/packages/examples/src/geometry-domain/textbook_problems/c11p12.trio.json
+++ b/packages/examples/src/geometry-domain/textbook_problems/c11p12.trio.json
@@ -2,5 +2,6 @@
   "substance": "./c11p12.substance",
   "style": ["../euclidean.style", "./c11p12.style"],
   "domain": "../geometry.domain",
-  "variation": "EdwardGuanaco94367"
+  "variation": "EdwardGuanaco94367",
+  "excludeWarnings": ["NoopDeleteWarning"]
 }

--- a/packages/examples/src/stochastic-process/stochastic-process.trio.json
+++ b/packages/examples/src/stochastic-process/stochastic-process.trio.json
@@ -2,5 +2,6 @@
   "substance": "./test.substance",
   "style": ["./stochastic-process.style"],
   "domain": "./stochastic-process.domain",
-  "variation": "ChambrayGoose54176"
+  "variation": "ChambrayGoose54176",
+  "excludeWarnings": ["BBoxApproximationWarning"]
 }


### PR DESCRIPTION
# Description

Since we now have a different set of example diagrams, some diagrams issue warnings like `BBoxApproximationWarning` and `NoopDeleteWarning`. This PR modify the trio files of affected examples to exclude these warnings from being reported.

# Checklist

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have reviewed any generated registry diagram changes
