### PR TITLE
fix: duplicate `<penrose>` tags in exported SVGs

### DIFF
--- a/packages/editor/src/components/DiagramPanel.tsx
+++ b/packages/editor/src/components/DiagramPanel.tsx
@@ -174,11 +174,8 @@ const SVGaddCode = (
   versionStr: string,
   variationStr: string,
 ): void => {
-  console.log(svg);
-
   // Create custom <penrose> tag to store metadata, or grab it if it already exists
   const metadataQuery = document.querySelector("penrose");
-  console.log(metadataQuery);
   let metadata: Element;
 
   if (metadataQuery === null) {

--- a/packages/editor/src/components/DiagramPanel.tsx
+++ b/packages/editor/src/components/DiagramPanel.tsx
@@ -174,8 +174,11 @@ const SVGaddCode = (
   versionStr: string,
   variationStr: string,
 ): void => {
+  console.log(svg);
+
   // Create custom <penrose> tag to store metadata, or grab it if it already exists
   const metadataQuery = document.querySelector("penrose");
+  console.log(metadataQuery);
   let metadata: Element;
 
   if (metadataQuery === null) {
@@ -183,6 +186,8 @@ const SVGaddCode = (
       "https://penrose.cs.cmu.edu/metadata",
       "penrose",
     );
+    // Add the <penrose> metadata tag to the parent <svg> tag
+    svg.appendChild(metadata);
   } else {
     metadata = metadataQuery!;
   }
@@ -225,9 +230,6 @@ const SVGaddCode = (
   metadata.appendChild(substance);
   metadata.appendChild(style);
   metadata.appendChild(dsl);
-
-  // Add the <penrose> metadata tag to the parent <svg> tag
-  svg.appendChild(metadata);
 };
 
 /**


### PR DESCRIPTION
# Description

Resolves #1586.

# Implementation strategy and design decisions

The cause is an extra `svg.appendChild(metadata)` call at the end of the `SVGAddCode` function introduced in https://github.com/penrose/penrose/pull/1171. This line should only be executed when there isn't already a `<penrose>` node.