### PR TITLE
chore: remove redundant TSConfig stuff for Roger

### DIFF
--- a/packages/roger/tsconfig.json
+++ b/packages/roger/tsconfig.json
@@ -3,8 +3,6 @@
   "compilerOptions": {
     "outDir": "dist",
     "sourceMap": true,
-    "noImplicitThis": true,
-    "resolveJsonModule": true,
-    "strictNullChecks": true
+    "resolveJsonModule": true
   }
 }

--- a/packages/roger/tsconfig.json
+++ b/packages/roger/tsconfig.json
@@ -2,7 +2,7 @@
   "extends": "../../tsconfig.json",
   "compilerOptions": {
     "outDir": "dist",
-    "sourceMap": true,
-    "resolveJsonModule": true
+    "resolveJsonModule": true,
+    "sourceMap": true
   }
 }


### PR DESCRIPTION
# Description

Followup to #1576 since [`noImplicitThis`](https://www.typescriptlang.org/tsconfig#noImplicitThis) and [`strictNullChecks`](https://www.typescriptlang.org/tsconfig#strictNullChecks) are both implied by [`strict`](https://www.typescriptlang.org/tsconfig#strict).

# Checklist

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have reviewed any generated registry diagram changes