### PR TITLE
docs: change gallery grid to use flex boxes

### DIFF
--- a/packages/docs-site/src/components/Gallery.vue
+++ b/packages/docs-site/src/components/Gallery.vue
@@ -44,6 +44,8 @@ export const cropSVG = (svg) => {
       svgNode.setAttribute("viewBox", cropped);
     }
   }
+  svgNode.setAttribute("width", "100%");
+  svgNode.setAttribute("height", "100%");
   return serializer.serializeToString(svgNode);
 };
 
@@ -98,7 +100,9 @@ export default {
 .example-container {
   width: 200px;
   height: 200px;
-  padding: 1.5em;
+  padding: 1.2em;
+  display: flex;
+  justify-content: center;
   background-color: #fff;
   border-radius: 10px;
   box-shadow: 0px 3px 3px rgba(0, 0, 0, 0.1);


### PR DESCRIPTION
# Description

#1631 introduced a relatively "long" SVG for our gallery, which overflowed the grid box container. 
![image](https://github.com/penrose/penrose/assets/11740102/1b946551-8028-494c-b5a6-bce56f90ff92)

This PR changes the CSS to use flex box to contain and center the SVG inside. I also reduced the padding a bit to make the diagrams more visible

# Examples with steps to reproduce them

![image](https://github.com/penrose/penrose/assets/11740102/3dc2b260-2e78-4260-a024-f3f0ca0943d7)


# Checklist

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have reviewed any generated registry diagram changes

# Open questions

Questions that require more discussion or to be addressed in future development:
