### PR TITLE
fix: averagePoint for vectors with more than two elements

### DIFF
--- a/packages/core/src/contrib/Functions.ts
+++ b/packages/core/src/contrib/Functions.ts
@@ -840,16 +840,8 @@ export const compDict = {
     name: "sumVectors",
     description: "Return the sum of vectors in a list of vectors.",
     params: [{ name: "vecs", description: "vectors", type: realNMT() }],
-    body: (_context: Context, vecs: ad.Num[][]): MayWarn<VectorV<ad.Num>> => {
-      if (vecs.length === 0) {
-        throw new Error("Expect a non-empty list of vectors");
-      }
-      const vlen = vecs[0].length;
-      const zeros: ad.Num[] = new Array(vlen).fill(0);
-      return noWarn(
-        vectorV(vecs.reduce((curr, v) => ops.vadd(curr, v), zeros)),
-      );
-    },
+    body: (_context: Context, vecs: ad.Num[][]): MayWarn<VectorV<ad.Num>> =>
+      noWarn(vectorV(sumVectors(vecs))),
     returns: realNT(),
   },
 
@@ -2163,17 +2155,14 @@ export const compDict = {
       { name: "points", type: realNMT(), description: "list of points" },
     ],
     body: (_context: Context, points: ad.Num[][]): MayWarn<VectorV<ad.Num>> => {
-      let mean: ad.Num[] = [0, 0];
-      for (let i = 0; i < points.length; i++) {
-        mean = ops.vadd(mean, points[i]);
-      }
-      mean = ops.vdiv(mean, points.length);
+      const sum = sumVectors(points);
+      const mean = ops.vdiv(sum, points.length);
       return noWarn({
         tag: "VectorV",
         contents: mean,
       });
     },
-    returns: valueT("Real2"),
+    returns: valueT("RealN"),
   },
 
   interpolatingSpline: {
@@ -5815,6 +5804,15 @@ export const compDict = {
 // `_compDictVals` causes TypeScript to enforce that every function in
 // `compDict` actually has type `CompFunc` with the right function signature, etc.
 const _compDictVals: CompFunc[] = Object.values(compDict);
+
+const sumVectors = (vecs: ad.Num[][]): ad.Num[] => {
+  if (vecs.length === 0) {
+    throw new Error("Expect a non-empty list of vectors");
+  }
+  const vlen = vecs[0].length;
+  const zeros: ad.Num[] = new Array(vlen).fill(0);
+  return vecs.reduce((curr, v) => ops.vadd(curr, v), zeros);
+};
 
 /*
   float msign(in float x) { return (x<0.0)?-1.0:1.0; }


### PR DESCRIPTION
# Description

Resolves #1616.

We make `averagePoint` use `sumVectors` (which correctly handles vectors with >2 elements) instead of performing the summation ourselves. We also update the documentation to specify, correctly, that the function takes in vectors of length N and outputs one vector of length N.

# Implementation strategy and design decisions

The function `sumVectors` was implemented inline. We extract the implementation of `sumVectors` to outside of the computation function dictionary so that it can be used in `averagePoint`.

# Checklist

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have reviewed any generated registry diagram changes
