### PR TITLE
fix: `CircleCenter` behavior in Euclidean geometry Style

### DIFF
--- a/packages/examples/src/geometry-domain/euclidean.style
+++ b/packages/examples/src/geometry-domain/euclidean.style
@@ -895,7 +895,7 @@ with Circle c {
 forall Point p
 where CircleCenter(c, p)
 with Circle c {
-  override p.vec = c.vec
+  ensure norm(p.vec - c.vec) == 0
 }
 
 forall Shape s1, s2


### PR DESCRIPTION
# Description

`CircleCenter` previously overrides the `vec` field of `Circle`, which can cause a circular assignment error when the `Circle` is defined with the same center:

```substance
Point A, B
Circle c := CircleR(A, B) -- circle with `A` as center and passing `B` 
CircleCenter(c, A) -- error: circular assignment of A.vec = A.vec
```

This PR changes to a more lenient approach by adding a constraint ensuring the circle center. 
