### PR TITLE
docs: fix `npx` command for roger

### DIFF
--- a/packages/docs-site/docs/ref/using.md
+++ b/packages/docs-site/docs/ref/using.md
@@ -60,7 +60,7 @@ Toggle "debug mode" to enable advanced features for debugging:
 You can use `roger` without installation by:
 
 ```shell
-npx roger
+npx @penrose/roger
 ```
 
 Or install it globally:


### PR DESCRIPTION
# Description

In the reference "Using Penrose" docs, the `npx` command suggestion seems to install [this package named `roger`](https://www.npmjs.com/package/roger), not the one we want.

# Implementation strategy and design decisions

Include a high-level summary of the implementation strategy and list important design decisions made, if any.

# Examples with steps to reproduce them

# Checklist

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have reviewed any generated registry diagram changes

# Open questions

Questions that require more discussion or to be addressed in future development:
