### PR TITLE
build: add rust-toolchain.toml for automatic toolchain installation

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -43,12 +43,6 @@ Be sure you have these tools installed:
 
 - [Rust][]
 
-  - the WebAssembly target for Rust:
-
-    ```sh
-    rustup target add wasm32-unknown-unknown
-    ```
-
   - `wasm-bindgen` CLI v0.2.84:
 
     ```sh

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,5 @@
+[toolchain]
+channel = "stable"
+components = []
+targets = [ "wasm32-unknown-unknown" ]
+profile = "default"

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,5 +1,5 @@
 [toolchain]
-channel = "stable"
+channel = "1.71.0"
 components = []
 targets = [ "wasm32-unknown-unknown" ]
 profile = "default"


### PR DESCRIPTION
# Description

While [packaging penrose for Nix](https://github.com/jhvst/nix-config/commit/d749ea86b31782f51c0cf10c0b407b636063bd84), I found that a common practice to add Rust toolchains or select specific version is by doing [overrides](https://rust-lang.github.io/rustup/overrides.html). Nix in particular likes the toolchain file, which if present, will automatically run the equivalent "rustup" command. In penrose case, the file can be used to add the wasm toolchain required to compile the roger binary.

As this helped me, I was wondering if you would be interested in merging this request and/or possibly pinning the Rust version furthermore using the toolchain file. For me, having this file on upstream skips a patch over the source repository.

# Implementation strategy and design decisions

N/A

# Examples with steps to reproduce them

N/A?

# Open questions

See above
