### PR TITLE
docs: fix anchors for functions

### DIFF
--- a/packages/docs-site/docs/ref/style/functions.md
+++ b/packages/docs-site/docs/ref/style/functions.md
@@ -10,7 +10,10 @@ const { objDict, compDict, constrDict } = data;
 
 <div v-for="f in constrDict">
 
-### {{ f.name }}
+<h3 :id="`constraint-${f.name}`">
+  {{ f.name }}
+  <a class="header-anchor" :href="`#constraint-${f.name}`" :aria-label="`Permalink to constraint &quot;${f.name}&quot;`">&ZeroWidthSpace;</a>
+</h3>
 
 <Function :name="f.name" :description="f.description" :params="f.params" :returns="f.returns" />
 
@@ -20,7 +23,10 @@ const { objDict, compDict, constrDict } = data;
 
 <div v-for="f in objDict">
 
-### {{ f.name }}
+<h3 :id="`objective-${f.name}`">
+  {{ f.name }}
+  <a class="header-anchor" :href="`#objective-${f.name}`" :aria-label="`Permalink to objective &quot;${f.name}&quot;`">&ZeroWidthSpace;</a>
+</h3>
 
 <Function :name="f.name" :description="f.description" :params="f.params" :returns="f.returns" />
 
@@ -30,7 +36,10 @@ const { objDict, compDict, constrDict } = data;
 
 <div v-for="f in compDict">
 
-### {{ f.name }}
+<h3 :id="`computation-${f.name}`">
+  {{ f.name }}
+  <a class="header-anchor" :href="`#computation-${f.name}`" :aria-label="`Permalink to computation &quot;${f.name}&quot;`">&ZeroWidthSpace;</a>
+</h3>
 
 <Function :name="f.name" :description="f.description" :params="f.params" :returns="f.returns" />
 


### PR DESCRIPTION
# Description

On the "Style Functions" reference page the function heading elements don't have unique IDs, so they can't be permalinked to and the "On this page" links on the right hand side don't work.

This change sets a unique ID on each of the headings, so each function can be linked to individually.

# Implementation strategy and design decisions

I'm not super familiar with `markdown-it`, but I couldn't find a nice way to get the ID from markdown `###` syntax, so we just write a `<h3>` element manually.

There are these issues in VitePress, but I don't think they handle this yet. vuejs/vitepress#785 and vuejs/vitepress#960. Maybe in the future this commit can be reverted.

# Examples with steps to reproduce them

# Checklist

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have reviewed any generated registry diagram changes

# Open questions

Questions that require more discussion or to be addressed in future development:

This change might break if we can't assume that:
a. Function names will be valid in a URL
b. Function names are unique within each section (which they seem to be at the moment)
