### PR TITLE
docs: "getting involved" page

### DIFF
--- a/packages/docs-site/.vitepress/config.ts
+++ b/packages/docs-site/.vitepress/config.ts
@@ -172,8 +172,8 @@ export default defineConfig({
       },
       { text: "Documentation", link: "/docs/ref", activeMatch: "/docs/ref" },
       { text: "Blog", link: "/blog", activeMatch: "/blog" },
-      { text: "Online Editor", link: "pathname:///try/index.html" },
       { text: "Team", link: "/docs/team" },
+      { text: "Online Editor", link: "pathname:///try/index.html" },
       //   {
       //     text: "News",
       //     items: [

--- a/packages/docs-site/.vitepress/config.ts
+++ b/packages/docs-site/.vitepress/config.ts
@@ -161,6 +161,11 @@ export default defineConfig({
         activeMatch: "/examples",
       },
       {
+        text: "Get Involved",
+        link: "/community",
+        activeMatch: "/community",
+      },
+      {
         text: "Learn Penrose",
         link: "/docs/tutorial/welcome",
         activeMatch: "/docs/tutorial",
@@ -170,20 +175,20 @@ export default defineConfig({
       { text: "Join Discord", link: "https://discord.gg/a7VXJU4dfR" },
       { text: "Team", link: "/docs/team" },
       { text: "Blog", link: "/blog", activeMatch: "/blog" },
-      {
-        text: "News",
-        items: [
-          { text: "SIGGRAPH'20 paper", link: "pathname:///siggraph20.html" },
-          {
-            text: "CHI'20 paper",
-            link: "https://www.cs.cmu.edu/~woden/assets/chi-20-natural-diagramming.pdf",
-          },
-          {
-            text: "Popular Mechanics",
-            link: "https://www.popularmechanics.com/science/math/a32743509/cmu-penrose-math-equations-into-pictures/",
-          },
-        ],
-      },
+      //   {
+      //     text: "News",
+      //     items: [
+      //       { text: "SIGGRAPH'20 paper", link: "pathname:///siggraph20.html" },
+      //       {
+      //         text: "CHI'20 paper",
+      //         link: "https://www.cs.cmu.edu/~woden/assets/chi-20-natural-diagramming.pdf",
+      //       },
+      //       {
+      //         text: "Popular Mechanics",
+      //         link: "https://www.popularmechanics.com/science/math/a32743509/cmu-penrose-math-equations-into-pictures/",
+      //       },
+      //     ],
+      //   },
     ],
 
     socialLinks: [

--- a/packages/docs-site/.vitepress/config.ts
+++ b/packages/docs-site/.vitepress/config.ts
@@ -171,10 +171,9 @@ export default defineConfig({
         activeMatch: "/docs/tutorial",
       },
       { text: "Documentation", link: "/docs/ref", activeMatch: "/docs/ref" },
-      { text: "Try Penrose", link: "pathname:///try/index.html" },
-      { text: "Join Discord", link: "https://discord.gg/a7VXJU4dfR" },
-      { text: "Team", link: "/docs/team" },
       { text: "Blog", link: "/blog", activeMatch: "/blog" },
+      { text: "Online Editor", link: "pathname:///try/index.html" },
+      { text: "Team", link: "/docs/team" },
       //   {
       //     text: "News",
       //     items: [

--- a/packages/docs-site/community.md
+++ b/packages/docs-site/community.md
@@ -83,7 +83,7 @@ We maintain a [blog][] and a [mailing list][] on Penrose and diagramming in gene
 - Next iteration on [SolidJS API for Penrose](/docs/ref/solid.md) and docs
 - Implement high-quality hidden strokes <Issue issue="517" />
 - Support arbitrary Penrose trios in [`obsidian-penrose-plugin`]
-- A single file format (`.penrose`) for Penrose trios
+- A single file format (`.penrose`) for Penrose diagrams
 
 <!-- ### 💭 Potential
 - -->

--- a/packages/docs-site/community.md
+++ b/packages/docs-site/community.md
@@ -1,27 +1,98 @@
-# Get Involved
+---
+layout: docs
+---
 
-## 🌹 Make Diagrams
+<div class="action-grid">
 
-## 🔭 Do Research
+<div class="action-group diagrams">
+
+<h1 class="action-header">🌹 Make Diagrams</h1>
+
+We are always excited to see diagrams made with Penrose! Share them in [#gallery][] on [Discord][] and we are happy to include them in our [example gallery][].
+
+- \_\_If you want to make
+
+</div>
+
+<div class="action-group research">
+
+<h1 class="action-header">🔭 Do Research</h1>
 
 Our team consist of interdisciplinary researchers in programming languages, computer graphics, human-computer interaction, software engineering, and more!
 
-- If you are interested in collaborating with us on research, reach out to us on [Discord]() and/or [email us](mailto:team@penrose.ink) with a brief description of your background and interests in Penrose!
-- If you are an undergrad looking for summer opportunities, consider applying for the [REUSE program](https://www.cmu.edu/scs/s3d/reuse/).
+- If you are interested in **collaborating with us on research**, reach out to us on [Discord][] and/or [email][] us with a brief description of your background and interests in Penrose!
+- If you are **an undergrad looking for summer opportunities**, consider applying for the [REUSE][] program.
 
-## 💻 Contribute Code and Docs
+</div>
 
-We welcome contributions to [our repository](https://github.com/penrose/penrose). Take a look at the [contributor guide](https://github.com/penrose/penrose/blob/main/CONTRIBUTING.md) to get started!
+<div class="action-group code-docs">
 
-## 💞 Integrate with Tools
+<h1 class="action-header">💻 Contribute Code and Docs</h1>
 
-We'd love to hear how you'd like to integrate Penrose with your favorite tools!
+We welcome contributions to our [repository][]. Take a look at the [contributor guide](https://github.com/penrose/penrose/blob/main/CONTRIBUTING.md) to get started!
+
+</div>
+
+<div class="action-group integration">
+
+<h1 class="action-header">💞 Integrate with Tools</h1>
+
+We'd love to hear how you'd like to integrate Penrose with your favorite tools! Here are some ongoing tool integration projects:
 
 - [Lean](https://leanprover.github.io/): [ProofWidgets](https://github.com/EdAyers/ProofWidgets4) based on Penrose.
-- [Obsidian](https://obsidian.md/): an experimental [plugin](https://github.com/wodeni/obsidian-penrose-plugin) in progress.
-- [Alloy](http://alloytools.org/)
-- Join [our Discord server](https://discord.gg/a7VXJU4dfR) and chat with us on [#integration](https://discord.com/channels/1115349463603617954/1130497270664679444) about integrating with external tools!
+- [Obsidian](https://obsidian.md/): an experimental [`obsidian-penrose-plugin`](https://github.com/wodeni/obsidian-penrose-plugin).
+- [Alloy](http://alloytools.org/) visualizer using Penrose.
 
-## 💬 Share Knowledge
+Join [our Discord server] and chat with us on [#integration](https://discord.com/channels/1115349463603617954/1130497270664679444) about integrating with external tools!
 
-We maintain a [blog](https://penrose.cs.cmu.edu/blog) and a [mailing list]() on Penrose and diagramming in general.
+</div>
+
+<div class="action-group posts">
+
+<h1 class="action-header">💬 Share Knowledge</h1>
+
+We maintain a [blog][] and a [mailing list][] on Penrose and diagramming in general. We are happy to host your posts!
+
+</div>
+</div>
+
+## Technical Roadmap
+
+<style>
+  .action-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(320px, 1fr)); 
+    grid-gap: 20px;
+    /* display: flex;
+    width: 100%;
+    flex-wrap: wrap; */
+  }
+
+  .action-group {
+    /* max-width: 50%; */
+    border-radius: 10px;
+    background-color: #f5f5f5;
+    padding: 20px;
+  }
+  .dark .action-group {
+    background-color: var(--vp-c-bg-soft);
+  }
+  .action-header {
+    font-size: 28px !important;
+  }
+  .research {
+    grid-row: span 2
+  }
+  .posts {
+    grid-row: span 1
+  }
+</style>
+
+[discord]: https://discord.gg/a7VXJU4dfR
+[email]: mailto:team@penrose.ink
+[#gallery]: https://discord.com/channels/1115349463603617954/1115717389787611155
+[blog]: /blog
+[REUSE]: https://www.cmu.edu/scs/s3d/reuse/
+[repository]: https://github.com/penrose/penrose
+[example gallery]: /examples
+[mailing list]: http://eepurl.com/cIapnn

--- a/packages/docs-site/community.md
+++ b/packages/docs-site/community.md
@@ -4,8 +4,24 @@
 
 ## 🔭 Do Research
 
+Our team consist of interdisciplinary researchers in programming languages, computer graphics, human-computer interaction, software engineering, and more!
+
+- If you are interested in collaborating with us on research, reach out to us on [Discord]() and/or [email us](mailto:team@penrose.ink) with a brief description of your background and interests in Penrose!
+- If you are an undergrad looking for summer opportunities, consider applying for the [REUSE program](https://www.cmu.edu/scs/s3d/reuse/).
+
 ## 💻 Contribute Code and Docs
+
+We welcome contributions to [our repository](https://github.com/penrose/penrose). Take a look at the [contributor guide](https://github.com/penrose/penrose/blob/main/CONTRIBUTING.md) to get started!
 
 ## 💞 Integrate with Tools
 
+We'd love to hear how you'd like to integrate Penrose with your favorite tools!
+
+- [Lean](https://leanprover.github.io/): [ProofWidgets](https://github.com/EdAyers/ProofWidgets4) based on Penrose.
+- [Obsidian](https://obsidian.md/): an experimental [plugin](https://github.com/wodeni/obsidian-penrose-plugin) in progress.
+- [Alloy](http://alloytools.org/)
+- Join [our Discord server](https://discord.gg/a7VXJU4dfR) and chat with us on [#integration](https://discord.com/channels/1115349463603617954/1130497270664679444) about integrating with external tools!
+
 ## 💬 Share Knowledge
+
+We maintain a [blog](https://penrose.cs.cmu.edu/blog) and a [mailing list]() on Penrose and diagramming in general.

--- a/packages/docs-site/community.md
+++ b/packages/docs-site/community.md
@@ -10,7 +10,8 @@ layout: docs
 
 We are always excited to see diagrams made with Penrose! Share them in [#gallery][] on [Discord][] and we are happy to include them in our [example gallery][].
 
-- \_\_If you want to make
+- **If you want to make diagrams using in existing domains**, check out our [tutorial][] and [gallery][example gallery] to learn how to use them!
+- **If you are making many diagrams in a new domain**, refer to our [docs][using penrose] to learn our toolings and [open a PR][contributing PR] in our repo so others can use your domain too!
 
 </div>
 
@@ -58,11 +59,22 @@ We maintain a [blog][] and a [mailing list][] on Penrose and diagramming in gene
 
 ## Technical Roadmap
 
+### 🚀 Active
+
+- Layout optimization on WebWorkers
+- Automatic differentiation based on [Rose][rose] 🌹
+
+### 🎯 Planned
+
+- [SolidJS API for Penrose](/docs/ref/solid.md)
+-
+
 <style>
   .action-grid {
     display: grid;
     grid-template-columns: repeat(auto-fit, minmax(320px, 1fr)); 
     grid-gap: 20px;
+    /* grid-auto-row: min-content; */
     /* display: flex;
     width: 100%;
     flex-wrap: wrap; */
@@ -80,12 +92,12 @@ We maintain a [blog][] and a [mailing list][] on Penrose and diagramming in gene
   .action-header {
     font-size: 28px !important;
   }
-  .research {
-    grid-row: span 2
-  }
-  .posts {
+  /* .research {
     grid-row: span 1
   }
+  .code-and-docs {
+    grid-row: span 1
+  } */
 </style>
 
 [discord]: https://discord.gg/a7VXJU4dfR
@@ -96,3 +108,7 @@ We maintain a [blog][] and a [mailing list][] on Penrose and diagramming in gene
 [repository]: https://github.com/penrose/penrose
 [example gallery]: /examples
 [mailing list]: http://eepurl.com/cIapnn
+[tutorial]: /docs/tutorial/welcome
+[using penrose]: /docs/ref/using
+[contributing PR]: https://github.com/penrose/penrose/blob/main/CONTRIBUTING.md#contributing
+[rose]: https://rosejs.dev/

--- a/packages/docs-site/community.md
+++ b/packages/docs-site/community.md
@@ -2,6 +2,12 @@
 layout: docs
 ---
 
+<script setup>
+  import PR  from "./src/components/GitHubPR.vue"
+</script>
+
+## What you can do
+
 <div class="action-grid">
 
 <div class="action-group diagrams">
@@ -32,6 +38,9 @@ Our team consist of interdisciplinary researchers in programming languages, comp
 
 We welcome contributions to our [repository][]. Take a look at the [contributor guide](https://github.com/penrose/penrose/blob/main/CONTRIBUTING.md) to get started!
 
+- Find out what's on the [roadmap][] for our next release. **We are looking for contributors to claim issues in the [planned](#🎯-planned) list**.
+- **Help us improve our docs!** We are planning to improve our [tutorial][] and start documenting our [gallery][example gallery] diagrams.
+
 </div>
 
 <div class="action-group integration">
@@ -44,7 +53,7 @@ We'd love to hear how you'd like to integrate Penrose with your favorite tools! 
 - [Obsidian](https://obsidian.md/): an experimental [`obsidian-penrose-plugin`](https://github.com/wodeni/obsidian-penrose-plugin).
 - [Alloy](http://alloytools.org/) visualizer using Penrose.
 
-Join [our Discord server] and chat with us on [#integration](https://discord.com/channels/1115349463603617954/1130497270664679444) about integrating with external tools!
+Join [our Discord server][discord] and chat with us on [#integration](https://discord.com/channels/1115349463603617954/1130497270664679444) about integrating with external tools!
 
 </div>
 
@@ -61,13 +70,16 @@ We maintain a [blog][] and a [mailing list][] on Penrose and diagramming in gene
 
 ### 🚀 Active
 
-- Layout optimization on WebWorkers
-- Automatic differentiation based on [Rose][rose] 🌹
+- Automatic differentiation based on [Rose][rose] 🌹 <PR pr="1636" />
+- Layout optimization on WebWorkers <PR pr="1528" />
 
 ### 🎯 Planned
 
-- [SolidJS API for Penrose](/docs/ref/solid.md)
+- Next iteration on [SolidJS API for Penrose](/docs/ref/solid.md) and docs
 -
+
+<!-- ### 💭 Potential
+- -->
 
 <style>
   .action-grid {
@@ -112,3 +124,4 @@ We maintain a [blog][] and a [mailing list][] on Penrose and diagramming in gene
 [using penrose]: /docs/ref/using
 [contributing PR]: https://github.com/penrose/penrose/blob/main/CONTRIBUTING.md#contributing
 [rose]: https://rosejs.dev/
+[roadmap]: #technical-roadmap

--- a/packages/docs-site/community.md
+++ b/packages/docs-site/community.md
@@ -1,0 +1,1 @@
+# Get Involved

--- a/packages/docs-site/community.md
+++ b/packages/docs-site/community.md
@@ -7,6 +7,10 @@ layout: docs
   import Issue from "./src/components/GitHubIssue.vue"
 </script>
 
+# Get Involved
+
+We are actively building a community of diagrammers! To get started, join the Penrose community now on [discord][] and see [what you can do](#what-you-can-do) to achieve the vision of democratizing diagramming and visual intuition.
+
 ## What you can do
 
 <div class="action-grid">
@@ -26,7 +30,7 @@ We are always excited to see diagrams made with Penrose! Share them in [#gallery
 
 <h1 class="action-header">🔭 Do Research</h1>
 
-Our team consists of interdisciplinary researchers in programming languages, computer graphics, human-computer interaction, software engineering, and more!
+Our [team][] consists of interdisciplinary researchers in programming languages, computer graphics, human-computer interaction, software engineering, and more!
 
 - If you are interested in **collaborating with us on research**, reach out to us on [Discord][] and/or [email][] us with a brief description of your background and interests in Penrose!
 - If you are **an undergrad looking for summer opportunities**, consider applying for the [REUSE][] program.
@@ -129,3 +133,4 @@ We maintain a [blog][] and a [mailing list][] on Penrose and diagramming in gene
 [rose]: https://rosejs.dev/
 [roadmap]: #technical-roadmap
 [`obsidian-penrose-plugin`]: https://github.com/wodeni/obsidian-penrose-plugin
+[team]: /docs/team

--- a/packages/docs-site/community.md
+++ b/packages/docs-site/community.md
@@ -1,1 +1,11 @@
 # Get Involved
+
+## 🌹 Make Diagrams
+
+## 🔭 Do Research
+
+## 💻 Contribute Code and Docs
+
+## 💞 Integrate with Tools
+
+## 💬 Share Knowledge

--- a/packages/docs-site/community.md
+++ b/packages/docs-site/community.md
@@ -3,7 +3,8 @@ layout: docs
 ---
 
 <script setup>
-  import PR  from "./src/components/GitHubPR.vue"
+  import PR from "./src/components/GitHubPR.vue"
+  import Issue from "./src/components/GitHubIssue.vue"
 </script>
 
 ## What you can do
@@ -25,7 +26,7 @@ We are always excited to see diagrams made with Penrose! Share them in [#gallery
 
 <h1 class="action-header">🔭 Do Research</h1>
 
-Our team consist of interdisciplinary researchers in programming languages, computer graphics, human-computer interaction, software engineering, and more!
+Our team consists of interdisciplinary researchers in programming languages, computer graphics, human-computer interaction, software engineering, and more!
 
 - If you are interested in **collaborating with us on research**, reach out to us on [Discord][] and/or [email][] us with a brief description of your background and interests in Penrose!
 - If you are **an undergrad looking for summer opportunities**, consider applying for the [REUSE][] program.
@@ -50,7 +51,7 @@ We welcome contributions to our [repository][]. Take a look at the [contributor 
 We'd love to hear how you'd like to integrate Penrose with your favorite tools! Here are some ongoing tool integration projects:
 
 - [Lean](https://leanprover.github.io/): [ProofWidgets](https://github.com/EdAyers/ProofWidgets4) based on Penrose.
-- [Obsidian](https://obsidian.md/): an experimental [`obsidian-penrose-plugin`](https://github.com/wodeni/obsidian-penrose-plugin).
+- [Obsidian](https://obsidian.md/): an experimental [`obsidian-penrose-plugin`][].
 - [Alloy](http://alloytools.org/) visualizer using Penrose.
 
 Join [our Discord server][discord] and chat with us on [#integration](https://discord.com/channels/1115349463603617954/1130497270664679444) about integrating with external tools!
@@ -76,7 +77,9 @@ We maintain a [blog][] and a [mailing list][] on Penrose and diagramming in gene
 ### 🎯 Planned
 
 - Next iteration on [SolidJS API for Penrose](/docs/ref/solid.md) and docs
--
+- Implement high-quality hidden strokes <Issue issue="517" />
+- Support arbitrary Penrose trios in [`obsidian-penrose-plugin`]
+- A single file format (`.penrose`) for Penrose trios
 
 <!-- ### 💭 Potential
 - -->
@@ -125,3 +128,4 @@ We maintain a [blog][] and a [mailing list][] on Penrose and diagramming in gene
 [contributing PR]: https://github.com/penrose/penrose/blob/main/CONTRIBUTING.md#contributing
 [rose]: https://rosejs.dev/
 [roadmap]: #technical-roadmap
+[`obsidian-penrose-plugin`]: https://github.com/wodeni/obsidian-penrose-plugin

--- a/packages/docs-site/docs/team.md
+++ b/packages/docs-site/docs/team.md
@@ -1,5 +1,6 @@
 <script setup>
 import { VPTeamMembers } from "vitepress/theme";
+import Contributors from "../src/components/Contributors.vue"
 
 // https://commons.wikimedia.org/wiki/File:Globe_icon_2.svg
 // https://creativecommons.org/licenses/by-sa/3.0/deed.en
@@ -169,3 +170,7 @@ in Pittsburgh, PA USA—and other locations around the world.
 - [Jenna Wise](https://www.cs.cmu.edu/~jlwise/)
 - [Helena Yang](https://heleaf.me/)
 - [Kai Ye](https://www.linkedin.com/in/kai-ye-83946725a/)
+
+## Contributors
+
+<Contributors />

--- a/packages/docs-site/docs/team.md
+++ b/packages/docs-site/docs/team.md
@@ -100,7 +100,7 @@ const members = [
   },
   {
     name: "Hwei-Shin Harriman",
-    title: "Software engineer @ Tableau",
+    title: "Ph.D. student @ CMU",
     avatar: "https://www.github.com/hsharriman.png",
     links: [
       { icon: { svg: website }, link: "https://hsharriman.github.io/" },

--- a/packages/docs-site/src/components/Contributors.vue
+++ b/packages/docs-site/src/components/Contributors.vue
@@ -1,0 +1,39 @@
+<script setup lang="ts">
+import { data as contributors } from "../contributors.data.js";
+</script>
+
+<template>
+  <div class="container">
+    <a
+      v-for="id in contributors"
+      :key="id"
+      :href="`https://github.com/${id}`"
+      class="m-0"
+      rel="noopener noreferrer"
+      :aria-label="`${id} on GitHub`"
+    >
+      <img
+        loading="lazy"
+        :src="`https://github.com/${id}.png`"
+        width="50"
+        height="50"
+        class="avatar"
+        :alt="`${id}'s avatar`"
+      />
+    </a>
+  </div>
+</template>
+
+<style>
+.container {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 2px;
+  justify-content: center;
+}
+.avatar {
+  width: 50px;
+  height: 50px;
+  border-radius: 100%;
+}
+</style>

--- a/packages/docs-site/src/components/Contributors.vue
+++ b/packages/docs-site/src/components/Contributors.vue
@@ -3,7 +3,7 @@ import { data as contributors } from "../contributors.data.js";
 </script>
 
 <template>
-  <div class="container">
+  <div class="contributor-container">
     <a
       v-for="id in contributors"
       :key="id"
@@ -25,7 +25,7 @@ import { data as contributors } from "../contributors.data.js";
 </template>
 
 <style>
-.container {
+.contributor-container {
   display: flex;
   flex-wrap: wrap;
   gap: 2px;

--- a/packages/docs-site/src/components/GitHubIssue.vue
+++ b/packages/docs-site/src/components/GitHubIssue.vue
@@ -14,10 +14,7 @@ export default defineComponent({
       rel="noopener noreferrer"
       :aria-label="`Issue ${pr} on GitHub`"
     >
-      <img
-        :src="`https://img.shields.io/badge/Issue-${issue}-green`"
-        class="avatar"
-      />
+      <img :src="`https://img.shields.io/badge/Issue-${issue}-green`" />
     </a>
   </span>
 </template>

--- a/packages/docs-site/src/components/GitHubIssue.vue
+++ b/packages/docs-site/src/components/GitHubIssue.vue
@@ -1,0 +1,31 @@
+<script ts>
+import { defineComponent } from "vue";
+export default defineComponent({
+  props: ["issue"],
+});
+</script>
+
+<template>
+  <span class="issue">
+    <a
+      :key="pr"
+      :href="`https://github.com/penrose/penrose/issue/${pr}`"
+      class="m-0"
+      rel="noopener noreferrer"
+      :aria-label="`Issue ${pr} on GitHub`"
+    >
+      <img
+        :src="`https://img.shields.io/badge/Issue-${issue}-green`"
+        width="50"
+        class="avatar"
+      />
+    </a>
+  </span>
+</template>
+
+<style>
+.issue {
+  display: inline-block;
+  width: 50px;
+}
+</style>

--- a/packages/docs-site/src/components/GitHubIssue.vue
+++ b/packages/docs-site/src/components/GitHubIssue.vue
@@ -9,14 +9,13 @@ export default defineComponent({
   <span class="issue">
     <a
       :key="pr"
-      :href="`https://github.com/penrose/penrose/issue/${pr}`"
+      :href="`https://github.com/penrose/penrose/issues/${issue}`"
       class="m-0"
       rel="noopener noreferrer"
       :aria-label="`Issue ${pr} on GitHub`"
     >
       <img
         :src="`https://img.shields.io/badge/Issue-${issue}-green`"
-        width="50"
         class="avatar"
       />
     </a>
@@ -26,6 +25,6 @@ export default defineComponent({
 <style>
 .issue {
   display: inline-block;
-  width: 50px;
+  height: 1em;
 }
 </style>

--- a/packages/docs-site/src/components/GitHubPR.vue
+++ b/packages/docs-site/src/components/GitHubPR.vue
@@ -14,7 +14,7 @@ export default defineComponent({
       rel="noopener noreferrer"
       :aria-label="`PR ${pr} on GitHub`"
     >
-      <img :src="`https://img.shields.io/badge/PR-${pr}-blue`" class="avatar" />
+      <img :src="`https://img.shields.io/badge/PR-${pr}-blue`" />
     </a>
   </span>
 </template>

--- a/packages/docs-site/src/components/GitHubPR.vue
+++ b/packages/docs-site/src/components/GitHubPR.vue
@@ -14,11 +14,7 @@ export default defineComponent({
       rel="noopener noreferrer"
       :aria-label="`PR ${pr} on GitHub`"
     >
-      <img
-        :src="`https://img.shields.io/badge/PR-${pr}-blue`"
-        width="50"
-        class="avatar"
-      />
+      <img :src="`https://img.shields.io/badge/PR-${pr}-blue`" class="avatar" />
     </a>
   </span>
 </template>
@@ -26,6 +22,6 @@ export default defineComponent({
 <style>
 .pr {
   display: inline-block;
-  width: 50px;
+  height: 1em;
 }
 </style>

--- a/packages/docs-site/src/components/GitHubPR.vue
+++ b/packages/docs-site/src/components/GitHubPR.vue
@@ -1,0 +1,31 @@
+<script ts>
+import { defineComponent } from "vue";
+export default defineComponent({
+  props: ["pr"],
+});
+</script>
+
+<template>
+  <span class="pr">
+    <a
+      :key="pr"
+      :href="`https://github.com/penrose/penrose/pull/${pr}`"
+      class="m-0"
+      rel="noopener noreferrer"
+      :aria-label="`PR ${pr} on GitHub`"
+    >
+      <img
+        :src="`https://img.shields.io/badge/PR-${pr}-blue`"
+        width="50"
+        class="avatar"
+      />
+    </a>
+  </span>
+</template>
+
+<style>
+.pr {
+  display: inline-block;
+  width: 50px;
+}
+</style>

--- a/packages/docs-site/src/contributors.data.ts
+++ b/packages/docs-site/src/contributors.data.ts
@@ -1,0 +1,37 @@
+// Adapted from https://github.dev/vitest-dev/vitest/blob/991ff33ab717caee85ef6cbe1c16dc514186b4cc/scripts/update-contributors.ts#L6
+
+interface Contributor {
+  login: string;
+}
+
+async function fetchContributors(): Promise<string[]> {
+  const collaborators: string[] = [];
+  try {
+    let page = 1;
+    let data: Contributor[] = [];
+    do {
+      const response = await fetch(
+        `https://api.github.com/repos/penrose/penrose/contributors?per_page=100&page=${page}`,
+        {
+          method: "GET",
+          headers: {
+            "content-type": "application/json",
+          },
+        },
+      );
+      data = await response.json();
+      collaborators.push(...data.map((i) => i.login));
+      console.log(`Fetched page ${page}`);
+      page++;
+    } while (data.length === 100);
+  } catch (e) {
+    /* contributors fetching failure must not hinder docs development */
+  }
+  return collaborators.filter((name) => !name.includes("[bot]"));
+}
+
+export default {
+  async load() {
+    return await fetchContributors();
+  },
+};


### PR DESCRIPTION
# Description

This PR adds a "getting involved" page on the website to encourage visitors to join the Penrose community and guide them to action items. The content on the page is by no means final. This PR mainly focuses on adding the infra for content in future PRs.

# Implementation strategy and design decisions

* To de-clutter the nav bar, I removed the news and join discord buttons. The content under news are mostly papers, which we should link to in the getting involved page as examples of research outcome. The discord link is already associated with the top-right icon.
* Add github icons of contributors to the team page
* Add a roadmap section and components for linking to github issues and prs. The content is TBD 

# Examples with steps to reproduce them

See deployment

# Checklist

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have reviewed any generated registry diagram changes

