### PR TITLE
fix: style selector on invalid function names

### DIFF
--- a/packages/core/src/compiler/Style.ts
+++ b/packages/core/src/compiler/Style.ts
@@ -862,37 +862,12 @@ const toSubExpr = <T>(env: Env, e: SelExpr<T>): SubExpr<T> => {
     case "SEBind": {
       return e.contents.contents;
     }
-    case "SEFunc": {
-      return {
-        ...e, // Puts the remnants of e's ASTNode info here -- is that ok?
-        tag: "ApplyFunction",
-        name: e.name,
-        args: e.args.map((e) => toSubExpr(env, e)),
-      };
-    }
-    case "SEValCons": {
-      return {
-        ...e,
-        tag: "ApplyConstructor",
-        name: e.name,
-        args: e.args.map((e) => toSubExpr(env, e)),
-      };
-    }
+    case "SEFunc":
+    case "SEValCons":
     case "SEFuncOrValCons": {
-      let tag: "ApplyFunction" | "ApplyConstructor";
-      if (env.constructors.has(e.name.value)) {
-        tag = "ApplyConstructor";
-      } else if (env.functions.has(e.name.value)) {
-        tag = "ApplyFunction";
-      } else {
-        // TODO: return TypeNotFound instead
-        throw new Error(
-          `Style internal error: expected '${e.name.value}' to be either a constructor or function, but was not found`,
-        );
-      }
       const res: SubExpr<T> = {
         ...e,
-        tag,
+        tag: "Func",
         name: e.name,
         args: e.args.map((e) => toSubExpr(env, e)),
       };


### PR DESCRIPTION
# Description

Resolves #1634.

The Style selector checks functions and constructors (`SEFunc`) as follows:

- convert the Style selector expression into an equivalent Substance expression, using function `toSubExpr`.
- call the `checkExpr` function (a part of the Substance checker) on the generated Substance expression.

The function `toSubExpr` takes in a `SEFunc` (variant of `SelExpr`) and checks the name of the `SEFunc`:

- if the name matches that of a function in the Domain, it returns the Substance expression `ApplyFunction`
- if the name matches that of a constructor in the Domain, it returns the Substance expression `ApplyConstructor`
- otherwise it ungracefully throws an error.

As such, when provided a function name that does not exist, `toSubExpr` throws an error ungracefully.

But all these in `toSubExpr` (distinguishing between `ApplyFunction` and `ApplyConstructor` and ungracefully throwing error) are unnecessary, since the `checkExpr` function in Substance compiler already does the same things in a graceful manner.

# Implementation strategy and design decisions

The solution is to change `toSubExpr` to just return `Func` and delay the checks (checking whether or not the function actually exists, and distinguishing between functions and constructors) to the Substance checker.

# Examples with steps to reproduce them

# Checklist

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have reviewed any generated registry diagram changes

# Open questions

Questions that require more discussion or to be addressed in future development:
