### PR TITLE
docs: add "Edit this page" button to pages

### DIFF
--- a/packages/docs-site/.vitepress/config.ts
+++ b/packages/docs-site/.vitepress/config.ts
@@ -150,6 +150,10 @@ export default defineConfig({
   themeConfig: {
     logo: "img/favicon.ico",
     outline: "deep",
+    editLink: {
+      pattern:
+        "https://github.com/penrose/penrose/edit/main/packages/docs-site/:path",
+    },
     nav: [
       {
         text: "Examples",


### PR DESCRIPTION
# Description

This PR enables the Vitepress [edit link feature](https://vitepress.dev/reference/default-theme-edit-link) so viewers can directly open a PR to edit our documentation pages.
