### PR TITLE
chore: bump version to 3.0.0-beta.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-## [v3.0.0-beta.0](https://github.com/penrose/penrose/compare/v2.3.0...v3.0.0-beta.0) (2023-07-14)
+## [v3.0.0](https://github.com/penrose/penrose/compare/v2.3.0...v3.0.0) (2023-07-14)
 
 ### :warning: BREAKING CHANGE
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-## [v3.0.0](https://github.com/penrose/penrose/compare/v2.3.0...v3.0.0) (2023-07-14)
+## [v3.0.0-beta.1](https://github.com/penrose/penrose/compare/v2.3.0...v3.0.0-beta.1) (2023-07-14)
 
 ### :warning: BREAKING CHANGE
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -168,7 +168,7 @@ checksum = "b1de2e551fb905ac83f73f7aedf2f0cb4a0da7e35efa24a202a936269f1f18e1"
 
 [[package]]
 name = "penrose-optimizer"
-version = "3.0.0-beta.0"
+version = "3.0.0"
 dependencies = [
  "console_error_panic_hook",
  "console_log",

--- a/lerna.json
+++ b/lerna.json
@@ -1,7 +1,7 @@
 {
   "packages": ["packages/*"],
   "npmClient": "yarn",
-  "version": "3.0.0-beta.0",
+  "version": "3.0.0",
   "useWorkspaces": true,
   "changelogPreset": {
     "name": "@spyke/conventional-changelog-preset"

--- a/lerna.json
+++ b/lerna.json
@@ -1,7 +1,7 @@
 {
   "packages": ["packages/*"],
   "npmClient": "yarn",
-  "version": "3.0.0",
+  "version": "3.0.0-beta.1",
   "useWorkspaces": true,
   "changelogPreset": {
     "name": "@spyke/conventional-changelog-preset"

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -3,7 +3,7 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-## [v3.0.0-beta.0](https://github.com/penrose/penrose/compare/v2.3.0...v3.0.0-beta.0) (2023-07-14)
+## [v3.0.0](https://github.com/penrose/penrose/compare/v2.3.0...v3.0.0) (2023-07-14)
 
 ### :warning: BREAKING CHANGE
 

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -3,7 +3,7 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-## [v3.0.0](https://github.com/penrose/penrose/compare/v2.3.0...v3.0.0) (2023-07-14)
+## [v3.0.0-beta.1](https://github.com/penrose/penrose/compare/v2.3.0...v3.0.0-beta.1) (2023-07-14)
 
 ### :warning: BREAKING CHANGE
 

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@penrose/components",
-  "version": "3.0.0-beta.0",
+  "version": "3.0.0",
   "license": "MIT",
   "type": "module",
   "main": "dist/index.js",
@@ -49,7 +49,7 @@
   },
   "dependencies": {
     "@monaco-editor/react": "^4.0.11",
-    "@penrose/core": "^3.0.0-beta.0",
+    "@penrose/core": "^3.0.0",
     "monaco-editor": "^0.31.0",
     "monaco-vim": "^0.3.4",
     "react-datasheet-grid": "^4.11.0",
@@ -60,7 +60,7 @@
   "devDependencies": {
     "@babel/core": "^7.18.0",
     "@mdx-js/preact": "^2.1.5",
-    "@penrose/examples": "^3.0.0-beta.0",
+    "@penrose/examples": "^3.0.0",
     "@storybook/addon-actions": "^6.5.15",
     "@storybook/addon-essentials": "^6.5.15",
     "@storybook/addon-interactions": "^6.5.15",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@penrose/components",
-  "version": "3.0.0",
+  "version": "3.0.0-beta.1",
   "license": "MIT",
   "type": "module",
   "main": "dist/index.js",
@@ -49,7 +49,7 @@
   },
   "dependencies": {
     "@monaco-editor/react": "^4.0.11",
-    "@penrose/core": "^3.0.0",
+    "@penrose/core": "^3.0.0-beta.1",
     "monaco-editor": "^0.31.0",
     "monaco-vim": "^0.3.4",
     "react-datasheet-grid": "^4.11.0",
@@ -60,7 +60,7 @@
   "devDependencies": {
     "@babel/core": "^7.18.0",
     "@mdx-js/preact": "^2.1.5",
-    "@penrose/examples": "^3.0.0",
+    "@penrose/examples": "^3.0.0-beta.1",
     "@storybook/addon-actions": "^6.5.15",
     "@storybook/addon-essentials": "^6.5.15",
     "@storybook/addon-interactions": "^6.5.15",

--- a/packages/components/src/Gallery.tsx
+++ b/packages/components/src/Gallery.tsx
@@ -1,4 +1,3 @@
-import registry from "@penrose/examples/dist/registry.js";
 import { useEffect, useState } from "react";
 import styled from "styled-components";
 import { cropSVG } from "./util.js";
@@ -60,7 +59,15 @@ const Example = ({
   );
 };
 
-export default ({ ideLink, dark }: { ideLink: string; dark?: boolean }) => {
+export default ({
+  registry,
+  ideLink,
+  dark,
+}: {
+  registry: Map<string, { trio: boolean; gallery?: boolean }>;
+  ideLink: string;
+  dark?: boolean;
+}) => {
   const entries = [...registry.entries()].filter(
     ([, meta]) => meta.trio && meta.gallery
   );

--- a/packages/components/src/stories/Gallery.stories.tsx
+++ b/packages/components/src/stories/Gallery.stories.tsx
@@ -1,3 +1,4 @@
+import registry from "@penrose/examples/dist/registry.js";
 import { ComponentMeta, ComponentStory } from "@storybook/react";
 import Gallery from "../Gallery";
 
@@ -8,7 +9,7 @@ export default {
 
 const Template: ComponentStory<typeof Gallery> = (args) => (
   <div style={{ width: "100%", height: "100%" }}>
-    <Gallery ideLink="https://penrose.cs.cmu.edu/try/" />
+    <Gallery registry={registry} ideLink="https://penrose.cs.cmu.edu/try/" />
   </div>
 );
 

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -3,7 +3,7 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-## [v3.0.0-beta.0](https://github.com/penrose/penrose/compare/v2.3.0...v3.0.0-beta.0) (2023-07-14)
+## [v3.0.0](https://github.com/penrose/penrose/compare/v2.3.0...v3.0.0) (2023-07-14)
 
 ### :warning: BREAKING CHANGE
 

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -3,7 +3,7 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-## [v3.0.0](https://github.com/penrose/penrose/compare/v2.3.0...v3.0.0) (2023-07-14)
+## [v3.0.0-beta.1](https://github.com/penrose/penrose/compare/v2.3.0...v3.0.0-beta.1) (2023-07-14)
 
 ### :warning: BREAKING CHANGE
 

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@penrose/core",
-  "version": "3.0.0-beta.0",
+  "version": "3.0.0",
   "type": "module",
   "main": "dist/index.js",
   "module": "dist/index.js",
@@ -75,7 +75,7 @@
   },
   "dependencies": {
     "@datastructures-js/queue": "^4.1.3",
-    "@penrose/optimizer": "^3.0.0-beta.0",
+    "@penrose/optimizer": "^3.0.0",
     "consola": "^2.15.2",
     "immutable": "^4.0.0-rc.12",
     "lodash": "^4.17.15",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@penrose/core",
-  "version": "3.0.0",
+  "version": "3.0.0-beta.1",
   "type": "module",
   "main": "dist/index.js",
   "module": "dist/index.js",
@@ -75,7 +75,7 @@
   },
   "dependencies": {
     "@datastructures-js/queue": "^4.1.3",
-    "@penrose/optimizer": "^3.0.0",
+    "@penrose/optimizer": "^3.0.0-beta.1",
     "consola": "^2.15.2",
     "immutable": "^4.0.0-rc.12",
     "lodash": "^4.17.15",

--- a/packages/docs-site/.vitepress/config.ts
+++ b/packages/docs-site/.vitepress/config.ts
@@ -163,7 +163,7 @@ export default defineConfig({
       },
       { text: "Documentation", link: "/docs/ref", activeMatch: "/docs/ref" },
       { text: "Try Penrose", link: "pathname:///try/index.html" },
-      { text: "Join Discord", link: "https://discord.gg/Y3K2kHxp2b" },
+      { text: "Join Discord", link: "https://discord.gg/a7VXJU4dfR" },
       { text: "Team", link: "/docs/team" },
       { text: "Blog", link: "/blog", activeMatch: "/blog" },
       {
@@ -185,7 +185,7 @@ export default defineConfig({
     socialLinks: [
       { icon: "github", link: "https://github.com/penrose/penrose" },
       { icon: "twitter", link: "https://twitter.com/UsePenrose" },
-      { icon: "discord", link: "https://discord.gg/Y3K2kHxp2b" },
+      { icon: "discord", link: "https://discord.gg/a7VXJU4dfR" },
     ],
 
     sidebar: {

--- a/packages/docs-site/CHANGELOG.md
+++ b/packages/docs-site/CHANGELOG.md
@@ -3,7 +3,7 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-## [v3.0.0-beta.0](https://github.com/penrose/penrose/compare/v2.3.0...v3.0.0-beta.0) (2023-07-14)
+## [v3.0.0](https://github.com/penrose/penrose/compare/v2.3.0...v3.0.0) (2023-07-14)
 
 ### :warning: BREAKING CHANGE
 

--- a/packages/docs-site/CHANGELOG.md
+++ b/packages/docs-site/CHANGELOG.md
@@ -3,7 +3,7 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-## [v3.0.0](https://github.com/penrose/penrose/compare/v2.3.0...v3.0.0) (2023-07-14)
+## [v3.0.0-beta.1](https://github.com/penrose/penrose/compare/v2.3.0...v3.0.0-beta.1) (2023-07-14)
 
 ### :warning: BREAKING CHANGE
 

--- a/packages/docs-site/package.json
+++ b/packages/docs-site/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@penrose/docs-site",
-  "version": "3.0.0",
+  "version": "3.0.0-beta.1",
   "type": "module",
   "private": true,
   "scripts": {
@@ -46,14 +46,14 @@
     }
   },
   "dependencies": {
-    "@penrose/components": "^3.0.0",
-    "@penrose/examples": "^3.0.0",
+    "@penrose/components": "^3.0.0-beta.1",
+    "@penrose/examples": "^3.0.0-beta.1",
     "veaury": "^2.3.11"
   },
   "devDependencies": {
-    "@penrose/core": "^3.0.0",
-    "@penrose/editor": "^3.0.0",
-    "@penrose/roger": "^3.0.0",
+    "@penrose/core": "^3.0.0-beta.1",
+    "@penrose/editor": "^3.0.0-beta.1",
+    "@penrose/roger": "^3.0.0-beta.1",
     "@tailwindcss/typography": "^0.5.4",
     "@types/markdown-it": "^12.2.3",
     "markdown-it": "^13.0.1",

--- a/packages/docs-site/package.json
+++ b/packages/docs-site/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@penrose/docs-site",
-  "version": "3.0.0-beta.0",
+  "version": "3.0.0",
   "type": "module",
   "private": true,
   "scripts": {
@@ -46,14 +46,14 @@
     }
   },
   "dependencies": {
-    "@penrose/components": "^3.0.0-beta.0",
-    "@penrose/examples": "^3.0.0-beta.0",
+    "@penrose/components": "^3.0.0",
+    "@penrose/examples": "^3.0.0",
     "veaury": "^2.3.11"
   },
   "devDependencies": {
-    "@penrose/core": "^3.0.0-beta.0",
-    "@penrose/editor": "^3.0.0-beta.0",
-    "@penrose/roger": "^3.0.0-beta.0",
+    "@penrose/core": "^3.0.0",
+    "@penrose/editor": "^3.0.0",
+    "@penrose/roger": "^3.0.0",
     "@tailwindcss/typography": "^0.5.4",
     "@types/markdown-it": "^12.2.3",
     "markdown-it": "^13.0.1",

--- a/packages/docs-site/src/components/GalleryWrapper.vue
+++ b/packages/docs-site/src/components/GalleryWrapper.vue
@@ -1,4 +1,5 @@
 <script setup lang="ts">
+import registry from "@penrose/examples/dist/registry.js";
 import { withBase, useData } from "vitepress";
 import { defineAsyncComponent } from "vue";
 
@@ -12,6 +13,10 @@ const link = withBase(`/try/index.html`);
 
 <template>
   <div style="width: 100%">
-    <Gallery :ideLink="link" :dark="useData().isDark.value" />
+    <Gallery
+      :registry="registry"
+      :ideLink="link"
+      :dark="useData().isDark.value"
+    />
   </div>
 </template>

--- a/packages/edgeworth/CHANGELOG.md
+++ b/packages/edgeworth/CHANGELOG.md
@@ -3,7 +3,7 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-## [v3.0.0-beta.0](https://github.com/penrose/penrose/compare/v2.3.0...v3.0.0-beta.0) (2023-07-14)
+## [v3.0.0](https://github.com/penrose/penrose/compare/v2.3.0...v3.0.0) (2023-07-14)
 
 ### :warning: BREAKING CHANGE
 

--- a/packages/edgeworth/CHANGELOG.md
+++ b/packages/edgeworth/CHANGELOG.md
@@ -3,7 +3,7 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-## [v3.0.0](https://github.com/penrose/penrose/compare/v2.3.0...v3.0.0) (2023-07-14)
+## [v3.0.0-beta.1](https://github.com/penrose/penrose/compare/v2.3.0...v3.0.0-beta.1) (2023-07-14)
 
 ### :warning: BREAKING CHANGE
 

--- a/packages/edgeworth/package.json
+++ b/packages/edgeworth/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@penrose/edgeworth",
   "private": true,
-  "version": "3.0.0",
+  "version": "3.0.0-beta.1",
   "scripts": {
     "dev": "vite",
     "watch": "vite",
@@ -56,9 +56,9 @@
   },
   "dependencies": {
     "@material-ui/core": "^4.12.3",
-    "@penrose/components": "^3.0.0",
-    "@penrose/core": "^3.0.0",
-    "@penrose/examples": "^3.0.0",
+    "@penrose/components": "^3.0.0-beta.1",
+    "@penrose/core": "^3.0.0-beta.1",
+    "@penrose/examples": "^3.0.0-beta.1",
     "@types/file-saver": "^2.0.5",
     "@types/jszip": "^3.4.1",
     "file-saver": "^2.0.5",

--- a/packages/edgeworth/package.json
+++ b/packages/edgeworth/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@penrose/edgeworth",
   "private": true,
-  "version": "3.0.0-beta.0",
+  "version": "3.0.0",
   "scripts": {
     "dev": "vite",
     "watch": "vite",
@@ -56,9 +56,9 @@
   },
   "dependencies": {
     "@material-ui/core": "^4.12.3",
-    "@penrose/components": "^3.0.0-beta.0",
-    "@penrose/core": "^3.0.0-beta.0",
-    "@penrose/examples": "^3.0.0-beta.0",
+    "@penrose/components": "^3.0.0",
+    "@penrose/core": "^3.0.0",
+    "@penrose/examples": "^3.0.0",
     "@types/file-saver": "^2.0.5",
     "@types/jszip": "^3.4.1",
     "file-saver": "^2.0.5",

--- a/packages/editor/CHANGELOG.md
+++ b/packages/editor/CHANGELOG.md
@@ -3,7 +3,7 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-## [v3.0.0-beta.0](https://github.com/penrose/penrose/compare/v2.3.0...v3.0.0-beta.0) (2023-07-14)
+## [v3.0.0](https://github.com/penrose/penrose/compare/v2.3.0...v3.0.0) (2023-07-14)
 
 ### :warning: BREAKING CHANGE
 

--- a/packages/editor/CHANGELOG.md
+++ b/packages/editor/CHANGELOG.md
@@ -3,7 +3,7 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-## [v3.0.0](https://github.com/penrose/penrose/compare/v2.3.0...v3.0.0) (2023-07-14)
+## [v3.0.0-beta.1](https://github.com/penrose/penrose/compare/v2.3.0...v3.0.0-beta.1) (2023-07-14)
 
 ### :warning: BREAKING CHANGE
 

--- a/packages/editor/package.json
+++ b/packages/editor/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@penrose/editor",
   "private": true,
-  "version": "3.0.0-beta.0",
+  "version": "3.0.0",
   "scripts": {
     "start": "cross-env NODE_OPTIONS='--max-old-space-size=8192' vite",
     "dev": "cross-env NODE_OPTIONS='--max-old-space-size=8192' vite",
@@ -41,9 +41,9 @@
     }
   },
   "dependencies": {
-    "@penrose/components": "^3.0.0-beta.0",
-    "@penrose/core": "^3.0.0-beta.0",
-    "@penrose/examples": "^3.0.0-beta.0",
+    "@penrose/components": "^3.0.0",
+    "@penrose/core": "^3.0.0",
+    "@penrose/examples": "^3.0.0",
     "animals": "^0.0.3",
     "color-name-list": "^8.38.0",
     "flexlayout-react": "^0.7.3",

--- a/packages/editor/package.json
+++ b/packages/editor/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@penrose/editor",
   "private": true,
-  "version": "3.0.0",
+  "version": "3.0.0-beta.1",
   "scripts": {
     "start": "cross-env NODE_OPTIONS='--max-old-space-size=8192' vite",
     "dev": "cross-env NODE_OPTIONS='--max-old-space-size=8192' vite",
@@ -41,9 +41,9 @@
     }
   },
   "dependencies": {
-    "@penrose/components": "^3.0.0",
-    "@penrose/core": "^3.0.0",
-    "@penrose/examples": "^3.0.0",
+    "@penrose/components": "^3.0.0-beta.1",
+    "@penrose/core": "^3.0.0-beta.1",
+    "@penrose/examples": "^3.0.0-beta.1",
     "animals": "^0.0.3",
     "color-name-list": "^8.38.0",
     "flexlayout-react": "^0.7.3",

--- a/packages/examples/CHANGELOG.md
+++ b/packages/examples/CHANGELOG.md
@@ -3,7 +3,7 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-## [v3.0.0-beta.0](https://github.com/penrose/penrose/compare/v2.3.0...v3.0.0-beta.0) (2023-07-14)
+## [v3.0.0](https://github.com/penrose/penrose/compare/v2.3.0...v3.0.0) (2023-07-14)
 
 ### :warning: BREAKING CHANGE
 

--- a/packages/examples/CHANGELOG.md
+++ b/packages/examples/CHANGELOG.md
@@ -3,7 +3,7 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-## [v3.0.0](https://github.com/penrose/penrose/compare/v2.3.0...v3.0.0) (2023-07-14)
+## [v3.0.0-beta.1](https://github.com/penrose/penrose/compare/v2.3.0...v3.0.0-beta.1) (2023-07-14)
 
 ### :warning: BREAKING CHANGE
 

--- a/packages/examples/package.json
+++ b/packages/examples/package.json
@@ -1,11 +1,11 @@
 {
   "name": "@penrose/examples",
-  "version": "3.0.0",
+  "version": "3.0.0-beta.1",
   "private": true,
   "type": "module",
   "dependencies": {
-    "@penrose/core": "^3.0.0",
-    "@penrose/solids": "^3.0.0",
+    "@penrose/core": "^3.0.0-beta.1",
+    "@penrose/solids": "^3.0.0-beta.1",
     "solid-js": "^1"
   },
   "devDependencies": {

--- a/packages/examples/package.json
+++ b/packages/examples/package.json
@@ -1,11 +1,11 @@
 {
   "name": "@penrose/examples",
-  "version": "3.0.0-beta.0",
+  "version": "3.0.0",
   "private": true,
   "type": "module",
   "dependencies": {
-    "@penrose/core": "^3.0.0-beta.0",
-    "@penrose/solids": "^3.0.0-beta.0",
+    "@penrose/core": "^3.0.0",
+    "@penrose/solids": "^3.0.0",
     "solid-js": "^1"
   },
   "devDependencies": {

--- a/packages/optimizer/CHANGELOG.md
+++ b/packages/optimizer/CHANGELOG.md
@@ -3,7 +3,7 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-## [v3.0.0-beta.0](https://github.com/penrose/penrose/compare/v2.3.0...v3.0.0-beta.0) (2023-07-14)
+## [v3.0.0](https://github.com/penrose/penrose/compare/v2.3.0...v3.0.0) (2023-07-14)
 
 ### :warning: BREAKING CHANGE
 

--- a/packages/optimizer/CHANGELOG.md
+++ b/packages/optimizer/CHANGELOG.md
@@ -3,7 +3,7 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-## [v3.0.0](https://github.com/penrose/penrose/compare/v2.3.0...v3.0.0) (2023-07-14)
+## [v3.0.0-beta.1](https://github.com/penrose/penrose/compare/v2.3.0...v3.0.0-beta.1) (2023-07-14)
 
 ### :warning: BREAKING CHANGE
 

--- a/packages/optimizer/Cargo.toml
+++ b/packages/optimizer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "penrose-optimizer"
-version = "3.0.0-beta.0"
+version = "3.0.0"
 edition = "2021"
 publish = false
 

--- a/packages/optimizer/package.json
+++ b/packages/optimizer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@penrose/optimizer",
-  "version": "3.0.0-beta.0",
+  "version": "3.0.0",
   "type": "module",
   "author": "Penrose Team (https://penrose.cs.cmu.edu/)",
   "license": "MIT",

--- a/packages/optimizer/package.json
+++ b/packages/optimizer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@penrose/optimizer",
-  "version": "3.0.0",
+  "version": "3.0.0-beta.1",
   "type": "module",
   "author": "Penrose Team (https://penrose.cs.cmu.edu/)",
   "license": "MIT",

--- a/packages/roger/CHANGELOG.md
+++ b/packages/roger/CHANGELOG.md
@@ -3,7 +3,7 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-## [v3.0.0-beta.0](https://github.com/penrose/penrose/compare/v2.3.0...v3.0.0-beta.0) (2023-07-14)
+## [v3.0.0](https://github.com/penrose/penrose/compare/v2.3.0...v3.0.0) (2023-07-14)
 
 ### :warning: BREAKING CHANGE
 

--- a/packages/roger/CHANGELOG.md
+++ b/packages/roger/CHANGELOG.md
@@ -3,7 +3,7 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-## [v3.0.0](https://github.com/penrose/penrose/compare/v2.3.0...v3.0.0) (2023-07-14)
+## [v3.0.0-beta.1](https://github.com/penrose/penrose/compare/v2.3.0...v3.0.0-beta.1) (2023-07-14)
 
 ### :warning: BREAKING CHANGE
 

--- a/packages/roger/README.md
+++ b/packages/roger/README.md
@@ -1,7 +1,7 @@
 # `@penrose/roger`: a CLI for Penrose
 
 This package is a command-line application that depends on `@penrose/core` and
-processes Penrose diagrams. See [the docs on the Penrose website][].
+processes Penrose diagrams. See [the docs on the Penrose website][website docs].
 
 Usage:
 

--- a/packages/roger/package.json
+++ b/packages/roger/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@penrose/roger",
-  "version": "3.0.0",
+  "version": "3.0.0-beta.1",
   "description": "",
   "type": "module",
   "main": "index.tsx",
@@ -26,7 +26,7 @@
   "author": "Penrose Team (https://penrose.cs.cmu.edu/)",
   "license": "MIT",
   "dependencies": {
-    "@penrose/core": "^3.0.0",
+    "@penrose/core": "^3.0.0-beta.1",
     "canvas": "^2.8.0",
     "chalk": "^3.0.0",
     "chokidar": "^3.5.3",

--- a/packages/roger/package.json
+++ b/packages/roger/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@penrose/roger",
-  "version": "3.0.0-beta.0",
+  "version": "3.0.0",
   "description": "",
   "type": "module",
   "main": "index.tsx",
@@ -26,7 +26,7 @@
   "author": "Penrose Team (https://penrose.cs.cmu.edu/)",
   "license": "MIT",
   "dependencies": {
-    "@penrose/core": "^3.0.0-beta.0",
+    "@penrose/core": "^3.0.0",
     "canvas": "^2.8.0",
     "chalk": "^3.0.0",
     "chokidar": "^3.5.3",

--- a/packages/solids/CHANGELOG.md
+++ b/packages/solids/CHANGELOG.md
@@ -3,7 +3,7 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-## [v3.0.0-beta.0](https://github.com/penrose/penrose/compare/v2.3.0...v3.0.0-beta.0) (2023-07-14)
+## [v3.0.0](https://github.com/penrose/penrose/compare/v2.3.0...v3.0.0) (2023-07-14)
 
 ### :warning: BREAKING CHANGE
 

--- a/packages/solids/CHANGELOG.md
+++ b/packages/solids/CHANGELOG.md
@@ -3,7 +3,7 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-## [v3.0.0](https://github.com/penrose/penrose/compare/v2.3.0...v3.0.0) (2023-07-14)
+## [v3.0.0-beta.1](https://github.com/penrose/penrose/compare/v2.3.0...v3.0.0-beta.1) (2023-07-14)
 
 ### :warning: BREAKING CHANGE
 

--- a/packages/solids/package.json
+++ b/packages/solids/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@penrose/solids",
-  "version": "3.0.0-beta.0",
+  "version": "3.0.0",
   "private": true,
   "type": "module",
   "exports": {
@@ -9,8 +9,8 @@
     "default": "./dist/ssr/index.js"
   },
   "dependencies": {
-    "@penrose/core": "^3.0.0-beta.0",
-    "@penrose/optimizer": "^3.0.0-beta.0",
+    "@penrose/core": "^3.0.0",
+    "@penrose/optimizer": "^3.0.0",
     "markdown-it": "^13.0.1",
     "markdown-it-mathjax3": "^4.3.2",
     "solid-js": "^1"

--- a/packages/solids/package.json
+++ b/packages/solids/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@penrose/solids",
-  "version": "3.0.0",
+  "version": "3.0.0-beta.1",
   "private": true,
   "type": "module",
   "exports": {
@@ -9,8 +9,8 @@
     "default": "./dist/ssr/index.js"
   },
   "dependencies": {
-    "@penrose/core": "^3.0.0",
-    "@penrose/optimizer": "^3.0.0",
+    "@penrose/core": "^3.0.0-beta.1",
+    "@penrose/optimizer": "^3.0.0-beta.1",
     "markdown-it": "^13.0.1",
     "markdown-it-mathjax3": "^4.3.2",
     "solid-js": "^1"

--- a/packages/vscode/CHANGELOG.md
+++ b/packages/vscode/CHANGELOG.md
@@ -3,7 +3,7 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-## [v3.0.0-beta.0](https://github.com/penrose/penrose/compare/v2.3.0...v3.0.0-beta.0) (2023-07-14)
+## [v3.0.0](https://github.com/penrose/penrose/compare/v2.3.0...v3.0.0) (2023-07-14)
 
 ### :warning: BREAKING CHANGE
 

--- a/packages/vscode/CHANGELOG.md
+++ b/packages/vscode/CHANGELOG.md
@@ -3,7 +3,7 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-## [v3.0.0](https://github.com/penrose/penrose/compare/v2.3.0...v3.0.0) (2023-07-14)
+## [v3.0.0-beta.1](https://github.com/penrose/penrose/compare/v2.3.0...v3.0.0-beta.1) (2023-07-14)
 
 ### :warning: BREAKING CHANGE
 

--- a/packages/vscode/package.json
+++ b/packages/vscode/package.json
@@ -3,7 +3,7 @@
   "displayName": "Penrose",
   "publisher": "penrose",
   "description": "Penrose languages bundle",
-  "version": "3.0.0",
+  "version": "3.0.0-beta.1",
   "author": "Penrose Team (https://penrose.cs.cmu.edu/)",
   "license": "MIT",
   "private": true,

--- a/packages/vscode/package.json
+++ b/packages/vscode/package.json
@@ -3,7 +3,7 @@
   "displayName": "Penrose",
   "publisher": "penrose",
   "description": "Penrose languages bundle",
-  "version": "3.0.0-beta.0",
+  "version": "3.0.0",
   "author": "Penrose Team (https://penrose.cs.cmu.edu/)",
   "license": "MIT",
   "private": true,


### PR DESCRIPTION
# Description

This PR follows up on #1542, releasing another beta with a few fixes:

- fixed link in [`@penrose/roger`](https://www.npmjs.com/package/@penrose/roger/v/3.0.0-beta.0) README
- `@penrose/components` now _actually_ doesn't depend on `@penrose/examples`
- Discord link now properly points to welcome channel

# Checklist

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have reviewed any generated registry diagram changes