### PR TITLE
chore: bump version to 3.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,42 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [v3.2.0](https://github.com/penrose/penrose/compare/v3.1.0...v3.2.0) (2023-08-08)
+
+### :rocket: New Feature
+
+- Add common matrix functions to standard library ([#1538](https://github.com/penrose/penrose/issues/1538)) ([fdbe56e](https://github.com/penrose/penrose/commit/fdbe56e6f983440f6225a8ea61ea5ef21236a1ed))
+- Add dinoshade example to registry ([#1601](https://github.com/penrose/penrose/issues/1601)) ([ef2a536](https://github.com/penrose/penrose/commit/ef2a5363f12d9f986ff45e9eb93760f467819eaa))
+- Penrose logo ([#1605](https://github.com/penrose/penrose/issues/1605)) ([f3e7369](https://github.com/penrose/penrose/commit/f3e7369f33dfeeac2d7452d98e19f1d2e5448e9d))
+- Substance indexed sets ([#1572](https://github.com/penrose/penrose/issues/1572)) ([83f3869](https://github.com/penrose/penrose/commit/83f386950415a0d839ce95ba080c9ed36c4413b7))
+- Update 3D Spectral Graphs ([#1550](https://github.com/penrose/penrose/issues/1550)) ([a2b813b](https://github.com/penrose/penrose/commit/a2b813bff5f180bdd735d2dc97cb6a2692923af6))
+- `numberof` and `nameof` ([#1583](https://github.com/penrose/penrose/issues/1583)) ([d3049af](https://github.com/penrose/penrose/commit/d3049afd47099e02dbfe3dc0d74bbbc7d2bb60fe))
+- diagrams for selected and generic Alloy models ([#1584](https://github.com/penrose/penrose/issues/1584)) ([1ca7d33](https://github.com/penrose/penrose/commit/1ca7d3314a41f6ef9cdd848e20bbf791beb4e01e))
+- row-indexing of matrices ([#1599](https://github.com/penrose/penrose/issues/1599)) ([b35b82d](https://github.com/penrose/penrose/commit/b35b82da8857af07c240bf971918d823aade7cef))
+
+### :bug: Bug Fix
+
+- Alloy example dining-philosophers use `numberof` and `nameof` ([#1587](https://github.com/penrose/penrose/issues/1587)) ([0503d5b](https://github.com/penrose/penrose/commit/0503d5ba5c93d66248f80a1553bfd7f87792c39f))
+- bounding boxes and points for rotated rects ([#1600](https://github.com/penrose/penrose/issues/1600)) ([ec0fa7b](https://github.com/penrose/penrose/commit/ec0fa7b5250d36571fc3e922e9857349d03c3ff1))
+
+### :memo: Documentation
+
+- Update README.md ([#1580](https://github.com/penrose/penrose/issues/1580)) ([f2d865f](https://github.com/penrose/penrose/commit/f2d865f280787c1ca957f43cdda5460eab54f79b))
+- allow TeX in Style function docs ([#1592](https://github.com/penrose/penrose/issues/1592)) ([95ab946](https://github.com/penrose/penrose/commit/95ab946ea5e3c842ffa399c102c85513235f0059))
+- blog post for tailoring graph domain ([#1590](https://github.com/penrose/penrose/issues/1590)) ([90398ca](https://github.com/penrose/penrose/commit/90398ca487056f40ac606d70c429fbc42fccbd9f))
+- fix anchors for functions ([#1570](https://github.com/penrose/penrose/issues/1570)) ([a145853](https://github.com/penrose/penrose/commit/a1458536fdf2dabc4bcd2c9ca4b423beb2c4416f))
+- fix single quotation mark ([#1579](https://github.com/penrose/penrose/issues/1579)) ([098c33d](https://github.com/penrose/penrose/commit/098c33de3feb2307c7ca80c6d3e0a0f5b842669d))
+- render Style function docstrings at build-time ([#1602](https://github.com/penrose/penrose/issues/1602)) ([81de1f4](https://github.com/penrose/penrose/commit/81de1f4b156c11d3d894c6f5797c87b7af0ee5df))
+- render markdown in function param description ([#1575](https://github.com/penrose/penrose/issues/1575)) ([1bd1e2d](https://github.com/penrose/penrose/commit/1bd1e2d23c52239ef34977956db73c249edc9d31))
+
+### :house: Internal
+
+- add `eslint-plugin-unary-minus` ([#1589](https://github.com/penrose/penrose/issues/1589)) ([100dc7a](https://github.com/penrose/penrose/commit/100dc7a16f4dccf097c0a458b2ca741a37d10014))
+- enable strict TS checking in `roger` ([#1576](https://github.com/penrose/penrose/issues/1576)) ([3a698f9](https://github.com/penrose/penrose/commit/3a698f99cc1021e377e3f6e46f2fa7666f521f6a))
+- go from `.eslintrc.cjs` to `.eslintrc.json` ([#1585](https://github.com/penrose/penrose/issues/1585)) ([7908f9f](https://github.com/penrose/penrose/commit/7908f9f1bad1b269656277af3884c9e6aee81be6))
+- graphs blog post fixes ([#1594](https://github.com/penrose/penrose/issues/1594)) ([6d74d93](https://github.com/penrose/penrose/commit/6d74d93a1c2f6003fec237a7f9da305c9d0e89cc))
+- remove redundant TSConfig stuff for Roger ([#1581](https://github.com/penrose/penrose/issues/1581)) ([0d2ac0a](https://github.com/penrose/penrose/commit/0d2ac0aacef5267f6d90adc9b2247dc112973b4d))
+
 ## [v3.1.0](https://github.com/penrose/penrose/compare/v3.0.0...v3.1.0) (2023-07-19)
 
 ### :rocket: New Feature

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -168,7 +168,7 @@ checksum = "b1de2e551fb905ac83f73f7aedf2f0cb4a0da7e35efa24a202a936269f1f18e1"
 
 [[package]]
 name = "penrose-optimizer"
-version = "3.1.0"
+version = "3.2.0"
 dependencies = [
  "console_error_panic_hook",
  "console_log",

--- a/lerna.json
+++ b/lerna.json
@@ -1,7 +1,7 @@
 {
   "packages": ["packages/*"],
   "npmClient": "yarn",
-  "version": "3.1.0",
+  "version": "3.2.0",
   "useWorkspaces": true,
   "changelogPreset": {
     "name": "@spyke/conventional-changelog-preset"

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -3,6 +3,21 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [v3.2.0](https://github.com/penrose/penrose/compare/v3.1.0...v3.2.0) (2023-08-08)
+
+### :rocket: New Feature
+
+- Substance indexed sets ([#1572](https://github.com/penrose/penrose/issues/1572)) ([83f3869](https://github.com/penrose/penrose/commit/83f386950415a0d839ce95ba080c9ed36c4413b7))
+- `numberof` and `nameof` ([#1583](https://github.com/penrose/penrose/issues/1583)) ([d3049af](https://github.com/penrose/penrose/commit/d3049afd47099e02dbfe3dc0d74bbbc7d2bb60fe))
+
+### :memo: Documentation
+
+- blog post for tailoring graph domain ([#1590](https://github.com/penrose/penrose/issues/1590)) ([90398ca](https://github.com/penrose/penrose/commit/90398ca487056f40ac606d70c429fbc42fccbd9f))
+
+### :house: Internal
+
+- add `eslint-plugin-unary-minus` ([#1589](https://github.com/penrose/penrose/issues/1589)) ([100dc7a](https://github.com/penrose/penrose/commit/100dc7a16f4dccf097c0a458b2ca741a37d10014))
+
 ## [v3.1.0](https://github.com/penrose/penrose/compare/v3.0.0...v3.1.0) (2023-07-19)
 
 ### :rocket: New Feature

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@penrose/components",
-  "version": "3.1.0",
+  "version": "3.2.0",
   "license": "MIT",
   "type": "module",
   "main": "dist/index.js",
@@ -49,7 +49,7 @@
   },
   "dependencies": {
     "@monaco-editor/react": "^4.0.11",
-    "@penrose/core": "^3.1.0",
+    "@penrose/core": "^3.2.0",
     "monaco-editor": "^0.31.0",
     "monaco-vim": "^0.3.4",
     "react-datasheet-grid": "^4.11.0",
@@ -60,7 +60,7 @@
   "devDependencies": {
     "@babel/core": "^7.18.0",
     "@mdx-js/preact": "^2.1.5",
-    "@penrose/examples": "^3.1.0",
+    "@penrose/examples": "^3.2.0",
     "@storybook/addon-actions": "^6.5.15",
     "@storybook/addon-essentials": "^6.5.15",
     "@storybook/addon-interactions": "^6.5.15",

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -3,6 +3,25 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [v3.2.0](https://github.com/penrose/penrose/compare/v3.1.0...v3.2.0) (2023-08-08)
+
+### :rocket: New Feature
+
+- Add common matrix functions to standard library ([#1538](https://github.com/penrose/penrose/issues/1538)) ([fdbe56e](https://github.com/penrose/penrose/commit/fdbe56e6f983440f6225a8ea61ea5ef21236a1ed))
+- Penrose logo ([#1605](https://github.com/penrose/penrose/issues/1605)) ([f3e7369](https://github.com/penrose/penrose/commit/f3e7369f33dfeeac2d7452d98e19f1d2e5448e9d))
+- Substance indexed sets ([#1572](https://github.com/penrose/penrose/issues/1572)) ([83f3869](https://github.com/penrose/penrose/commit/83f386950415a0d839ce95ba080c9ed36c4413b7))
+- `numberof` and `nameof` ([#1583](https://github.com/penrose/penrose/issues/1583)) ([d3049af](https://github.com/penrose/penrose/commit/d3049afd47099e02dbfe3dc0d74bbbc7d2bb60fe))
+- row-indexing of matrices ([#1599](https://github.com/penrose/penrose/issues/1599)) ([b35b82d](https://github.com/penrose/penrose/commit/b35b82da8857af07c240bf971918d823aade7cef))
+
+### :bug: Bug Fix
+
+- bounding boxes and points for rotated rects ([#1600](https://github.com/penrose/penrose/issues/1600)) ([ec0fa7b](https://github.com/penrose/penrose/commit/ec0fa7b5250d36571fc3e922e9857349d03c3ff1))
+
+### :house: Internal
+
+- add `eslint-plugin-unary-minus` ([#1589](https://github.com/penrose/penrose/issues/1589)) ([100dc7a](https://github.com/penrose/penrose/commit/100dc7a16f4dccf097c0a458b2ca741a37d10014))
+- go from `.eslintrc.cjs` to `.eslintrc.json` ([#1585](https://github.com/penrose/penrose/issues/1585)) ([7908f9f](https://github.com/penrose/penrose/commit/7908f9f1bad1b269656277af3884c9e6aee81be6))
+
 ## [v3.1.0](https://github.com/penrose/penrose/compare/v3.0.0...v3.1.0) (2023-07-19)
 
 ### :rocket: New Feature

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -92,7 +92,7 @@
   },
   "dependencies": {
     "@datastructures-js/queue": "^4.1.3",
-    "@penrose/optimizer": "^3.1.0",
+    "@penrose/optimizer": "^3.2.0",
     "consola": "^2.15.2",
     "immutable": "^4.0.0-rc.12",
     "lodash": "^4.17.15",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@penrose/core",
-  "version": "3.1.0",
+  "version": "3.2.0",
   "type": "module",
   "main": "dist/index.js",
   "module": "dist/index.js",

--- a/packages/docs-site/CHANGELOG.md
+++ b/packages/docs-site/CHANGELOG.md
@@ -3,6 +3,27 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [v3.2.0](https://github.com/penrose/penrose/compare/v3.1.0...v3.2.0) (2023-08-08)
+
+### :rocket: New Feature
+
+- Add common matrix functions to standard library ([#1538](https://github.com/penrose/penrose/issues/1538)) ([fdbe56e](https://github.com/penrose/penrose/commit/fdbe56e6f983440f6225a8ea61ea5ef21236a1ed))
+- Substance indexed sets ([#1572](https://github.com/penrose/penrose/issues/1572)) ([83f3869](https://github.com/penrose/penrose/commit/83f386950415a0d839ce95ba080c9ed36c4413b7))
+- `numberof` and `nameof` ([#1583](https://github.com/penrose/penrose/issues/1583)) ([d3049af](https://github.com/penrose/penrose/commit/d3049afd47099e02dbfe3dc0d74bbbc7d2bb60fe))
+
+### :memo: Documentation
+
+- allow TeX in Style function docs ([#1592](https://github.com/penrose/penrose/issues/1592)) ([95ab946](https://github.com/penrose/penrose/commit/95ab946ea5e3c842ffa399c102c85513235f0059))
+- blog post for tailoring graph domain ([#1590](https://github.com/penrose/penrose/issues/1590)) ([90398ca](https://github.com/penrose/penrose/commit/90398ca487056f40ac606d70c429fbc42fccbd9f))
+- fix anchors for functions ([#1570](https://github.com/penrose/penrose/issues/1570)) ([a145853](https://github.com/penrose/penrose/commit/a1458536fdf2dabc4bcd2c9ca4b423beb2c4416f))
+- fix single quotation mark ([#1579](https://github.com/penrose/penrose/issues/1579)) ([098c33d](https://github.com/penrose/penrose/commit/098c33de3feb2307c7ca80c6d3e0a0f5b842669d))
+- render Style function docstrings at build-time ([#1602](https://github.com/penrose/penrose/issues/1602)) ([81de1f4](https://github.com/penrose/penrose/commit/81de1f4b156c11d3d894c6f5797c87b7af0ee5df))
+- render markdown in function param description ([#1575](https://github.com/penrose/penrose/issues/1575)) ([1bd1e2d](https://github.com/penrose/penrose/commit/1bd1e2d23c52239ef34977956db73c249edc9d31))
+
+### :house: Internal
+
+- graphs blog post fixes ([#1594](https://github.com/penrose/penrose/issues/1594)) ([6d74d93](https://github.com/penrose/penrose/commit/6d74d93a1c2f6003fec237a7f9da305c9d0e89cc))
+
 ## [v3.1.0](https://github.com/penrose/penrose/compare/v3.0.0...v3.1.0) (2023-07-19)
 
 ### :bug: Bug Fix

--- a/packages/docs-site/package.json
+++ b/packages/docs-site/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@penrose/docs-site",
-  "version": "3.1.0",
+  "version": "3.2.0",
   "type": "module",
   "private": true,
   "scripts": {
@@ -46,14 +46,14 @@
     }
   },
   "dependencies": {
-    "@penrose/components": "^3.1.0",
-    "@penrose/examples": "^3.1.0",
+    "@penrose/components": "^3.2.0",
+    "@penrose/examples": "^3.2.0",
     "veaury": "^2.3.11"
   },
   "devDependencies": {
-    "@penrose/core": "^3.1.0",
-    "@penrose/editor": "^3.1.0",
-    "@penrose/roger": "^3.1.0",
+    "@penrose/core": "^3.2.0",
+    "@penrose/editor": "^3.2.0",
+    "@penrose/roger": "^3.2.0",
     "@tailwindcss/typography": "^0.5.4",
     "@types/markdown-it": "^12.2.3",
     "chalk": "^3.0.0",

--- a/packages/docs-site/public/vanilla-js-demo.html
+++ b/packages/docs-site/public/vanilla-js-demo.html
@@ -13,12 +13,12 @@
     <script type="importmap">
       {
         "imports": {
-          "@penrose/core": "https://ga.jspm.io/npm:@penrose/core@3.1.0/dist/index.js"
+          "@penrose/core": "https://ga.jspm.io/npm:@penrose/core@3.2.0/dist/index.js"
         },
         "scopes": {
           "https://ga.jspm.io/": {
             "@datastructures-js/queue": "https://ga.jspm.io/npm:@datastructures-js/queue@4.2.3/index.js",
-            "@penrose/optimizer": "https://ga.jspm.io/npm:@penrose/optimizer@3.1.0/dist/index.js",
+            "@penrose/optimizer": "https://ga.jspm.io/npm:@penrose/optimizer@3.2.0/dist/index.js",
             "consola": "https://ga.jspm.io/npm:consola@2.15.3/dist/consola.browser.js",
             "crypto": "https://ga.jspm.io/npm:@jspm/core@2.0.1/nodelibs/browser/crypto.js",
             "immutable": "https://ga.jspm.io/npm:immutable@4.3.1/dist/immutable.es.js",

--- a/packages/edgeworth/CHANGELOG.md
+++ b/packages/edgeworth/CHANGELOG.md
@@ -3,6 +3,12 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [v3.2.0](https://github.com/penrose/penrose/compare/v3.1.0...v3.2.0) (2023-08-08)
+
+### :rocket: New Feature
+
+- Substance indexed sets ([#1572](https://github.com/penrose/penrose/issues/1572)) ([83f3869](https://github.com/penrose/penrose/commit/83f386950415a0d839ce95ba080c9ed36c4413b7))
+
 ## [v3.1.0](https://github.com/penrose/penrose/compare/v3.0.0...v3.1.0) (2023-07-19)
 
 ### :rocket: New Feature

--- a/packages/edgeworth/package.json
+++ b/packages/edgeworth/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@penrose/edgeworth",
   "private": true,
-  "version": "3.1.0",
+  "version": "3.2.0",
   "scripts": {
     "dev": "vite",
     "watch": "vite",
@@ -56,9 +56,9 @@
   },
   "dependencies": {
     "@material-ui/core": "^4.12.3",
-    "@penrose/components": "^3.1.0",
-    "@penrose/core": "^3.1.0",
-    "@penrose/examples": "^3.1.0",
+    "@penrose/components": "^3.2.0",
+    "@penrose/core": "^3.2.0",
+    "@penrose/examples": "^3.2.0",
     "@types/file-saver": "^2.0.5",
     "@types/jszip": "^3.4.1",
     "file-saver": "^2.0.5",

--- a/packages/editor/CHANGELOG.md
+++ b/packages/editor/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [v3.2.0](https://github.com/penrose/penrose/compare/v3.1.0...v3.2.0) (2023-08-08)
+
+**Note:** Version bump only for package @penrose/editor
+
 ## [v3.1.0](https://github.com/penrose/penrose/compare/v3.0.0...v3.1.0) (2023-07-19)
 
 **Note:** Version bump only for package @penrose/editor

--- a/packages/editor/package.json
+++ b/packages/editor/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@penrose/editor",
   "private": true,
-  "version": "3.1.0",
+  "version": "3.2.0",
   "scripts": {
     "start": "cross-env NODE_OPTIONS='--max-old-space-size=8192' vite",
     "dev": "cross-env NODE_OPTIONS='--max-old-space-size=8192' vite",
@@ -41,9 +41,9 @@
     }
   },
   "dependencies": {
-    "@penrose/components": "^3.1.0",
-    "@penrose/core": "^3.1.0",
-    "@penrose/examples": "^3.1.0",
+    "@penrose/components": "^3.2.0",
+    "@penrose/core": "^3.2.0",
+    "@penrose/examples": "^3.2.0",
     "animals": "^0.0.3",
     "color-name-list": "^8.38.0",
     "flexlayout-react": "^0.7.3",

--- a/packages/examples/CHANGELOG.md
+++ b/packages/examples/CHANGELOG.md
@@ -3,6 +3,26 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [v3.2.0](https://github.com/penrose/penrose/compare/v3.1.0...v3.2.0) (2023-08-08)
+
+### :rocket: New Feature
+
+- Add common matrix functions to standard library ([#1538](https://github.com/penrose/penrose/issues/1538)) ([fdbe56e](https://github.com/penrose/penrose/commit/fdbe56e6f983440f6225a8ea61ea5ef21236a1ed))
+- Add dinoshade example to registry ([#1601](https://github.com/penrose/penrose/issues/1601)) ([ef2a536](https://github.com/penrose/penrose/commit/ef2a5363f12d9f986ff45e9eb93760f467819eaa))
+- Penrose logo ([#1605](https://github.com/penrose/penrose/issues/1605)) ([f3e7369](https://github.com/penrose/penrose/commit/f3e7369f33dfeeac2d7452d98e19f1d2e5448e9d))
+- Substance indexed sets ([#1572](https://github.com/penrose/penrose/issues/1572)) ([83f3869](https://github.com/penrose/penrose/commit/83f386950415a0d839ce95ba080c9ed36c4413b7))
+- Update 3D Spectral Graphs ([#1550](https://github.com/penrose/penrose/issues/1550)) ([a2b813b](https://github.com/penrose/penrose/commit/a2b813bff5f180bdd735d2dc97cb6a2692923af6))
+- diagrams for selected and generic Alloy models ([#1584](https://github.com/penrose/penrose/issues/1584)) ([1ca7d33](https://github.com/penrose/penrose/commit/1ca7d3314a41f6ef9cdd848e20bbf791beb4e01e))
+
+### :bug: Bug Fix
+
+- Alloy example dining-philosophers use `numberof` and `nameof` ([#1587](https://github.com/penrose/penrose/issues/1587)) ([0503d5b](https://github.com/penrose/penrose/commit/0503d5ba5c93d66248f80a1553bfd7f87792c39f))
+
+### :memo: Documentation
+
+- Update README.md ([#1580](https://github.com/penrose/penrose/issues/1580)) ([f2d865f](https://github.com/penrose/penrose/commit/f2d865f280787c1ca957f43cdda5460eab54f79b))
+- blog post for tailoring graph domain ([#1590](https://github.com/penrose/penrose/issues/1590)) ([90398ca](https://github.com/penrose/penrose/commit/90398ca487056f40ac606d70c429fbc42fccbd9f))
+
 ## [v3.1.0](https://github.com/penrose/penrose/compare/v3.0.0...v3.1.0) (2023-07-19)
 
 ### :rocket: New Feature

--- a/packages/examples/package.json
+++ b/packages/examples/package.json
@@ -1,11 +1,11 @@
 {
   "name": "@penrose/examples",
-  "version": "3.1.0",
+  "version": "3.2.0",
   "private": true,
   "type": "module",
   "dependencies": {
-    "@penrose/core": "^3.1.0",
-    "@penrose/solids": "^3.1.0",
+    "@penrose/core": "^3.2.0",
+    "@penrose/solids": "^3.2.0",
     "solid-js": "^1"
   },
   "devDependencies": {

--- a/packages/optimizer/Cargo.toml
+++ b/packages/optimizer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "penrose-optimizer"
-version = "3.1.0"
+version = "3.2.0"
 edition = "2021"
 publish = false
 

--- a/packages/optimizer/package.json
+++ b/packages/optimizer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@penrose/optimizer",
-  "version": "3.1.0",
+  "version": "3.2.0",
   "type": "module",
   "author": "Penrose Team (https://penrose.cs.cmu.edu/)",
   "license": "MIT",

--- a/packages/roger/CHANGELOG.md
+++ b/packages/roger/CHANGELOG.md
@@ -3,6 +3,13 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [v3.2.0](https://github.com/penrose/penrose/compare/v3.1.0...v3.2.0) (2023-08-08)
+
+### :house: Internal
+
+- enable strict TS checking in `roger` ([#1576](https://github.com/penrose/penrose/issues/1576)) ([3a698f9](https://github.com/penrose/penrose/commit/3a698f99cc1021e377e3f6e46f2fa7666f521f6a))
+- remove redundant TSConfig stuff for Roger ([#1581](https://github.com/penrose/penrose/issues/1581)) ([0d2ac0a](https://github.com/penrose/penrose/commit/0d2ac0aacef5267f6d90adc9b2247dc112973b4d))
+
 ## [v3.1.0](https://github.com/penrose/penrose/compare/v3.0.0...v3.1.0) (2023-07-19)
 
 ### :bug: Bug Fix

--- a/packages/roger/package.json
+++ b/packages/roger/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@penrose/roger",
-  "version": "3.1.0",
+  "version": "3.2.0",
   "description": "",
   "type": "module",
   "main": "dist/index.js",
@@ -30,7 +30,7 @@
   "author": "Penrose Team (https://penrose.cs.cmu.edu/)",
   "license": "MIT",
   "dependencies": {
-    "@penrose/core": "^3.1.0",
+    "@penrose/core": "^3.2.0",
     "canvas": "^2.8.0",
     "chalk": "^3.0.0",
     "chokidar": "^3.5.3",

--- a/packages/solids/CHANGELOG.md
+++ b/packages/solids/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [v3.2.0](https://github.com/penrose/penrose/compare/v3.1.0...v3.2.0) (2023-08-08)
+
+**Note:** Version bump only for package @penrose/solids
+
 ## [v3.1.0](https://github.com/penrose/penrose/compare/v3.0.0...v3.1.0) (2023-07-19)
 
 **Note:** Version bump only for package @penrose/solids

--- a/packages/solids/package.json
+++ b/packages/solids/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@penrose/solids",
-  "version": "3.1.0",
+  "version": "3.2.0",
   "private": true,
   "type": "module",
   "exports": {
@@ -9,7 +9,7 @@
     "default": "./dist/ssr/index.js"
   },
   "dependencies": {
-    "@penrose/core": "^3.1.0",
+    "@penrose/core": "^3.2.0",
     "@penrose/optimizer": "^3.1.0",
     "markdown-it": "^13.0.1",
     "markdown-it-mathjax3": "^4.3.2",

--- a/packages/solids/package.json
+++ b/packages/solids/package.json
@@ -10,7 +10,7 @@
   },
   "dependencies": {
     "@penrose/core": "^3.2.0",
-    "@penrose/optimizer": "^3.1.0",
+    "@penrose/optimizer": "^3.2.0",
     "markdown-it": "^13.0.1",
     "markdown-it-mathjax3": "^4.3.2",
     "solid-js": "^1"

--- a/packages/vscode/CHANGELOG.md
+++ b/packages/vscode/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [v3.2.0](https://github.com/penrose/penrose/compare/v3.1.0...v3.2.0) (2023-08-08)
+
+### :rocket: New Feature
+
+- Add common matrix functions to standard library ([#1538](https://github.com/penrose/penrose/issues/1538)) ([fdbe56e](https://github.com/penrose/penrose/commit/fdbe56e6f983440f6225a8ea61ea5ef21236a1ed))
+- Substance indexed sets ([#1572](https://github.com/penrose/penrose/issues/1572)) ([83f3869](https://github.com/penrose/penrose/commit/83f386950415a0d839ce95ba080c9ed36c4413b7))
+- `numberof` and `nameof` ([#1583](https://github.com/penrose/penrose/issues/1583)) ([d3049af](https://github.com/penrose/penrose/commit/d3049afd47099e02dbfe3dc0d74bbbc7d2bb60fe))
+
 ## [v3.1.0](https://github.com/penrose/penrose/compare/v3.0.0...v3.1.0) (2023-07-19)
 
 **Note:** Version bump only for package penrose-vs

--- a/packages/vscode/package.json
+++ b/packages/vscode/package.json
@@ -3,7 +3,7 @@
   "displayName": "Penrose",
   "publisher": "penrose",
   "description": "Penrose languages bundle",
-  "version": "3.1.0",
+  "version": "3.2.0",
   "author": "Penrose Team (https://penrose.cs.cmu.edu/)",
   "license": "MIT",
   "private": true,


### PR DESCRIPTION
# Description

This PR bumps all package versions to `v3.2.0`