### PR TITLE
feat: TeX-ifying strings using braces

### DIFF
--- a/packages/core/src/contrib/Functions.ts
+++ b/packages/core/src/contrib/Functions.ts
@@ -5817,17 +5817,24 @@ export const compDict = {
     description: "Returns the TeX-ified version of a string.",
     params: [{ name: "str", type: stringT() }],
     body: (_context: Context, str: string): MayWarn<StrV> => {
-      return noWarn(
-        strV(
-          str
-            .split("_")
-            .map((s) => `{${s}}`)
-            .join("_"),
-        ),
-      );
+      const splitted = str.split("_");
+      return noWarn(strV(TeXifyHelper(splitted)));
     },
     returns: stringT(),
   },
+};
+
+const TeXifyHelper = (segments: string[]): string => {
+  if (segments.length === 0) {
+    return "";
+  }
+
+  const [first, ...rest] = segments;
+  if (rest.length === 0) {
+    return `{${first}}`;
+  } else {
+    return `{${first}}_{${TeXifyHelper(rest)}}`;
+  }
 };
 
 // `_compDictVals` causes TypeScript to enforce that every function in

--- a/packages/core/src/contrib/Functions.ts
+++ b/packages/core/src/contrib/Functions.ts
@@ -72,6 +72,7 @@ import {
   MatrixV,
   PathDataV,
   PtListV,
+  StrV,
   TupV,
   VectorV,
 } from "../types/value.js";
@@ -100,6 +101,7 @@ import {
   rectlikeT,
   shapeListT,
   shapeT,
+  strV,
   stringT,
   unionT,
   unitT,
@@ -5809,6 +5811,22 @@ export const compDict = {
       );
     },
     returns: real2NT(),
+  },
+  TeXify: {
+    name: "TeXify",
+    description: "Returns the TeX-ified version of a string.",
+    params: [{ name: "str", type: stringT() }],
+    body: (_context: Context, str: string): MayWarn<StrV> => {
+      return noWarn(
+        strV(
+          str
+            .split("_")
+            .map((s) => `{${s}}`)
+            .join("_"),
+        ),
+      );
+    },
+    returns: stringT(),
   },
 };
 

--- a/packages/core/src/contrib/Functions.ts
+++ b/packages/core/src/contrib/Functions.ts
@@ -5803,7 +5803,8 @@ export const compDict = {
   },
   TeXify: {
     name: "TeXify",
-    description: "Returns the TeX-ified version of a string.",
+    description:
+      'Returns the TeX-fied version of a string where subscripts are handled in a way suitable for equation rendering. For example, "hello_world" becomes "{hello}_{world}".',
     params: [{ name: "str", type: stringT() }],
     body: (_context: Context, str: string): MayWarn<StrV> => {
       const splitted = str.split("_");

--- a/packages/core/src/contrib/Functions.ts
+++ b/packages/core/src/contrib/Functions.ts
@@ -5825,6 +5825,7 @@ export const compDict = {
 };
 
 const TeXifyHelper = (segments: string[]): string => {
+  // This function performs cascading.
   if (segments.length === 0) {
     return "";
   }


### PR DESCRIPTION
# Description

We add a computation function `TeXify` that takes in a string separated by underscores (`_`) and returns "reasonable" version of the string that can be gracefully rendered by LaTeX.

As an example, if we just try to render `"hello_world"` as an equation, it would look like $hello_world$. If we instead render `TeXify("hello_world")`, it would look like ${hello}_{world}$ which is more reasonable. This is because `TeXify("hello_world")` outputs `"{hello}_{world}"` which is rendered reasonably by LaTeX.

Another instance where this comes up is, with substance indexed sets, we can easily generate objects with large indices. For example,
```
Node n_i for i in [0, 105]
```
would generate `n_0, n_1, ..., n_103, n_104, n_105`. If we just render an `Equation` shape with `"n_105"`, it would look like $n_105$.`TeXify("n_105")` becomes `"{n}_{105}"` which is rendered as ${n}_{105}$.


# Implementation strategy and design decisions

The rough strategy is to split the string by underscores, add curly braces around each sub-string, and re-assembly them together using underscores. While this strategy works well for strings with one index, it fails for those with multiple indices. Say if we have `"hello_world_123"`. `TeXify` would give us `"{hello}_{world}_{123}"` which cannot be rendered as MathJax, since MathJax gives error
```
MathJax could not render ${hello}_{world}_{123}$: Double subscripts: use braces to clarify
```

The simple solution is to just "cascade" the curly braces. Instead of generating `"{hello}_{world}_{123}"`, the "cascading" approach generates `"{hello}_{{world}_{123}}"` which is rendered as ${hello}\_{{world}\_{123}}$ reasonably.

# Examples with steps to reproduce them

Here is an example that has cascading.

https://7593e662.penrose-72l.pages.dev/try/?gist=ac1734ef01759069f7ca788a6f6ca376

# Checklist

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have reviewed any generated registry diagram changes
