### PR TITLE
chore: fix labeling objective in ray tracing Style

### DIFF
--- a/packages/examples/src/ray-tracing/ray-tracing.style
+++ b/packages/examples/src/ray-tracing/ray-tracing.style
@@ -138,7 +138,7 @@ where p has math label {
    }
 
    -- in the labeling stage of layout, try to put the label near the point
-   encourage norm( p.labelText.center - p.x ) == 10 in labelingStage
+   p.near = encourage norm( p.labelText.center - p.x ) == 10 in labelingStage
 
    -- draw the label in front of the dot, which is in turn in front
    -- of other things like the scene geometry
@@ -458,6 +458,7 @@ forall Ray r; Light L {
 -- from the point.
 forall Scene S; Point p; Ray r
 where p := intersect(r,S); p has label {
+   delete p.near
    override p.labelText.center = p.x - 10*p.n
 }
 


### PR DESCRIPTION
# Description

While implementing experiments like #1636, #1657, and #1658, I was getting errors for our ray tracing examples. I was able to fix these errors by applying the diff in this PR, which deletes a labeling nearness objective when the position of the label has been directly overridden to be near by construction. I believe that this was just an oversight in the Style program, so this PR fixes the bug.

# Checklist

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have reviewed any generated registry diagram changes