### PR TITLE
refactor: delete `OptStatus::NewIter`

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -309,13 +309,6 @@ export const isError = (state: State): boolean =>
 export const finalStage = (state: State): boolean =>
   state.currentStageIndex === state.optStages.length - 1;
 
-/**
- * Returns true if state is the initial frame
- * @param state current state
- */
-export const isInitial = (state: State): boolean =>
-  state.params.optStatus === "NewIter";
-
 const evalGrad = (s: State): ad.OptOutputs => {
   const { constraintSets, optStages, currentStageIndex } = s;
   const stage = optStages[currentStageIndex];

--- a/packages/optimizer/src/lib.rs
+++ b/packages/optimizer/src/lib.rs
@@ -25,7 +25,6 @@ extern "C" {
 #[derive(Clone, Deserialize, Serialize, TS)]
 #[ts(export)]
 enum OptStatus {
-    NewIter,
     UnconstrainedRunning,
     UnconstrainedConverged,
     EPConverged,
@@ -178,17 +177,6 @@ fn step_until(
     );
 
     match opt_status {
-        OptStatus::NewIter => {
-            return Params {
-                weight: INIT_CONSTRAINT_WEIGHT,
-                uo_round: 0,
-                ep_round: 0,
-                opt_status: OptStatus::UnconstrainedRunning,
-                lbfgs_info: DEFAULT_LBFGS_PARAMS,
-                ..state
-            }
-        }
-
         OptStatus::UnconstrainedRunning => {
             // NOTE: use cached varying values
 


### PR DESCRIPTION
# Description

It's completely unused, and the `isInitial` function is not mentioned in our docs and thus not part of our public API.

# Checklist

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have reviewed any generated registry diagram changes