### PR TITLE
feat: row-indexing of matrices

### DIFF
--- a/packages/core/src/compiler/Style.test.ts
+++ b/packages/core/src/compiler/Style.test.ts
@@ -1,5 +1,6 @@
 import im from "immutable";
 import { describe, expect, test } from "vitest";
+import { numsOf } from "../contrib/Utils.js";
 import { C } from "../types/ast.js";
 import { Either } from "../types/common.js";
 import { Env } from "../types/domain.js";
@@ -1417,5 +1418,31 @@ delete x.z.p }`,
         ["`t`.vals", "1:0:match_id"].sort(),
       );
     });
+  });
+
+  test("Indexing", async () => {
+    const dsl = "type T";
+    const sub = "T t";
+    const sty =
+      canvasPreamble +
+      `
+      forall T t {
+        mat = [(1, 2, 3), (4, 5, 6), (7, 8, 9)]
+        t.row = mat[2]
+      }
+    `;
+
+    const { translation } = await loadProgs({ dsl, sub, sty });
+    const rowVal = translation.symbols.get("`t`.row");
+    expect(rowVal !== undefined).toBe(true);
+    if (rowVal !== undefined) {
+      expect(rowVal.tag).toEqual("Val");
+      if (rowVal.tag === "Val") {
+        expect(rowVal.contents.tag).toEqual("VectorV");
+        if (rowVal.contents.tag === "VectorV") {
+          expect(numsOf(rowVal.contents.contents)).toEqual([7, 8, 9]);
+        }
+      }
+    }
   });
 });

--- a/packages/core/src/compiler/Style.ts
+++ b/packages/core/src/compiler/Style.ts
@@ -2916,7 +2916,7 @@ const evalAccess = (
   expr: Path<C>,
   coll: Value<ad.Num>,
   indices: number[],
-): Result<FloatV<ad.Num>, StyleError> => {
+): Result<Value<ad.Num>, StyleError> => {
   switch (coll.tag) {
     case "ListV":
     case "TupV":
@@ -2933,18 +2933,27 @@ const evalAccess = (
     case "LListV":
     case "MatrixV":
     case "PtListV": {
-      if (indices.length !== 2) {
+      if (indices.length === 1) {
+        // get i-th row
+        const [i] = indices;
+        if (!isValidIndex(coll.contents, i)) {
+          return err({ tag: "OutOfBoundsError", expr, indices });
+        }
+        return ok(vectorV(coll.contents[i]));
+      } else if (indices.length === 2) {
+        // get i-th row, j-th column
+        const [i, j] = indices;
+        if (!isValidIndex(coll.contents, i)) {
+          return err({ tag: "OutOfBoundsError", expr, indices });
+        }
+        const row = coll.contents[i];
+        if (!isValidIndex(row, j)) {
+          return err({ tag: "OutOfBoundsError", expr, indices });
+        }
+        return ok(floatV(row[j]));
+      } else {
         return err({ tag: "BadIndexError", expr });
       }
-      const [i, j] = indices;
-      if (!isValidIndex(coll.contents, i)) {
-        return err({ tag: "OutOfBoundsError", expr, indices });
-      }
-      const row = coll.contents[i];
-      if (!isValidIndex(row, j)) {
-        return err({ tag: "OutOfBoundsError", expr, indices });
-      }
-      return ok(floatV(row[j]));
     }
     case "ShapeListV": {
       return err({ tag: "IndexIntoShapeListError", expr });


### PR DESCRIPTION
# Description

Resolves #1509.

This PR allows Style writers to extract an entire row from a matrix. Previously, we only allow indexing for a specific element of matrix with two indices.

# Implementation strategy and design decisions

We add a case when the number of indices is 1. In that case, after checking for out-of-bound errors, we directly extract that row as a vector.

# Checklist

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have reviewed any generated registry diagram changes
