### PR TITLE
build: don't explicitly install Rust Wasm target

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -7,9 +7,6 @@ runs:
       with:
         node-version: "16"
         registry-url: "https://registry.npmjs.org"
-    - name: Install Wasm target
-      run: rustup target add wasm32-unknown-unknown
-      shell: bash
     - name: Install wasm-bindgen
       run: |
         wget https://github.com/rustwasm/wasm-bindgen/releases/download/0.2.84/wasm-bindgen-0.2.84-x86_64-unknown-linux-musl.tar.gz

--- a/cloudflare.sh
+++ b/cloudflare.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -euxo pipefail
 
-curl https://sh.rustup.rs -sSf | sh -s -- -yt wasm32-unknown-unknown
+curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
 source "$HOME/.cargo/env"
 
 wget https://github.com/rustwasm/wasm-bindgen/releases/download/0.2.84/wasm-bindgen-0.2.84-x86_64-unknown-linux-musl.tar.gz


### PR DESCRIPTION
# Description

These should be unnecessary as of #1593.

# Implementation strategy and design decisions

I copied the Rust installation command from here: https://www.rust-lang.org/tools/install

# Checklist

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have reviewed any generated registry diagram changes