### PR TITLE
docs: replace outdated `arrowheadSize` in tutorial

### DIFF
--- a/packages/docs-site/docs/tutorial/functions.md
+++ b/packages/docs-site/docs/tutorial/functions.md
@@ -62,7 +62,7 @@ u.shape = Line {
   strokeWidth : 3.0
   strokeColor : const.lightBlue /* or any color you want */
   endArrowhead: "straight"
-  arrowheadSize : const.arrowheadSize /* feel free to play with other values */
+  endArrowheadSize : const.arrowheadSize /* feel free to play with other values */
 }
 ```
 

--- a/packages/examples/src/tutorials/solutions/tutorial3.md
+++ b/packages/examples/src/tutorials/solutions/tutorial3.md
@@ -52,7 +52,7 @@ forall VectorSpace U {
         strokeColor : U.axisColor
         startArrowhead: "straight"
         endArrowhead: "straight"
-        arrowheadSize : const.arrowheadSize * 2.
+        endArrowheadSize : const.arrowheadSize * 2.
     }
 
     U.yAxis = Line {
@@ -63,7 +63,7 @@ forall VectorSpace U {
         strokeColor : U.axisColor
         startArrowhead: "straight"
         endArrowhead: "straight"
-        arrowheadSize : const.arrowheadSize * 2.
+        endArrowheadSize : const.arrowheadSize * 2.
     }
 
     U.text = Equation {
@@ -85,7 +85,7 @@ where In(u,U) {
     strokeWidth : 3.0
     strokeColor : const.lightBlue
     endArrowhead: "straight"
-    arrowheadSize : const.arrowheadSize
+    endArrowheadSize : const.arrowheadSize
   }
 
   u.text = Equation {
@@ -145,7 +145,7 @@ where In(u,U) {
     strokeWidth : 3.0
     strokeColor : const.lightBlue
     endArrowhead: "straight"
-    arrowheadSize : const.arrowheadSize
+    endArrowheadSize : const.arrowheadSize
   }
 
   u.text = Equation {
@@ -309,7 +309,7 @@ where u := addV(v,w); In(u, U); In(v, U); In(w, U) {
     endArrowhead: "straight"
     strokeWidth : const.arrowThickness
     strokeStyle : "dashed"
-    arrowheadSize : const.arrowheadSize
+    endArrowheadSize : const.arrowheadSize
   }
 
   u.dashed_w = Line {
@@ -318,7 +318,7 @@ where u := addV(v,w); In(u, U); In(v, U); In(w, U) {
     endArrowhead: "straight"
     strokeWidth : const.arrowThickness
     strokeStyle : "dashed"
-    arrowheadSize : const.arrowheadSize
+    endArrowheadSize : const.arrowheadSize
   }
 
   u.dashed_w below u.shape

--- a/packages/examples/src/tutorials/supplementary/tutorial3/walkthrough.md
+++ b/packages/examples/src/tutorials/supplementary/tutorial3/walkthrough.md
@@ -109,7 +109,7 @@ The real fun starts! 🥁 To draw a vector space, we have a background, an origi
       strokeColor : U.axisColor
       startArrowhead: "straight"
       endArrowhead: "straight"
-      arrowheadSize : const.arrowheadSize * 2.
+      endArrowheadSize : const.arrowheadSize * 2.
   }
   ```
 


### PR DESCRIPTION
# Description

Fixes #1614.

# Checklist

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have reviewed any generated registry diagram changes