### PR TITLE
perf: CI workflow for comparing registry performance

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -22,27 +22,31 @@ jobs:
         with:
           path: first/
           ref: e0207aff773856edcf4478ee71cb186f835a4a2a
+      - name: Change to first repo
+        run: cd first
       - name: Setup
         uses: ./.github/actions/setup
       - name: Generate diagrams and metadata for the first commit
         run: yarn registry
-        working-directory: first/
       - name: Upload generated diagrams and metadata
         uses: actions/upload-artifact@v3
         with:
           name: diagrams-1
-          path: first/packages/examples/diagrams/
+          path: packages/examples/diagrams/
       # run second commit
+      - name: Change to Home
+        run: cd
       - name: Checkout second commit
         uses: actions/checkout@v3
         with:
           path: second/
           ref: 90048e996c4e1cfb637005a25de70a42dacc0aea
+      - name: Change to second repo
+        run: cd second
       - name: Setup
         uses: ./.github/actions/setup
       - name: Generate diagrams and metadata for the second commit
         run: yarn registry
-        working-directory: second/
       - name: Upload generated diagrams and metadata
         uses: actions/upload-artifact@v3
         with:

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -1,0 +1,40 @@
+name: Benchmark
+on:
+  workflow_dispatch:
+    inputs:
+      sha:
+        description: "Commit SHA to benchmark"
+        required: true
+        type: string
+jobs:
+  bench-first:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Setup
+        uses: ./.github/actions/setup
+      - name: Checkout commit
+        uses: actions/checkout@v3
+        with:
+          path: packages/examples/diagrams/
+          ref: ${{ inputs.sha }}/
+      - name: Generate diagrams and metadata for the first commit
+        run: yarn registry
+      - name: Upload generated diagrams and metadata
+        uses: actions/upload-artifact@v3
+        with:
+          name: diagrams-${{ inputs.sha }}
+          path: packages/examples/diagrams/
+      - name: Checkout commit
+        uses: actions/checkout@v3
+        with:
+          path: packages/examples/diagrams/
+          ref: ${{ inputs.sha }}/
+      - name: Generate diagrams and metadata for the first commit
+        run: yarn registry
+      - name: Upload generated diagrams and metadata
+        uses: actions/upload-artifact@v3
+        with:
+          name: diagrams-${{ inputs.sha }}
+          path: packages/examples/diagrams/

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -36,7 +36,7 @@ jobs:
           git fetch --no-tags --prune --progress --no-recurse-submodules --depth=1 origin 90048e996c4e1cfb637005a25de70a42dacc0aea
           git checkout --force --progress 90048e996c4e1cfb637005a25de70a42dacc0aea
       - name: Clean working tree
-        run: git rm -rf .
+        run: git clean -dfx
       - name: Reinstall packages
         run: yarn
         shell: bash

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -1,17 +1,15 @@
 name: Benchmark
 on:
-  # workflow_dispatch:
-  #   inputs:
-  #     commit_1:
-  #       description: "First Commit SHA to benchmark"
-  #       required: true
-  #       type: string
-  #     commit_2:
-  #       description: "Second Commit SHA to benchmark"
-  #       required: true
-  #       type: string
-  pull_request:
-
+  workflow_dispatch:
+    inputs:
+      commit_1:
+        description: "First Commit SHA"
+        required: true
+        type: string
+      commit_2:
+        description: "Second Commit SHA"
+        required: true
+        type: string
 jobs:
   bench:
     runs-on: ubuntu-22.04
@@ -20,7 +18,7 @@ jobs:
       - name: Checkout first commit
         uses: actions/checkout@v3
         with:
-          ref: e0207aff773856edcf4478ee71cb186f835a4a2a
+          ref: ${{ inputs.commit_1 }}
       - name: Setup
         uses: ./.github/actions/setup
       - name: Generate diagrams and metadata for the first commit

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -24,10 +24,10 @@ jobs:
           ref: e0207aff773856edcf4478ee71cb186f835a4a2a
       - name: Setup
         uses: ./.github/actions/setup
-        working_directory: first/
+        working-directory: first/
       - name: Generate diagrams and metadata for the first commit
         run: yarn registry
-        working_directory: first/
+        working-directory: first/
       - name: Upload generated diagrams and metadata
         uses: actions/upload-artifact@v3
         with:
@@ -41,10 +41,10 @@ jobs:
           ref: 90048e996c4e1cfb637005a25de70a42dacc0aea
       - name: Setup
         uses: ./.github/actions/setup
-        working_directory: second/
+        working-directory: second/
       - name: Generate diagrams and metadata for the second commit
         run: yarn registry
-        working_directory: second/
+        working-directory: second/
       - name: Upload generated diagrams and metadata
         uses: actions/upload-artifact@v3
         with:

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -38,6 +38,11 @@ jobs:
         with:
           path: packages/examples/diagrams/
           ref: 90048e996c4e1cfb637005a25de70a42dacc0aea
+      - name: Clean target working tree
+        working-directory: packages/examples/diagrams/
+        run: git rm -rf .
+      - name: Generate diagrams and metadata for the first commit
+        run: yarn registry
       - name: Upload generated diagrams and metadata
         uses: actions/upload-artifact@v3
         with:

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -20,25 +20,33 @@ jobs:
       - name: Checkout first commit
         uses: actions/checkout@v3
         with:
+          path: first/
           ref: e0207aff773856edcf4478ee71cb186f835a4a2a
       - name: Setup
         uses: ./.github/actions/setup
+        working_directory: first/
       - name: Generate diagrams and metadata for the first commit
         run: yarn registry
+        working_directory: first/
       - name: Upload generated diagrams and metadata
         uses: actions/upload-artifact@v3
         with:
           name: diagrams-1
-          path: packages/examples/diagrams/
+          path: first/packages/examples/diagrams/
       # run second commit
       - name: Checkout second commit
-        run: git checkout 90048e996c4e1cfb637005a25de70a42dacc0aea
-      - name: Clean target working tree
-        run: git rm -rf .
+        uses: actions/checkout@v3
+        with:
+          path: second/
+          ref: 90048e996c4e1cfb637005a25de70a42dacc0aea
+      - name: Setup
+        uses: ./.github/actions/setup
+        working_directory: second/
       - name: Generate diagrams and metadata for the second commit
         run: yarn registry
+        working_directory: second/
       - name: Upload generated diagrams and metadata
         uses: actions/upload-artifact@v3
         with:
           name: diagrams-2
-          path: packages/examples/diagrams/
+          path: second/packages/examples/diagrams/

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -24,7 +24,6 @@ jobs:
           ref: e0207aff773856edcf4478ee71cb186f835a4a2a
       - name: Setup
         uses: ./.github/actions/setup
-        working-directory: first/
       - name: Generate diagrams and metadata for the first commit
         run: yarn registry
         working-directory: first/
@@ -41,7 +40,6 @@ jobs:
           ref: 90048e996c4e1cfb637005a25de70a42dacc0aea
       - name: Setup
         uses: ./.github/actions/setup
-        working-directory: second/
       - name: Generate diagrams and metadata for the second commit
         run: yarn registry
         working-directory: second/

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -1,11 +1,17 @@
 name: Benchmark
 on:
-  workflow_dispatch:
-    inputs:
-      sha:
-        description: "Commit SHA to benchmark"
-        required: true
-        type: string
+  # workflow_dispatch:
+  #   inputs:
+  #     commit_1:
+  #       description: "First Commit SHA to benchmark"
+  #       required: true
+  #       type: string
+  #     commit_2:
+  #       description: "Second Commit SHA to benchmark"
+  #       required: true
+  #       type: string
+  pull_request:
+
 jobs:
   bench-first:
     runs-on: ubuntu-latest
@@ -18,23 +24,22 @@ jobs:
         uses: actions/checkout@v3
         with:
           path: packages/examples/diagrams/
-          ref: ${{ inputs.sha }}/
+          ref: e0207aff773856edcf4478ee71cb186f835a4a2a
       - name: Generate diagrams and metadata for the first commit
         run: yarn registry
       - name: Upload generated diagrams and metadata
         uses: actions/upload-artifact@v3
         with:
-          name: diagrams-${{ inputs.sha }}
+          name: diagrams-1
           path: packages/examples/diagrams/
+
       - name: Checkout commit
         uses: actions/checkout@v3
         with:
           path: packages/examples/diagrams/
-          ref: ${{ inputs.sha }}/
-      - name: Generate diagrams and metadata for the first commit
-        run: yarn registry
+          ref: 90048e996c4e1cfb637005a25de70a42dacc0aea
       - name: Upload generated diagrams and metadata
         uses: actions/upload-artifact@v3
         with:
-          name: diagrams-${{ inputs.sha }}
+          name: diagrams-2
           path: packages/examples/diagrams/

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -14,16 +14,16 @@ on:
 
 jobs:
   bench-first:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
-      - name: Checkout
+      # run first commit
+      - name: Checkout repo
         uses: actions/checkout@v3
       - name: Setup
         uses: ./.github/actions/setup
-      - name: Checkout commit
+      - name: Checkout first commit
         uses: actions/checkout@v3
         with:
-          path: packages/examples/diagrams/
           ref: e0207aff773856edcf4478ee71cb186f835a4a2a
       - name: Generate diagrams and metadata for the first commit
         run: yarn registry
@@ -32,16 +32,15 @@ jobs:
         with:
           name: diagrams-1
           path: packages/examples/diagrams/
-
-      - name: Checkout commit
+      # run second commit
+      - name: Checkout second commit
         uses: actions/checkout@v3
         with:
-          path: packages/examples/diagrams/
           ref: 90048e996c4e1cfb637005a25de70a42dacc0aea
       - name: Clean target working tree
         working-directory: packages/examples/diagrams/
         run: git rm -rf .
-      - name: Generate diagrams and metadata for the first commit
+      - name: Generate diagrams and metadata for the second commit
         run: yarn registry
       - name: Upload generated diagrams and metadata
         uses: actions/upload-artifact@v3

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -35,6 +35,8 @@ jobs:
         run: |
           git fetch --no-tags --prune --progress --no-recurse-submodules --depth=1 origin 90048e996c4e1cfb637005a25de70a42dacc0aea
           git checkout --force --progress 90048e996c4e1cfb637005a25de70a42dacc0aea
+      - name: Clean working tree
+        run: git rm -rf .
       - name: Reinstall packages
         run: yarn
         shell: bash
@@ -44,4 +46,4 @@ jobs:
         uses: actions/upload-artifact@v3
         with:
           name: diagrams-2
-          path: second/packages/examples/diagrams/
+          path: packages/examples/diagrams/

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -20,10 +20,7 @@ jobs:
       - name: Checkout first commit
         uses: actions/checkout@v3
         with:
-          path: first/
           ref: e0207aff773856edcf4478ee71cb186f835a4a2a
-      - name: Change to first repo
-        run: cd first
       - name: Setup
         uses: ./.github/actions/setup
       - name: Generate diagrams and metadata for the first commit
@@ -34,17 +31,13 @@ jobs:
           name: diagrams-1
           path: packages/examples/diagrams/
       # run second commit
-      - name: Change to Home
-        run: cd
-      - name: Checkout second commit
-        uses: actions/checkout@v3
-        with:
-          path: second/
-          ref: 90048e996c4e1cfb637005a25de70a42dacc0aea
-      - name: Change to second repo
-        run: cd second
-      - name: Setup
-        uses: ./.github/actions/setup
+      - name: Fetch and checkout second commit
+        run: |
+          git fetch --no-tags --prune --progress --no-recurse-submodules --depth=1 origin 90048e996c4e1cfb637005a25de70a42dacc0aea
+          git checkout --force --progress 90048e996c4e1cfb637005a25de70a42dacc0aea
+      - name: Reinstall packages
+        run: yarn
+        shell: bash
       - name: Generate diagrams and metadata for the second commit
         run: yarn registry
       - name: Upload generated diagrams and metadata

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -32,7 +32,7 @@ jobs:
           path: packages/examples/diagrams/
       # run second commit
       - name: Checkout second commit
-        runs: git checkout 90048e996c4e1cfb637005a25de70a42dacc0aea
+        run: git checkout 90048e996c4e1cfb637005a25de70a42dacc0aea
       - name: Clean target working tree
         run: git rm -rf .
       - name: Generate diagrams and metadata for the second commit

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -13,18 +13,16 @@ on:
   pull_request:
 
 jobs:
-  bench-first:
+  bench:
     runs-on: ubuntu-22.04
     steps:
       # run first commit
-      - name: Checkout repo
-        uses: actions/checkout@v3
-      - name: Setup
-        uses: ./.github/actions/setup
       - name: Checkout first commit
         uses: actions/checkout@v3
         with:
           ref: e0207aff773856edcf4478ee71cb186f835a4a2a
+      - name: Setup
+        uses: ./.github/actions/setup
       - name: Generate diagrams and metadata for the first commit
         run: yarn registry
       - name: Upload generated diagrams and metadata
@@ -34,11 +32,8 @@ jobs:
           path: packages/examples/diagrams/
       # run second commit
       - name: Checkout second commit
-        uses: actions/checkout@v3
-        with:
-          ref: 90048e996c4e1cfb637005a25de70a42dacc0aea
+        runs: git checkout 90048e996c4e1cfb637005a25de70a42dacc0aea
       - name: Clean target working tree
-        working-directory: packages/examples/diagrams/
         run: git rm -rf .
       - name: Generate diagrams and metadata for the second commit
         run: yarn registry


### PR DESCRIPTION
# Description

This PR adds a simple manual CI workflow for comparing two commits on `main`. The workflow takes two commit SHAs and run `yarn registry` on both commits. For consistency, the workflow runs them on the same runner sequentially. 

Tested by switching to `pull_request` trigger but testing `workflow_dispatch` requires merging into `main` first.

# Checklist

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have reviewed any generated registry diagram changes

# Open questions

N/A
