### PR TITLE
docs: allow TeX in Style function docs

### DIFF
--- a/packages/docs-site/src/components/Function.vue
+++ b/packages/docs-site/src/components/Function.vue
@@ -1,9 +1,11 @@
 <script lang="ts">
 import { defineComponent } from "vue";
 import Markdown from "markdown-it";
+import markdownItKatex from "markdown-it-katex";
 import { describeType } from "@penrose/core";
 import { FuncParam } from "@penrose/core/dist/types/functions";
 const md = new Markdown();
+md.use(markdownItKatex);
 export default defineComponent({
   props: ["name", "description", "params", "returns"],
   computed: {


### PR DESCRIPTION
# Description

Our main site uses KaTeX (https://github.com/penrose/penrose/pull/926) to allow math notations in markdown. This PR add support for math notations in the core Style function library docs as well.