### PR TITLE
feat: nondistinct matching

### DIFF
--- a/packages/components/src/editing/languages/StyleConfig.ts
+++ b/packages/components/src/editing/languages/StyleConfig.ts
@@ -66,6 +66,7 @@ const styleCustoms = {
     "text",
     "in",
     "except",
+    "repeatable",
   ],
   types: [
     "scalar",

--- a/packages/core/src/compiler/Style.test.ts
+++ b/packages/core/src/compiler/Style.test.ts
@@ -686,16 +686,26 @@ predicate Bond(Atom, Atom)`;
     });
 
     test("repeatable", async () => {
-      const dsl = `type T`;
-      const sub = `T t1, t2`;
-      const sty =
+      const dsl = "type T\npredicate P(T, T, T)";
+      const sub =
+        "T t1, t2, t3\nP(t1, t2, t3)\nP(t1, t1, t3)\nP(t2,t2,t3)\nP(t1,t3,t1)";
+      const sty1 =
         canvasPreamble +
         `forall repeatable T t1; T t2 {
           Circle {}
         }`;
 
-      const { state } = await loadProgs({ dsl, sub, sty });
-      expect(state.shapes.length).toEqual(3);
+      const res1 = await loadProgs({ dsl, sub, sty: sty1 });
+      expect(res1.state.shapes.length).toEqual(6);
+
+      const sty2 =
+        canvasPreamble +
+        `forall repeatable T t1; T t2; T t3
+        where P(t1, t2, t3) {
+          Circle {}
+        }`;
+      const res2 = await loadProgs({ dsl, sub, sty: sty2 });
+      expect(res2.state.shapes.length).toEqual(4);
     });
   });
 

--- a/packages/core/src/compiler/Style.test.ts
+++ b/packages/core/src/compiler/Style.test.ts
@@ -684,6 +684,19 @@ predicate Bond(Atom, Atom)`;
       const { state } = await loadProgs({ dsl, sub, sty });
       expect(state.shapes.length).toEqual(1);
     });
+
+    test("repeatable", async () => {
+      const dsl = `type T`;
+      const sub = `T t1, t2`;
+      const sty =
+        canvasPreamble +
+        `forall repeatable T t1; T t2 {
+          Circle {}
+        }`;
+
+      const { state } = await loadProgs({ dsl, sub, sty });
+      expect(state.shapes.length).toEqual(3);
+    });
   });
 
   describe("predicate alias", () => {

--- a/packages/core/src/compiler/Style.ts
+++ b/packages/core/src/compiler/Style.ts
@@ -216,7 +216,7 @@ const flatErrs = (es: StyleDiagnostics[]): StyleDiagnostics => {
 
 const addDiags = <T extends { diagnostics: StyleDiagnostics }>(
   { errors, warnings }: StyleDiagnostics,
-  x: T,
+  x: T
 ): T => ({
   ...x,
   diagnostics: {
@@ -316,7 +316,7 @@ const addMapping = (
   k: BindingForm<A>,
   v: StyT<A>,
   m: SelEnv,
-  p: ProgType,
+  p: ProgType
 ): SelEnv => {
   m.sTypeVarMap[toString(k)] = v;
   m.varProgTypeMap[toString(k)] = [p, k];
@@ -337,7 +337,7 @@ const addErrSel = (selEnv: SelEnv, err: StyleError): SelEnv => {
 const checkDeclPatternAndMakeEnv = (
   varEnv: Env,
   selEnv: SelEnv,
-  stmt: DeclPattern<A>,
+  stmt: DeclPattern<A>
 ): SelEnv => {
   const [styType, bVar] = [stmt.type, stmt.id];
 
@@ -397,11 +397,11 @@ const checkDeclPatternAndMakeEnv = (
 const checkDeclPatternsAndMakeEnv = (
   varEnv: Env,
   selEnv: SelEnv,
-  decls: DeclPattern<A>[],
+  decls: DeclPattern<A>[]
 ): SelEnv => {
   return decls.reduce(
     (s, p) => checkDeclPatternAndMakeEnv(varEnv, s, p),
-    selEnv,
+    selEnv
   );
 };
 
@@ -447,7 +447,7 @@ const getSelectorStyVarNames = (selEnv: SelEnv): string[] => {
 const aliasConflictsWithDomainOrSelectorKeyword = (
   alias: Identifier<A>,
   varEnv: Env,
-  selEnv: SelEnv,
+  selEnv: SelEnv
 ): boolean => {
   const domainKeywords = getDomainKeywords(varEnv);
   const selectorKeywords = getSelectorStyVarNames(selEnv);
@@ -462,7 +462,7 @@ const aliasConflictsWithDomainOrSelectorKeyword = (
 const checkRelPattern = (
   varEnv: Env,
   selEnv: SelEnv,
-  rel: RelationPattern<A>,
+  rel: RelationPattern<A>
 ): StyleError[] => {
   // rule Bind-Context
   switch (rel.tag) {
@@ -545,10 +545,10 @@ const checkRelPattern = (
 const checkRelPatterns = (
   varEnv: Env,
   selEnv: SelEnv,
-  rels: RelationPattern<A>[],
+  rels: RelationPattern<A>[]
 ): StyleError[] => {
   return _.flatMap(rels, (rel: RelationPattern<A>): StyleError[] =>
-    checkRelPattern(varEnv, selEnv, rel),
+    checkRelPattern(varEnv, selEnv, rel)
   );
 };
 
@@ -567,7 +567,7 @@ const toSubstanceType = (styT: StyT<A>): TypeConsApp<A> => {
 const mergeMapping = (
   varProgTypeMap: { [k: string]: [ProgType, BindingForm<A>] },
   varEnv: Env,
-  [varName, styType]: [string, StyT<A>],
+  [varName, styType]: [string, StyT<A>]
 ): Env => {
   const res = varProgTypeMap[varName];
   if (!res) {
@@ -576,7 +576,7 @@ const mergeMapping = (
   const [, bindingForm] = res;
   const vars = varEnv.vars.set(
     bindingForm.contents.value,
-    toSubstanceType(styType),
+    toSubstanceType(styType)
   );
   switch (bindingForm.tag) {
     case "StyVar":
@@ -605,7 +605,7 @@ const mergeMapping = (
 const mergeEnv = (varEnv: Env, selEnv: SelEnv): Env => {
   return Object.entries(selEnv.sTypeVarMap).reduce(
     (acc, curr) => mergeMapping(selEnv.varProgTypeMap, acc, curr),
-    varEnv,
+    varEnv
   );
 };
 
@@ -614,14 +614,14 @@ const checkSelector = (varEnv: Env, sel: Selector<A>): SelEnv => {
   const selEnv_afterHead = checkDeclPatternsAndMakeEnv(
     varEnv,
     initSelEnv(),
-    sel.head.contents,
+    sel.head.contents
   );
   // Check `with` statements
   // TODO: Did we get rid of `with` statements?
   const selEnv_decls = checkDeclPatternsAndMakeEnv(
     varEnv,
     selEnv_afterHead,
-    safeContentsList(sel.with),
+    safeContentsList(sel.with)
   );
 
   // Basically creates a new, empty environment.
@@ -629,7 +629,7 @@ const checkSelector = (varEnv: Env, sel: Selector<A>): SelEnv => {
   const relErrs = checkRelPatterns(
     mergeEnv(emptyVarsEnv, selEnv_decls),
     selEnv_decls,
-    safeContentsList(sel.where),
+    safeContentsList(sel.where)
   );
 
   // TODO(error): The errors returned in the top 3 statements
@@ -643,23 +643,23 @@ const checkCollector = (varEnv: Env, col: Collector<A>): SelEnv => {
   const selEnv_afterHead = checkDeclPatternAndMakeEnv(
     varEnv,
     initSelEnv(),
-    col.head,
+    col.head
   );
   const selEnv_afterWith = checkDeclPatternsAndMakeEnv(
     varEnv,
     selEnv_afterHead,
-    safeContentsList(col.with),
+    safeContentsList(col.with)
   );
   const selEnv_afterGroupby = checkDeclPatternsAndMakeEnv(
     varEnv,
     selEnv_afterWith,
-    safeContentsList(col.foreach),
+    safeContentsList(col.foreach)
   );
   const emptyVarsEnv: Env = { ...varEnv, vars: im.Map(), varIDs: [] };
   const relErrs = checkRelPatterns(
     mergeEnv(emptyVarsEnv, selEnv_afterGroupby),
     selEnv_afterGroupby,
-    safeContentsList(col.where),
+    safeContentsList(col.where)
   );
 
   return {
@@ -716,7 +716,7 @@ export const uniqueKeysAndVals = (subst: Subst): boolean => {
  * Returns the substitution for a predicate alias
  */
 const getSubPredAliasInstanceName = (
-  pred: ApplyPredicate<A> | ApplyFunction<A> | ApplyConstructor<A>,
+  pred: ApplyPredicate<A> | ApplyFunction<A> | ApplyConstructor<A>
 ): string => {
   let name = pred.name.value;
   for (const arg of pred.args) {
@@ -743,7 +743,7 @@ const getSubPredAliasInstanceName = (
 const substituteBform = (
   lv: LocalVarSubst | undefined,
   subst: Subst,
-  bform: BindingForm<A>,
+  bform: BindingForm<A>
 ): BindingForm<A> => {
   // theta(B) = ...
   switch (bform.tag) {
@@ -817,7 +817,7 @@ const substitutePredArg = (subst: Subst, predArg: PredArg<A>): PredArg<A> => {
 // theta(|S_r) = ...
 export const substituteRel = (
   subst: Subst,
-  rel: RelationPattern<A>,
+  rel: RelationPattern<A>
 ): RelationPattern<A> => {
   switch (rel.tag) {
     case "RelBind": {
@@ -884,7 +884,7 @@ const toSubExpr = <T>(env: Env, e: SelExpr<T>): SubExpr<T> => {
       } else {
         // TODO: return TypeNotFound instead
         throw new Error(
-          `Style internal error: expected '${e.name.value}' to be either a constructor or function, but was not found`,
+          `Style internal error: expected '${e.name.value}' to be either a constructor or function, but was not found`
         );
       }
       const res: SubExpr<T> = {
@@ -950,7 +950,7 @@ const subFnsEq = (p1: SubPredArg<A>, p2: SubPredArg<A>, env: Env): boolean => {
     const predicateDecl = env.predicates.get(p1.name.value);
     if (predicateDecl && predicateDecl.symmetric) {
       return zip2(p1.args, [p2.args[1], p2.args[0]]).every(([a1, a2]) =>
-        argsEq(a1, a2, env),
+        argsEq(a1, a2, env)
       );
     } else {
       return false;
@@ -988,7 +988,7 @@ const deduplicate = (
   subEnv: SubstanceEnv,
   subProg: SubProg<A>,
   rels: RelationPattern<A>[],
-  pSubsts: im.List<[Subst, im.Set<SubStmt<A> | undefined>]>,
+  pSubsts: im.List<[Subst, im.Set<SubStmt<A> | undefined>]>
 ): im.List<Subst> => {
   const initSubsts: im.List<Subst> = im.List();
 
@@ -1009,7 +1009,7 @@ const deduplicate = (
         return [currMatches.add(record), currSubsts.push(subst)];
       }
     },
-    [initMatches, initSubsts],
+    [initMatches, initSubsts]
   );
   return goodSubsts;
 };
@@ -1039,7 +1039,7 @@ const combine = (s1: Subst, s2: Subst): Subst => {
  */
 const merge = (
   s1: im.List<[Subst, im.Set<SubStmt<A>>]>,
-  s2: im.List<[Subst, im.Set<SubStmt<A>>]>,
+  s2: im.List<[Subst, im.Set<SubStmt<A>>]>
 ): im.List<[Subst, im.Set<SubStmt<A>>]> => {
   if (s1.size === 0 || s2.size === 0) {
     return im.List();
@@ -1057,7 +1057,7 @@ const merge = (
     ([aSubst, aStmts], [bSubst, bStmts]) => [
       combine(aSubst, bSubst),
       aStmts.union(bStmts),
-    ],
+    ]
   );
   return im.List(result);
 };
@@ -1089,7 +1089,7 @@ const consistentSubsts = (a: Subst, b: Subst): boolean => {
 const typesMatched = (
   varEnv: Env,
   substanceType: TypeConsApp<A>,
-  styleType: StyT<A>,
+  styleType: StyT<A>
 ): boolean => {
   if (substanceType.args.length === 0) {
     // Style type needs to be more generic than Style type
@@ -1098,14 +1098,14 @@ const typesMatched = (
 
   // TODO(errors)
   throw Error(
-    "internal error: expected two nullary types (parametrized types to be implemented)",
+    "internal error: expected two nullary types (parametrized types to be implemented)"
   );
 };
 
 // Judgment 10. theta |- x <| B
 const matchBvar = (
   subVar: Identifier<A>,
-  bf: BindingForm<A>,
+  bf: BindingForm<A>
 ): Subst | undefined => {
   switch (bf.tag) {
     case "StyVar": {
@@ -1129,7 +1129,7 @@ const matchBvar = (
 const matchDeclLine = (
   varEnv: Env,
   line: SubStmt<A>,
-  decl: DeclPattern<A>,
+  decl: DeclPattern<A>
 ): Subst | undefined => {
   if (line.tag === "Decl") {
     const [subT, subVar] = [line.type, line.name];
@@ -1149,7 +1149,7 @@ const matchDeclLine = (
 const matchDecl = (
   varEnv: Env,
   subProg: SubProg<A>,
-  decl: DeclPattern<A>,
+  decl: DeclPattern<A>
 ): im.List<Subst> => {
   const initDSubsts: im.List<Subst> = im.List();
   // Judgment 14. G; [theta] |- [S] <| |S_o
@@ -1174,7 +1174,7 @@ const matchStyArgToSubArg = (
   subTypeMap: { [k: string]: TypeConsApp<A> },
   varEnv: Env,
   styArg: PredArg<A> | SelExpr<A>,
-  subArg: SubPredArg<A> | SubExpr<A>,
+  subArg: SubPredArg<A> | SubExpr<A>
 ): Subst[] => {
   if (styArg.tag === "SEBind" && subArg.tag === "Identifier") {
     const styBForm = styArg.contents;
@@ -1206,7 +1206,7 @@ const matchStyArgToSubArg = (
       subTypeMap,
       varEnv,
       styArg,
-      subArg,
+      subArg
     );
   }
   if (
@@ -1218,7 +1218,7 @@ const matchStyArgToSubArg = (
       subTypeMap,
       varEnv,
       styArg,
-      subArg,
+      subArg
     );
   }
   if (
@@ -1230,7 +1230,7 @@ const matchStyArgToSubArg = (
       subTypeMap,
       varEnv,
       styArg,
-      subArg,
+      subArg
     );
   }
   return [];
@@ -1245,7 +1245,7 @@ const matchStyArgsToSubArgs = (
   subTypeMap: { [k: string]: TypeConsApp<A> },
   varEnv: Env,
   styArgs: PredArg<A>[] | SelExpr<A>[],
-  subArgs: SubPredArg<A>[] | SubExpr<A>[],
+  subArgs: SubPredArg<A>[] | SubExpr<A>[]
 ): Subst[] => {
   const stySubArgPairs = zip2<
     PredArg<A> | SelExpr<A>,
@@ -1258,7 +1258,7 @@ const matchStyArgsToSubArgs = (
       subTypeMap,
       varEnv,
       styArg,
-      subArg,
+      subArg
     );
     return argSubsts;
   });
@@ -1279,10 +1279,10 @@ const matchStyArgsToSubArgs = (
           currSubsts,
           substsForArg,
           (aSubst, bSubst) => consistentSubsts(aSubst, bSubst),
-          (aSubst, bSubst) => combine(aSubst, bSubst),
+          (aSubst, bSubst) => combine(aSubst, bSubst)
         );
       },
-      first,
+      first
     );
     return substs;
   } else {
@@ -1308,7 +1308,7 @@ const matchStyApplyToSubApply = (
   subTypeMap: { [k: string]: TypeConsApp<A> },
   varEnv: Env,
   styRel: RelPred<A> | SelExpr<A>,
-  subRel: ApplyPredicate<A> | SubExpr<A>,
+  subRel: ApplyPredicate<A> | SubExpr<A>
 ): Subst[] => {
   // Predicate Applications
   if (styRel.tag === "RelPred" && subRel.tag === "ApplyPredicate") {
@@ -1323,7 +1323,7 @@ const matchStyApplyToSubApply = (
       subTypeMap,
       varEnv,
       styRel.args,
-      subRel.args,
+      subRel.args
     );
 
     // Consider the symmetric, flipped-argument version
@@ -1337,7 +1337,7 @@ const matchStyApplyToSubApply = (
         subTypeMap,
         varEnv,
         flippedStyArgs,
-        subRel.args,
+        subRel.args
       );
     }
 
@@ -1374,7 +1374,7 @@ const matchStyApplyToSubApply = (
       subTypeMap,
       varEnv,
       styRel.args,
-      subRel.args,
+      subRel.args
     );
     return rSubst;
   }
@@ -1396,7 +1396,7 @@ const matchRelField = (
   varEnv: Env,
   subEnv: SubstanceEnv,
   rel: RelField<A>,
-  subDecl: Decl<A>,
+  subDecl: Decl<A>
 ): Subst | undefined => {
   const styName = toString(rel.name);
   const styType = styTypeMap[styName];
@@ -1422,7 +1422,7 @@ const matchRelField = (
 };
 
 const getStyPredOrFuncOrConsArgNames = (
-  arg: PredArg<A> | SelExpr<A>,
+  arg: PredArg<A> | SelExpr<A>
 ): im.Set<string> => {
   if (arg.tag === "RelPred") {
     return getStyRelArgNames(arg);
@@ -1460,7 +1460,7 @@ const matchStyRelToSubRels = (
   varEnv: Env,
   subEnv: SubstanceEnv,
   rel: RelationPattern<A>,
-  subProg: SubProg<A>,
+  subProg: SubProg<A>
 ): [im.Set<string>, im.List<[Subst, im.Set<SubStmt<A>>]>] => {
   const initUsedStyVars = im.Set<string>();
   const initRSubsts = im.List<[Subst, im.Set<SubStmt<A>>]>();
@@ -1476,7 +1476,7 @@ const matchStyRelToSubRels = (
           subTypeMap,
           varEnv,
           styPred,
-          statement,
+          statement
         );
 
         return rSubstsForPred.reduce((rSubsts, rSubstForPred) => {
@@ -1486,7 +1486,7 @@ const matchStyRelToSubRels = (
           ]);
         }, rSubsts);
       },
-      initRSubsts,
+      initRSubsts
     );
     return [getStyRelArgNames(rel), newRSubsts];
   } else if (rel.tag === "RelBind") {
@@ -1506,7 +1506,7 @@ const matchStyRelToSubRels = (
         subTypeMap,
         varEnv,
         styBindedExpr,
-        subBindedExpr,
+        subBindedExpr
       );
 
       return rSubstsForExpr.reduce((rSubsts, rSubstForExpr) => {
@@ -1529,7 +1529,7 @@ const matchStyRelToSubRels = (
           varEnv,
           subEnv,
           rel,
-          statement,
+          statement
         );
         if (rSubst === undefined) {
           return rSubsts;
@@ -1566,7 +1566,7 @@ const makeListRSubstsForStyleRels = (
   varEnv: Env,
   subEnv: SubstanceEnv,
   rels: RelationPattern<A>[],
-  subProg: SubProg<A>,
+  subProg: SubProg<A>
 ): [im.Set<string>, im.List<im.List<[Subst, im.Set<SubStmt<A>>]>>] => {
   const initUsedStyVars: im.Set<string> = im.Set();
   const initListRSubsts: im.List<im.List<[Subst, im.Set<SubStmt<A>>]>> =
@@ -1580,11 +1580,11 @@ const makeListRSubstsForStyleRels = (
         varEnv,
         subEnv,
         rel,
-        subProg,
+        subProg
       );
       return [usedStyVars.union(relUsedStyVars), listRSubsts.push(relRSubsts)];
     },
-    [initUsedStyVars, initListRSubsts],
+    [initUsedStyVars, initListRSubsts]
   );
 
   return [newUsedStyVars, newListRSubsts];
@@ -1599,7 +1599,7 @@ const makePotentialSubsts = (
   subEnv: SubstanceEnv,
   subProg: SubProg<A>,
   decls: DeclPattern<A>[],
-  rels: RelationPattern<A>[],
+  rels: RelationPattern<A>[]
 ): im.List<[Subst, im.Set<SubStmt<A>>]> => {
   const subTypeMap = subProg.statements.reduce<{ [k: string]: TypeConsApp<A> }>(
     (result, statement) => {
@@ -1610,7 +1610,7 @@ const makePotentialSubsts = (
         return result;
       }
     },
-    {},
+    {}
   );
   const styTypeMap: { [k: string]: StyT<A> } = selEnv.sTypeVarMap;
   const [usedStyVars, listRSubsts] = makeListRSubstsForStyleRels(
@@ -1619,7 +1619,7 @@ const makePotentialSubsts = (
     varEnv,
     subEnv,
     rels,
-    subProg,
+    subProg
   );
   // Add in variables that are not present in the relations.
   const listPSubsts = decls.reduce((currListPSubsts, decl) => {
@@ -1628,7 +1628,7 @@ const makePotentialSubsts = (
     } else {
       const pSubsts = matchDecl(varEnv, subProg, decl);
       return currListPSubsts.push(
-        pSubsts.map((pSubst) => [pSubst, im.Set<SubStmt<A>>()]),
+        pSubsts.map((pSubst) => [pSubst, im.Set<SubStmt<A>>()])
       );
     }
   }, listRSubsts);
@@ -1665,7 +1665,7 @@ const getSubsts = (
   subEnv: SubstanceEnv,
   selEnv: SelEnv,
   subProg: SubProg<A>,
-  header: Collector<A> | Selector<A>,
+  header: Collector<A> | Selector<A>
 ): Subst[] => {
   const decls = getDecls(header);
   const rels = safeContentsList(header.where);
@@ -1675,16 +1675,21 @@ const getSubsts = (
     subEnv,
     subProg,
     decls,
-    rels,
+    rels
   );
   log.debug("total number of raw substs: ", rawSubsts.size);
 
   // Ensures there are no duplicated substitutions in terms of both
   // matched relations and substitution targets.
   const filteredSubsts = deduplicate(varEnv, subEnv, subProg, rels, rawSubsts);
-  const correctSubsts = filteredSubsts.filter(uniqueKeysAndVals);
+  const { repeatable } = header;
 
-  return correctSubsts.toArray();
+  if (repeatable) {
+    return filteredSubsts.toArray();
+  } else {
+    const correctSubsts = filteredSubsts.filter(uniqueKeysAndVals);
+    return correctSubsts.toArray();
+  }
 };
 
 type GroupbyBucket = {
@@ -1696,7 +1701,7 @@ const collectSubsts = (
   substs: Subst[],
   toCollect: string,
   collectInto: string,
-  groupbys: string[],
+  groupbys: string[]
 ): CollectionSubst[] => {
   const buckets: Map<string, GroupbyBucket> = new Map();
 
@@ -1734,7 +1739,7 @@ const findSubstsSel = (
   varEnv: Env,
   subEnv: SubstanceEnv,
   subProg: SubProg<A>,
-  [header, selEnv]: [Header<A>, SelEnv],
+  [header, selEnv]: [Header<A>, SelEnv]
 ): StySubst[] => {
   if (header.tag === "Selector") {
     return getSubsts(varEnv, subEnv, selEnv, subProg, header).map((subst) => ({
@@ -1769,7 +1774,7 @@ const updateExpr = (
   errTagGlobal: "AssignGlobalError" | "DeleteGlobalError",
   errTagSubstance: "AssignSubstanceError" | "DeleteSubstanceError",
   // this function performs the actual dictionary updates. `updateExpr` only needs to extract the path to pass to `f`.
-  f: (field: Field, prop: PropID | undefined, fielded: FieldDict) => FieldedRes,
+  f: (field: Field, prop: PropID | undefined, fielded: FieldDict) => FieldedRes
 ): BlockAssignment => {
   switch (path.tag) {
     case "Global": {
@@ -1778,7 +1783,7 @@ const updateExpr = (
       } else if (path.members.length > 2) {
         return addDiags(
           oneErr({ tag: "PropertyMemberError", path }),
-          assignment,
+          assignment
         );
       }
       const field = path.members[0].value;
@@ -1799,7 +1804,7 @@ const updateExpr = (
       if (path.members.length > 1) {
         return addDiags(
           oneErr({ tag: "PropertyMemberError", path }),
-          assignment,
+          assignment
         );
       }
       // remember, we don't use `--noUncheckedIndexedAccess`
@@ -1818,7 +1823,7 @@ const updateExpr = (
       } else if (path.members.length > 2) {
         return addDiags(
           oneErr({ tag: "PropertyMemberError", path }),
-          assignment,
+          assignment
         );
       }
       const field = path.members[0].value;
@@ -1840,7 +1845,7 @@ const updateExpr = (
 
 const processExpr = (
   context: Context,
-  expr: Expr<C>,
+  expr: Expr<C>
 ): Result<FieldSource, StyleError> => {
   if (expr.tag !== "GPIDecl") {
     return ok({ tag: "OtherSource", expr: { context, expr } });
@@ -1857,7 +1862,7 @@ const processExpr = (
       }
       return ok(m.set(name.value, { context, expr: value }));
     },
-    ok(im.Map()),
+    ok(im.Map())
   );
   return andThen((props) => ok({ tag: "ShapeSource", shapeType, props }), res);
 };
@@ -1866,7 +1871,7 @@ const insertExpr = (
   block: BlockInfo,
   path: ResolvedPath<C>,
   expr: Expr<C>,
-  assignment: BlockAssignment,
+  assignment: BlockAssignment
 ): BlockAssignment =>
   updateExpr(
     path,
@@ -1878,7 +1883,7 @@ const insertExpr = (
       if (prop === undefined) {
         const source = processExpr(
           { ...block, locals: assignment.locals },
-          expr,
+          expr
         );
         if (source.isErr()) {
           return err(source.error);
@@ -1912,12 +1917,12 @@ const insertExpr = (
           warns,
         });
       }
-    },
+    }
   );
 
 const deleteExpr = (
   path: ResolvedPath<C>,
-  assignment: BlockAssignment,
+  assignment: BlockAssignment
 ): BlockAssignment =>
   updateExpr(
     path,
@@ -1946,13 +1951,13 @@ const deleteExpr = (
           warns: [],
         });
       }
-    },
+    }
   );
 
 const resolveLhsName = (
   { block, subst }: BlockInfo,
   assignment: BlockAssignment,
-  name: BindingForm<C>,
+  name: BindingForm<C>
 ): ResolvedName => {
   const { value } = name.contents;
   switch (name.tag) {
@@ -1981,7 +1986,7 @@ const resolveLhsName = (
 const resolveLhsPath = (
   block: BlockInfo,
   assignment: BlockAssignment,
-  path: Path<C>,
+  path: Path<C>
 ): Result<ResolvedPath<C>, StyleError> => {
   const { start, end, name, members, indices } = path;
   return indices.length > 0
@@ -1998,7 +2003,7 @@ const processStmt = (
   block: BlockInfo,
   index: number,
   stmt: Stmt<C>,
-  assignment: BlockAssignment,
+  assignment: BlockAssignment
 ): BlockAssignment => {
   switch (stmt.tag) {
     case "PathAssign": {
@@ -2019,7 +2024,7 @@ const processStmt = (
         block,
         path.value,
         stmt.value,
-        deleteExpr(path.value, assignment),
+        deleteExpr(path.value, assignment)
       );
     }
     case "Delete": {
@@ -2044,7 +2049,7 @@ const processStmt = (
           members: [],
         },
         stmt.contents,
-        assignment,
+        assignment
       );
     }
   }
@@ -2053,7 +2058,7 @@ const processStmt = (
 const blockId = (
   blockIndex: number,
   substIndex: number,
-  header: Header<A>,
+  header: Header<A>
 ): LocalVarSubst => {
   switch (header.tag) {
     case "Selector":
@@ -2110,7 +2115,7 @@ const processBlock = (
   subEnv: SubstanceEnv,
   blockIndex: number,
   hb: HeaderBlock<C>,
-  assignment: Assignment,
+  assignment: Assignment
 ): Assignment => {
   // Run static checks first
   const selEnv = checkHeader(varEnv, hb.header);
@@ -2137,7 +2142,7 @@ const processBlock = (
           redeclareNamespaceError(block.contents, {
             start: hb.header.start,
             end: hb.header.end,
-          }),
+          })
         );
       } else {
         // prepopulate with an empty namespace if it doesn't exist
@@ -2150,7 +2155,7 @@ const processBlock = (
 
     const matchTotalAssignment = makeFakeIntPathAssign(
       "match_total",
-      substs.length,
+      substs.length
     );
 
     const augmentedStatements = im
@@ -2164,7 +2169,7 @@ const processBlock = (
       augmentedStatements.reduce(
         (assignment, stmt, stmtIndex) =>
           processStmt({ block, subst }, stmtIndex, stmt, assignment),
-        withLocals,
+        withLocals
       );
 
     switch (block.tag) {
@@ -2192,7 +2197,7 @@ const processBlock = (
 export const buildAssignment = (
   varEnv: Env,
   subEnv: SubstanceEnv,
-  styProg: StyProg<C>,
+  styProg: StyProg<C>
 ): Assignment => {
   // insert Substance label string; use dummy AST node location pattern from
   // `engine/ParserUtil`
@@ -2226,7 +2231,7 @@ export const buildAssignment = (
             },
           },
         ],
-      ]),
+      ])
     ),
   };
   return styProg.items.reduce(
@@ -2234,7 +2239,7 @@ export const buildAssignment = (
       item.tag === "HeaderBlock"
         ? processBlock(varEnv, subEnv, index, item, assignment)
         : assignment,
-    assignment,
+    assignment
   );
 };
 
@@ -2268,7 +2273,7 @@ const findPathsExpr = <T>(expr: Expr<T>, context: Context): Path<T>[] => {
     }
     case "GPIDecl": {
       return expr.properties.flatMap((prop) =>
-        findPathsExpr(prop.value, context),
+        findPathsExpr(prop.value, context)
       );
     }
     case "Layering": {
@@ -2322,7 +2327,7 @@ const findPathsExpr = <T>(expr: Expr<T>, context: Context): Path<T>[] => {
               },
             ],
             indices: [],
-          }),
+          })
         );
         return paths.flatMap((p) => findPathsExpr(p, context));
       } else {
@@ -2346,7 +2351,7 @@ const resolveRhsPath = (p: WithContext<Path<C>>): ResolvedPath<C> => {
 const gatherExpr = (
   graph: DepGraph,
   w: string,
-  expr: WithContext<NotShape>,
+  expr: WithContext<NotShape>
 ): void => {
   graph.setNode(w, expr);
   for (const p of findPathsWithContext(expr)) {
@@ -2356,7 +2361,7 @@ const gatherExpr = (
         j: w,
         e: undefined,
       },
-      () => undefined,
+      () => undefined
     );
   }
 };
@@ -2426,12 +2431,12 @@ const evalExprs = (
   stages: OptPipeline,
   context: Context,
   args: Expr<C>[],
-  trans: Translation,
+  trans: Translation
 ): Result<ArgVal<ad.Num>[], StyleDiagnostics> =>
   all(
     args.map((expr) => {
       return evalExpr(mut, canvas, stages, { context, expr }, trans);
-    }),
+    })
   ).mapErr(flatErrs);
 
 const evalVals = (
@@ -2440,7 +2445,7 @@ const evalVals = (
   stages: OptPipeline,
   context: Context,
   args: Expr<C>[],
-  trans: Translation,
+  trans: Translation
 ): Result<Value<ad.Num>[], StyleDiagnostics> =>
   evalExprs(mut, canvas, stages, context, args, trans).andThen((argVals) =>
     all(
@@ -2453,15 +2458,15 @@ const evalVals = (
             return ok(argVal.contents);
           }
         }
-      }),
-    ).mapErr(flatErrs),
+      })
+    ).mapErr(flatErrs)
   );
 
 const evalBinOpScalars = (
   error: BinOpTypeError,
   op: BinaryOp,
   left: ad.Num,
-  right: ad.Num,
+  right: ad.Num
 ): Result<ad.Num, StyleError> => {
   switch (op) {
     case "BPlus": {
@@ -2490,7 +2495,7 @@ const evalBinOpVectors = (
   error: BinOpTypeError,
   op: BinaryOp,
   left: ad.Num[],
-  right: ad.Num[],
+  right: ad.Num[]
 ): Result<ad.Num[], StyleError> => {
   switch (op) {
     case "BPlus": {
@@ -2517,7 +2522,7 @@ const evalBinOpScalarVector = (
   error: BinOpTypeError,
   op: BinaryOp,
   left: ad.Num,
-  right: ad.Num[],
+  right: ad.Num[]
 ): Result<ad.Num[], StyleError> => {
   switch (op) {
     case "Multiply": {
@@ -2538,7 +2543,7 @@ const evalBinOpVectorScalar = (
   error: BinOpTypeError,
   op: BinaryOp,
   left: ad.Num[],
-  right: ad.Num,
+  right: ad.Num
 ): Result<ad.Num[], StyleError> => {
   switch (op) {
     case "Multiply": {
@@ -2561,7 +2566,7 @@ const evalBinOpScalarMatrix = (
   error: BinOpTypeError,
   op: BinaryOp,
   left: ad.Num,
-  right: ad.Num[][],
+  right: ad.Num[][]
 ): Result<ad.Num[][], StyleError> => {
   switch (op) {
     case "Multiply": {
@@ -2582,7 +2587,7 @@ const evalBinOpMatrixScalar = (
   error: BinOpTypeError,
   op: BinaryOp,
   left: ad.Num[][],
-  right: ad.Num,
+  right: ad.Num
 ): Result<ad.Num[][], StyleError> => {
   switch (op) {
     case "Multiply": {
@@ -2605,7 +2610,7 @@ const evalBinOpMatrixVector = (
   error: BinOpTypeError,
   op: BinaryOp,
   left: ad.Num[][],
-  right: ad.Num[],
+  right: ad.Num[]
 ): Result<ad.Num[], StyleError> => {
   switch (op) {
     case "Multiply": {
@@ -2626,7 +2631,7 @@ const evalBinOpVectorMatrix = (
   error: BinOpTypeError,
   op: BinaryOp,
   left: ad.Num[],
-  right: ad.Num[][],
+  right: ad.Num[][]
 ): Result<ad.Num[], StyleError> => {
   switch (op) {
     case "Multiply": {
@@ -2647,7 +2652,7 @@ const evalBinOpMatrixMatrix = (
   error: BinOpTypeError,
   op: BinaryOp,
   left: ad.Num[][],
-  right: ad.Num[][],
+  right: ad.Num[][]
 ): Result<ad.Num[][], StyleError> => {
   switch (op) {
     case "BPlus": {
@@ -2676,7 +2681,7 @@ const evalBinOpStrings = (
   error: BinOpTypeError,
   op: BinaryOp,
   left: string,
-  right: string,
+  right: string
 ): Result<string, StyleError> => {
   switch (op) {
     case "BPlus": {
@@ -2696,7 +2701,7 @@ const evalBinOpStrings = (
 const evalBinOp = (
   expr: BinOp<C>,
   left: Value<ad.Num>,
-  right: Value<ad.Num>,
+  right: Value<ad.Num>
 ): Result<Value<ad.Num>, StyleError> => {
   const error: BinOpTypeError = {
     tag: "BinOpTypeError",
@@ -2706,64 +2711,64 @@ const evalBinOp = (
   };
   if (left.tag === "FloatV" && right.tag === "FloatV") {
     return evalBinOpScalars(error, expr.op, left.contents, right.contents).map(
-      floatV,
+      floatV
     );
   } else if (left.tag === "VectorV" && right.tag === "VectorV") {
     return evalBinOpVectors(error, expr.op, left.contents, right.contents).map(
-      vectorV,
+      vectorV
     );
   } else if (left.tag === "FloatV" && right.tag === "VectorV") {
     return evalBinOpScalarVector(
       error,
       expr.op,
       left.contents,
-      right.contents,
+      right.contents
     ).map(vectorV);
   } else if (left.tag === "VectorV" && right.tag === "FloatV") {
     return evalBinOpVectorScalar(
       error,
       expr.op,
       left.contents,
-      right.contents,
+      right.contents
     ).map(vectorV);
   } else if (left.tag === "FloatV" && right.tag === "MatrixV") {
     return evalBinOpScalarMatrix(
       error,
       expr.op,
       left.contents,
-      right.contents,
+      right.contents
     ).map(matrixV);
   } else if (left.tag === "MatrixV" && right.tag === "FloatV") {
     return evalBinOpMatrixScalar(
       error,
       expr.op,
       left.contents,
-      right.contents,
+      right.contents
     ).map(matrixV);
   } else if (left.tag === "MatrixV" && right.tag === "VectorV") {
     return evalBinOpMatrixVector(
       error,
       expr.op,
       left.contents,
-      right.contents,
+      right.contents
     ).map(vectorV);
   } else if (left.tag === "VectorV" && right.tag === "MatrixV") {
     return evalBinOpVectorMatrix(
       error,
       expr.op,
       left.contents,
-      right.contents,
+      right.contents
     ).map(vectorV);
   } else if (left.tag === "MatrixV" && right.tag === "MatrixV") {
     return evalBinOpMatrixMatrix(
       error,
       expr.op,
       left.contents,
-      right.contents,
+      right.contents
     ).map(matrixV);
   } else if (left.tag === "StrV" && right.tag === "StrV") {
     return evalBinOpStrings(error, expr.op, left.contents, right.contents).map(
-      strV,
+      strV
     );
   } else {
     return err(error);
@@ -2773,7 +2778,7 @@ const evalBinOp = (
 const eval1D = (
   coll: List<C> | Vector<C> | CollectionAccess<C>,
   first: FloatV<ad.Num>,
-  rest: ArgVal<ad.Num>[],
+  rest: ArgVal<ad.Num>[]
 ): Result<ListV<ad.Num> | VectorV<ad.Num>, StyleDiagnostics> => {
   const elems = [first.contents];
   for (const v of rest) {
@@ -2799,7 +2804,7 @@ const eval1D = (
 const eval2D = (
   coll: List<C> | Vector<C> | CollectionAccess<C>,
   first: VectorV<ad.Num> | ListV<ad.Num> | TupV<ad.Num>,
-  rest: ArgVal<ad.Num>[],
+  rest: ArgVal<ad.Num>[]
 ): Result<
   LListV<ad.Num> | MatrixV<ad.Num> | PtListV<ad.Num>,
   StyleDiagnostics
@@ -2835,7 +2840,7 @@ const eval2D = (
 const evalShapeList = (
   coll: List<C> | Vector<C> | CollectionAccess<C>,
   first: Shape<ad.Num>,
-  rest: ArgVal<ad.Num>[],
+  rest: ArgVal<ad.Num>[]
 ): Result<ShapeListV<ad.Num>, StyleDiagnostics> => {
   const elems = [first];
   for (const v of rest) {
@@ -2854,7 +2859,7 @@ const evalListOrVector = (
   stages: OptPipeline,
   context: Context,
   coll: List<C> | Vector<C>,
-  trans: Translation,
+  trans: Translation
 ): Result<Value<ad.Num>, StyleDiagnostics> => {
   return evalExprs(mut, canvas, stages, context, coll.contents, trans).andThen(
     (argVals) => {
@@ -2894,7 +2899,7 @@ const evalListOrVector = (
           }
         }
       }
-    },
+    }
   );
 };
 
@@ -2904,7 +2909,7 @@ const isValidIndex = (a: unknown[], i: number): boolean =>
 const evalAccess = (
   expr: Path<C>,
   coll: Value<ad.Num>,
-  indices: number[],
+  indices: number[]
 ): Result<FloatV<ad.Num>, StyleError> => {
   switch (coll.tag) {
     case "ListV":
@@ -2952,7 +2957,7 @@ const evalAccess = (
 
 const evalUMinus = (
   expr: UOp<C>,
-  arg: Value<ad.Num>,
+  arg: Value<ad.Num>
 ): Result<Value<ad.Num>, StyleError> => {
   switch (arg.tag) {
     case "FloatV": {
@@ -2979,7 +2984,7 @@ const evalUMinus = (
 
 const evalUTranspose = (
   expr: UOp<C>,
-  arg: Value<ad.Num>,
+  arg: Value<ad.Num>
 ): Result<Value<ad.Num>, StyleError> => {
   switch (arg.tag) {
     case "MatrixV": {
@@ -3007,7 +3012,7 @@ const evalExpr = (
   canvas: Canvas,
   layoutStages: OptPipeline,
   { context, expr }: WithContext<Expr<C>>,
-  trans: Translation,
+  trans: Translation
 ): Result<ArgVal<ad.Num>, StyleDiagnostics> => {
   switch (expr.tag) {
     case "BinOp": {
@@ -3017,7 +3022,7 @@ const evalExpr = (
         layoutStages,
         context,
         [expr.left, expr.right],
-        trans,
+        trans
       ).andThen(([left, right]) => {
         const res = evalBinOp(expr, left, right);
         if (res.isErr()) {
@@ -3045,7 +3050,7 @@ const evalExpr = (
         layoutStages,
         context,
         expr.args,
-        trans,
+        trans
       );
       if (args.isErr()) {
         return err(args.error);
@@ -3060,7 +3065,7 @@ const evalExpr = (
       const { name, start, end } = expr;
       if (!isKeyOf(name.value, compDict)) {
         return err(
-          oneErr({ tag: "InvalidFunctionNameError", givenName: name }),
+          oneErr({ tag: "InvalidFunctionNameError", givenName: name })
         );
       }
       const f = compDict[name.value];
@@ -3089,7 +3094,7 @@ const evalExpr = (
         layoutStages,
         context,
         expr,
-        trans,
+        trans
       ).map(val);
     }
     case "Path": {
@@ -3116,7 +3121,7 @@ const evalExpr = (
             canvas,
             layoutStages,
             { context, expr: e },
-            trans,
+            trans
           ).andThen<number>((i) => {
             if (i.tag === "ShapeVal") {
               return err(oneErr({ tag: "NotValueError", expr: e }));
@@ -3128,8 +3133,8 @@ const evalExpr = (
             } else {
               return err(oneErr({ tag: "BadIndexError", expr: e }));
             }
-          }),
-        ),
+          })
+        )
       );
       if (res.isErr()) {
         return err(flatErrs(res.error));
@@ -3150,7 +3155,7 @@ const evalExpr = (
         layoutStages,
         context,
         expr.contents,
-        trans,
+        trans
       ).andThen(([left, right]) => {
         if (left.tag !== "FloatV") {
           return err(oneErr({ tag: "BadElementError", coll: expr, index: 0 }));
@@ -3167,7 +3172,7 @@ const evalExpr = (
         canvas,
         layoutStages,
         { context, expr: expr.arg },
-        trans,
+        trans
       ).andThen((argVal) => {
         if (argVal.tag === "ShapeVal") {
           return err(oneErr({ tag: "NotValueError", expr }));
@@ -3195,7 +3200,7 @@ const evalExpr = (
       const stages: OptStages = stageExpr(
         layoutStages,
         exclude,
-        expr.stages.map((s) => s.value),
+        expr.stages.map((s) => s.value)
       );
       return ok(
         val(
@@ -3203,9 +3208,9 @@ const evalExpr = (
             mut.makeInput({
               init: { tag: "Sampled", sampler: uniform(...canvas.xRange) },
               stages,
-            }),
-          ),
-        ),
+            })
+          )
+        )
       );
     }
     case "CollectionAccess": {
@@ -3234,8 +3239,8 @@ const evalExpr = (
             unexpectedCollectionAccessError(name.value, {
               start: expr.start,
               end: expr.end,
-            }),
-          ),
+            })
+          )
         );
       }
     }
@@ -3253,7 +3258,7 @@ type CollectionType<T> =
 
 const collectIntoVal = (
   coll: ArgVal<ad.Num>[],
-  expr: CollectionAccess<C>,
+  expr: CollectionAccess<C>
 ): Result<CollectionType<ad.Num>, StyleDiagnostics> => {
   if (coll.length === 0) {
     return ok(vectorV([]));
@@ -3278,7 +3283,7 @@ const collectIntoVal = (
           tag: "BadElementError",
           coll: expr,
           index: 0,
-        }),
+        })
       );
     }
   }
@@ -3287,7 +3292,7 @@ const collectIntoVal = (
 const stageExpr = (
   overallStages: string[],
   excludeFlag: boolean,
-  stageList: string[],
+  stageList: string[]
 ): OptStages => {
   if (excludeFlag) {
     const stages = new Set(overallStages);
@@ -3301,7 +3306,7 @@ const stageExpr = (
 };
 
 const extractObjConstrBody = (
-  body: InlineComparison<C> | FunctionCall<C>,
+  body: InlineComparison<C> | FunctionCall<C>
 ): { name: Identifier<C>; argExprs: Expr<C>[] } => {
   if (body.tag === "InlineComparison") {
     const mapInlineOpToFunctionName = (op: "<" | "==" | ">"): string => {
@@ -3341,7 +3346,7 @@ const translateExpr = (
   layoutStages: OptPipeline,
   path: string,
   e: WithContext<NotShape>,
-  trans: Translation,
+  trans: Translation
 ): Translation => {
   switch (e.expr.tag) {
     case "BinOp":
@@ -3374,7 +3379,7 @@ const translateExpr = (
         layoutStages,
         e.context,
         argExprs,
-        trans,
+        trans
       );
       if (args.isErr()) {
         return addDiags(args.error, trans);
@@ -3389,13 +3394,13 @@ const translateExpr = (
       if (!isKeyOf(fname, constrDict)) {
         return addDiags(
           oneErr({ tag: "InvalidConstraintNameError", givenName: name }),
-          trans,
+          trans
         );
       }
       const output = callObjConstrFunc(
         constrDict[fname],
         { start: e.expr.start, end: e.expr.end },
-        argsWithSourceLoc,
+        argsWithSourceLoc
       );
       if (output.isErr()) {
         return addDiags(oneErr(output.error), trans);
@@ -3406,7 +3411,7 @@ const translateExpr = (
       const optStages: OptStages = stageExpr(
         layoutStages,
         exclude,
-        stages.map((s) => s.value),
+        stages.map((s) => s.value)
       );
       return {
         ...trans,
@@ -3429,7 +3434,7 @@ const translateExpr = (
         layoutStages,
         e.context,
         argExprs,
-        trans,
+        trans
       );
       if (args.isErr()) {
         return addDiags(args.error, trans);
@@ -3444,19 +3449,19 @@ const translateExpr = (
       if (!isKeyOf(fname, objDict)) {
         return addDiags(
           oneErr({ tag: "InvalidObjectiveNameError", givenName: name }),
-          trans,
+          trans
         );
       }
 
       const optStages: OptStages = stageExpr(
         layoutStages,
         exclude,
-        stages.map((s) => s.value),
+        stages.map((s) => s.value)
       );
       const output = callObjConstrFunc(
         objDict[fname],
         { start: e.expr.start, end: e.expr.end },
-        argsWithSourceLoc,
+        argsWithSourceLoc
       );
       if (output.isErr()) {
         return addDiags(oneErr(output.error), trans);
@@ -3479,17 +3484,17 @@ const translateExpr = (
       const { expr, context } = e;
 
       const leftPp = prettyPrintResolvedPath(
-        resolveRhsPath({ context: context, expr: expr.left }),
+        resolveRhsPath({ context: context, expr: expr.left })
       );
       const leftResolved = evalExpr(
         mut,
         canvas,
         layoutStages,
         { context, expr: expr.left },
-        trans,
+        trans
       );
       const rightListPp = expr.right.map((r: Path<C>) =>
-        prettyPrintResolvedPath(resolveRhsPath({ context: context, expr: r })),
+        prettyPrintResolvedPath(resolveRhsPath({ context: context, expr: r }))
       );
       const rightListResolved = evalExprs(
         mut,
@@ -3497,7 +3502,7 @@ const translateExpr = (
         layoutStages,
         context,
         expr.right,
-        trans,
+        trans
       );
       if (leftResolved.isErr()) {
         return addDiags(leftResolved.error, trans);
@@ -3512,7 +3517,7 @@ const translateExpr = (
             },
             expr: leftPp,
           }),
-          trans,
+          trans
         );
       }
 
@@ -3530,7 +3535,7 @@ const translateExpr = (
               },
               expr: rightListPp[i],
             }),
-            trans,
+            trans
           );
         }
       }
@@ -3554,7 +3559,7 @@ const translateExpr = (
 const evalGPI = (
   path: string,
   shapeType: ShapeType,
-  trans: Translation,
+  trans: Translation
 ): Result<Shape<ad.Num>, StyleError> => {
   return checkShape(shapeType, path, trans);
 };
@@ -3564,7 +3569,7 @@ export const translate = (
   canvas: Canvas,
   stages: OptPipeline,
   graph: DepGraph,
-  warnings: im.List<StyleWarning>,
+  warnings: im.List<StyleWarning>
 ): Translation => {
   let symbols = im.Map<string, ArgVal<ad.Num>>();
   for (const path of graph.nodes()) {
@@ -3595,7 +3600,7 @@ export const translate = (
             ? undefined
             : { start: e.expr.start, end: e.expr.end },
       };
-    }),
+    })
   );
   if (cycles.length > 0) {
     return {
@@ -3660,7 +3665,7 @@ export type LayerGraph = Graph<string>;
 export const processLayering = (
   { below, above }: Layer,
   groupGraph: GroupGraph,
-  layerGraph: LayerGraph,
+  layerGraph: LayerGraph
 ): void => {
   // Path from the root to the node, excluding the root
   // [..., below]
@@ -3687,7 +3692,7 @@ export const processLayering = (
 export const computeLayerOrdering = (
   allGPINames: string[],
   partialOrderings: Layer[],
-  groupGraph: GroupGraph,
+  groupGraph: GroupGraph
 ): {
   shapeOrdering: string[];
   warning?: LayerCycleWarning;
@@ -3720,7 +3725,7 @@ export const computeLayerOrdering = (
 
 const pseudoTopsort = (graph: Graph<string>): string[] => {
   const indegree = new Map<string, number>(
-    graph.nodes().map((i) => [i, graph.inEdges(i).length]),
+    graph.nodes().map((i) => [i, graph.inEdges(i).length])
   );
   // Nodes with lower in-degrees have highest priority.
   // Swap if a has higher in-degree than b.
@@ -3747,7 +3752,7 @@ const pseudoTopsort = (graph: Graph<string>): string[] => {
 // Check that canvas dimensions exist and have the proper type.
 export const getCanvasDim = (
   attr: "width" | "height",
-  graph: DepGraph,
+  graph: DepGraph
 ): Result<number, StyleError> => {
   const i = `canvas.${attr}`;
   if (!graph.hasNode(i))
@@ -3776,7 +3781,7 @@ export const parseStyle = (p: string): Result<StyProg<C>, ParseError> => {
       return ok(ast);
     } else {
       return err(
-        parseError(`Unexpected end of input`, lastLocation(parser), "Style"),
+        parseError(`Unexpected end of input`, lastLocation(parser), "Style")
       );
     }
   } catch (e) {
@@ -3785,10 +3790,10 @@ export const parseStyle = (p: string): Result<StyProg<C>, ParseError> => {
 };
 
 export const getLayoutStages = (
-  prog: StyProg<C>,
+  prog: StyProg<C>
 ): Result<OptPipeline, MultipleLayoutError> => {
   const layoutStmts: LayoutStages<C>[] = prog.items.filter(
-    (i): i is LayoutStages<C> => i.tag === "LayoutStages",
+    (i): i is LayoutStages<C> => i.tag === "LayoutStages"
   );
   if (layoutStmts.length === 0) {
     // if no stages specified, default to "" because that way nobody can refer
@@ -3808,7 +3813,7 @@ export const getLayoutStages = (
 
 const getShapesList = (
   { symbols }: Translation,
-  shapeOrdering: string[],
+  shapeOrdering: string[]
 ): Shape<ad.Num>[] => {
   return shapeOrdering.map((path) => {
     const shape = symbols.get(path);
@@ -3836,7 +3841,7 @@ const onCanvases = (canvas: Canvas, shapes: Shape<ad.Num>[]): Fn[] => {
       const output = constrDict.onCanvas.body(
         shape,
         canvas.width,
-        canvas.height,
+        canvas.height
       ).value;
       fns.push({
         ast: {
@@ -3878,7 +3883,7 @@ export const stageConstraints = (
   inputs: InputMeta[],
   constrFns: Fn[],
   objFns: Fn[],
-  stages: OptPipeline,
+  stages: OptPipeline
 ): StagedConstraints =>
   new Map(
     stages.map((stage) => [
@@ -3886,18 +3891,18 @@ export const stageConstraints = (
       {
         inputMask: inputs.map((i) => i.stages === "All" || i.stages.has(stage)),
         constrMask: constrFns.map(
-          ({ optStages }) => optStages === "All" || optStages.has(stage),
+          ({ optStages }) => optStages === "All" || optStages.has(stage)
         ),
         objMask: objFns.map(
-          ({ optStages }) => optStages === "All" || optStages.has(stage),
+          ({ optStages }) => optStages === "All" || optStages.has(stage)
         ),
       },
-    ]),
+    ])
   );
 
 const processPassthrough = (
   { symbols }: Translation,
-  nameShapeMap: Map<string, Shape<ad.Num>>,
+  nameShapeMap: Map<string, Shape<ad.Num>>
 ): Result<void, StyleError> => {
   for (const [key, value] of symbols) {
     const i = key.lastIndexOf(".");
@@ -3912,7 +3917,7 @@ const processPassthrough = (
           shape.passthrough.set(propName, value.contents);
         } else {
           return err(
-            badShapeParamTypeError(key, value, "StrV or FloatV", true),
+            badShapeParamTypeError(key, value, "StrV or FloatV", true)
           );
         }
       } else {
@@ -3927,7 +3932,7 @@ export const compileStyleHelper = async (
   variation: string,
   stySource: string,
   subEnv: SubstanceEnv,
-  varEnv: Env,
+  varEnv: Env
 ): Promise<
   Result<
     {
@@ -3968,7 +3973,7 @@ export const compileStyleHelper = async (
   const graph = gatherDependencies(assignment);
 
   const canvas = getCanvasDim("width", graph).andThen((w) =>
-    getCanvasDim("height", graph).map((h) => makeCanvas(w, h)),
+    getCanvasDim("height", graph).map((h) => makeCanvas(w, h))
   );
   if (canvas.isErr()) {
     return err(toStyleErrors([canvas.error]));
@@ -3994,7 +3999,7 @@ export const compileStyleHelper = async (
     canvas.value,
     optimizationStages.value,
     graph,
-    assignment.diagnostics.warnings,
+    assignment.diagnostics.warnings
   );
 
   log.info("translation (before genOptProblem)", translation);
@@ -4006,7 +4011,7 @@ export const compileStyleHelper = async (
   const groupGraph: GroupGraph = makeGroupGraph(
     getShapesList(translation, [
       ...graph.nodes().filter((p) => typeof graph.node(p) === "string"),
-    ]),
+    ])
   );
 
   const groupWarnings = checkGroupGraph(groupGraph);
@@ -4015,7 +4020,7 @@ export const compileStyleHelper = async (
     computeLayerOrdering(
       [...graph.nodes().filter((p) => typeof graph.node(p) === "string")],
       [...translation.layering],
-      groupGraph,
+      groupGraph
     );
 
   // Fix the ordering between nodes of the group graph
@@ -4041,7 +4046,7 @@ export const compileStyleHelper = async (
   const renderGraph = buildRenderGraph(
     findOrderedRoots(groupGraph),
     groupGraph,
-    nameShapeMap,
+    nameShapeMap
   );
 
   const objFns = [...translation.objectives];
@@ -4055,7 +4060,7 @@ export const compileStyleHelper = async (
     metas,
     constrFns,
     objFns,
-    optimizationStages.value,
+    optimizationStages.value
   );
 
   const computeShapes = await compileCompGraph(inputs, renderGraph);
@@ -4063,7 +4068,7 @@ export const compileStyleHelper = async (
   const gradient = await genGradient(
     inputs,
     objFns.map(({ output }) => output),
-    constrFns.map(({ output }) => output),
+    constrFns.map(({ output }) => output)
   );
 
   const params = genOptProblem(varyingValues.length);
@@ -4103,15 +4108,15 @@ export const compileStyle = async (
   stySource: string,
   excludeWarnings: string[],
   subEnv: SubstanceEnv,
-  varEnv: Env,
+  varEnv: Env
 ): Promise<Result<State, PenroseError>> =>
   (await compileStyleHelper(variation, stySource, subEnv, varEnv)).map(
     ({ state }) => ({
       ...state,
       warnings: state.warnings.filter(
-        (warning) => !excludeWarnings.includes(warning.tag),
+        (warning) => !excludeWarnings.includes(warning.tag)
       ),
-    }),
+    })
   );
 
 //#endregion Main funcitons

--- a/packages/core/src/compiler/Style.ts
+++ b/packages/core/src/compiler/Style.ts
@@ -216,7 +216,7 @@ const flatErrs = (es: StyleDiagnostics[]): StyleDiagnostics => {
 
 const addDiags = <T extends { diagnostics: StyleDiagnostics }>(
   { errors, warnings }: StyleDiagnostics,
-  x: T
+  x: T,
 ): T => ({
   ...x,
   diagnostics: {
@@ -316,7 +316,7 @@ const addMapping = (
   k: BindingForm<A>,
   v: StyT<A>,
   m: SelEnv,
-  p: ProgType
+  p: ProgType,
 ): SelEnv => {
   m.sTypeVarMap[toString(k)] = v;
   m.varProgTypeMap[toString(k)] = [p, k];
@@ -337,7 +337,7 @@ const addErrSel = (selEnv: SelEnv, err: StyleError): SelEnv => {
 const checkDeclPatternAndMakeEnv = (
   varEnv: Env,
   selEnv: SelEnv,
-  stmt: DeclPattern<A>
+  stmt: DeclPattern<A>,
 ): SelEnv => {
   const [styType, bVar] = [stmt.type, stmt.id];
 
@@ -397,11 +397,11 @@ const checkDeclPatternAndMakeEnv = (
 const checkDeclPatternsAndMakeEnv = (
   varEnv: Env,
   selEnv: SelEnv,
-  decls: DeclPattern<A>[]
+  decls: DeclPattern<A>[],
 ): SelEnv => {
   return decls.reduce(
     (s, p) => checkDeclPatternAndMakeEnv(varEnv, s, p),
-    selEnv
+    selEnv,
   );
 };
 
@@ -447,7 +447,7 @@ const getSelectorStyVarNames = (selEnv: SelEnv): string[] => {
 const aliasConflictsWithDomainOrSelectorKeyword = (
   alias: Identifier<A>,
   varEnv: Env,
-  selEnv: SelEnv
+  selEnv: SelEnv,
 ): boolean => {
   const domainKeywords = getDomainKeywords(varEnv);
   const selectorKeywords = getSelectorStyVarNames(selEnv);
@@ -462,7 +462,7 @@ const aliasConflictsWithDomainOrSelectorKeyword = (
 const checkRelPattern = (
   varEnv: Env,
   selEnv: SelEnv,
-  rel: RelationPattern<A>
+  rel: RelationPattern<A>,
 ): StyleError[] => {
   // rule Bind-Context
   switch (rel.tag) {
@@ -545,10 +545,10 @@ const checkRelPattern = (
 const checkRelPatterns = (
   varEnv: Env,
   selEnv: SelEnv,
-  rels: RelationPattern<A>[]
+  rels: RelationPattern<A>[],
 ): StyleError[] => {
   return _.flatMap(rels, (rel: RelationPattern<A>): StyleError[] =>
-    checkRelPattern(varEnv, selEnv, rel)
+    checkRelPattern(varEnv, selEnv, rel),
   );
 };
 
@@ -567,7 +567,7 @@ const toSubstanceType = (styT: StyT<A>): TypeConsApp<A> => {
 const mergeMapping = (
   varProgTypeMap: { [k: string]: [ProgType, BindingForm<A>] },
   varEnv: Env,
-  [varName, styType]: [string, StyT<A>]
+  [varName, styType]: [string, StyT<A>],
 ): Env => {
   const res = varProgTypeMap[varName];
   if (!res) {
@@ -576,7 +576,7 @@ const mergeMapping = (
   const [, bindingForm] = res;
   const vars = varEnv.vars.set(
     bindingForm.contents.value,
-    toSubstanceType(styType)
+    toSubstanceType(styType),
   );
   switch (bindingForm.tag) {
     case "StyVar":
@@ -605,7 +605,7 @@ const mergeMapping = (
 const mergeEnv = (varEnv: Env, selEnv: SelEnv): Env => {
   return Object.entries(selEnv.sTypeVarMap).reduce(
     (acc, curr) => mergeMapping(selEnv.varProgTypeMap, acc, curr),
-    varEnv
+    varEnv,
   );
 };
 
@@ -614,14 +614,14 @@ const checkSelector = (varEnv: Env, sel: Selector<A>): SelEnv => {
   const selEnv_afterHead = checkDeclPatternsAndMakeEnv(
     varEnv,
     initSelEnv(),
-    sel.head.contents
+    sel.head.contents,
   );
   // Check `with` statements
   // TODO: Did we get rid of `with` statements?
   const selEnv_decls = checkDeclPatternsAndMakeEnv(
     varEnv,
     selEnv_afterHead,
-    safeContentsList(sel.with)
+    safeContentsList(sel.with),
   );
 
   // Basically creates a new, empty environment.
@@ -629,7 +629,7 @@ const checkSelector = (varEnv: Env, sel: Selector<A>): SelEnv => {
   const relErrs = checkRelPatterns(
     mergeEnv(emptyVarsEnv, selEnv_decls),
     selEnv_decls,
-    safeContentsList(sel.where)
+    safeContentsList(sel.where),
   );
 
   // TODO(error): The errors returned in the top 3 statements
@@ -643,23 +643,23 @@ const checkCollector = (varEnv: Env, col: Collector<A>): SelEnv => {
   const selEnv_afterHead = checkDeclPatternAndMakeEnv(
     varEnv,
     initSelEnv(),
-    col.head
+    col.head,
   );
   const selEnv_afterWith = checkDeclPatternsAndMakeEnv(
     varEnv,
     selEnv_afterHead,
-    safeContentsList(col.with)
+    safeContentsList(col.with),
   );
   const selEnv_afterGroupby = checkDeclPatternsAndMakeEnv(
     varEnv,
     selEnv_afterWith,
-    safeContentsList(col.foreach)
+    safeContentsList(col.foreach),
   );
   const emptyVarsEnv: Env = { ...varEnv, vars: im.Map(), varIDs: [] };
   const relErrs = checkRelPatterns(
     mergeEnv(emptyVarsEnv, selEnv_afterGroupby),
     selEnv_afterGroupby,
-    safeContentsList(col.where)
+    safeContentsList(col.where),
   );
 
   return {
@@ -716,7 +716,7 @@ export const uniqueKeysAndVals = (subst: Subst): boolean => {
  * Returns the substitution for a predicate alias
  */
 const getSubPredAliasInstanceName = (
-  pred: ApplyPredicate<A> | ApplyFunction<A> | ApplyConstructor<A>
+  pred: ApplyPredicate<A> | ApplyFunction<A> | ApplyConstructor<A>,
 ): string => {
   let name = pred.name.value;
   for (const arg of pred.args) {
@@ -743,7 +743,7 @@ const getSubPredAliasInstanceName = (
 const substituteBform = (
   lv: LocalVarSubst | undefined,
   subst: Subst,
-  bform: BindingForm<A>
+  bform: BindingForm<A>,
 ): BindingForm<A> => {
   // theta(B) = ...
   switch (bform.tag) {
@@ -817,7 +817,7 @@ const substitutePredArg = (subst: Subst, predArg: PredArg<A>): PredArg<A> => {
 // theta(|S_r) = ...
 export const substituteRel = (
   subst: Subst,
-  rel: RelationPattern<A>
+  rel: RelationPattern<A>,
 ): RelationPattern<A> => {
   switch (rel.tag) {
     case "RelBind": {
@@ -884,7 +884,7 @@ const toSubExpr = <T>(env: Env, e: SelExpr<T>): SubExpr<T> => {
       } else {
         // TODO: return TypeNotFound instead
         throw new Error(
-          `Style internal error: expected '${e.name.value}' to be either a constructor or function, but was not found`
+          `Style internal error: expected '${e.name.value}' to be either a constructor or function, but was not found`,
         );
       }
       const res: SubExpr<T> = {
@@ -950,7 +950,7 @@ const subFnsEq = (p1: SubPredArg<A>, p2: SubPredArg<A>, env: Env): boolean => {
     const predicateDecl = env.predicates.get(p1.name.value);
     if (predicateDecl && predicateDecl.symmetric) {
       return zip2(p1.args, [p2.args[1], p2.args[0]]).every(([a1, a2]) =>
-        argsEq(a1, a2, env)
+        argsEq(a1, a2, env),
       );
     } else {
       return false;
@@ -988,7 +988,7 @@ const deduplicate = (
   subEnv: SubstanceEnv,
   subProg: SubProg<A>,
   rels: RelationPattern<A>[],
-  pSubsts: im.List<[Subst, im.Set<SubStmt<A> | undefined>]>
+  pSubsts: im.List<[Subst, im.Set<SubStmt<A> | undefined>]>,
 ): im.List<Subst> => {
   const initSubsts: im.List<Subst> = im.List();
 
@@ -1009,7 +1009,7 @@ const deduplicate = (
         return [currMatches.add(record), currSubsts.push(subst)];
       }
     },
-    [initMatches, initSubsts]
+    [initMatches, initSubsts],
   );
   return goodSubsts;
 };
@@ -1039,7 +1039,7 @@ const combine = (s1: Subst, s2: Subst): Subst => {
  */
 const merge = (
   s1: im.List<[Subst, im.Set<SubStmt<A>>]>,
-  s2: im.List<[Subst, im.Set<SubStmt<A>>]>
+  s2: im.List<[Subst, im.Set<SubStmt<A>>]>,
 ): im.List<[Subst, im.Set<SubStmt<A>>]> => {
   if (s1.size === 0 || s2.size === 0) {
     return im.List();
@@ -1057,7 +1057,7 @@ const merge = (
     ([aSubst, aStmts], [bSubst, bStmts]) => [
       combine(aSubst, bSubst),
       aStmts.union(bStmts),
-    ]
+    ],
   );
   return im.List(result);
 };
@@ -1089,7 +1089,7 @@ const consistentSubsts = (a: Subst, b: Subst): boolean => {
 const typesMatched = (
   varEnv: Env,
   substanceType: TypeConsApp<A>,
-  styleType: StyT<A>
+  styleType: StyT<A>,
 ): boolean => {
   if (substanceType.args.length === 0) {
     // Style type needs to be more generic than Style type
@@ -1098,14 +1098,14 @@ const typesMatched = (
 
   // TODO(errors)
   throw Error(
-    "internal error: expected two nullary types (parametrized types to be implemented)"
+    "internal error: expected two nullary types (parametrized types to be implemented)",
   );
 };
 
 // Judgment 10. theta |- x <| B
 const matchBvar = (
   subVar: Identifier<A>,
-  bf: BindingForm<A>
+  bf: BindingForm<A>,
 ): Subst | undefined => {
   switch (bf.tag) {
     case "StyVar": {
@@ -1129,7 +1129,7 @@ const matchBvar = (
 const matchDeclLine = (
   varEnv: Env,
   line: SubStmt<A>,
-  decl: DeclPattern<A>
+  decl: DeclPattern<A>,
 ): Subst | undefined => {
   if (line.tag === "Decl") {
     const [subT, subVar] = [line.type, line.name];
@@ -1149,7 +1149,7 @@ const matchDeclLine = (
 const matchDecl = (
   varEnv: Env,
   subProg: SubProg<A>,
-  decl: DeclPattern<A>
+  decl: DeclPattern<A>,
 ): im.List<Subst> => {
   const initDSubsts: im.List<Subst> = im.List();
   // Judgment 14. G; [theta] |- [S] <| |S_o
@@ -1174,7 +1174,7 @@ const matchStyArgToSubArg = (
   subTypeMap: { [k: string]: TypeConsApp<A> },
   varEnv: Env,
   styArg: PredArg<A> | SelExpr<A>,
-  subArg: SubPredArg<A> | SubExpr<A>
+  subArg: SubPredArg<A> | SubExpr<A>,
 ): Subst[] => {
   if (styArg.tag === "SEBind" && subArg.tag === "Identifier") {
     const styBForm = styArg.contents;
@@ -1206,7 +1206,7 @@ const matchStyArgToSubArg = (
       subTypeMap,
       varEnv,
       styArg,
-      subArg
+      subArg,
     );
   }
   if (
@@ -1218,7 +1218,7 @@ const matchStyArgToSubArg = (
       subTypeMap,
       varEnv,
       styArg,
-      subArg
+      subArg,
     );
   }
   if (
@@ -1230,7 +1230,7 @@ const matchStyArgToSubArg = (
       subTypeMap,
       varEnv,
       styArg,
-      subArg
+      subArg,
     );
   }
   return [];
@@ -1245,7 +1245,7 @@ const matchStyArgsToSubArgs = (
   subTypeMap: { [k: string]: TypeConsApp<A> },
   varEnv: Env,
   styArgs: PredArg<A>[] | SelExpr<A>[],
-  subArgs: SubPredArg<A>[] | SubExpr<A>[]
+  subArgs: SubPredArg<A>[] | SubExpr<A>[],
 ): Subst[] => {
   const stySubArgPairs = zip2<
     PredArg<A> | SelExpr<A>,
@@ -1258,7 +1258,7 @@ const matchStyArgsToSubArgs = (
       subTypeMap,
       varEnv,
       styArg,
-      subArg
+      subArg,
     );
     return argSubsts;
   });
@@ -1279,10 +1279,10 @@ const matchStyArgsToSubArgs = (
           currSubsts,
           substsForArg,
           (aSubst, bSubst) => consistentSubsts(aSubst, bSubst),
-          (aSubst, bSubst) => combine(aSubst, bSubst)
+          (aSubst, bSubst) => combine(aSubst, bSubst),
         );
       },
-      first
+      first,
     );
     return substs;
   } else {
@@ -1308,7 +1308,7 @@ const matchStyApplyToSubApply = (
   subTypeMap: { [k: string]: TypeConsApp<A> },
   varEnv: Env,
   styRel: RelPred<A> | SelExpr<A>,
-  subRel: ApplyPredicate<A> | SubExpr<A>
+  subRel: ApplyPredicate<A> | SubExpr<A>,
 ): Subst[] => {
   // Predicate Applications
   if (styRel.tag === "RelPred" && subRel.tag === "ApplyPredicate") {
@@ -1323,7 +1323,7 @@ const matchStyApplyToSubApply = (
       subTypeMap,
       varEnv,
       styRel.args,
-      subRel.args
+      subRel.args,
     );
 
     // Consider the symmetric, flipped-argument version
@@ -1337,7 +1337,7 @@ const matchStyApplyToSubApply = (
         subTypeMap,
         varEnv,
         flippedStyArgs,
-        subRel.args
+        subRel.args,
       );
     }
 
@@ -1374,7 +1374,7 @@ const matchStyApplyToSubApply = (
       subTypeMap,
       varEnv,
       styRel.args,
-      subRel.args
+      subRel.args,
     );
     return rSubst;
   }
@@ -1396,7 +1396,7 @@ const matchRelField = (
   varEnv: Env,
   subEnv: SubstanceEnv,
   rel: RelField<A>,
-  subDecl: Decl<A>
+  subDecl: Decl<A>,
 ): Subst | undefined => {
   const styName = toString(rel.name);
   const styType = styTypeMap[styName];
@@ -1422,7 +1422,7 @@ const matchRelField = (
 };
 
 const getStyPredOrFuncOrConsArgNames = (
-  arg: PredArg<A> | SelExpr<A>
+  arg: PredArg<A> | SelExpr<A>,
 ): im.Set<string> => {
   if (arg.tag === "RelPred") {
     return getStyRelArgNames(arg);
@@ -1460,7 +1460,7 @@ const matchStyRelToSubRels = (
   varEnv: Env,
   subEnv: SubstanceEnv,
   rel: RelationPattern<A>,
-  subProg: SubProg<A>
+  subProg: SubProg<A>,
 ): [im.Set<string>, im.List<[Subst, im.Set<SubStmt<A>>]>] => {
   const initUsedStyVars = im.Set<string>();
   const initRSubsts = im.List<[Subst, im.Set<SubStmt<A>>]>();
@@ -1476,7 +1476,7 @@ const matchStyRelToSubRels = (
           subTypeMap,
           varEnv,
           styPred,
-          statement
+          statement,
         );
 
         return rSubstsForPred.reduce((rSubsts, rSubstForPred) => {
@@ -1486,7 +1486,7 @@ const matchStyRelToSubRels = (
           ]);
         }, rSubsts);
       },
-      initRSubsts
+      initRSubsts,
     );
     return [getStyRelArgNames(rel), newRSubsts];
   } else if (rel.tag === "RelBind") {
@@ -1506,7 +1506,7 @@ const matchStyRelToSubRels = (
         subTypeMap,
         varEnv,
         styBindedExpr,
-        subBindedExpr
+        subBindedExpr,
       );
 
       return rSubstsForExpr.reduce((rSubsts, rSubstForExpr) => {
@@ -1529,7 +1529,7 @@ const matchStyRelToSubRels = (
           varEnv,
           subEnv,
           rel,
-          statement
+          statement,
         );
         if (rSubst === undefined) {
           return rSubsts;
@@ -1566,7 +1566,7 @@ const makeListRSubstsForStyleRels = (
   varEnv: Env,
   subEnv: SubstanceEnv,
   rels: RelationPattern<A>[],
-  subProg: SubProg<A>
+  subProg: SubProg<A>,
 ): [im.Set<string>, im.List<im.List<[Subst, im.Set<SubStmt<A>>]>>] => {
   const initUsedStyVars: im.Set<string> = im.Set();
   const initListRSubsts: im.List<im.List<[Subst, im.Set<SubStmt<A>>]>> =
@@ -1580,11 +1580,11 @@ const makeListRSubstsForStyleRels = (
         varEnv,
         subEnv,
         rel,
-        subProg
+        subProg,
       );
       return [usedStyVars.union(relUsedStyVars), listRSubsts.push(relRSubsts)];
     },
-    [initUsedStyVars, initListRSubsts]
+    [initUsedStyVars, initListRSubsts],
   );
 
   return [newUsedStyVars, newListRSubsts];
@@ -1599,7 +1599,7 @@ const makePotentialSubsts = (
   subEnv: SubstanceEnv,
   subProg: SubProg<A>,
   decls: DeclPattern<A>[],
-  rels: RelationPattern<A>[]
+  rels: RelationPattern<A>[],
 ): im.List<[Subst, im.Set<SubStmt<A>>]> => {
   const subTypeMap = subProg.statements.reduce<{ [k: string]: TypeConsApp<A> }>(
     (result, statement) => {
@@ -1610,7 +1610,7 @@ const makePotentialSubsts = (
         return result;
       }
     },
-    {}
+    {},
   );
   const styTypeMap: { [k: string]: StyT<A> } = selEnv.sTypeVarMap;
   const [usedStyVars, listRSubsts] = makeListRSubstsForStyleRels(
@@ -1619,7 +1619,7 @@ const makePotentialSubsts = (
     varEnv,
     subEnv,
     rels,
-    subProg
+    subProg,
   );
   // Add in variables that are not present in the relations.
   const listPSubsts = decls.reduce((currListPSubsts, decl) => {
@@ -1628,7 +1628,7 @@ const makePotentialSubsts = (
     } else {
       const pSubsts = matchDecl(varEnv, subProg, decl);
       return currListPSubsts.push(
-        pSubsts.map((pSubst) => [pSubst, im.Set<SubStmt<A>>()])
+        pSubsts.map((pSubst) => [pSubst, im.Set<SubStmt<A>>()]),
       );
     }
   }, listRSubsts);
@@ -1665,7 +1665,7 @@ const getSubsts = (
   subEnv: SubstanceEnv,
   selEnv: SelEnv,
   subProg: SubProg<A>,
-  header: Collector<A> | Selector<A>
+  header: Collector<A> | Selector<A>,
 ): Subst[] => {
   const decls = getDecls(header);
   const rels = safeContentsList(header.where);
@@ -1675,7 +1675,7 @@ const getSubsts = (
     subEnv,
     subProg,
     decls,
-    rels
+    rels,
   );
   log.debug("total number of raw substs: ", rawSubsts.size);
 
@@ -1701,7 +1701,7 @@ const collectSubsts = (
   substs: Subst[],
   toCollect: string,
   collectInto: string,
-  groupbys: string[]
+  groupbys: string[],
 ): CollectionSubst[] => {
   const buckets: Map<string, GroupbyBucket> = new Map();
 
@@ -1739,7 +1739,7 @@ const findSubstsSel = (
   varEnv: Env,
   subEnv: SubstanceEnv,
   subProg: SubProg<A>,
-  [header, selEnv]: [Header<A>, SelEnv]
+  [header, selEnv]: [Header<A>, SelEnv],
 ): StySubst[] => {
   if (header.tag === "Selector") {
     return getSubsts(varEnv, subEnv, selEnv, subProg, header).map((subst) => ({
@@ -1774,7 +1774,7 @@ const updateExpr = (
   errTagGlobal: "AssignGlobalError" | "DeleteGlobalError",
   errTagSubstance: "AssignSubstanceError" | "DeleteSubstanceError",
   // this function performs the actual dictionary updates. `updateExpr` only needs to extract the path to pass to `f`.
-  f: (field: Field, prop: PropID | undefined, fielded: FieldDict) => FieldedRes
+  f: (field: Field, prop: PropID | undefined, fielded: FieldDict) => FieldedRes,
 ): BlockAssignment => {
   switch (path.tag) {
     case "Global": {
@@ -1783,7 +1783,7 @@ const updateExpr = (
       } else if (path.members.length > 2) {
         return addDiags(
           oneErr({ tag: "PropertyMemberError", path }),
-          assignment
+          assignment,
         );
       }
       const field = path.members[0].value;
@@ -1804,7 +1804,7 @@ const updateExpr = (
       if (path.members.length > 1) {
         return addDiags(
           oneErr({ tag: "PropertyMemberError", path }),
-          assignment
+          assignment,
         );
       }
       // remember, we don't use `--noUncheckedIndexedAccess`
@@ -1823,7 +1823,7 @@ const updateExpr = (
       } else if (path.members.length > 2) {
         return addDiags(
           oneErr({ tag: "PropertyMemberError", path }),
-          assignment
+          assignment,
         );
       }
       const field = path.members[0].value;
@@ -1845,7 +1845,7 @@ const updateExpr = (
 
 const processExpr = (
   context: Context,
-  expr: Expr<C>
+  expr: Expr<C>,
 ): Result<FieldSource, StyleError> => {
   if (expr.tag !== "GPIDecl") {
     return ok({ tag: "OtherSource", expr: { context, expr } });
@@ -1862,7 +1862,7 @@ const processExpr = (
       }
       return ok(m.set(name.value, { context, expr: value }));
     },
-    ok(im.Map())
+    ok(im.Map()),
   );
   return andThen((props) => ok({ tag: "ShapeSource", shapeType, props }), res);
 };
@@ -1871,7 +1871,7 @@ const insertExpr = (
   block: BlockInfo,
   path: ResolvedPath<C>,
   expr: Expr<C>,
-  assignment: BlockAssignment
+  assignment: BlockAssignment,
 ): BlockAssignment =>
   updateExpr(
     path,
@@ -1883,7 +1883,7 @@ const insertExpr = (
       if (prop === undefined) {
         const source = processExpr(
           { ...block, locals: assignment.locals },
-          expr
+          expr,
         );
         if (source.isErr()) {
           return err(source.error);
@@ -1917,12 +1917,12 @@ const insertExpr = (
           warns,
         });
       }
-    }
+    },
   );
 
 const deleteExpr = (
   path: ResolvedPath<C>,
-  assignment: BlockAssignment
+  assignment: BlockAssignment,
 ): BlockAssignment =>
   updateExpr(
     path,
@@ -1951,13 +1951,13 @@ const deleteExpr = (
           warns: [],
         });
       }
-    }
+    },
   );
 
 const resolveLhsName = (
   { block, subst }: BlockInfo,
   assignment: BlockAssignment,
-  name: BindingForm<C>
+  name: BindingForm<C>,
 ): ResolvedName => {
   const { value } = name.contents;
   switch (name.tag) {
@@ -1986,7 +1986,7 @@ const resolveLhsName = (
 const resolveLhsPath = (
   block: BlockInfo,
   assignment: BlockAssignment,
-  path: Path<C>
+  path: Path<C>,
 ): Result<ResolvedPath<C>, StyleError> => {
   const { start, end, name, members, indices } = path;
   return indices.length > 0
@@ -2003,7 +2003,7 @@ const processStmt = (
   block: BlockInfo,
   index: number,
   stmt: Stmt<C>,
-  assignment: BlockAssignment
+  assignment: BlockAssignment,
 ): BlockAssignment => {
   switch (stmt.tag) {
     case "PathAssign": {
@@ -2024,7 +2024,7 @@ const processStmt = (
         block,
         path.value,
         stmt.value,
-        deleteExpr(path.value, assignment)
+        deleteExpr(path.value, assignment),
       );
     }
     case "Delete": {
@@ -2049,7 +2049,7 @@ const processStmt = (
           members: [],
         },
         stmt.contents,
-        assignment
+        assignment,
       );
     }
   }
@@ -2058,7 +2058,7 @@ const processStmt = (
 const blockId = (
   blockIndex: number,
   substIndex: number,
-  header: Header<A>
+  header: Header<A>,
 ): LocalVarSubst => {
   switch (header.tag) {
     case "Selector":
@@ -2115,7 +2115,7 @@ const processBlock = (
   subEnv: SubstanceEnv,
   blockIndex: number,
   hb: HeaderBlock<C>,
-  assignment: Assignment
+  assignment: Assignment,
 ): Assignment => {
   // Run static checks first
   const selEnv = checkHeader(varEnv, hb.header);
@@ -2142,7 +2142,7 @@ const processBlock = (
           redeclareNamespaceError(block.contents, {
             start: hb.header.start,
             end: hb.header.end,
-          })
+          }),
         );
       } else {
         // prepopulate with an empty namespace if it doesn't exist
@@ -2155,7 +2155,7 @@ const processBlock = (
 
     const matchTotalAssignment = makeFakeIntPathAssign(
       "match_total",
-      substs.length
+      substs.length,
     );
 
     const augmentedStatements = im
@@ -2169,7 +2169,7 @@ const processBlock = (
       augmentedStatements.reduce(
         (assignment, stmt, stmtIndex) =>
           processStmt({ block, subst }, stmtIndex, stmt, assignment),
-        withLocals
+        withLocals,
       );
 
     switch (block.tag) {
@@ -2197,7 +2197,7 @@ const processBlock = (
 export const buildAssignment = (
   varEnv: Env,
   subEnv: SubstanceEnv,
-  styProg: StyProg<C>
+  styProg: StyProg<C>,
 ): Assignment => {
   // insert Substance label string; use dummy AST node location pattern from
   // `engine/ParserUtil`
@@ -2231,7 +2231,7 @@ export const buildAssignment = (
             },
           },
         ],
-      ])
+      ]),
     ),
   };
   return styProg.items.reduce(
@@ -2239,7 +2239,7 @@ export const buildAssignment = (
       item.tag === "HeaderBlock"
         ? processBlock(varEnv, subEnv, index, item, assignment)
         : assignment,
-    assignment
+    assignment,
   );
 };
 
@@ -2273,7 +2273,7 @@ const findPathsExpr = <T>(expr: Expr<T>, context: Context): Path<T>[] => {
     }
     case "GPIDecl": {
       return expr.properties.flatMap((prop) =>
-        findPathsExpr(prop.value, context)
+        findPathsExpr(prop.value, context),
       );
     }
     case "Layering": {
@@ -2327,7 +2327,7 @@ const findPathsExpr = <T>(expr: Expr<T>, context: Context): Path<T>[] => {
               },
             ],
             indices: [],
-          })
+          }),
         );
         return paths.flatMap((p) => findPathsExpr(p, context));
       } else {
@@ -2351,7 +2351,7 @@ const resolveRhsPath = (p: WithContext<Path<C>>): ResolvedPath<C> => {
 const gatherExpr = (
   graph: DepGraph,
   w: string,
-  expr: WithContext<NotShape>
+  expr: WithContext<NotShape>,
 ): void => {
   graph.setNode(w, expr);
   for (const p of findPathsWithContext(expr)) {
@@ -2361,7 +2361,7 @@ const gatherExpr = (
         j: w,
         e: undefined,
       },
-      () => undefined
+      () => undefined,
     );
   }
 };
@@ -2431,12 +2431,12 @@ const evalExprs = (
   stages: OptPipeline,
   context: Context,
   args: Expr<C>[],
-  trans: Translation
+  trans: Translation,
 ): Result<ArgVal<ad.Num>[], StyleDiagnostics> =>
   all(
     args.map((expr) => {
       return evalExpr(mut, canvas, stages, { context, expr }, trans);
-    })
+    }),
   ).mapErr(flatErrs);
 
 const evalVals = (
@@ -2445,7 +2445,7 @@ const evalVals = (
   stages: OptPipeline,
   context: Context,
   args: Expr<C>[],
-  trans: Translation
+  trans: Translation,
 ): Result<Value<ad.Num>[], StyleDiagnostics> =>
   evalExprs(mut, canvas, stages, context, args, trans).andThen((argVals) =>
     all(
@@ -2458,15 +2458,15 @@ const evalVals = (
             return ok(argVal.contents);
           }
         }
-      })
-    ).mapErr(flatErrs)
+      }),
+    ).mapErr(flatErrs),
   );
 
 const evalBinOpScalars = (
   error: BinOpTypeError,
   op: BinaryOp,
   left: ad.Num,
-  right: ad.Num
+  right: ad.Num,
 ): Result<ad.Num, StyleError> => {
   switch (op) {
     case "BPlus": {
@@ -2495,7 +2495,7 @@ const evalBinOpVectors = (
   error: BinOpTypeError,
   op: BinaryOp,
   left: ad.Num[],
-  right: ad.Num[]
+  right: ad.Num[],
 ): Result<ad.Num[], StyleError> => {
   switch (op) {
     case "BPlus": {
@@ -2522,7 +2522,7 @@ const evalBinOpScalarVector = (
   error: BinOpTypeError,
   op: BinaryOp,
   left: ad.Num,
-  right: ad.Num[]
+  right: ad.Num[],
 ): Result<ad.Num[], StyleError> => {
   switch (op) {
     case "Multiply": {
@@ -2543,7 +2543,7 @@ const evalBinOpVectorScalar = (
   error: BinOpTypeError,
   op: BinaryOp,
   left: ad.Num[],
-  right: ad.Num
+  right: ad.Num,
 ): Result<ad.Num[], StyleError> => {
   switch (op) {
     case "Multiply": {
@@ -2566,7 +2566,7 @@ const evalBinOpScalarMatrix = (
   error: BinOpTypeError,
   op: BinaryOp,
   left: ad.Num,
-  right: ad.Num[][]
+  right: ad.Num[][],
 ): Result<ad.Num[][], StyleError> => {
   switch (op) {
     case "Multiply": {
@@ -2587,7 +2587,7 @@ const evalBinOpMatrixScalar = (
   error: BinOpTypeError,
   op: BinaryOp,
   left: ad.Num[][],
-  right: ad.Num
+  right: ad.Num,
 ): Result<ad.Num[][], StyleError> => {
   switch (op) {
     case "Multiply": {
@@ -2610,7 +2610,7 @@ const evalBinOpMatrixVector = (
   error: BinOpTypeError,
   op: BinaryOp,
   left: ad.Num[][],
-  right: ad.Num[]
+  right: ad.Num[],
 ): Result<ad.Num[], StyleError> => {
   switch (op) {
     case "Multiply": {
@@ -2631,7 +2631,7 @@ const evalBinOpVectorMatrix = (
   error: BinOpTypeError,
   op: BinaryOp,
   left: ad.Num[],
-  right: ad.Num[][]
+  right: ad.Num[][],
 ): Result<ad.Num[], StyleError> => {
   switch (op) {
     case "Multiply": {
@@ -2652,7 +2652,7 @@ const evalBinOpMatrixMatrix = (
   error: BinOpTypeError,
   op: BinaryOp,
   left: ad.Num[][],
-  right: ad.Num[][]
+  right: ad.Num[][],
 ): Result<ad.Num[][], StyleError> => {
   switch (op) {
     case "BPlus": {
@@ -2681,7 +2681,7 @@ const evalBinOpStrings = (
   error: BinOpTypeError,
   op: BinaryOp,
   left: string,
-  right: string
+  right: string,
 ): Result<string, StyleError> => {
   switch (op) {
     case "BPlus": {
@@ -2701,7 +2701,7 @@ const evalBinOpStrings = (
 const evalBinOp = (
   expr: BinOp<C>,
   left: Value<ad.Num>,
-  right: Value<ad.Num>
+  right: Value<ad.Num>,
 ): Result<Value<ad.Num>, StyleError> => {
   const error: BinOpTypeError = {
     tag: "BinOpTypeError",
@@ -2711,64 +2711,64 @@ const evalBinOp = (
   };
   if (left.tag === "FloatV" && right.tag === "FloatV") {
     return evalBinOpScalars(error, expr.op, left.contents, right.contents).map(
-      floatV
+      floatV,
     );
   } else if (left.tag === "VectorV" && right.tag === "VectorV") {
     return evalBinOpVectors(error, expr.op, left.contents, right.contents).map(
-      vectorV
+      vectorV,
     );
   } else if (left.tag === "FloatV" && right.tag === "VectorV") {
     return evalBinOpScalarVector(
       error,
       expr.op,
       left.contents,
-      right.contents
+      right.contents,
     ).map(vectorV);
   } else if (left.tag === "VectorV" && right.tag === "FloatV") {
     return evalBinOpVectorScalar(
       error,
       expr.op,
       left.contents,
-      right.contents
+      right.contents,
     ).map(vectorV);
   } else if (left.tag === "FloatV" && right.tag === "MatrixV") {
     return evalBinOpScalarMatrix(
       error,
       expr.op,
       left.contents,
-      right.contents
+      right.contents,
     ).map(matrixV);
   } else if (left.tag === "MatrixV" && right.tag === "FloatV") {
     return evalBinOpMatrixScalar(
       error,
       expr.op,
       left.contents,
-      right.contents
+      right.contents,
     ).map(matrixV);
   } else if (left.tag === "MatrixV" && right.tag === "VectorV") {
     return evalBinOpMatrixVector(
       error,
       expr.op,
       left.contents,
-      right.contents
+      right.contents,
     ).map(vectorV);
   } else if (left.tag === "VectorV" && right.tag === "MatrixV") {
     return evalBinOpVectorMatrix(
       error,
       expr.op,
       left.contents,
-      right.contents
+      right.contents,
     ).map(vectorV);
   } else if (left.tag === "MatrixV" && right.tag === "MatrixV") {
     return evalBinOpMatrixMatrix(
       error,
       expr.op,
       left.contents,
-      right.contents
+      right.contents,
     ).map(matrixV);
   } else if (left.tag === "StrV" && right.tag === "StrV") {
     return evalBinOpStrings(error, expr.op, left.contents, right.contents).map(
-      strV
+      strV,
     );
   } else {
     return err(error);
@@ -2778,7 +2778,7 @@ const evalBinOp = (
 const eval1D = (
   coll: List<C> | Vector<C> | CollectionAccess<C>,
   first: FloatV<ad.Num>,
-  rest: ArgVal<ad.Num>[]
+  rest: ArgVal<ad.Num>[],
 ): Result<ListV<ad.Num> | VectorV<ad.Num>, StyleDiagnostics> => {
   const elems = [first.contents];
   for (const v of rest) {
@@ -2804,7 +2804,7 @@ const eval1D = (
 const eval2D = (
   coll: List<C> | Vector<C> | CollectionAccess<C>,
   first: VectorV<ad.Num> | ListV<ad.Num> | TupV<ad.Num>,
-  rest: ArgVal<ad.Num>[]
+  rest: ArgVal<ad.Num>[],
 ): Result<
   LListV<ad.Num> | MatrixV<ad.Num> | PtListV<ad.Num>,
   StyleDiagnostics
@@ -2840,7 +2840,7 @@ const eval2D = (
 const evalShapeList = (
   coll: List<C> | Vector<C> | CollectionAccess<C>,
   first: Shape<ad.Num>,
-  rest: ArgVal<ad.Num>[]
+  rest: ArgVal<ad.Num>[],
 ): Result<ShapeListV<ad.Num>, StyleDiagnostics> => {
   const elems = [first];
   for (const v of rest) {
@@ -2859,7 +2859,7 @@ const evalListOrVector = (
   stages: OptPipeline,
   context: Context,
   coll: List<C> | Vector<C>,
-  trans: Translation
+  trans: Translation,
 ): Result<Value<ad.Num>, StyleDiagnostics> => {
   return evalExprs(mut, canvas, stages, context, coll.contents, trans).andThen(
     (argVals) => {
@@ -2899,7 +2899,7 @@ const evalListOrVector = (
           }
         }
       }
-    }
+    },
   );
 };
 
@@ -2909,7 +2909,7 @@ const isValidIndex = (a: unknown[], i: number): boolean =>
 const evalAccess = (
   expr: Path<C>,
   coll: Value<ad.Num>,
-  indices: number[]
+  indices: number[],
 ): Result<FloatV<ad.Num>, StyleError> => {
   switch (coll.tag) {
     case "ListV":
@@ -2957,7 +2957,7 @@ const evalAccess = (
 
 const evalUMinus = (
   expr: UOp<C>,
-  arg: Value<ad.Num>
+  arg: Value<ad.Num>,
 ): Result<Value<ad.Num>, StyleError> => {
   switch (arg.tag) {
     case "FloatV": {
@@ -2984,7 +2984,7 @@ const evalUMinus = (
 
 const evalUTranspose = (
   expr: UOp<C>,
-  arg: Value<ad.Num>
+  arg: Value<ad.Num>,
 ): Result<Value<ad.Num>, StyleError> => {
   switch (arg.tag) {
     case "MatrixV": {
@@ -3012,7 +3012,7 @@ const evalExpr = (
   canvas: Canvas,
   layoutStages: OptPipeline,
   { context, expr }: WithContext<Expr<C>>,
-  trans: Translation
+  trans: Translation,
 ): Result<ArgVal<ad.Num>, StyleDiagnostics> => {
   switch (expr.tag) {
     case "BinOp": {
@@ -3022,7 +3022,7 @@ const evalExpr = (
         layoutStages,
         context,
         [expr.left, expr.right],
-        trans
+        trans,
       ).andThen(([left, right]) => {
         const res = evalBinOp(expr, left, right);
         if (res.isErr()) {
@@ -3050,7 +3050,7 @@ const evalExpr = (
         layoutStages,
         context,
         expr.args,
-        trans
+        trans,
       );
       if (args.isErr()) {
         return err(args.error);
@@ -3065,7 +3065,7 @@ const evalExpr = (
       const { name, start, end } = expr;
       if (!isKeyOf(name.value, compDict)) {
         return err(
-          oneErr({ tag: "InvalidFunctionNameError", givenName: name })
+          oneErr({ tag: "InvalidFunctionNameError", givenName: name }),
         );
       }
       const f = compDict[name.value];
@@ -3094,7 +3094,7 @@ const evalExpr = (
         layoutStages,
         context,
         expr,
-        trans
+        trans,
       ).map(val);
     }
     case "Path": {
@@ -3121,7 +3121,7 @@ const evalExpr = (
             canvas,
             layoutStages,
             { context, expr: e },
-            trans
+            trans,
           ).andThen<number>((i) => {
             if (i.tag === "ShapeVal") {
               return err(oneErr({ tag: "NotValueError", expr: e }));
@@ -3133,8 +3133,8 @@ const evalExpr = (
             } else {
               return err(oneErr({ tag: "BadIndexError", expr: e }));
             }
-          })
-        )
+          }),
+        ),
       );
       if (res.isErr()) {
         return err(flatErrs(res.error));
@@ -3155,7 +3155,7 @@ const evalExpr = (
         layoutStages,
         context,
         expr.contents,
-        trans
+        trans,
       ).andThen(([left, right]) => {
         if (left.tag !== "FloatV") {
           return err(oneErr({ tag: "BadElementError", coll: expr, index: 0 }));
@@ -3172,7 +3172,7 @@ const evalExpr = (
         canvas,
         layoutStages,
         { context, expr: expr.arg },
-        trans
+        trans,
       ).andThen((argVal) => {
         if (argVal.tag === "ShapeVal") {
           return err(oneErr({ tag: "NotValueError", expr }));
@@ -3200,7 +3200,7 @@ const evalExpr = (
       const stages: OptStages = stageExpr(
         layoutStages,
         exclude,
-        expr.stages.map((s) => s.value)
+        expr.stages.map((s) => s.value),
       );
       return ok(
         val(
@@ -3208,9 +3208,9 @@ const evalExpr = (
             mut.makeInput({
               init: { tag: "Sampled", sampler: uniform(...canvas.xRange) },
               stages,
-            })
-          )
-        )
+            }),
+          ),
+        ),
       );
     }
     case "CollectionAccess": {
@@ -3239,8 +3239,8 @@ const evalExpr = (
             unexpectedCollectionAccessError(name.value, {
               start: expr.start,
               end: expr.end,
-            })
-          )
+            }),
+          ),
         );
       }
     }
@@ -3258,7 +3258,7 @@ type CollectionType<T> =
 
 const collectIntoVal = (
   coll: ArgVal<ad.Num>[],
-  expr: CollectionAccess<C>
+  expr: CollectionAccess<C>,
 ): Result<CollectionType<ad.Num>, StyleDiagnostics> => {
   if (coll.length === 0) {
     return ok(vectorV([]));
@@ -3283,7 +3283,7 @@ const collectIntoVal = (
           tag: "BadElementError",
           coll: expr,
           index: 0,
-        })
+        }),
       );
     }
   }
@@ -3292,7 +3292,7 @@ const collectIntoVal = (
 const stageExpr = (
   overallStages: string[],
   excludeFlag: boolean,
-  stageList: string[]
+  stageList: string[],
 ): OptStages => {
   if (excludeFlag) {
     const stages = new Set(overallStages);
@@ -3306,7 +3306,7 @@ const stageExpr = (
 };
 
 const extractObjConstrBody = (
-  body: InlineComparison<C> | FunctionCall<C>
+  body: InlineComparison<C> | FunctionCall<C>,
 ): { name: Identifier<C>; argExprs: Expr<C>[] } => {
   if (body.tag === "InlineComparison") {
     const mapInlineOpToFunctionName = (op: "<" | "==" | ">"): string => {
@@ -3346,7 +3346,7 @@ const translateExpr = (
   layoutStages: OptPipeline,
   path: string,
   e: WithContext<NotShape>,
-  trans: Translation
+  trans: Translation,
 ): Translation => {
   switch (e.expr.tag) {
     case "BinOp":
@@ -3379,7 +3379,7 @@ const translateExpr = (
         layoutStages,
         e.context,
         argExprs,
-        trans
+        trans,
       );
       if (args.isErr()) {
         return addDiags(args.error, trans);
@@ -3394,13 +3394,13 @@ const translateExpr = (
       if (!isKeyOf(fname, constrDict)) {
         return addDiags(
           oneErr({ tag: "InvalidConstraintNameError", givenName: name }),
-          trans
+          trans,
         );
       }
       const output = callObjConstrFunc(
         constrDict[fname],
         { start: e.expr.start, end: e.expr.end },
-        argsWithSourceLoc
+        argsWithSourceLoc,
       );
       if (output.isErr()) {
         return addDiags(oneErr(output.error), trans);
@@ -3411,7 +3411,7 @@ const translateExpr = (
       const optStages: OptStages = stageExpr(
         layoutStages,
         exclude,
-        stages.map((s) => s.value)
+        stages.map((s) => s.value),
       );
       return {
         ...trans,
@@ -3434,7 +3434,7 @@ const translateExpr = (
         layoutStages,
         e.context,
         argExprs,
-        trans
+        trans,
       );
       if (args.isErr()) {
         return addDiags(args.error, trans);
@@ -3449,19 +3449,19 @@ const translateExpr = (
       if (!isKeyOf(fname, objDict)) {
         return addDiags(
           oneErr({ tag: "InvalidObjectiveNameError", givenName: name }),
-          trans
+          trans,
         );
       }
 
       const optStages: OptStages = stageExpr(
         layoutStages,
         exclude,
-        stages.map((s) => s.value)
+        stages.map((s) => s.value),
       );
       const output = callObjConstrFunc(
         objDict[fname],
         { start: e.expr.start, end: e.expr.end },
-        argsWithSourceLoc
+        argsWithSourceLoc,
       );
       if (output.isErr()) {
         return addDiags(oneErr(output.error), trans);
@@ -3484,17 +3484,17 @@ const translateExpr = (
       const { expr, context } = e;
 
       const leftPp = prettyPrintResolvedPath(
-        resolveRhsPath({ context: context, expr: expr.left })
+        resolveRhsPath({ context: context, expr: expr.left }),
       );
       const leftResolved = evalExpr(
         mut,
         canvas,
         layoutStages,
         { context, expr: expr.left },
-        trans
+        trans,
       );
       const rightListPp = expr.right.map((r: Path<C>) =>
-        prettyPrintResolvedPath(resolveRhsPath({ context: context, expr: r }))
+        prettyPrintResolvedPath(resolveRhsPath({ context: context, expr: r })),
       );
       const rightListResolved = evalExprs(
         mut,
@@ -3502,7 +3502,7 @@ const translateExpr = (
         layoutStages,
         context,
         expr.right,
-        trans
+        trans,
       );
       if (leftResolved.isErr()) {
         return addDiags(leftResolved.error, trans);
@@ -3517,7 +3517,7 @@ const translateExpr = (
             },
             expr: leftPp,
           }),
-          trans
+          trans,
         );
       }
 
@@ -3535,7 +3535,7 @@ const translateExpr = (
               },
               expr: rightListPp[i],
             }),
-            trans
+            trans,
           );
         }
       }
@@ -3559,7 +3559,7 @@ const translateExpr = (
 const evalGPI = (
   path: string,
   shapeType: ShapeType,
-  trans: Translation
+  trans: Translation,
 ): Result<Shape<ad.Num>, StyleError> => {
   return checkShape(shapeType, path, trans);
 };
@@ -3569,7 +3569,7 @@ export const translate = (
   canvas: Canvas,
   stages: OptPipeline,
   graph: DepGraph,
-  warnings: im.List<StyleWarning>
+  warnings: im.List<StyleWarning>,
 ): Translation => {
   let symbols = im.Map<string, ArgVal<ad.Num>>();
   for (const path of graph.nodes()) {
@@ -3600,7 +3600,7 @@ export const translate = (
             ? undefined
             : { start: e.expr.start, end: e.expr.end },
       };
-    })
+    }),
   );
   if (cycles.length > 0) {
     return {
@@ -3665,7 +3665,7 @@ export type LayerGraph = Graph<string>;
 export const processLayering = (
   { below, above }: Layer,
   groupGraph: GroupGraph,
-  layerGraph: LayerGraph
+  layerGraph: LayerGraph,
 ): void => {
   // Path from the root to the node, excluding the root
   // [..., below]
@@ -3692,7 +3692,7 @@ export const processLayering = (
 export const computeLayerOrdering = (
   allGPINames: string[],
   partialOrderings: Layer[],
-  groupGraph: GroupGraph
+  groupGraph: GroupGraph,
 ): {
   shapeOrdering: string[];
   warning?: LayerCycleWarning;
@@ -3725,7 +3725,7 @@ export const computeLayerOrdering = (
 
 const pseudoTopsort = (graph: Graph<string>): string[] => {
   const indegree = new Map<string, number>(
-    graph.nodes().map((i) => [i, graph.inEdges(i).length])
+    graph.nodes().map((i) => [i, graph.inEdges(i).length]),
   );
   // Nodes with lower in-degrees have highest priority.
   // Swap if a has higher in-degree than b.
@@ -3752,7 +3752,7 @@ const pseudoTopsort = (graph: Graph<string>): string[] => {
 // Check that canvas dimensions exist and have the proper type.
 export const getCanvasDim = (
   attr: "width" | "height",
-  graph: DepGraph
+  graph: DepGraph,
 ): Result<number, StyleError> => {
   const i = `canvas.${attr}`;
   if (!graph.hasNode(i))
@@ -3781,7 +3781,7 @@ export const parseStyle = (p: string): Result<StyProg<C>, ParseError> => {
       return ok(ast);
     } else {
       return err(
-        parseError(`Unexpected end of input`, lastLocation(parser), "Style")
+        parseError(`Unexpected end of input`, lastLocation(parser), "Style"),
       );
     }
   } catch (e) {
@@ -3790,10 +3790,10 @@ export const parseStyle = (p: string): Result<StyProg<C>, ParseError> => {
 };
 
 export const getLayoutStages = (
-  prog: StyProg<C>
+  prog: StyProg<C>,
 ): Result<OptPipeline, MultipleLayoutError> => {
   const layoutStmts: LayoutStages<C>[] = prog.items.filter(
-    (i): i is LayoutStages<C> => i.tag === "LayoutStages"
+    (i): i is LayoutStages<C> => i.tag === "LayoutStages",
   );
   if (layoutStmts.length === 0) {
     // if no stages specified, default to "" because that way nobody can refer
@@ -3813,7 +3813,7 @@ export const getLayoutStages = (
 
 const getShapesList = (
   { symbols }: Translation,
-  shapeOrdering: string[]
+  shapeOrdering: string[],
 ): Shape<ad.Num>[] => {
   return shapeOrdering.map((path) => {
     const shape = symbols.get(path);
@@ -3841,7 +3841,7 @@ const onCanvases = (canvas: Canvas, shapes: Shape<ad.Num>[]): Fn[] => {
       const output = constrDict.onCanvas.body(
         shape,
         canvas.width,
-        canvas.height
+        canvas.height,
       ).value;
       fns.push({
         ast: {
@@ -3883,7 +3883,7 @@ export const stageConstraints = (
   inputs: InputMeta[],
   constrFns: Fn[],
   objFns: Fn[],
-  stages: OptPipeline
+  stages: OptPipeline,
 ): StagedConstraints =>
   new Map(
     stages.map((stage) => [
@@ -3891,18 +3891,18 @@ export const stageConstraints = (
       {
         inputMask: inputs.map((i) => i.stages === "All" || i.stages.has(stage)),
         constrMask: constrFns.map(
-          ({ optStages }) => optStages === "All" || optStages.has(stage)
+          ({ optStages }) => optStages === "All" || optStages.has(stage),
         ),
         objMask: objFns.map(
-          ({ optStages }) => optStages === "All" || optStages.has(stage)
+          ({ optStages }) => optStages === "All" || optStages.has(stage),
         ),
       },
-    ])
+    ]),
   );
 
 const processPassthrough = (
   { symbols }: Translation,
-  nameShapeMap: Map<string, Shape<ad.Num>>
+  nameShapeMap: Map<string, Shape<ad.Num>>,
 ): Result<void, StyleError> => {
   for (const [key, value] of symbols) {
     const i = key.lastIndexOf(".");
@@ -3917,7 +3917,7 @@ const processPassthrough = (
           shape.passthrough.set(propName, value.contents);
         } else {
           return err(
-            badShapeParamTypeError(key, value, "StrV or FloatV", true)
+            badShapeParamTypeError(key, value, "StrV or FloatV", true),
           );
         }
       } else {
@@ -3932,7 +3932,7 @@ export const compileStyleHelper = async (
   variation: string,
   stySource: string,
   subEnv: SubstanceEnv,
-  varEnv: Env
+  varEnv: Env,
 ): Promise<
   Result<
     {
@@ -3973,7 +3973,7 @@ export const compileStyleHelper = async (
   const graph = gatherDependencies(assignment);
 
   const canvas = getCanvasDim("width", graph).andThen((w) =>
-    getCanvasDim("height", graph).map((h) => makeCanvas(w, h))
+    getCanvasDim("height", graph).map((h) => makeCanvas(w, h)),
   );
   if (canvas.isErr()) {
     return err(toStyleErrors([canvas.error]));
@@ -3999,7 +3999,7 @@ export const compileStyleHelper = async (
     canvas.value,
     optimizationStages.value,
     graph,
-    assignment.diagnostics.warnings
+    assignment.diagnostics.warnings,
   );
 
   log.info("translation (before genOptProblem)", translation);
@@ -4011,7 +4011,7 @@ export const compileStyleHelper = async (
   const groupGraph: GroupGraph = makeGroupGraph(
     getShapesList(translation, [
       ...graph.nodes().filter((p) => typeof graph.node(p) === "string"),
-    ])
+    ]),
   );
 
   const groupWarnings = checkGroupGraph(groupGraph);
@@ -4020,7 +4020,7 @@ export const compileStyleHelper = async (
     computeLayerOrdering(
       [...graph.nodes().filter((p) => typeof graph.node(p) === "string")],
       [...translation.layering],
-      groupGraph
+      groupGraph,
     );
 
   // Fix the ordering between nodes of the group graph
@@ -4046,7 +4046,7 @@ export const compileStyleHelper = async (
   const renderGraph = buildRenderGraph(
     findOrderedRoots(groupGraph),
     groupGraph,
-    nameShapeMap
+    nameShapeMap,
   );
 
   const objFns = [...translation.objectives];
@@ -4060,7 +4060,7 @@ export const compileStyleHelper = async (
     metas,
     constrFns,
     objFns,
-    optimizationStages.value
+    optimizationStages.value,
   );
 
   const computeShapes = await compileCompGraph(inputs, renderGraph);
@@ -4068,7 +4068,7 @@ export const compileStyleHelper = async (
   const gradient = await genGradient(
     inputs,
     objFns.map(({ output }) => output),
-    constrFns.map(({ output }) => output)
+    constrFns.map(({ output }) => output),
   );
 
   const params = genOptProblem(varyingValues.length);
@@ -4108,15 +4108,15 @@ export const compileStyle = async (
   stySource: string,
   excludeWarnings: string[],
   subEnv: SubstanceEnv,
-  varEnv: Env
+  varEnv: Env,
 ): Promise<Result<State, PenroseError>> =>
   (await compileStyleHelper(variation, stySource, subEnv, varEnv)).map(
     ({ state }) => ({
       ...state,
       warnings: state.warnings.filter(
-        (warning) => !excludeWarnings.includes(warning.tag)
+        (warning) => !excludeWarnings.includes(warning.tag),
       ),
-    })
+    }),
   );
 
 //#endregion Main funcitons

--- a/packages/core/src/compiler/Style.ts
+++ b/packages/core/src/compiler/Style.ts
@@ -1684,9 +1684,11 @@ const getSubsts = (
   const filteredSubsts = deduplicate(varEnv, subEnv, subProg, rels, rawSubsts);
   const { repeatable } = header;
 
+  // If we want repeatable matchings, this is good
   if (repeatable) {
     return filteredSubsts.toArray();
   } else {
+    // Otherwise need to remove all duplications
     const correctSubsts = filteredSubsts.filter(uniqueKeysAndVals);
     return correctSubsts.toArray();
   }

--- a/packages/core/src/parser/Style.ne
+++ b/packages/core/src/parser/Style.ne
@@ -62,6 +62,7 @@ const lexer = moo.compile({
       override: "override",
       in: "in",
       except: "except",
+      repeatable: "repeatable"
     })
   }
 });
@@ -83,15 +84,17 @@ const declList = (type: StyT<C>, ids: BindingForm<C>[]): DeclPattern<C>[] => {
 
 
 const selector = (
+  repeatable: any,
   hd: DeclPatterns<C>,
   wth?: DeclPatterns<C>,
   whr?: RelationPatterns<C>,
-  namespace?: Namespace<C>
+  namespace?: Namespace<C>,
 ): Selector<C> => {
   return {
     ...nodeData,
     ...rangeFrom(_.compact([hd, wth, whr])),
     tag: "Selector",
+    repeatable: repeatable ? true : false,
     head: hd,
     with: wth,
     where: whr,
@@ -99,6 +102,7 @@ const selector = (
 }
 
 const collector = (
+  repeatable: any,
   hd: DeclPattern<C>,
   it: BindingForm<C>,
   whr?: RelationPatterns<C>,
@@ -109,6 +113,7 @@ const collector = (
     ...nodeData,
     ...rangeFrom(_.compact([hd, it, whr, wth, fe])),
     tag: "Collector",
+    repeatable: repeatable ? true : false,
     head: hd,
     into: it,
     where: whr,
@@ -178,50 +183,50 @@ header
   |  namespace {% id %}
 
 selector -> 
-    forall decl_patterns _ml  
-    {% (d) => selector(d[1], undefined, undefined) %}
-  | forall decl_patterns _ml select_where 
-    {% (d) => selector(d[1], undefined, d[3]) %} 
-  | forall decl_patterns _ml select_with 
-    {% (d) => selector(d[1], d[3], undefined)%}   
-  | forall decl_patterns _ml select_where select_with 
-    {% (d) => selector(d[1], d[4], d[3]) %} 
-  | forall decl_patterns _ml select_with select_where 
-    {% (d) => selector(d[1], d[3], d[4]) %}
+    forall ("repeatable" __):? decl_patterns _ml  
+    {% (d) => selector(d[1], d[2], undefined, undefined) %}
+  | forall ("repeatable" __):? decl_patterns _ml select_where 
+    {% (d) => selector(d[1], d[2], undefined, d[4]) %} 
+  | forall ("repeatable" __):? decl_patterns _ml select_with 
+    {% (d) => selector(d[1], d[2], d[4], undefined)%}   
+  | forall ("repeatable" __):? decl_patterns _ml select_where select_with 
+    {% (d) => selector(d[1], d[2], d[5], d[4]) %} 
+  | forall ("repeatable" __):? decl_patterns _ml select_with select_where 
+    {% (d) => selector(d[1], d[2], d[4], d[5]) %}
 
 collector ->
-    collect decl _ml into _ml
-    {% (d) => collector(d[1], d[3], undefined, undefined, undefined) %}
-  | collect decl _ml into _ml select_where
-    {% (d) => collector(d[1], d[3], d[5], undefined, undefined) %}
-  | collect decl _ml into _ml select_where select_with
-    {% (d) => collector(d[1], d[3], d[5], d[6], undefined) %}
-  | collect decl _ml into _ml select_where select_with foreach
-    {% (d) => collector(d[1], d[3], d[5], d[6], d[7]) %}
-  | collect decl _ml into _ml select_where foreach
-    {% (d) => collector(d[1], d[3], d[5], undefined, d[6]) %}
-  | collect decl _ml into _ml select_where foreach select_with
-    {% (d) => collector(d[1], d[3], d[5], d[7], d[6]) %}
-  | collect decl _ml into _ml select_with
-    {% (d) => collector(d[1], d[3], undefined, d[5], undefined) %}
-  | collect decl _ml into _ml select_with select_where
-    {% (d) => collector(d[1], d[3], d[6], d[5], undefined) %}
-  | collect decl _ml into _ml select_with select_where foreach
-    {% (d) => collector(d[1], d[3], d[6], d[5], d[7]) %}
-  | collect decl _ml into _ml select_with foreach
-    {% (d) => collector(d[1], d[3], undefined, d[5], d[6]) %}
-  | collect decl _ml into _ml select_with foreach select_where
-    {% (d) => collector(d[1], d[3], d[7], d[5], d[6]) %}
-  | collect decl _ml into _ml foreach
-    {% (d) => collector(d[1], d[3], undefined, undefined, d[5]) %}
-  | collect decl _ml into _ml foreach select_where
-    {% (d) => collector(d[1], d[3], d[6], undefined, d[5]) %}
-  | collect decl _ml into _ml foreach select_where select_with
-    {% (d) => collector(d[1], d[3], d[6], d[7], d[5]) %}
-  | collect decl _ml into _ml foreach select_with
-    {% (d) => collector(d[1], d[3], undefined, d[6], d[5]) %}
-  | collect decl _ml into _ml foreach select_with select_where
-    {% (d) => collector(d[1], d[3], d[7], d[6], d[5]) %}
+    collect ("repeatable" __):? decl _ml into _ml
+    {% (d) => collector(d[1], d[2], d[4], undefined, undefined, undefined) %}
+  | collect ("repeatable" __):? decl _ml into _ml select_where
+    {% (d) => collector(d[1], d[2], d[4], d[6], undefined, undefined) %}
+  | collect ("repeatable" __):? decl _ml into _ml select_where select_with
+    {% (d) => collector(d[1], d[2], d[4], d[6], d[7], undefined) %}
+  | collect ("repeatable" __):? decl _ml into _ml select_where select_with foreach
+    {% (d) => collector(d[1], d[2], d[4], d[6], d[7], d[8]) %}
+  | collect ("repeatable" __):? decl _ml into _ml select_where foreach
+    {% (d) => collector(d[1], d[2], d[4], d[6], undefined, d[7]) %}
+  | collect ("repeatable" __):? decl _ml into _ml select_where foreach select_with
+    {% (d) => collector(d[1], d[2], d[4], d[6], d[8], d[7]) %}
+  | collect ("repeatable" __):? decl _ml into _ml select_with
+    {% (d) => collector(d[1], d[2], d[4], undefined, d[6], undefined) %}
+  | collect ("repeatable" __):? decl _ml into _ml select_with select_where
+    {% (d) => collector(d[1], d[2], d[4], d[7], d[6], undefined) %}
+  | collect ("repeatable" __):? decl _ml into _ml select_with select_where foreach
+    {% (d) => collector(d[1], d[2], d[4], d[7], d[6], d[8]) %}
+  | collect ("repeatable" __):? decl _ml into _ml select_with foreach
+    {% (d) => collector(d[1], d[2], d[4], undefined, d[6], d[7]) %}
+  | collect ("repeatable" __):? decl _ml into _ml select_with foreach select_where
+    {% (d) => collector(d[1], d[2], d[4], d[8], d[6], d[7]) %}
+  | collect ("repeatable" __):? decl _ml into _ml foreach
+    {% (d) => collector(d[1], d[2], d[4], undefined, undefined, d[6]) %}
+  | collect ("repeatable" __):? decl _ml into _ml foreach select_where
+    {% (d) => collector(d[1], d[2], d[4], d[7], undefined, d[6]) %}
+  | collect ("repeatable" __):? decl _ml into _ml foreach select_where select_with
+    {% (d) => collector(d[1], d[2], d[4], d[7], d[8], d[6]) %}
+  | collect ("repeatable" __):? decl _ml into _ml foreach select_with
+    {% (d) => collector(d[1], d[2], d[4], undefined, d[7], d[6]) %}
+  | collect ("repeatable" __):? decl _ml into _ml foreach select_with select_where
+    {% (d) => collector(d[1], d[2], d[4], d[8], d[7], d[6]) %}
 
 into -> "into" __ binding_form {% nth(2) %}
 

--- a/packages/core/src/types/style.ts
+++ b/packages/core/src/types/style.ts
@@ -34,6 +34,7 @@ export type Header<T> = Selector<T> | Namespace<T> | Collector<T>;
 
 export type Selector<T> = ASTNode<T> & {
   tag: "Selector";
+  repeatable: boolean;
   head: DeclPatterns<T>;
   with?: DeclPatterns<T>;
   where?: RelationPatterns<T>;
@@ -41,6 +42,7 @@ export type Selector<T> = ASTNode<T> & {
 
 export type Collector<T> = ASTNode<T> & {
   tag: "Collector";
+  repeatable: boolean;
   head: DeclPattern<T>;
   into: BindingForm<T>;
   where?: RelationPatterns<T>;

--- a/packages/examples/src/group-theory/CayleyGraph.style
+++ b/packages/examples/src/group-theory/CayleyGraph.style
@@ -88,7 +88,7 @@ forall Element g1; Element g2
 }
 
 -- rule for any two elements g1, g2 related by a generator s
-forall Element g1; Element g2; Element s
+forall repeatable Element g1; Element g2; Element s
 where IsGenerator(s); IsProduct( g2, g1, s )
 {
    -- draw an arrow from g1 to g2
@@ -117,80 +117,6 @@ where IsGenerator(s); IsProduct( g2, g1, s )
 
    -- encourage these nodes to be close together, by minimizing a spring energy
    vec2 x1 = g1.icon.center
-   scalar d = norm( x1 - x2 )
-   scalar k = 1. -- spring stiffness
-   scalar L = global.targetEdgeLength -- rest length
-   encourage equal( 0., k*(d-L)*(d-L)/2. ) -- minimize ½ k(d-L)²
-}
-
--- same rule as above, but catches the special case where g1 is the identity
--- (since we don't currently support matching on non-distinct tuples)
-forall Element s; Element e
-where IsGenerator(s); IsProduct( s, e, s )
-{
-   -- draw an arrow from e to s
-   vec2 x0 = e.icon.center
-   vec2 x2 = s.icon.center
-   vec2 u = (x2-x0)/norm(x2-x0)
-   vec2 n = rot90(u)
-   vec2 p0 = x0
-   vec2 p2 = x2 - 10*u + 3*n
-   vec2 m = (p0+p2)/2
-   vec2 p1 = m + 3.*n
-   shape orientedPath = Path {
-      d: interpolateQuadraticFromPoints( "open", p0, p1, p2 )
-      strokeColor: s.icon.fillColor
-      endArrowhead: "straight"
-      endArrowheadSize: 0.75
-      strokeWidth: global.pathWidth
-   }
-   shape pathOutline = Path {
-      d: interpolateQuadraticFromPoints( "open", p0, p1, p2 )
-      strokeColor: colors.white
-      endArrowhead: "none"
-      strokeWidth: global.pathOutlineWidth
-   }
-   layer pathOutline below orientedPath
-
-   -- encourage these nodes to be close together, by minimizing a spring energy
-   vec2 x1 = e.icon.center
-   scalar d = norm( x1 - x2 )
-   scalar k = 1. -- spring stiffness
-   scalar L = global.targetEdgeLength -- rest length
-   encourage equal( 0., k*(d-L)*(d-L)/2. ) -- minimize ½ k(d-L)²
-}
-
--- same rule as above, but catches the special case where g1 = s
--- (since we don't currently support matching on non-distinct tuples)
-forall Element g; Element s
-where IsGenerator(s); IsProduct( g, s, s )
-{
-   -- draw an arrow from s to g
-   vec2 x0 = s.icon.center
-   vec2 x2 = g.icon.center
-   vec2 u = (x2-x0)/norm(x2-x0)
-   vec2 n = rot90(u)
-   vec2 p0 = x0
-   vec2 p2 = x2 - 10*u + 3*n
-   vec2 m = (p0+p2)/2
-   vec2 p1 = m + 3.*n
-   shape orientedPath = Path {
-      d: interpolateQuadraticFromPoints( "open", p0, p1, p2 )
-      strokeColor: s.icon.fillColor
-      endArrowhead: "straight"
-      endArrowheadSize: 0.75
-      strokeWidth: global.pathWidth
-   }
-   shape pathOutline = Path {
-      d: interpolateQuadraticFromPoints( "open", p0, p1, p2 )
-      strokeColor: colors.white
-      endArrowhead: "none"
-      strokeWidth: global.pathOutlineWidth
-   }
-   layer pathOutline below orientedPath
-
-   -- encourage these nodes to be close together, by minimizing a spring energy
-   vec2 x1 = s.icon.center
    scalar d = norm( x1 - x2 )
    scalar k = 1. -- spring stiffness
    scalar L = global.targetEdgeLength -- rest length

--- a/packages/examples/src/group-theory/MultiplicationTable.style
+++ b/packages/examples/src/group-theory/MultiplicationTable.style
@@ -85,7 +85,7 @@ forall Element g
 -- }
 
 -- draw a box for each product in the multiplication table
-forall Element a; Element b; Element c
+forall repeatable Element a; Element b; Element c
 where IsProduct( a, b, c )
 {
    shape productShape = Rectangle {
@@ -101,89 +101,5 @@ where IsProduct( a, b, c )
       center: productShape.center
       fontSize: "8px"
       fillColor: a.labelColor
-   }
-}
-
--- draw a box for each product in the multiplication table
--- (since we can't match on non-distinct tuples, we must duplicate and specialize the rule for distinct tuples)
-forall Element a; Element e
-where IsProduct( a, e, a )
-{
-   shape productShape = Rectangle {
-      center: ( e.u, a.v )
-      width: a.width - global.boxPadding
-      height: a.height - global.boxPadding
-      cornerRadius: 2.0
-      fillColor: a.boxColor
-   }
-
-   shape productText = Equation {
-      string: a.label
-      center: productShape.center
-      fontSize: "8px"
-      fillColor: a.labelColor
-   }
-}
-
--- draw a box for each product in the multiplication table
--- (since we can't match on non-distinct tuples, we must duplicate and specialize the rule for distinct tuples)
-forall Element a; Element e
-where IsProduct( a, a, e )
-{
-   shape productShape = Rectangle {
-      center: ( a.u, e.v )
-      width: a.width - global.boxPadding
-      height: a.height - global.boxPadding
-      cornerRadius: 2.0
-      fillColor: a.boxColor
-   }
-
-   shape productText = Equation {
-      string: a.label
-      center: productShape.center
-      fontSize: "8px"
-      fillColor: a.labelColor
-   }
-}
-
--- draw a box for each product in the multiplication table
--- (since we can't match on non-distinct tuples, we must duplicate and specialize the rule for distinct tuples)
-forall Element a; Element b
-where IsProduct( a, b, b )
-{
-   shape productShape = Rectangle {
-      center: ( b.u, b.v )
-      width: a.width - global.boxPadding
-      height: a.height - global.boxPadding
-      cornerRadius: 2.0
-      fillColor: a.boxColor
-   }
-
-   shape productText = Equation {
-      string: a.label
-      center: productShape.center
-      fontSize: "8px"
-      fillColor: a.labelColor
-   }
-}
-
--- draw a box for each product in the multiplication table
--- (since we can't match on non-distinct tuples, we must duplicate and specialize the rule for distinct tuples)
-forall Element e
-where IsProduct( e, e, e )
-{
-   shape productShape = Rectangle {
-      center: ( e.u, e.v )
-      width: e.width - global.boxPadding
-      height: e.height - global.boxPadding
-      cornerRadius: 2.0
-      fillColor: e.boxColor
-   }
-
-   shape productText = Equation {
-      string: e.label
-      center: productShape.center
-      fontSize: "8px"
-      fillColor: e.labelColor
    }
 }


### PR DESCRIPTION
# Description

Resolves #1065 .

We implement Solution 1 from #1065 to support nondistinct matching.

# Implementation strategy and design decisions

A new keyword, `repeatable`, is added to selectors and collectors. The `repeatable` essentially allows the selector / collector block to match multiple Style variables to the same Substance variable. This is done by disabling the filter when the `repeatable` flag is enabled:
```
  if (repeatable) {
    return filteredSubsts.toArray();
  } else {
    const correctSubsts = filteredSubsts.filter(uniqueKeysAndVals);
    return correctSubsts.toArray();
  }
```

# Examples with steps to reproduce them

We modify the "Quaternions as table" example and the "Quaternions as Cayley graph" example to use `repeatable`.

# Checklist

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have reviewed any generated registry diagram changes

