### PR TITLE
docs: load Style function data using SSR

### DIFF
--- a/packages/docs-site/docs/ref/style/functions.data.ts
+++ b/packages/docs-site/docs/ref/style/functions.data.ts
@@ -1,0 +1,11 @@
+import { compDict, constrDict, objDict } from "@penrose/core";
+export default {
+  load() {
+    return {
+      constrDict,
+      objDict,
+      compDict,
+      data: "hello",
+    };
+  },
+};

--- a/packages/docs-site/docs/ref/style/functions.md
+++ b/packages/docs-site/docs/ref/style/functions.md
@@ -1,6 +1,7 @@
-<script setup>
+<script setup lang="ts">
 import Function from "../../../src/components/Function.vue"
-import { constrDict, objDict, compDict } from "@penrose/core"
+import { data } from "./functions.data.js"
+const { objDict, compDict, constrDict } = data;
 </script>
 
 # Style Functions


### PR DESCRIPTION
# Description

Following up on #1427. The previous solution was client-side. This PR does [build-time data loading](https://vitepress.dev/guide/data-loading) for Style functions.