### PR TITLE
chore: remove duplicate Möbius registry entry

### DIFF
--- a/packages/examples/src/registry.json
+++ b/packages/examples/src/registry.json
@@ -260,7 +260,6 @@
     "name": "Methane Combustion Reaction",
     "gallery": true
   },
-  "mobius/mobius": {},
   "molecules/glutamine": {},
   "matrix-ops/tests/matrix-matrix-addition": {
     "name": "Matrix-matrix addition",


### PR DESCRIPTION
# Description

#1505 tried to add the `mobius/mobius` example to the gallery, but this was prevented by a duplicate `mobius/mobius` entry further down in the `registry.json` file without `"gallery": true`, which took precedence. This PR fixes the issue by removing the latter entry.

# Examples with steps to reproduce them

Look at [the website's gallery page](https://penrose.cs.cmu.edu/examples).

# Checklist

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have reviewed any generated registry diagram changes