### PR TITLE
feat: Update 3D Spectral Graphs

### DIFF
--- a/packages/examples/src/registry.json
+++ b/packages/examples/src/registry.json
@@ -427,7 +427,7 @@
   },
   "spectral-graphs/examples/dodecahedral-graph": {
     "name": "Dodecahedral Graph",
-    "gallery": false
+    "gallery": true
   },
   "atoms-and-bonds/wet-floor": { "name": "Wet Floor", "gallery": true },
   "curve-examples/offset": {
@@ -446,8 +446,12 @@
     "name": "Evolute of Cardioid",
     "gallery": false
   },
+  "spectral-graphs/examples/truncated-cube-graph": {
+    "name": "Truncated Cube Graph",
+    "gallery": false
+  },
   "spectral-graphs/examples/torus": {
     "name": "Periodic 2D Grid",
-    "gallery": true
+    "gallery": false
   }
 }

--- a/packages/examples/src/registry.json
+++ b/packages/examples/src/registry.json
@@ -453,5 +453,9 @@
   "spectral-graphs/examples/torus": {
     "name": "Periodic 2D Grid",
     "gallery": false
+  },
+  "spectral-graphs/examples/periodic-hexagonal-grid": {
+    "name": "Periodic Hexagonal Grid",
+    "gallery": false
   }
 }

--- a/packages/examples/src/registry.json
+++ b/packages/examples/src/registry.json
@@ -454,7 +454,7 @@
     "name": "Periodic 2D Grid",
     "gallery": false
   },
-  "spectral-graphs/examples/periodic-hexagonal-grid": {
+  "spectral-graphs/examples/periodic-hexagonal-lattice": {
     "name": "Periodic Hexagonal Grid",
     "gallery": false
   }

--- a/packages/examples/src/registry.json
+++ b/packages/examples/src/registry.json
@@ -427,7 +427,7 @@
   },
   "spectral-graphs/examples/dodecahedral-graph": {
     "name": "Dodecahedral Graph",
-    "gallery": true
+    "gallery": false
   },
   "atoms-and-bonds/wet-floor": { "name": "Wet Floor", "gallery": true },
   "curve-examples/offset": {
@@ -445,5 +445,9 @@
   "curve-examples/evolute-of-cardioid": {
     "name": "Evolute of Cardioid",
     "gallery": false
+  },
+  "spectral-graphs/examples/torus": {
+    "name": "Periodic 2D Grid",
+    "gallery": true
   }
 }

--- a/packages/examples/src/spectral-graphs/3d.style
+++ b/packages/examples/src/spectral-graphs/3d.style
@@ -3,9 +3,29 @@ canvas {
   height = 400
 }
 
-color {
-  black = #000000ff
-  gray = #5b5b5ba2
+colors {
+  scalar hue = ?
+  color background = hsva(hue, 80, 40, 1)
+  color bloom = hsva(hue, 50, 80, .6)
+  color center = hsva(hue, 0, 100, 1)
+  color edge = hsva(hue, 20, 90, 0.5)
+  color black = #000000ff
+}
+
+global {
+  shape background = Rectangle {
+    center: (0,0)
+    width: canvas.width
+    height: canvas.height
+    fillColor: colors.background
+  }
+  shape shade = Circle {
+    center: (0,0)
+    r: canvas.width / 2
+    fillColor: colors.black
+    style: "filter:blur(50px);"
+  }
+  shade above background
 }
 
 forall Node n {
@@ -14,8 +34,16 @@ forall Node n {
     shape n.icon = Circle {
         center: (n.center[0], n.center[1])
         r: 4 + n.center[2] / 40
-        fillColor: color.black
+        fillColor: colors.bloom
+        style: "filter:blur(1.8px);"
     }
+    shape n.icon2 = Circle {
+        center: (n.center[0], n.center[1])
+        r: 0.5 * (4 + n.center[2] / 40)
+        fillColor: colors.center
+        style: "filter:blur(0.4px);"
+    }
+    n.icon2 above n.icon
 }
 
 forall Edge e; Node a; Node b
@@ -25,8 +53,9 @@ where e := MakeEdge(a, b) {
     shape e.icon = Line {
         start: a.icon.center
         end: b.icon.center
-        strokeWidth: 3 + e.z / 60
-        strokeColor: color.gray
+        strokeWidth: 0.5 * (3 + e.z / 60)
+        strokeColor: colors.edge
+        style: "filter:blur(0.3px);"
     }
 }
 

--- a/packages/examples/src/spectral-graphs/examples/dodecahedral-graph.trio.json
+++ b/packages/examples/src/spectral-graphs/examples/dodecahedral-graph.trio.json
@@ -1,6 +1,6 @@
 {
   "substance": "./dodecahedral-graph.substance",
-  "style": ["./../3d.style"],
+  "style": ["./../colors.style"],
   "domain": "./../graph.domain",
-  "variation": "MeridianTarsier82735"
+  "variation": "StromboliCat61816"
 }

--- a/packages/examples/src/spectral-graphs/examples/dodecahedral-graph.trio.json
+++ b/packages/examples/src/spectral-graphs/examples/dodecahedral-graph.trio.json
@@ -1,6 +1,6 @@
 {
   "substance": "./dodecahedral-graph.substance",
-  "style": ["./../colors.style"],
+  "style": ["./../3d.style"],
   "domain": "./../graph.domain",
-  "variation": "StromboliCat61816"
+  "variation": "MeridianTarsier82735"
 }

--- a/packages/examples/src/spectral-graphs/examples/generator.py
+++ b/packages/examples/src/spectral-graphs/examples/generator.py
@@ -1,0 +1,37 @@
+import networkx as nx
+
+
+def basic_substance(nx_func, *args) -> str:
+    sub = ''
+    g = nx_func(*args)
+    for node in g.nodes():
+        sub += f'Node n{node}\n'
+    for i, (a, b) in enumerate(g.edges()):
+        sub += f'Edge e{i} := MakeEdge(n{a}, n{b})\n'
+    return sub
+
+
+def _grid_node_str(node: tuple[int]) -> str:
+    return 'n' + 'x'.join(str(i) for i in node)
+
+
+def grid_substance(nx_func, *args) -> str:
+    g = nx_func(*args)
+    sub = ''
+    for node in g.nodes():
+        sub += f'Node {_grid_node_str(node)}\n'
+    for i, (a, b) in enumerate(g.edges()):
+        sub += f'Edge e{i} := MakeEdge({_grid_node_str(a)}, {_grid_node_str(b)})\n'
+    return sub
+
+
+if __name__ == '__main__':
+    # Usage examples:
+    # sub = basic_substance(nx.truncated_cube_graph)
+    sub = grid_substance(nx.hexagonal_lattice_graph, 9, 6, True)
+
+    # See documentation:
+    # https://networkx.org/documentation/stable/reference/generators.html
+
+    # Print or save to file:
+    print(sub)

--- a/packages/examples/src/spectral-graphs/examples/periodic-hexagonal-lattice.substance
+++ b/packages/examples/src/spectral-graphs/examples/periodic-hexagonal-lattice.substance
@@ -1,0 +1,150 @@
+Node n0x0
+Node n0x1
+Node n0x2
+Node n0x3
+Node n0x4
+Node n0x5
+Node n0x6
+Node n0x7
+Node n0x8
+Node n0x9
+Node n1x0
+Node n1x1
+Node n1x2
+Node n1x3
+Node n1x4
+Node n1x5
+Node n1x6
+Node n1x7
+Node n1x8
+Node n1x9
+Node n2x0
+Node n2x1
+Node n2x2
+Node n2x3
+Node n2x4
+Node n2x5
+Node n2x6
+Node n2x7
+Node n2x8
+Node n2x9
+Node n3x0
+Node n3x1
+Node n3x2
+Node n3x3
+Node n3x4
+Node n3x5
+Node n3x6
+Node n3x7
+Node n3x8
+Node n3x9
+Node n4x0
+Node n4x1
+Node n4x2
+Node n4x3
+Node n4x4
+Node n4x5
+Node n4x6
+Node n4x7
+Node n4x8
+Node n4x9
+Node n5x0
+Node n5x1
+Node n5x2
+Node n5x3
+Node n5x4
+Node n5x5
+Node n5x6
+Node n5x7
+Node n5x8
+Node n5x9
+Edge e0 := MakeEdge(n0x0, n0x1)
+Edge e1 := MakeEdge(n0x0, n1x0)
+Edge e2 := MakeEdge(n0x0, n0x9)
+Edge e3 := MakeEdge(n0x1, n0x2)
+Edge e4 := MakeEdge(n0x1, n5x1)
+Edge e5 := MakeEdge(n0x2, n0x3)
+Edge e6 := MakeEdge(n0x2, n1x2)
+Edge e7 := MakeEdge(n0x3, n0x4)
+Edge e8 := MakeEdge(n0x3, n5x3)
+Edge e9 := MakeEdge(n0x4, n0x5)
+Edge e10 := MakeEdge(n0x4, n1x4)
+Edge e11 := MakeEdge(n0x5, n0x6)
+Edge e12 := MakeEdge(n0x5, n5x5)
+Edge e13 := MakeEdge(n0x6, n0x7)
+Edge e14 := MakeEdge(n0x6, n1x6)
+Edge e15 := MakeEdge(n0x7, n0x8)
+Edge e16 := MakeEdge(n0x7, n5x7)
+Edge e17 := MakeEdge(n0x8, n0x9)
+Edge e18 := MakeEdge(n0x8, n1x8)
+Edge e19 := MakeEdge(n0x9, n5x9)
+Edge e20 := MakeEdge(n1x0, n1x1)
+Edge e21 := MakeEdge(n1x0, n1x9)
+Edge e22 := MakeEdge(n1x1, n1x2)
+Edge e23 := MakeEdge(n1x1, n2x1)
+Edge e24 := MakeEdge(n1x2, n1x3)
+Edge e25 := MakeEdge(n1x3, n1x4)
+Edge e26 := MakeEdge(n1x3, n2x3)
+Edge e27 := MakeEdge(n1x4, n1x5)
+Edge e28 := MakeEdge(n1x5, n1x6)
+Edge e29 := MakeEdge(n1x5, n2x5)
+Edge e30 := MakeEdge(n1x6, n1x7)
+Edge e31 := MakeEdge(n1x7, n1x8)
+Edge e32 := MakeEdge(n1x7, n2x7)
+Edge e33 := MakeEdge(n1x8, n1x9)
+Edge e34 := MakeEdge(n1x9, n2x9)
+Edge e35 := MakeEdge(n2x0, n2x1)
+Edge e36 := MakeEdge(n2x0, n3x0)
+Edge e37 := MakeEdge(n2x0, n2x9)
+Edge e38 := MakeEdge(n2x1, n2x2)
+Edge e39 := MakeEdge(n2x2, n2x3)
+Edge e40 := MakeEdge(n2x2, n3x2)
+Edge e41 := MakeEdge(n2x3, n2x4)
+Edge e42 := MakeEdge(n2x4, n2x5)
+Edge e43 := MakeEdge(n2x4, n3x4)
+Edge e44 := MakeEdge(n2x5, n2x6)
+Edge e45 := MakeEdge(n2x6, n2x7)
+Edge e46 := MakeEdge(n2x6, n3x6)
+Edge e47 := MakeEdge(n2x7, n2x8)
+Edge e48 := MakeEdge(n2x8, n2x9)
+Edge e49 := MakeEdge(n2x8, n3x8)
+Edge e50 := MakeEdge(n3x0, n3x1)
+Edge e51 := MakeEdge(n3x0, n3x9)
+Edge e52 := MakeEdge(n3x1, n3x2)
+Edge e53 := MakeEdge(n3x1, n4x1)
+Edge e54 := MakeEdge(n3x2, n3x3)
+Edge e55 := MakeEdge(n3x3, n3x4)
+Edge e56 := MakeEdge(n3x3, n4x3)
+Edge e57 := MakeEdge(n3x4, n3x5)
+Edge e58 := MakeEdge(n3x5, n3x6)
+Edge e59 := MakeEdge(n3x5, n4x5)
+Edge e60 := MakeEdge(n3x6, n3x7)
+Edge e61 := MakeEdge(n3x7, n3x8)
+Edge e62 := MakeEdge(n3x7, n4x7)
+Edge e63 := MakeEdge(n3x8, n3x9)
+Edge e64 := MakeEdge(n3x9, n4x9)
+Edge e65 := MakeEdge(n4x0, n4x1)
+Edge e66 := MakeEdge(n4x0, n5x0)
+Edge e67 := MakeEdge(n4x0, n4x9)
+Edge e68 := MakeEdge(n4x1, n4x2)
+Edge e69 := MakeEdge(n4x2, n4x3)
+Edge e70 := MakeEdge(n4x2, n5x2)
+Edge e71 := MakeEdge(n4x3, n4x4)
+Edge e72 := MakeEdge(n4x4, n4x5)
+Edge e73 := MakeEdge(n4x4, n5x4)
+Edge e74 := MakeEdge(n4x5, n4x6)
+Edge e75 := MakeEdge(n4x6, n4x7)
+Edge e76 := MakeEdge(n4x6, n5x6)
+Edge e77 := MakeEdge(n4x7, n4x8)
+Edge e78 := MakeEdge(n4x8, n4x9)
+Edge e79 := MakeEdge(n4x8, n5x8)
+Edge e80 := MakeEdge(n5x0, n5x1)
+Edge e81 := MakeEdge(n5x0, n5x9)
+Edge e82 := MakeEdge(n5x1, n5x2)
+Edge e83 := MakeEdge(n5x2, n5x3)
+Edge e84 := MakeEdge(n5x3, n5x4)
+Edge e85 := MakeEdge(n5x4, n5x5)
+Edge e86 := MakeEdge(n5x5, n5x6)
+Edge e87 := MakeEdge(n5x6, n5x7)
+Edge e88 := MakeEdge(n5x7, n5x8)
+Edge e89 := MakeEdge(n5x8, n5x9)

--- a/packages/examples/src/spectral-graphs/examples/periodic-hexagonal-lattice.trio.json
+++ b/packages/examples/src/spectral-graphs/examples/periodic-hexagonal-lattice.trio.json
@@ -1,0 +1,6 @@
+{
+  "substance": "./periodic-hexagonal-lattice.substance",
+  "style": ["./../3d.style"],
+  "domain": "./../graph.domain",
+  "variation": "BeetrootFrog89085"
+}

--- a/packages/examples/src/spectral-graphs/examples/torus.substance
+++ b/packages/examples/src/spectral-graphs/examples/torus.substance
@@ -1,0 +1,289 @@
+Node n0x0
+Node n0x1
+Node n0x2
+Node n0x3
+Node n0x4
+Node n0x5
+Node n0x6
+Node n0x7
+Node n0x8
+Node n0x9
+Node n0x10
+Node n0x11
+Node n0x12
+Node n0x13
+Node n0x14
+Node n0x15
+Node n1x0
+Node n1x1
+Node n1x2
+Node n1x3
+Node n1x4
+Node n1x5
+Node n1x6
+Node n1x7
+Node n1x8
+Node n1x9
+Node n1x10
+Node n1x11
+Node n1x12
+Node n1x13
+Node n1x14
+Node n1x15
+Node n2x0
+Node n2x1
+Node n2x2
+Node n2x3
+Node n2x4
+Node n2x5
+Node n2x6
+Node n2x7
+Node n2x8
+Node n2x9
+Node n2x10
+Node n2x11
+Node n2x12
+Node n2x13
+Node n2x14
+Node n2x15
+Node n3x0
+Node n3x1
+Node n3x2
+Node n3x3
+Node n3x4
+Node n3x5
+Node n3x6
+Node n3x7
+Node n3x8
+Node n3x9
+Node n3x10
+Node n3x11
+Node n3x12
+Node n3x13
+Node n3x14
+Node n3x15
+Node n4x0
+Node n4x1
+Node n4x2
+Node n4x3
+Node n4x4
+Node n4x5
+Node n4x6
+Node n4x7
+Node n4x8
+Node n4x9
+Node n4x10
+Node n4x11
+Node n4x12
+Node n4x13
+Node n4x14
+Node n4x15
+Node n5x0
+Node n5x1
+Node n5x2
+Node n5x3
+Node n5x4
+Node n5x5
+Node n5x6
+Node n5x7
+Node n5x8
+Node n5x9
+Node n5x10
+Node n5x11
+Node n5x12
+Node n5x13
+Node n5x14
+Node n5x15
+
+Edge e0 := MakeEdge(n0x0, n1x0)
+Edge e1 := MakeEdge(n0x0, n5x0)
+Edge e2 := MakeEdge(n0x0, n0x1)
+Edge e3 := MakeEdge(n0x0, n0x15)
+Edge e4 := MakeEdge(n0x1, n1x1)
+Edge e5 := MakeEdge(n0x1, n5x1)
+Edge e6 := MakeEdge(n0x1, n0x2)
+Edge e7 := MakeEdge(n0x2, n1x2)
+Edge e8 := MakeEdge(n0x2, n5x2)
+Edge e9 := MakeEdge(n0x2, n0x3)
+Edge e10 := MakeEdge(n0x3, n1x3)
+Edge e11 := MakeEdge(n0x3, n5x3)
+Edge e12 := MakeEdge(n0x3, n0x4)
+Edge e13 := MakeEdge(n0x4, n1x4)
+Edge e14 := MakeEdge(n0x4, n5x4)
+Edge e15 := MakeEdge(n0x4, n0x5)
+Edge e16 := MakeEdge(n0x5, n1x5)
+Edge e17 := MakeEdge(n0x5, n5x5)
+Edge e18 := MakeEdge(n0x5, n0x6)
+Edge e19 := MakeEdge(n0x6, n1x6)
+Edge e20 := MakeEdge(n0x6, n5x6)
+Edge e21 := MakeEdge(n0x6, n0x7)
+Edge e22 := MakeEdge(n0x7, n1x7)
+Edge e23 := MakeEdge(n0x7, n5x7)
+Edge e24 := MakeEdge(n0x7, n0x8)
+Edge e25 := MakeEdge(n0x8, n1x8)
+Edge e26 := MakeEdge(n0x8, n5x8)
+Edge e27 := MakeEdge(n0x8, n0x9)
+Edge e28 := MakeEdge(n0x9, n1x9)
+Edge e29 := MakeEdge(n0x9, n5x9)
+Edge e30 := MakeEdge(n0x9, n0x10)
+Edge e31 := MakeEdge(n0x10, n1x10)
+Edge e32 := MakeEdge(n0x10, n5x10)
+Edge e33 := MakeEdge(n0x10, n0x11)
+Edge e34 := MakeEdge(n0x11, n1x11)
+Edge e35 := MakeEdge(n0x11, n5x11)
+Edge e36 := MakeEdge(n0x11, n0x12)
+Edge e37 := MakeEdge(n0x12, n1x12)
+Edge e38 := MakeEdge(n0x12, n5x12)
+Edge e39 := MakeEdge(n0x12, n0x13)
+Edge e40 := MakeEdge(n0x13, n1x13)
+Edge e41 := MakeEdge(n0x13, n5x13)
+Edge e42 := MakeEdge(n0x13, n0x14)
+Edge e43 := MakeEdge(n0x14, n1x14)
+Edge e44 := MakeEdge(n0x14, n5x14)
+Edge e45 := MakeEdge(n0x14, n0x15)
+Edge e46 := MakeEdge(n0x15, n1x15)
+Edge e47 := MakeEdge(n0x15, n5x15)
+Edge e48 := MakeEdge(n1x0, n2x0)
+Edge e49 := MakeEdge(n1x0, n1x1)
+Edge e50 := MakeEdge(n1x0, n1x15)
+Edge e51 := MakeEdge(n1x1, n2x1)
+Edge e52 := MakeEdge(n1x1, n1x2)
+Edge e53 := MakeEdge(n1x2, n2x2)
+Edge e54 := MakeEdge(n1x2, n1x3)
+Edge e55 := MakeEdge(n1x3, n2x3)
+Edge e56 := MakeEdge(n1x3, n1x4)
+Edge e57 := MakeEdge(n1x4, n2x4)
+Edge e58 := MakeEdge(n1x4, n1x5)
+Edge e59 := MakeEdge(n1x5, n2x5)
+Edge e60 := MakeEdge(n1x5, n1x6)
+Edge e61 := MakeEdge(n1x6, n2x6)
+Edge e62 := MakeEdge(n1x6, n1x7)
+Edge e63 := MakeEdge(n1x7, n2x7)
+Edge e64 := MakeEdge(n1x7, n1x8)
+Edge e65 := MakeEdge(n1x8, n2x8)
+Edge e66 := MakeEdge(n1x8, n1x9)
+Edge e67 := MakeEdge(n1x9, n2x9)
+Edge e68 := MakeEdge(n1x9, n1x10)
+Edge e69 := MakeEdge(n1x10, n2x10)
+Edge e70 := MakeEdge(n1x10, n1x11)
+Edge e71 := MakeEdge(n1x11, n2x11)
+Edge e72 := MakeEdge(n1x11, n1x12)
+Edge e73 := MakeEdge(n1x12, n2x12)
+Edge e74 := MakeEdge(n1x12, n1x13)
+Edge e75 := MakeEdge(n1x13, n2x13)
+Edge e76 := MakeEdge(n1x13, n1x14)
+Edge e77 := MakeEdge(n1x14, n2x14)
+Edge e78 := MakeEdge(n1x14, n1x15)
+Edge e79 := MakeEdge(n1x15, n2x15)
+Edge e80 := MakeEdge(n2x0, n3x0)
+Edge e81 := MakeEdge(n2x0, n2x1)
+Edge e82 := MakeEdge(n2x0, n2x15)
+Edge e83 := MakeEdge(n2x1, n3x1)
+Edge e84 := MakeEdge(n2x1, n2x2)
+Edge e85 := MakeEdge(n2x2, n3x2)
+Edge e86 := MakeEdge(n2x2, n2x3)
+Edge e87 := MakeEdge(n2x3, n3x3)
+Edge e88 := MakeEdge(n2x3, n2x4)
+Edge e89 := MakeEdge(n2x4, n3x4)
+Edge e90 := MakeEdge(n2x4, n2x5)
+Edge e91 := MakeEdge(n2x5, n3x5)
+Edge e92 := MakeEdge(n2x5, n2x6)
+Edge e93 := MakeEdge(n2x6, n3x6)
+Edge e94 := MakeEdge(n2x6, n2x7)
+Edge e95 := MakeEdge(n2x7, n3x7)
+Edge e96 := MakeEdge(n2x7, n2x8)
+Edge e97 := MakeEdge(n2x8, n3x8)
+Edge e98 := MakeEdge(n2x8, n2x9)
+Edge e99 := MakeEdge(n2x9, n3x9)
+Edge e100 := MakeEdge(n2x9, n2x10)
+Edge e101 := MakeEdge(n2x10, n3x10)
+Edge e102 := MakeEdge(n2x10, n2x11)
+Edge e103 := MakeEdge(n2x11, n3x11)
+Edge e104 := MakeEdge(n2x11, n2x12)
+Edge e105 := MakeEdge(n2x12, n3x12)
+Edge e106 := MakeEdge(n2x12, n2x13)
+Edge e107 := MakeEdge(n2x13, n3x13)
+Edge e108 := MakeEdge(n2x13, n2x14)
+Edge e109 := MakeEdge(n2x14, n3x14)
+Edge e110 := MakeEdge(n2x14, n2x15)
+Edge e111 := MakeEdge(n2x15, n3x15)
+Edge e112 := MakeEdge(n3x0, n4x0)
+Edge e113 := MakeEdge(n3x0, n3x1)
+Edge e114 := MakeEdge(n3x0, n3x15)
+Edge e115 := MakeEdge(n3x1, n4x1)
+Edge e116 := MakeEdge(n3x1, n3x2)
+Edge e117 := MakeEdge(n3x2, n4x2)
+Edge e118 := MakeEdge(n3x2, n3x3)
+Edge e119 := MakeEdge(n3x3, n4x3)
+Edge e120 := MakeEdge(n3x3, n3x4)
+Edge e121 := MakeEdge(n3x4, n4x4)
+Edge e122 := MakeEdge(n3x4, n3x5)
+Edge e123 := MakeEdge(n3x5, n4x5)
+Edge e124 := MakeEdge(n3x5, n3x6)
+Edge e125 := MakeEdge(n3x6, n4x6)
+Edge e126 := MakeEdge(n3x6, n3x7)
+Edge e127 := MakeEdge(n3x7, n4x7)
+Edge e128 := MakeEdge(n3x7, n3x8)
+Edge e129 := MakeEdge(n3x8, n4x8)
+Edge e130 := MakeEdge(n3x8, n3x9)
+Edge e131 := MakeEdge(n3x9, n4x9)
+Edge e132 := MakeEdge(n3x9, n3x10)
+Edge e133 := MakeEdge(n3x10, n4x10)
+Edge e134 := MakeEdge(n3x10, n3x11)
+Edge e135 := MakeEdge(n3x11, n4x11)
+Edge e136 := MakeEdge(n3x11, n3x12)
+Edge e137 := MakeEdge(n3x12, n4x12)
+Edge e138 := MakeEdge(n3x12, n3x13)
+Edge e139 := MakeEdge(n3x13, n4x13)
+Edge e140 := MakeEdge(n3x13, n3x14)
+Edge e141 := MakeEdge(n3x14, n4x14)
+Edge e142 := MakeEdge(n3x14, n3x15)
+Edge e143 := MakeEdge(n3x15, n4x15)
+Edge e144 := MakeEdge(n4x0, n5x0)
+Edge e145 := MakeEdge(n4x0, n4x1)
+Edge e146 := MakeEdge(n4x0, n4x15)
+Edge e147 := MakeEdge(n4x1, n5x1)
+Edge e148 := MakeEdge(n4x1, n4x2)
+Edge e149 := MakeEdge(n4x2, n5x2)
+Edge e150 := MakeEdge(n4x2, n4x3)
+Edge e151 := MakeEdge(n4x3, n5x3)
+Edge e152 := MakeEdge(n4x3, n4x4)
+Edge e153 := MakeEdge(n4x4, n5x4)
+Edge e154 := MakeEdge(n4x4, n4x5)
+Edge e155 := MakeEdge(n4x5, n5x5)
+Edge e156 := MakeEdge(n4x5, n4x6)
+Edge e157 := MakeEdge(n4x6, n5x6)
+Edge e158 := MakeEdge(n4x6, n4x7)
+Edge e159 := MakeEdge(n4x7, n5x7)
+Edge e160 := MakeEdge(n4x7, n4x8)
+Edge e161 := MakeEdge(n4x8, n5x8)
+Edge e162 := MakeEdge(n4x8, n4x9)
+Edge e163 := MakeEdge(n4x9, n5x9)
+Edge e164 := MakeEdge(n4x9, n4x10)
+Edge e165 := MakeEdge(n4x10, n5x10)
+Edge e166 := MakeEdge(n4x10, n4x11)
+Edge e167 := MakeEdge(n4x11, n5x11)
+Edge e168 := MakeEdge(n4x11, n4x12)
+Edge e169 := MakeEdge(n4x12, n5x12)
+Edge e170 := MakeEdge(n4x12, n4x13)
+Edge e171 := MakeEdge(n4x13, n5x13)
+Edge e172 := MakeEdge(n4x13, n4x14)
+Edge e173 := MakeEdge(n4x14, n5x14)
+Edge e174 := MakeEdge(n4x14, n4x15)
+Edge e175 := MakeEdge(n4x15, n5x15)
+Edge e176 := MakeEdge(n5x0, n5x1)
+Edge e177 := MakeEdge(n5x0, n5x15)
+Edge e178 := MakeEdge(n5x1, n5x2)
+Edge e179 := MakeEdge(n5x2, n5x3)
+Edge e180 := MakeEdge(n5x3, n5x4)
+Edge e181 := MakeEdge(n5x4, n5x5)
+Edge e182 := MakeEdge(n5x5, n5x6)
+Edge e183 := MakeEdge(n5x6, n5x7)
+Edge e184 := MakeEdge(n5x7, n5x8)
+Edge e185 := MakeEdge(n5x8, n5x9)
+Edge e186 := MakeEdge(n5x9, n5x10)
+Edge e187 := MakeEdge(n5x10, n5x11)
+Edge e188 := MakeEdge(n5x11, n5x12)
+Edge e189 := MakeEdge(n5x12, n5x13)
+Edge e190 := MakeEdge(n5x13, n5x14)
+Edge e191 := MakeEdge(n5x14, n5x15)

--- a/packages/examples/src/spectral-graphs/examples/torus.trio.json
+++ b/packages/examples/src/spectral-graphs/examples/torus.trio.json
@@ -1,0 +1,6 @@
+{
+  "substance": "./torus.substance",
+  "style": ["./../3d.style"],
+  "domain": "./../graph.domain",
+  "variation": "LagoonDogfish071"
+}

--- a/packages/examples/src/spectral-graphs/examples/truncated-cube-graph.substance
+++ b/packages/examples/src/spectral-graphs/examples/truncated-cube-graph.substance
@@ -1,0 +1,60 @@
+Node n0
+Node n1
+Node n2
+Node n3
+Node n4
+Node n5
+Node n6
+Node n7
+Node n8
+Node n9
+Node n10
+Node n11
+Node n12
+Node n13
+Node n14
+Node n15
+Node n16
+Node n17
+Node n18
+Node n19
+Node n20
+Node n21
+Node n22
+Node n23
+Edge e0 := MakeEdge(n0, n1)
+Edge e1 := MakeEdge(n0, n2)
+Edge e2 := MakeEdge(n0, n4)
+Edge e3 := MakeEdge(n1, n11)
+Edge e4 := MakeEdge(n1, n14)
+Edge e5 := MakeEdge(n2, n3)
+Edge e6 := MakeEdge(n2, n4)
+Edge e7 := MakeEdge(n3, n6)
+Edge e8 := MakeEdge(n3, n8)
+Edge e9 := MakeEdge(n4, n5)
+Edge e10 := MakeEdge(n5, n16)
+Edge e11 := MakeEdge(n5, n18)
+Edge e12 := MakeEdge(n6, n7)
+Edge e13 := MakeEdge(n6, n8)
+Edge e14 := MakeEdge(n7, n10)
+Edge e15 := MakeEdge(n7, n12)
+Edge e16 := MakeEdge(n8, n9)
+Edge e17 := MakeEdge(n9, n17)
+Edge e18 := MakeEdge(n9, n20)
+Edge e19 := MakeEdge(n10, n11)
+Edge e20 := MakeEdge(n10, n12)
+Edge e21 := MakeEdge(n11, n14)
+Edge e22 := MakeEdge(n12, n13)
+Edge e23 := MakeEdge(n13, n21)
+Edge e24 := MakeEdge(n13, n22)
+Edge e25 := MakeEdge(n14, n15)
+Edge e26 := MakeEdge(n15, n19)
+Edge e27 := MakeEdge(n15, n23)
+Edge e28 := MakeEdge(n16, n17)
+Edge e29 := MakeEdge(n16, n18)
+Edge e30 := MakeEdge(n17, n20)
+Edge e31 := MakeEdge(n18, n19)
+Edge e32 := MakeEdge(n19, n23)
+Edge e33 := MakeEdge(n20, n21)
+Edge e34 := MakeEdge(n21, n22)
+Edge e35 := MakeEdge(n22, n23)

--- a/packages/examples/src/spectral-graphs/examples/truncated-cube-graph.trio.json
+++ b/packages/examples/src/spectral-graphs/examples/truncated-cube-graph.trio.json
@@ -1,0 +1,6 @@
+{
+  "substance": "./truncated-cube-graph.substance",
+  "style": ["./../3d.style"],
+  "domain": "./../graph.domain",
+  "variation": "ParamountMonkey376"
+}


### PR DESCRIPTION
# Description

Updated 3D style of spectral graphs from #1487. Added 3 examples to the registry.

# Implementation strategy and design decisions

Heavily uses blur effect from SVG enabled by #1517.

Added a python script for generating substance files for more complex examples:
`packages/examples/src/spectral-graphs/examples/generator.py`

# Examples with steps to reproduce them

<img src="https://github.com/penrose/penrose/assets/77366866/115458d6-b874-4929-b9da-70bb2f37a08f" width="400" height="400">

<img src="https://github.com/penrose/penrose/assets/77366866/2a785453-b5e0-4128-a613-cad162e1b98c" width="400" height="400">

<img src="https://github.com/penrose/penrose/assets/77366866/e67badfd-79ad-4899-a98c-f559019e58e5" width="400" height="400">

<img src="https://github.com/penrose/penrose/assets/77366866/d14aba57-4da8-45da-8d01-e84c31d04fa1" width="400" height="400">

<img src="https://github.com/penrose/penrose/assets/77366866/529c436e-80a2-4938-bdfc-12286d9fabdb" width="400" height="400">

<img src="https://github.com/penrose/penrose/assets/77366866/e665887f-3e06-42a2-bb43-fb4183cc5c5b" width="400" height="400">

<img src="https://github.com/penrose/penrose/assets/77366866/ea246409-4a2d-4cbf-8bdd-005916a7f629" width="400" height="400">

<img src="https://github.com/penrose/penrose/assets/77366866/0315e679-168e-4147-a475-8589e5706654" width="400" height="400">

# Checklist

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have reviewed any generated registry diagram changes

# Open questions

- Use perspective projection instead of orthogonal (using matrix operations from #1538)
