### PR TITLE
chore: Point to gallery

### DIFF
--- a/packages/docs-site/docs/ref/domain/examples.md
+++ b/packages/docs-site/docs/ref/domain/examples.md
@@ -1,3 +1,3 @@
 # Examples
 
-See the [Tutorial](/docs/tutorial/welcome) for extensive examples of using the language.
+The best way to get a feel for Domain schemas is to take a look at the many working examples in the [example gallery](https://penrose.cs.cmu.edu/examples). The [tutorial](/docs/tutorial/welcome) also walks through several examples.

--- a/packages/docs-site/docs/ref/style/examples.md
+++ b/packages/docs-site/docs/ref/style/examples.md
@@ -1,3 +1,3 @@
 # Examples
 
-See the [Tutorial](/docs/tutorial/welcome) for extensive examples of using the language.
+The best way to get a feel for the Style language is to take a look at the many working examples in the [example gallery](https://penrose.cs.cmu.edu/examples). The [tutorial](/docs/tutorial/welcome) also walks through several examples.

--- a/packages/docs-site/docs/ref/substance/examples.md
+++ b/packages/docs-site/docs/ref/substance/examples.md
@@ -1,3 +1,3 @@
 # Examples
 
-See the [Tutorial](/docs/tutorial/welcome) for extensive examples of using the language.
+The best way to get a feel for the Substance language is to take a look at the many working examples in the [example gallery](https://penrose.cs.cmu.edu/examples). The [tutorial](/docs/tutorial/welcome) also walks through several examples.


### PR DESCRIPTION
Just points each of the `Examples` pages in the documentation to the [examples gallery](https://penrose.cs.cmu.edu/examples), since these working examples may give a better sense of how to actually use the language than some of the smaller tutorial examples.