### PR TITLE
docs: add a short intro to v3 blog post

### DIFF
--- a/packages/docs-site/blog/v3.md
+++ b/packages/docs-site/blog/v3.md
@@ -21,11 +21,13 @@ const trios = [...registry.entries()]
 
 <BlogMeta />
 
-We are excited to announce Penrose 3.0! We've added many exciting diagrams to
+We are excited to announce [Penrose](/) 3.0! We've added many exciting diagrams to
 our collection, reworked our core API, and improved support for more complex
 geometric queries... among many other things!
 
 ---
+
+[Penrose](/) is a tool for making beautiful diagrams in any area of science, mathematics, or engineering.
 
 ## 🎨 New Diagrams
 

--- a/packages/docs-site/blog/v3.md
+++ b/packages/docs-site/blog/v3.md
@@ -27,7 +27,7 @@ geometric queries... among many other things!
 
 ---
 
-[Penrose](/) is a tool for making beautiful diagrams in any area of science, mathematics, or engineering.
+[Penrose](/) is a tool for making beautiful diagrams in any area of science, mathematics, or engineering. It’s made for those of us who can’t (or don’t want to!) draw beautiful diagrams by hand.
 
 ## 🎨 New Diagrams
 


### PR DESCRIPTION
# Description

Adding a short intro to Penrose to the beginning of https://penrose.cs.cmu.edu/blog/v3 for better context.