### PR TITLE
refactor: simplify derivative of `div`

### DIFF
--- a/packages/core/src/engine/Autodiff.ts
+++ b/packages/core/src/engine/Autodiff.ts
@@ -191,7 +191,7 @@ const binarySensitivities = (z: ad.Binary): { left: ad.Num; right: ad.Num } => {
       return { left: 1, right: -1 };
     }
     case "/": {
-      return { left: inverse(w), right: neg(div(v, squared(w))) };
+      return { left: inverse(w), right: neg(div(z, w)) };
     }
     case "max": {
       const cond = gt(v, w);


### PR DESCRIPTION
# Description

I was staring at our derivative expression for division and realized we don't need to call `squared`.

# Checklist

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have reviewed any generated registry diagram changes