### PR TITLE
fix: layering on nonexistent objects

### DIFF
--- a/packages/core/src/compiler/Style.test.ts
+++ b/packages/core/src/compiler/Style.test.ts
@@ -927,6 +927,9 @@ delete x.z.p }`,
            x.z = 1.0
            x.y = x.z.p
 }`,
+        `forall Set x {
+          layer AAA above BBB
+        }`,
       ],
       CanvasNonexistentDimsError: [
         `foo {
@@ -1064,6 +1067,13 @@ delete x.z.p }`,
         }`,
         `collect Set a into aa foreach Set b {
           x = listof c from x
+        }`,
+      ],
+      LayerOnNonShapesError: [
+        `block {
+          x = 100
+          y = 200
+          layer x above y
         }`,
       ],
       BadElementError: [

--- a/packages/core/src/types/errors.ts
+++ b/packages/core/src/types/errors.ts
@@ -214,6 +214,7 @@ export type StyleError =
   | FunctionInternalError
   | RedeclareNamespaceError
   | UnexpectedCollectionAccessError
+  | LayerOnNonShapesError
   // Runtime errors
   | RuntimeValueTypeError;
 
@@ -519,6 +520,12 @@ export interface UnexpectedCollectionAccessError {
   tag: "UnexpectedCollectionAccessError";
   name: string;
   location: SourceRange;
+}
+
+export interface LayerOnNonShapesError {
+  tag: "LayerOnNonShapesError";
+  location: SourceRange;
+  expr: string;
 }
 
 //#endregion

--- a/packages/core/src/utils/Error.ts
+++ b/packages/core/src/utils/Error.ts
@@ -555,6 +555,12 @@ canvas {
       const locStr = locc("Style", location);
       return `Style variable \`${name}\` cannot be accessed via the collection access operator (at ${locStr}) because it is not a collection.`;
     }
+
+    case "LayerOnNonShapesError": {
+      const { location, expr } = error;
+      const locStr = locc("Style", location);
+      return `Expects \`${expr}\` (at ${locStr}) to be a shape, but provided with a non-shape.`;
+    }
     // --- END COMPILATION ERRORS
 
     // TODO(errors): use identifiers here
@@ -829,7 +835,8 @@ export const errLocs = (
 
     case "FunctionInternalError":
     case "RedeclareNamespaceError":
-    case "UnexpectedCollectionAccessError": {
+    case "UnexpectedCollectionAccessError":
+    case "LayerOnNonShapesError": {
       return [
         toErrorLoc({
           ...e.location,


### PR DESCRIPTION
# Description

Resolves #1557 .

This PR fixes the bug of uncaught error when a `layer` directive is applied to nonexistent objects. As an example,
```
canvas {
    height = 800
    width = 700

    layer a above b
}
```
The compiler doesn't check that `a` and `b` actually exist, nor does it confirm that indeed, `a` and `b` are shapes.

# Implementation strategy and design decisions

When translating `layer` statements, the compiler now resolves each expression and ensures that each object exists and are of `Shape` type. If not, it reports an error.


# Examples with steps to reproduce them

The Style code used in the example now properly reports an error when necessary.

# Checklist

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have reviewed any generated registry diagram changes