### PR TITLE
docs: fix single quotation mark

### DIFF
--- a/packages/docs-site/blog/v3.md
+++ b/packages/docs-site/blog/v3.md
@@ -27,7 +27,7 @@ geometric queries... among many other things!
 
 ---
 
-[Penrose](/) is a tool for making beautiful diagrams in any area of science, mathematics, or engineering. It’s made for those of us who can’t (or don’t want to!) draw beautiful diagrams by hand.
+[Penrose](/) is a tool for making beautiful diagrams in any area of science, mathematics, or engineering. It's made for those of us who can't (or don't want to!) draw beautiful diagrams by hand.
 
 ## 🎨 New Diagrams
 


### PR DESCRIPTION
# Description

This PR fixes three single-quotation marks in the blog page about Penrose 3.0.