### PR TITLE
fix: regex for int literals

### DIFF
--- a/packages/core/src/parser/Substance.ne
+++ b/packages/core/src/parser/Substance.ne
@@ -16,7 +16,7 @@ import { IndexSet, RangeAssign, Range, NumberConstant, BinaryExpr, UnaryExpr, Co
 const lexer = moo.compile({
   tex_literal: /\$.*?\$/, // TeX string enclosed by dollar signs
   double_arrow: "<->",
-  int_literal: /[+-]?(?<!\.)\b[0-9]+\b(?!\.[0-9])/,
+  int_literal: /[+-]?[1-9][0-9]*|0(?!\.[0-9])/,
   float_literal: /([+-]?([0-9]*[.])?[0-9]+)/,
   ...basicSymbols,
   identifier: {


### PR DESCRIPTION
# Description

Resolves #1620.

The online IDE fails because of a faulty regex for integer literals in the Substance parser introduced in #1572. This PR removes the `?<` group (possibly intended for [lookbehind](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Regular_expressions/Lookbehind_assertion) but incorrect anyway). 