### PR TITLE
chore: bump version to 3.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,38 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [v3.1.0](https://github.com/penrose/penrose/compare/v3.0.0...v3.1.0) (2023-07-19)
+
+### :rocket: New Feature
+
+* added UI for LLM program generation in `edgeworth` ([#1556](https://github.com/penrose/penrose/issues/1556)) ([865ee9e](https://github.com/penrose/penrose/commit/865ee9e7f6b598bc0f07e416ab73bea978bba6e7))
+* added `mod` function to `Functions.ts` ([#1565](https://github.com/penrose/penrose/issues/1565)) ([b7a7c3b](https://github.com/penrose/penrose/commit/b7a7c3b2710865f05e7040e913d5f7d5e825c1d1))
+* nondistinct matching ([#1567](https://github.com/penrose/penrose/issues/1567)) ([77e2714](https://github.com/penrose/penrose/commit/77e2714fb5bcf888136a2f65340b56c5d0025661))
+
+### :bug: Bug Fix
+
+* `CircleCenter` behavior in Euclidean geometry Style ([#1571](https://github.com/penrose/penrose/issues/1571)) ([a2ed8e1](https://github.com/penrose/penrose/commit/a2ed8e171cd406666ecf25f398dbea7e7a54c2cb))
+* compile `@penrose/roger` for distribution 💂‍♂️ ([#1562](https://github.com/penrose/penrose/issues/1562)) ([7b36125](https://github.com/penrose/penrose/commit/7b3612539bb104ea16edf01ad4884a919c3eac4a))
+* gallery loading by switching to pure Vue ([#1549](https://github.com/penrose/penrose/issues/1549)) ([7c96d70](https://github.com/penrose/penrose/commit/7c96d70f93d9da1810c32d3c7bcd467a343f5be1))
+* layering on nonexistent objects ([#1560](https://github.com/penrose/penrose/issues/1560)) ([0bbe47c](https://github.com/penrose/penrose/commit/0bbe47c505b9920db83dd152a914b452129b6668))
+
+### :memo: Documentation
+
+* Correct domain code snippet type ([#1566](https://github.com/penrose/penrose/issues/1566)) ([ad0005a](https://github.com/penrose/penrose/commit/ad0005a92230efd5338f6e143f4bc5eb78009596))
+* add "Edit this page" button to pages ([#1555](https://github.com/penrose/penrose/issues/1555)) ([2ca37bd](https://github.com/penrose/penrose/commit/2ca37bd5d03e444f8cbd6b809558f349a9b78ebf))
+* add Discord badge to GitHub README ([#1548](https://github.com/penrose/penrose/issues/1548)) ([84cf567](https://github.com/penrose/penrose/commit/84cf567302ffdfd404cfaf245b32d93d26575609))
+* add a short intro to v3 blog post ([#1551](https://github.com/penrose/penrose/issues/1551)) ([4c8f75c](https://github.com/penrose/penrose/commit/4c8f75c6fa5eba192dec51ff5fa74bf68ef46d9a))
+* explain the origin of the project name ([#1554](https://github.com/penrose/penrose/issues/1554)) ([add467a](https://github.com/penrose/penrose/commit/add467abaa9ded9ab46234aff673a6f3ba09c313))
+* fix `npx` command for roger ([#1568](https://github.com/penrose/penrose/issues/1568)) ([cea1d0e](https://github.com/penrose/penrose/commit/cea1d0ee81f24264a68ad3fb39d4c33c3db9169a))
+* improve blog excerpt styling ([#1552](https://github.com/penrose/penrose/issues/1552)) ([b4514ca](https://github.com/penrose/penrose/commit/b4514cafb0b0ae037641f7cafab2811c4f67b144))
+* update Vanilla JS usage for v3 ([#1544](https://github.com/penrose/penrose/issues/1544)) ([d1ee0ea](https://github.com/penrose/penrose/commit/d1ee0ead2160d35e414cf562245e327904d808e5))
+
+### :house: Internal
+
+* Update `team.md` with new website URL for Rijul Jain ([#1559](https://github.com/penrose/penrose/issues/1559)) ([93ecea1](https://github.com/penrose/penrose/commit/93ecea130e478f383fc8f2ae305b4fd09ab47cb2))
+* enable Prettier for `*.jsx` in VS Code ([#1558](https://github.com/penrose/penrose/issues/1558)) ([fb47302](https://github.com/penrose/penrose/commit/fb47302c01e6a45713034acc321caaa921b64fab))
+
+
 ## [v3.0.0](https://github.com/penrose/penrose/compare/v2.3.0...v3.0.0) (2023-07-14)
 
 ### :warning: BREAKING CHANGE

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,33 +7,32 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 ### :rocket: New Feature
 
-* added UI for LLM program generation in `edgeworth` ([#1556](https://github.com/penrose/penrose/issues/1556)) ([865ee9e](https://github.com/penrose/penrose/commit/865ee9e7f6b598bc0f07e416ab73bea978bba6e7))
-* added `mod` function to `Functions.ts` ([#1565](https://github.com/penrose/penrose/issues/1565)) ([b7a7c3b](https://github.com/penrose/penrose/commit/b7a7c3b2710865f05e7040e913d5f7d5e825c1d1))
-* nondistinct matching ([#1567](https://github.com/penrose/penrose/issues/1567)) ([77e2714](https://github.com/penrose/penrose/commit/77e2714fb5bcf888136a2f65340b56c5d0025661))
+- added UI for LLM program generation in `edgeworth` ([#1556](https://github.com/penrose/penrose/issues/1556)) ([865ee9e](https://github.com/penrose/penrose/commit/865ee9e7f6b598bc0f07e416ab73bea978bba6e7))
+- added `mod` function to `Functions.ts` ([#1565](https://github.com/penrose/penrose/issues/1565)) ([b7a7c3b](https://github.com/penrose/penrose/commit/b7a7c3b2710865f05e7040e913d5f7d5e825c1d1))
+- nondistinct matching ([#1567](https://github.com/penrose/penrose/issues/1567)) ([77e2714](https://github.com/penrose/penrose/commit/77e2714fb5bcf888136a2f65340b56c5d0025661))
 
 ### :bug: Bug Fix
 
-* `CircleCenter` behavior in Euclidean geometry Style ([#1571](https://github.com/penrose/penrose/issues/1571)) ([a2ed8e1](https://github.com/penrose/penrose/commit/a2ed8e171cd406666ecf25f398dbea7e7a54c2cb))
-* compile `@penrose/roger` for distribution 💂‍♂️ ([#1562](https://github.com/penrose/penrose/issues/1562)) ([7b36125](https://github.com/penrose/penrose/commit/7b3612539bb104ea16edf01ad4884a919c3eac4a))
-* gallery loading by switching to pure Vue ([#1549](https://github.com/penrose/penrose/issues/1549)) ([7c96d70](https://github.com/penrose/penrose/commit/7c96d70f93d9da1810c32d3c7bcd467a343f5be1))
-* layering on nonexistent objects ([#1560](https://github.com/penrose/penrose/issues/1560)) ([0bbe47c](https://github.com/penrose/penrose/commit/0bbe47c505b9920db83dd152a914b452129b6668))
+- `CircleCenter` behavior in Euclidean geometry Style ([#1571](https://github.com/penrose/penrose/issues/1571)) ([a2ed8e1](https://github.com/penrose/penrose/commit/a2ed8e171cd406666ecf25f398dbea7e7a54c2cb))
+- compile `@penrose/roger` for distribution 💂‍♂️ ([#1562](https://github.com/penrose/penrose/issues/1562)) ([7b36125](https://github.com/penrose/penrose/commit/7b3612539bb104ea16edf01ad4884a919c3eac4a))
+- gallery loading by switching to pure Vue ([#1549](https://github.com/penrose/penrose/issues/1549)) ([7c96d70](https://github.com/penrose/penrose/commit/7c96d70f93d9da1810c32d3c7bcd467a343f5be1))
+- layering on nonexistent objects ([#1560](https://github.com/penrose/penrose/issues/1560)) ([0bbe47c](https://github.com/penrose/penrose/commit/0bbe47c505b9920db83dd152a914b452129b6668))
 
 ### :memo: Documentation
 
-* Correct domain code snippet type ([#1566](https://github.com/penrose/penrose/issues/1566)) ([ad0005a](https://github.com/penrose/penrose/commit/ad0005a92230efd5338f6e143f4bc5eb78009596))
-* add "Edit this page" button to pages ([#1555](https://github.com/penrose/penrose/issues/1555)) ([2ca37bd](https://github.com/penrose/penrose/commit/2ca37bd5d03e444f8cbd6b809558f349a9b78ebf))
-* add Discord badge to GitHub README ([#1548](https://github.com/penrose/penrose/issues/1548)) ([84cf567](https://github.com/penrose/penrose/commit/84cf567302ffdfd404cfaf245b32d93d26575609))
-* add a short intro to v3 blog post ([#1551](https://github.com/penrose/penrose/issues/1551)) ([4c8f75c](https://github.com/penrose/penrose/commit/4c8f75c6fa5eba192dec51ff5fa74bf68ef46d9a))
-* explain the origin of the project name ([#1554](https://github.com/penrose/penrose/issues/1554)) ([add467a](https://github.com/penrose/penrose/commit/add467abaa9ded9ab46234aff673a6f3ba09c313))
-* fix `npx` command for roger ([#1568](https://github.com/penrose/penrose/issues/1568)) ([cea1d0e](https://github.com/penrose/penrose/commit/cea1d0ee81f24264a68ad3fb39d4c33c3db9169a))
-* improve blog excerpt styling ([#1552](https://github.com/penrose/penrose/issues/1552)) ([b4514ca](https://github.com/penrose/penrose/commit/b4514cafb0b0ae037641f7cafab2811c4f67b144))
-* update Vanilla JS usage for v3 ([#1544](https://github.com/penrose/penrose/issues/1544)) ([d1ee0ea](https://github.com/penrose/penrose/commit/d1ee0ead2160d35e414cf562245e327904d808e5))
+- Correct domain code snippet type ([#1566](https://github.com/penrose/penrose/issues/1566)) ([ad0005a](https://github.com/penrose/penrose/commit/ad0005a92230efd5338f6e143f4bc5eb78009596))
+- add "Edit this page" button to pages ([#1555](https://github.com/penrose/penrose/issues/1555)) ([2ca37bd](https://github.com/penrose/penrose/commit/2ca37bd5d03e444f8cbd6b809558f349a9b78ebf))
+- add Discord badge to GitHub README ([#1548](https://github.com/penrose/penrose/issues/1548)) ([84cf567](https://github.com/penrose/penrose/commit/84cf567302ffdfd404cfaf245b32d93d26575609))
+- add a short intro to v3 blog post ([#1551](https://github.com/penrose/penrose/issues/1551)) ([4c8f75c](https://github.com/penrose/penrose/commit/4c8f75c6fa5eba192dec51ff5fa74bf68ef46d9a))
+- explain the origin of the project name ([#1554](https://github.com/penrose/penrose/issues/1554)) ([add467a](https://github.com/penrose/penrose/commit/add467abaa9ded9ab46234aff673a6f3ba09c313))
+- fix `npx` command for roger ([#1568](https://github.com/penrose/penrose/issues/1568)) ([cea1d0e](https://github.com/penrose/penrose/commit/cea1d0ee81f24264a68ad3fb39d4c33c3db9169a))
+- improve blog excerpt styling ([#1552](https://github.com/penrose/penrose/issues/1552)) ([b4514ca](https://github.com/penrose/penrose/commit/b4514cafb0b0ae037641f7cafab2811c4f67b144))
+- update Vanilla JS usage for v3 ([#1544](https://github.com/penrose/penrose/issues/1544)) ([d1ee0ea](https://github.com/penrose/penrose/commit/d1ee0ead2160d35e414cf562245e327904d808e5))
 
 ### :house: Internal
 
-* Update `team.md` with new website URL for Rijul Jain ([#1559](https://github.com/penrose/penrose/issues/1559)) ([93ecea1](https://github.com/penrose/penrose/commit/93ecea130e478f383fc8f2ae305b4fd09ab47cb2))
-* enable Prettier for `*.jsx` in VS Code ([#1558](https://github.com/penrose/penrose/issues/1558)) ([fb47302](https://github.com/penrose/penrose/commit/fb47302c01e6a45713034acc321caaa921b64fab))
-
+- Update `team.md` with new website URL for Rijul Jain ([#1559](https://github.com/penrose/penrose/issues/1559)) ([93ecea1](https://github.com/penrose/penrose/commit/93ecea130e478f383fc8f2ae305b4fd09ab47cb2))
+- enable Prettier for `*.jsx` in VS Code ([#1558](https://github.com/penrose/penrose/issues/1558)) ([fb47302](https://github.com/penrose/penrose/commit/fb47302c01e6a45713034acc321caaa921b64fab))
 
 ## [v3.0.0](https://github.com/penrose/penrose/compare/v2.3.0...v3.0.0) (2023-07-14)
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -168,7 +168,7 @@ checksum = "b1de2e551fb905ac83f73f7aedf2f0cb4a0da7e35efa24a202a936269f1f18e1"
 
 [[package]]
 name = "penrose-optimizer"
-version = "3.0.0"
+version = "3.1.0"
 dependencies = [
  "console_error_panic_hook",
  "console_log",

--- a/lerna.json
+++ b/lerna.json
@@ -1,7 +1,9 @@
 {
-  "packages": ["packages/*"],
+  "packages": [
+    "packages/*"
+  ],
   "npmClient": "yarn",
-  "version": "3.0.0",
+  "version": "3.1.0",
   "useWorkspaces": true,
   "changelogPreset": {
     "name": "@spyke/conventional-changelog-preset"

--- a/lerna.json
+++ b/lerna.json
@@ -1,7 +1,5 @@
 {
-  "packages": [
-    "packages/*"
-  ],
+  "packages": ["packages/*"],
   "npmClient": "yarn",
   "version": "3.1.0",
   "useWorkspaces": true,

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -7,12 +7,11 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 ### :rocket: New Feature
 
-* nondistinct matching ([#1567](https://github.com/penrose/penrose/issues/1567)) ([77e2714](https://github.com/penrose/penrose/commit/77e2714fb5bcf888136a2f65340b56c5d0025661))
+- nondistinct matching ([#1567](https://github.com/penrose/penrose/issues/1567)) ([77e2714](https://github.com/penrose/penrose/commit/77e2714fb5bcf888136a2f65340b56c5d0025661))
 
 ### :bug: Bug Fix
 
-* gallery loading by switching to pure Vue ([#1549](https://github.com/penrose/penrose/issues/1549)) ([7c96d70](https://github.com/penrose/penrose/commit/7c96d70f93d9da1810c32d3c7bcd467a343f5be1))
-
+- gallery loading by switching to pure Vue ([#1549](https://github.com/penrose/penrose/issues/1549)) ([7c96d70](https://github.com/penrose/penrose/commit/7c96d70f93d9da1810c32d3c7bcd467a343f5be1))
 
 ## [v3.0.0](https://github.com/penrose/penrose/compare/v2.3.0...v3.0.0) (2023-07-14)
 

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [v3.1.0](https://github.com/penrose/penrose/compare/v3.0.0...v3.1.0) (2023-07-19)
+
+### :rocket: New Feature
+
+* nondistinct matching ([#1567](https://github.com/penrose/penrose/issues/1567)) ([77e2714](https://github.com/penrose/penrose/commit/77e2714fb5bcf888136a2f65340b56c5d0025661))
+
+### :bug: Bug Fix
+
+* gallery loading by switching to pure Vue ([#1549](https://github.com/penrose/penrose/issues/1549)) ([7c96d70](https://github.com/penrose/penrose/commit/7c96d70f93d9da1810c32d3c7bcd467a343f5be1))
+
+
 ## [v3.0.0](https://github.com/penrose/penrose/compare/v2.3.0...v3.0.0) (2023-07-14)
 
 ### :warning: BREAKING CHANGE

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@penrose/components",
-  "version": "3.0.0",
+  "version": "3.1.0",
   "license": "MIT",
   "type": "module",
   "main": "dist/index.js",
@@ -49,7 +49,7 @@
   },
   "dependencies": {
     "@monaco-editor/react": "^4.0.11",
-    "@penrose/core": "^3.0.0",
+    "@penrose/core": "^3.1.0",
     "monaco-editor": "^0.31.0",
     "monaco-vim": "^0.3.4",
     "react-datasheet-grid": "^4.11.0",
@@ -60,7 +60,7 @@
   "devDependencies": {
     "@babel/core": "^7.18.0",
     "@mdx-js/preact": "^2.1.5",
-    "@penrose/examples": "^3.0.0",
+    "@penrose/examples": "^3.1.0",
     "@storybook/addon-actions": "^6.5.15",
     "@storybook/addon-essentials": "^6.5.15",
     "@storybook/addon-interactions": "^6.5.15",

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -7,13 +7,12 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 ### :rocket: New Feature
 
-* added `mod` function to `Functions.ts` ([#1565](https://github.com/penrose/penrose/issues/1565)) ([b7a7c3b](https://github.com/penrose/penrose/commit/b7a7c3b2710865f05e7040e913d5f7d5e825c1d1))
-* nondistinct matching ([#1567](https://github.com/penrose/penrose/issues/1567)) ([77e2714](https://github.com/penrose/penrose/commit/77e2714fb5bcf888136a2f65340b56c5d0025661))
+- added `mod` function to `Functions.ts` ([#1565](https://github.com/penrose/penrose/issues/1565)) ([b7a7c3b](https://github.com/penrose/penrose/commit/b7a7c3b2710865f05e7040e913d5f7d5e825c1d1))
+- nondistinct matching ([#1567](https://github.com/penrose/penrose/issues/1567)) ([77e2714](https://github.com/penrose/penrose/commit/77e2714fb5bcf888136a2f65340b56c5d0025661))
 
 ### :bug: Bug Fix
 
-* layering on nonexistent objects ([#1560](https://github.com/penrose/penrose/issues/1560)) ([0bbe47c](https://github.com/penrose/penrose/commit/0bbe47c505b9920db83dd152a914b452129b6668))
-
+- layering on nonexistent objects ([#1560](https://github.com/penrose/penrose/issues/1560)) ([0bbe47c](https://github.com/penrose/penrose/commit/0bbe47c505b9920db83dd152a914b452129b6668))
 
 ## [v3.0.0](https://github.com/penrose/penrose/compare/v2.3.0...v3.0.0) (2023-07-14)
 

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -3,6 +3,18 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [v3.1.0](https://github.com/penrose/penrose/compare/v3.0.0...v3.1.0) (2023-07-19)
+
+### :rocket: New Feature
+
+* added `mod` function to `Functions.ts` ([#1565](https://github.com/penrose/penrose/issues/1565)) ([b7a7c3b](https://github.com/penrose/penrose/commit/b7a7c3b2710865f05e7040e913d5f7d5e825c1d1))
+* nondistinct matching ([#1567](https://github.com/penrose/penrose/issues/1567)) ([77e2714](https://github.com/penrose/penrose/commit/77e2714fb5bcf888136a2f65340b56c5d0025661))
+
+### :bug: Bug Fix
+
+* layering on nonexistent objects ([#1560](https://github.com/penrose/penrose/issues/1560)) ([0bbe47c](https://github.com/penrose/penrose/commit/0bbe47c505b9920db83dd152a914b452129b6668))
+
+
 ## [v3.0.0](https://github.com/penrose/penrose/compare/v2.3.0...v3.0.0) (2023-07-14)
 
 ### :warning: BREAKING CHANGE

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@penrose/core",
-  "version": "3.0.0",
+  "version": "3.1.0",
   "type": "module",
   "main": "dist/index.js",
   "module": "dist/index.js",
@@ -75,7 +75,7 @@
   },
   "dependencies": {
     "@datastructures-js/queue": "^4.1.3",
-    "@penrose/optimizer": "^3.0.0",
+    "@penrose/optimizer": "^3.1.0",
     "consola": "^2.15.2",
     "immutable": "^4.0.0-rc.12",
     "lodash": "^4.17.15",

--- a/packages/docs-site/CHANGELOG.md
+++ b/packages/docs-site/CHANGELOG.md
@@ -7,23 +7,22 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 ### :bug: Bug Fix
 
-* compile `@penrose/roger` for distribution 💂‍♂️ ([#1562](https://github.com/penrose/penrose/issues/1562)) ([7b36125](https://github.com/penrose/penrose/commit/7b3612539bb104ea16edf01ad4884a919c3eac4a))
-* gallery loading by switching to pure Vue ([#1549](https://github.com/penrose/penrose/issues/1549)) ([7c96d70](https://github.com/penrose/penrose/commit/7c96d70f93d9da1810c32d3c7bcd467a343f5be1))
+- compile `@penrose/roger` for distribution 💂‍♂️ ([#1562](https://github.com/penrose/penrose/issues/1562)) ([7b36125](https://github.com/penrose/penrose/commit/7b3612539bb104ea16edf01ad4884a919c3eac4a))
+- gallery loading by switching to pure Vue ([#1549](https://github.com/penrose/penrose/issues/1549)) ([7c96d70](https://github.com/penrose/penrose/commit/7c96d70f93d9da1810c32d3c7bcd467a343f5be1))
 
 ### :memo: Documentation
 
-* Correct domain code snippet type ([#1566](https://github.com/penrose/penrose/issues/1566)) ([ad0005a](https://github.com/penrose/penrose/commit/ad0005a92230efd5338f6e143f4bc5eb78009596))
-* add "Edit this page" button to pages ([#1555](https://github.com/penrose/penrose/issues/1555)) ([2ca37bd](https://github.com/penrose/penrose/commit/2ca37bd5d03e444f8cbd6b809558f349a9b78ebf))
-* add a short intro to v3 blog post ([#1551](https://github.com/penrose/penrose/issues/1551)) ([4c8f75c](https://github.com/penrose/penrose/commit/4c8f75c6fa5eba192dec51ff5fa74bf68ef46d9a))
-* explain the origin of the project name ([#1554](https://github.com/penrose/penrose/issues/1554)) ([add467a](https://github.com/penrose/penrose/commit/add467abaa9ded9ab46234aff673a6f3ba09c313))
-* fix `npx` command for roger ([#1568](https://github.com/penrose/penrose/issues/1568)) ([cea1d0e](https://github.com/penrose/penrose/commit/cea1d0ee81f24264a68ad3fb39d4c33c3db9169a))
-* improve blog excerpt styling ([#1552](https://github.com/penrose/penrose/issues/1552)) ([b4514ca](https://github.com/penrose/penrose/commit/b4514cafb0b0ae037641f7cafab2811c4f67b144))
-* update Vanilla JS usage for v3 ([#1544](https://github.com/penrose/penrose/issues/1544)) ([d1ee0ea](https://github.com/penrose/penrose/commit/d1ee0ead2160d35e414cf562245e327904d808e5))
+- Correct domain code snippet type ([#1566](https://github.com/penrose/penrose/issues/1566)) ([ad0005a](https://github.com/penrose/penrose/commit/ad0005a92230efd5338f6e143f4bc5eb78009596))
+- add "Edit this page" button to pages ([#1555](https://github.com/penrose/penrose/issues/1555)) ([2ca37bd](https://github.com/penrose/penrose/commit/2ca37bd5d03e444f8cbd6b809558f349a9b78ebf))
+- add a short intro to v3 blog post ([#1551](https://github.com/penrose/penrose/issues/1551)) ([4c8f75c](https://github.com/penrose/penrose/commit/4c8f75c6fa5eba192dec51ff5fa74bf68ef46d9a))
+- explain the origin of the project name ([#1554](https://github.com/penrose/penrose/issues/1554)) ([add467a](https://github.com/penrose/penrose/commit/add467abaa9ded9ab46234aff673a6f3ba09c313))
+- fix `npx` command for roger ([#1568](https://github.com/penrose/penrose/issues/1568)) ([cea1d0e](https://github.com/penrose/penrose/commit/cea1d0ee81f24264a68ad3fb39d4c33c3db9169a))
+- improve blog excerpt styling ([#1552](https://github.com/penrose/penrose/issues/1552)) ([b4514ca](https://github.com/penrose/penrose/commit/b4514cafb0b0ae037641f7cafab2811c4f67b144))
+- update Vanilla JS usage for v3 ([#1544](https://github.com/penrose/penrose/issues/1544)) ([d1ee0ea](https://github.com/penrose/penrose/commit/d1ee0ead2160d35e414cf562245e327904d808e5))
 
 ### :house: Internal
 
-* Update `team.md` with new website URL for Rijul Jain ([#1559](https://github.com/penrose/penrose/issues/1559)) ([93ecea1](https://github.com/penrose/penrose/commit/93ecea130e478f383fc8f2ae305b4fd09ab47cb2))
-
+- Update `team.md` with new website URL for Rijul Jain ([#1559](https://github.com/penrose/penrose/issues/1559)) ([93ecea1](https://github.com/penrose/penrose/commit/93ecea130e478f383fc8f2ae305b4fd09ab47cb2))
 
 ## [v3.0.0](https://github.com/penrose/penrose/compare/v2.3.0...v3.0.0) (2023-07-14)
 

--- a/packages/docs-site/CHANGELOG.md
+++ b/packages/docs-site/CHANGELOG.md
@@ -3,6 +3,28 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [v3.1.0](https://github.com/penrose/penrose/compare/v3.0.0...v3.1.0) (2023-07-19)
+
+### :bug: Bug Fix
+
+* compile `@penrose/roger` for distribution 💂‍♂️ ([#1562](https://github.com/penrose/penrose/issues/1562)) ([7b36125](https://github.com/penrose/penrose/commit/7b3612539bb104ea16edf01ad4884a919c3eac4a))
+* gallery loading by switching to pure Vue ([#1549](https://github.com/penrose/penrose/issues/1549)) ([7c96d70](https://github.com/penrose/penrose/commit/7c96d70f93d9da1810c32d3c7bcd467a343f5be1))
+
+### :memo: Documentation
+
+* Correct domain code snippet type ([#1566](https://github.com/penrose/penrose/issues/1566)) ([ad0005a](https://github.com/penrose/penrose/commit/ad0005a92230efd5338f6e143f4bc5eb78009596))
+* add "Edit this page" button to pages ([#1555](https://github.com/penrose/penrose/issues/1555)) ([2ca37bd](https://github.com/penrose/penrose/commit/2ca37bd5d03e444f8cbd6b809558f349a9b78ebf))
+* add a short intro to v3 blog post ([#1551](https://github.com/penrose/penrose/issues/1551)) ([4c8f75c](https://github.com/penrose/penrose/commit/4c8f75c6fa5eba192dec51ff5fa74bf68ef46d9a))
+* explain the origin of the project name ([#1554](https://github.com/penrose/penrose/issues/1554)) ([add467a](https://github.com/penrose/penrose/commit/add467abaa9ded9ab46234aff673a6f3ba09c313))
+* fix `npx` command for roger ([#1568](https://github.com/penrose/penrose/issues/1568)) ([cea1d0e](https://github.com/penrose/penrose/commit/cea1d0ee81f24264a68ad3fb39d4c33c3db9169a))
+* improve blog excerpt styling ([#1552](https://github.com/penrose/penrose/issues/1552)) ([b4514ca](https://github.com/penrose/penrose/commit/b4514cafb0b0ae037641f7cafab2811c4f67b144))
+* update Vanilla JS usage for v3 ([#1544](https://github.com/penrose/penrose/issues/1544)) ([d1ee0ea](https://github.com/penrose/penrose/commit/d1ee0ead2160d35e414cf562245e327904d808e5))
+
+### :house: Internal
+
+* Update `team.md` with new website URL for Rijul Jain ([#1559](https://github.com/penrose/penrose/issues/1559)) ([93ecea1](https://github.com/penrose/penrose/commit/93ecea130e478f383fc8f2ae305b4fd09ab47cb2))
+
+
 ## [v3.0.0](https://github.com/penrose/penrose/compare/v2.3.0...v3.0.0) (2023-07-14)
 
 ### :warning: BREAKING CHANGE

--- a/packages/docs-site/package.json
+++ b/packages/docs-site/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@penrose/docs-site",
-  "version": "3.0.0",
+  "version": "3.1.0",
   "type": "module",
   "private": true,
   "scripts": {
@@ -46,22 +46,22 @@
     }
   },
   "dependencies": {
-    "@penrose/components": "^3.0.0",
-    "@penrose/examples": "^3.0.0",
+    "@penrose/components": "^3.1.0",
+    "@penrose/examples": "^3.1.0",
     "veaury": "^2.3.11"
   },
   "devDependencies": {
-    "@penrose/core": "^3.0.0",
-    "@penrose/editor": "^3.0.0",
-    "@penrose/roger": "^3.0.0",
+    "@penrose/core": "^3.1.0",
+    "@penrose/editor": "^3.1.0",
+    "@penrose/roger": "^3.1.0",
     "@tailwindcss/typography": "^0.5.4",
     "@types/markdown-it": "^12.2.3",
+    "chalk": "^3.0.0",
     "markdown-it": "^13.0.1",
     "markdown-it-katex": "^2.0.3",
     "shx": "^0.3.3",
     "tailwindcss": "^3.1.8",
     "vite-plugin-top-level-await": "^1.2.3",
-    "vitepress": "^1.0.0-beta.1",
-    "chalk": "^3.0.0"
+    "vitepress": "^1.0.0-beta.1"
   }
 }

--- a/packages/docs-site/public/vanilla-js-demo.html
+++ b/packages/docs-site/public/vanilla-js-demo.html
@@ -2,7 +2,7 @@
 <html>
   <head>
     <meta charset="utf-8" />
-    <title>Untitled</title>
+    <title>Penrose Vanilla JS Demo</title>
     <meta name="viewport" content="width=device-width, initial-scale=1" />
   </head>
   <body>
@@ -13,12 +13,12 @@
     <script type="importmap">
       {
         "imports": {
-          "@penrose/core": "https://ga.jspm.io/npm:@penrose/core@3.0.0/dist/index.js"
+          "@penrose/core": "https://ga.jspm.io/npm:@penrose/core@3.1.0/dist/index.js"
         },
         "scopes": {
           "https://ga.jspm.io/": {
             "@datastructures-js/queue": "https://ga.jspm.io/npm:@datastructures-js/queue@4.2.3/index.js",
-            "@penrose/optimizer": "https://ga.jspm.io/npm:@penrose/optimizer@3.0.0-beta.0/dist/index.js",
+            "@penrose/optimizer": "https://ga.jspm.io/npm:@penrose/optimizer@3.1.0/dist/index.js",
             "consola": "https://ga.jspm.io/npm:consola@2.15.3/dist/consola.browser.js",
             "crypto": "https://ga.jspm.io/npm:@jspm/core@2.0.1/nodelibs/browser/crypto.js",
             "immutable": "https://ga.jspm.io/npm:immutable@4.3.1/dist/immutable.es.js",

--- a/packages/edgeworth/CHANGELOG.md
+++ b/packages/edgeworth/CHANGELOG.md
@@ -3,6 +3,13 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [v3.1.0](https://github.com/penrose/penrose/compare/v3.0.0...v3.1.0) (2023-07-19)
+
+### :rocket: New Feature
+
+* added UI for LLM program generation in `edgeworth` ([#1556](https://github.com/penrose/penrose/issues/1556)) ([865ee9e](https://github.com/penrose/penrose/commit/865ee9e7f6b598bc0f07e416ab73bea978bba6e7))
+
+
 ## [v3.0.0](https://github.com/penrose/penrose/compare/v2.3.0...v3.0.0) (2023-07-14)
 
 ### :warning: BREAKING CHANGE

--- a/packages/edgeworth/CHANGELOG.md
+++ b/packages/edgeworth/CHANGELOG.md
@@ -7,8 +7,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 ### :rocket: New Feature
 
-* added UI for LLM program generation in `edgeworth` ([#1556](https://github.com/penrose/penrose/issues/1556)) ([865ee9e](https://github.com/penrose/penrose/commit/865ee9e7f6b598bc0f07e416ab73bea978bba6e7))
-
+- added UI for LLM program generation in `edgeworth` ([#1556](https://github.com/penrose/penrose/issues/1556)) ([865ee9e](https://github.com/penrose/penrose/commit/865ee9e7f6b598bc0f07e416ab73bea978bba6e7))
 
 ## [v3.0.0](https://github.com/penrose/penrose/compare/v2.3.0...v3.0.0) (2023-07-14)
 

--- a/packages/edgeworth/package.json
+++ b/packages/edgeworth/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@penrose/edgeworth",
   "private": true,
-  "version": "3.0.0",
+  "version": "3.1.0",
   "scripts": {
     "dev": "vite",
     "watch": "vite",
@@ -56,9 +56,9 @@
   },
   "dependencies": {
     "@material-ui/core": "^4.12.3",
-    "@penrose/components": "^3.0.0",
-    "@penrose/core": "^3.0.0",
-    "@penrose/examples": "^3.0.0",
+    "@penrose/components": "^3.1.0",
+    "@penrose/core": "^3.1.0",
+    "@penrose/examples": "^3.1.0",
     "@types/file-saver": "^2.0.5",
     "@types/jszip": "^3.4.1",
     "file-saver": "^2.0.5",

--- a/packages/editor/CHANGELOG.md
+++ b/packages/editor/CHANGELOG.md
@@ -7,10 +7,6 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 **Note:** Version bump only for package @penrose/editor
 
-
-
-
-
 ## [v3.0.0](https://github.com/penrose/penrose/compare/v2.3.0...v3.0.0) (2023-07-14)
 
 ### :warning: BREAKING CHANGE

--- a/packages/editor/CHANGELOG.md
+++ b/packages/editor/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [v3.1.0](https://github.com/penrose/penrose/compare/v3.0.0...v3.1.0) (2023-07-19)
+
+**Note:** Version bump only for package @penrose/editor
+
+
+
+
+
 ## [v3.0.0](https://github.com/penrose/penrose/compare/v2.3.0...v3.0.0) (2023-07-14)
 
 ### :warning: BREAKING CHANGE

--- a/packages/editor/package.json
+++ b/packages/editor/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@penrose/editor",
   "private": true,
-  "version": "3.0.0",
+  "version": "3.1.0",
   "scripts": {
     "start": "cross-env NODE_OPTIONS='--max-old-space-size=8192' vite",
     "dev": "cross-env NODE_OPTIONS='--max-old-space-size=8192' vite",
@@ -41,9 +41,9 @@
     }
   },
   "dependencies": {
-    "@penrose/components": "^3.0.0",
-    "@penrose/core": "^3.0.0",
-    "@penrose/examples": "^3.0.0",
+    "@penrose/components": "^3.1.0",
+    "@penrose/core": "^3.1.0",
+    "@penrose/examples": "^3.1.0",
     "animals": "^0.0.3",
     "color-name-list": "^8.38.0",
     "flexlayout-react": "^0.7.3",

--- a/packages/examples/CHANGELOG.md
+++ b/packages/examples/CHANGELOG.md
@@ -7,13 +7,12 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 ### :rocket: New Feature
 
-* added UI for LLM program generation in `edgeworth` ([#1556](https://github.com/penrose/penrose/issues/1556)) ([865ee9e](https://github.com/penrose/penrose/commit/865ee9e7f6b598bc0f07e416ab73bea978bba6e7))
-* nondistinct matching ([#1567](https://github.com/penrose/penrose/issues/1567)) ([77e2714](https://github.com/penrose/penrose/commit/77e2714fb5bcf888136a2f65340b56c5d0025661))
+- added UI for LLM program generation in `edgeworth` ([#1556](https://github.com/penrose/penrose/issues/1556)) ([865ee9e](https://github.com/penrose/penrose/commit/865ee9e7f6b598bc0f07e416ab73bea978bba6e7))
+- nondistinct matching ([#1567](https://github.com/penrose/penrose/issues/1567)) ([77e2714](https://github.com/penrose/penrose/commit/77e2714fb5bcf888136a2f65340b56c5d0025661))
 
 ### :bug: Bug Fix
 
-* `CircleCenter` behavior in Euclidean geometry Style ([#1571](https://github.com/penrose/penrose/issues/1571)) ([a2ed8e1](https://github.com/penrose/penrose/commit/a2ed8e171cd406666ecf25f398dbea7e7a54c2cb))
-
+- `CircleCenter` behavior in Euclidean geometry Style ([#1571](https://github.com/penrose/penrose/issues/1571)) ([a2ed8e1](https://github.com/penrose/penrose/commit/a2ed8e171cd406666ecf25f398dbea7e7a54c2cb))
 
 ## [v3.0.0](https://github.com/penrose/penrose/compare/v2.3.0...v3.0.0) (2023-07-14)
 

--- a/packages/examples/CHANGELOG.md
+++ b/packages/examples/CHANGELOG.md
@@ -3,6 +3,18 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [v3.1.0](https://github.com/penrose/penrose/compare/v3.0.0...v3.1.0) (2023-07-19)
+
+### :rocket: New Feature
+
+* added UI for LLM program generation in `edgeworth` ([#1556](https://github.com/penrose/penrose/issues/1556)) ([865ee9e](https://github.com/penrose/penrose/commit/865ee9e7f6b598bc0f07e416ab73bea978bba6e7))
+* nondistinct matching ([#1567](https://github.com/penrose/penrose/issues/1567)) ([77e2714](https://github.com/penrose/penrose/commit/77e2714fb5bcf888136a2f65340b56c5d0025661))
+
+### :bug: Bug Fix
+
+* `CircleCenter` behavior in Euclidean geometry Style ([#1571](https://github.com/penrose/penrose/issues/1571)) ([a2ed8e1](https://github.com/penrose/penrose/commit/a2ed8e171cd406666ecf25f398dbea7e7a54c2cb))
+
+
 ## [v3.0.0](https://github.com/penrose/penrose/compare/v2.3.0...v3.0.0) (2023-07-14)
 
 ### :warning: BREAKING CHANGE

--- a/packages/examples/package.json
+++ b/packages/examples/package.json
@@ -1,11 +1,11 @@
 {
   "name": "@penrose/examples",
-  "version": "3.0.0",
+  "version": "3.1.0",
   "private": true,
   "type": "module",
   "dependencies": {
-    "@penrose/core": "^3.0.0",
-    "@penrose/solids": "^3.0.0",
+    "@penrose/core": "^3.1.0",
+    "@penrose/solids": "^3.1.0",
     "solid-js": "^1"
   },
   "devDependencies": {

--- a/packages/optimizer/CHANGELOG.md
+++ b/packages/optimizer/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [v3.1.0](https://github.com/penrose/penrose/compare/v3.0.0...v3.1.0) (2023-07-19)
+
+**Note:** Version bump only for package @penrose/optimizer
+
+
+
+
+
 ## [v3.0.0](https://github.com/penrose/penrose/compare/v2.3.0...v3.0.0) (2023-07-14)
 
 ### :warning: BREAKING CHANGE

--- a/packages/optimizer/CHANGELOG.md
+++ b/packages/optimizer/CHANGELOG.md
@@ -7,10 +7,6 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 **Note:** Version bump only for package @penrose/optimizer
 
-
-
-
-
 ## [v3.0.0](https://github.com/penrose/penrose/compare/v2.3.0...v3.0.0) (2023-07-14)
 
 ### :warning: BREAKING CHANGE

--- a/packages/optimizer/Cargo.toml
+++ b/packages/optimizer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "penrose-optimizer"
-version = "3.0.0"
+version = "3.1.0"
 edition = "2021"
 publish = false
 

--- a/packages/optimizer/package.json
+++ b/packages/optimizer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@penrose/optimizer",
-  "version": "3.0.0",
+  "version": "3.1.0",
   "type": "module",
   "author": "Penrose Team (https://penrose.cs.cmu.edu/)",
   "license": "MIT",

--- a/packages/roger/CHANGELOG.md
+++ b/packages/roger/CHANGELOG.md
@@ -7,8 +7,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 ### :bug: Bug Fix
 
-* compile `@penrose/roger` for distribution 💂‍♂️ ([#1562](https://github.com/penrose/penrose/issues/1562)) ([7b36125](https://github.com/penrose/penrose/commit/7b3612539bb104ea16edf01ad4884a919c3eac4a))
-
+- compile `@penrose/roger` for distribution 💂‍♂️ ([#1562](https://github.com/penrose/penrose/issues/1562)) ([7b36125](https://github.com/penrose/penrose/commit/7b3612539bb104ea16edf01ad4884a919c3eac4a))
 
 ## [v3.0.0](https://github.com/penrose/penrose/compare/v2.3.0...v3.0.0) (2023-07-14)
 

--- a/packages/roger/CHANGELOG.md
+++ b/packages/roger/CHANGELOG.md
@@ -3,6 +3,13 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [v3.1.0](https://github.com/penrose/penrose/compare/v3.0.0...v3.1.0) (2023-07-19)
+
+### :bug: Bug Fix
+
+* compile `@penrose/roger` for distribution 💂‍♂️ ([#1562](https://github.com/penrose/penrose/issues/1562)) ([7b36125](https://github.com/penrose/penrose/commit/7b3612539bb104ea16edf01ad4884a919c3eac4a))
+
+
 ## [v3.0.0](https://github.com/penrose/penrose/compare/v2.3.0...v3.0.0) (2023-07-14)
 
 ### :warning: BREAKING CHANGE

--- a/packages/roger/package.json
+++ b/packages/roger/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@penrose/roger",
-  "version": "3.0.0",
+  "version": "3.1.0",
   "description": "",
   "type": "module",
   "main": "dist/index.js",
@@ -30,7 +30,7 @@
   "author": "Penrose Team (https://penrose.cs.cmu.edu/)",
   "license": "MIT",
   "dependencies": {
-    "@penrose/core": "^3.0.0",
+    "@penrose/core": "^3.1.0",
     "canvas": "^2.8.0",
     "chalk": "^3.0.0",
     "chokidar": "^3.5.3",

--- a/packages/solids/CHANGELOG.md
+++ b/packages/solids/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [v3.1.0](https://github.com/penrose/penrose/compare/v3.0.0...v3.1.0) (2023-07-19)
+
+**Note:** Version bump only for package @penrose/solids
+
+
+
+
+
 ## [v3.0.0](https://github.com/penrose/penrose/compare/v2.3.0...v3.0.0) (2023-07-14)
 
 ### :warning: BREAKING CHANGE

--- a/packages/solids/CHANGELOG.md
+++ b/packages/solids/CHANGELOG.md
@@ -7,10 +7,6 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 **Note:** Version bump only for package @penrose/solids
 
-
-
-
-
 ## [v3.0.0](https://github.com/penrose/penrose/compare/v2.3.0...v3.0.0) (2023-07-14)
 
 ### :warning: BREAKING CHANGE

--- a/packages/solids/package.json
+++ b/packages/solids/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@penrose/solids",
-  "version": "3.0.0",
+  "version": "3.1.0",
   "private": true,
   "type": "module",
   "exports": {
@@ -9,8 +9,8 @@
     "default": "./dist/ssr/index.js"
   },
   "dependencies": {
-    "@penrose/core": "^3.0.0",
-    "@penrose/optimizer": "^3.0.0",
+    "@penrose/core": "^3.1.0",
+    "@penrose/optimizer": "^3.1.0",
     "markdown-it": "^13.0.1",
     "markdown-it-mathjax3": "^4.3.2",
     "solid-js": "^1"

--- a/packages/vscode/CHANGELOG.md
+++ b/packages/vscode/CHANGELOG.md
@@ -7,10 +7,6 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 **Note:** Version bump only for package penrose-vs
 
-
-
-
-
 ## [v3.0.0](https://github.com/penrose/penrose/compare/v2.3.0...v3.0.0) (2023-07-14)
 
 ### :warning: BREAKING CHANGE

--- a/packages/vscode/CHANGELOG.md
+++ b/packages/vscode/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [v3.1.0](https://github.com/penrose/penrose/compare/v3.0.0...v3.1.0) (2023-07-19)
+
+**Note:** Version bump only for package penrose-vs
+
+
+
+
+
 ## [v3.0.0](https://github.com/penrose/penrose/compare/v2.3.0...v3.0.0) (2023-07-14)
 
 ### :warning: BREAKING CHANGE

--- a/packages/vscode/package.json
+++ b/packages/vscode/package.json
@@ -3,7 +3,7 @@
   "displayName": "Penrose",
   "publisher": "penrose",
   "description": "Penrose languages bundle",
-  "version": "3.0.0",
+  "version": "3.1.0",
   "author": "Penrose Team (https://penrose.cs.cmu.edu/)",
   "license": "MIT",
   "private": true,


### PR DESCRIPTION
# Description

This PR bumps the version to `v3.1.0`
