### PR TITLE
docs: improve blog excerpt styling

### DIFF
--- a/packages/docs-site/.vitepress/theme/BlogHome.vue
+++ b/packages/docs-site/.vitepress/theme/BlogHome.vue
@@ -26,7 +26,7 @@
                 </h2>
                 <div
                   v-if="excerpt"
-                  class="prose dark:prose-invert max-w-none text-slate-900 dark:text-gray-400"
+                  class="max-w-none py-4"
                   v-html="excerpt"
                 ></div>
               </div>

--- a/packages/docs-site/blog.md
+++ b/packages/docs-site/blog.md
@@ -1,5 +1,5 @@
 ---
-layout: home
+layout: page
 title: Penrose Blog
 subtext: Welcome to the Penrose blog! We post about new features, technical insights, and thoughts on diagramming here regularly.
 ---


### PR DESCRIPTION
# Description

For some reason tailwind's dark mode doesn't play well with our site. This PR makes sure we vitepress instead of tailwind for dark/light mode styling. We also change from `home` to `page` layout so the left bar is always visible.