### PR TITLE
chore: enable Prettier for `*.jsx` in VS Code

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,7 +1,12 @@
 {
+  // Prettier pretty much needs you to specify all the individual filetypes you
+  // want it to run on, because if you just turn it on by default then it'll try
+  // to also run on other code (e.g. Rust) and break. You can find the list of
+  // Prettier-supported languages here: https://prettier.io/docs/en/index.html
   "[css]": { "editor.defaultFormatter": "esbenp.prettier-vscode" },
   "[html]": { "editor.defaultFormatter": "esbenp.prettier-vscode" },
   "[javascript]": { "editor.defaultFormatter": "esbenp.prettier-vscode" },
+  "[javascriptreact]": { "editor.defaultFormatter": "esbenp.prettier-vscode" },
   "[json]": { "editor.defaultFormatter": "esbenp.prettier-vscode" },
   "[jsonc]": { "editor.defaultFormatter": "esbenp.prettier-vscode" },
   "[markdown]": { "editor.defaultFormatter": "esbenp.prettier-vscode" },


### PR DESCRIPTION
# Description

Earlier today I made a `*.jsx` file in the Penrose repo and was confused that Prettier wasn't autoformatting it. We don't currently have any such files in our repo, but this PR adds that file type to our `.vscode/settings.json` to prevent such confusion in the future. I also added a comment explaining why we specifically enable only for certain file types.

# Checklist

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have reviewed any generated registry diagram changes