### PR TITLE
feat: added `mod` function to `Functions.ts`

### DIFF
--- a/packages/core/src/contrib/Functions.ts
+++ b/packages/core/src/contrib/Functions.ts
@@ -435,6 +435,22 @@ export const compDict = {
   },
 
   /**
+   * Return `mod(x)`.
+   */
+  mod: {
+    name: "mod",
+    description: "Return `mod(a, n)`.",
+    params: [{ name: "a", description: "`a`", type: realT() }, { name: "n", description: "`n`", type: realT() }],
+    body: (_context: Context, a: ad.Num, n: ad.Num): MayWarn<FloatV<ad.Num>> => {
+      return noWarn({
+        tag: "FloatV",
+        contents: sub(a, mul(n, floor(div(a, n)))),
+      });
+    },
+    returns: valueT("Real"),
+  },
+
+  /**
    * Return `atan(x)`.
    */
   atan: {

--- a/packages/core/src/contrib/Functions.ts
+++ b/packages/core/src/contrib/Functions.ts
@@ -440,8 +440,15 @@ export const compDict = {
   mod: {
     name: "mod",
     description: "Return `mod(a, n)`.",
-    params: [{ name: "a", description: "`a`", type: realT() }, { name: "n", description: "`n`", type: realT() }],
-    body: (_context: Context, a: ad.Num, n: ad.Num): MayWarn<FloatV<ad.Num>> => {
+    params: [
+      { name: "a", description: "`a`", type: realT() },
+      { name: "n", description: "`n`", type: realT() },
+    ],
+    body: (
+      _context: Context,
+      a: ad.Num,
+      n: ad.Num,
+    ): MayWarn<FloatV<ad.Num>> => {
       return noWarn({
         tag: "FloatV",
         contents: sub(a, mul(n, floor(div(a, n)))),

--- a/packages/core/src/contrib/Functions.ts
+++ b/packages/core/src/contrib/Functions.ts
@@ -435,7 +435,7 @@ export const compDict = {
   },
 
   /**
-   * Return `mod(x)`.
+   * Return `mod(a, n)`.
    */
   mod: {
     name: "mod",


### PR DESCRIPTION
# Description

Resolves #1563.

This PR adds a `mod` function to `Functions.ts`, allowing the modulus to be calculated in Style.

# Implementation strategy and design decisions

We obtain `mod(a, n)` by computing `a-n*floor(a,n)`.

# Examples with steps to reproduce them

The following program is an example usage of the `mod` function in Style, which should display a circle of radius 1:

```
canvas {
    height = 10
    width = 10

    Circle {
        r: mod(75,2)
    }
}
```

# Checklist

- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have reviewed any generated registry diagram changes
