### PR TITLE
build: exclude test files from `core` npm pack

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -9,7 +9,9 @@
   "license": "MIT",
   "files": [
     "dist/**/*.d.ts",
-    "dist/**/*.js"
+    "dist/**/*.js",
+    "!dist/**/*.test.js",
+    "!dist/**/*.test.d.ts"
   ],
   "scripts": {
     "build-parsers": "nearleyc src/parser/Domain.ne > src/parser/DomainParser.ts && nearleyc src/parser/Substance.ne > src/parser/SubstanceParser.ts && nearleyc src/parser/Style.ne > src/parser/StyleParser.ts",


### PR DESCRIPTION
# Description

Currently, the unpacked size of `@penrose/core` is 1.32M. As a first step to reduce the size of the package, this PR excludes test files from the npm distribution. 

# Open questions

We might want to consider providing bundles of core in CJS and ESM (related issue with size in #423) along with the ES modules. It's a bit surprising that `core` is this big without any bundles. Wondering what the best practices are for distribution.
