### PR TITLE
docs: render markdown in function param description

### DIFF
--- a/packages/docs-site/src/components/Function.vue
+++ b/packages/docs-site/src/components/Function.vue
@@ -17,6 +17,7 @@ export default defineComponent({
       return this.params.map((p: any) => ({
         ...p,
         type: describeType(p.type),
+        description: p.description ? md.render(p.description) : "",
       }));
     },
   },
@@ -46,7 +47,7 @@ export default defineComponent({
           </td>
           <td>{{ param.type.symbol }}</td>
           <td>{{ param.type.description }}</td>
-          <td>{{ param.description }}</td>
+          <td v-html="param.description"></td>
           <td v-if="parameters.filter((p: FuncParam) => p.default).length > 0">
             {{ param.default ?? "" }}
           </td>


### PR DESCRIPTION
# Description

Our [Style function docs page](https://penrose.cs.cmu.edu/docs/ref/style/functions) renders the markdown syntax in function descriptions correctly, but not the parameter descriptions. This PR fixes it.

<img width="643" alt="image" src="https://github.com/penrose/penrose/assets/11740102/131a3ef1-0c75-48da-a264-5ea8db70d171">
 