### PR TITLE
docs: explain the origin of the project name

### DIFF
--- a/packages/docs-site/docs/ref.md
+++ b/packages/docs-site/docs/ref.md
@@ -10,7 +10,7 @@ Penrose, instead, provides the level of abstraction needed to separate _content_
 
 Penrose already understands the diagram's domain and how to style the diagram. You just define the objects and relationships. Penrose goes to work by converting the three programs into an optimization problem that it solves using symbolic differentiation. If you need to add a new shape, it's not a painstaking exercise -- Penrose automatically creates a new diagram that meets all of your constraints.
 
-## Why "Penrose"?
+## Why "Penrose?"
 
 We named Penrose after Sir Roger Penrose, who, in addition to possessing a euphonious name, is known for his Escher-inspired illustrations of impossible objects, Penrose notations, and Penrose diagrams. "Pen" and "rose" also encapsulate our goal of turning notations ✍️ to beautiful diagrams 🌹.
 

--- a/packages/docs-site/docs/ref.md
+++ b/packages/docs-site/docs/ref.md
@@ -10,6 +10,10 @@ Penrose, instead, provides the level of abstraction needed to separate _content_
 
 Penrose already understands the diagram's domain and how to style the diagram. You just define the objects and relationships. Penrose goes to work by converting the three programs into an optimization problem that it solves using symbolic differentiation. If you need to add a new shape, it's not a painstaking exercise -- Penrose automatically creates a new diagram that meets all of your constraints.
 
+## Why "Penrose"?
+
+We named Penrose after Sir Roger Penrose, who, in addition to possessing a euphonious name, is known for his Escher-inspired illustrations of impossible objects, Penrose notations, and Penrose diagrams. "Pen" and "rose" also encapsulate our goal of turning notations ✍️ to beautiful diagrams 🌹.
+
 ## The Penrose trio
 
 A diagram made in Penrose involves a _trio_ of three programs:


### PR DESCRIPTION
# Description

This PR answers a frequent question from various HN discussions in the past: why did you pick "penrose" as the project name? Added a small section to the documentation landing page:

> We named Penrose after Sir Roger Penrose, who, in addition to possessing a euphonious name, is known for his Escher-inspired illustrations of impossible objects, Penrose notations, and Penrose diagrams. "Pen" and "rose" also encapsulate our goal of turning notations ✍️ to beautiful diagrams 🌹.
