### PR TITLE
ci: deploy Edgeworth manually

### DIFF
--- a/.github/workflows/edgeworth.yml
+++ b/.github/workflows/edgeworth.yml
@@ -1,9 +1,11 @@
 name: Edgeworth
 on:
-  push:
-    branches:
-      - main
-      - "edgeworth/**"
+  workflow_dispatch:
+    inputs:
+      path:
+        description: "Path to deploy"
+        required: true
+        type: string
 jobs:
   deploy:
     runs-on: ubuntu-latest
@@ -19,7 +21,7 @@ jobs:
         with:
           branch: gh-pages
           folder: packages/edgeworth/dist
-          target-folder: edgeworth/${{ github.sha }}/
+          target-folder: edgeworth/${{ inputs.path }}/
       - name: Add .nojekyll
         run: |
           mkdir extra/


### PR DESCRIPTION
# Description

The automatic Edgeworth deployments are taking up a lot of space in `gh-pages` branch. This PR removes the automatic deployment triggers and move to a manual workflow, where we go to "Actions" and trigger the deployment. 

The deployment script takes a single string for the path to the deployment: `penrose.github.io/penrose/edgeworth/<path>`.

