### PR TITLE
refactor: replace `safe` util with nicer `unwrap`

### DIFF
--- a/packages/core/src/compiler/Style.ts
+++ b/packages/core/src/compiler/Style.ts
@@ -169,6 +169,7 @@ import {
   shapeListV,
   strV,
   tupV,
+  unwrap,
   val,
   vectorV,
   zip2,
@@ -573,10 +574,10 @@ const mergeMapping = (
   varEnv: Env,
   [varName, styType]: [string, StyT<A>],
 ): Env => {
-  const res = varProgTypeMap[varName];
-  if (!res) {
-    throw Error("var has no binding form?");
-  }
+  const res = unwrap(
+    varProgTypeMap[varName],
+    () => `var has no binding form: ${varName}`,
+  );
   const [, bindingForm] = res;
   const vars = varEnv.vars.set(
     bindingForm.contents.value,

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -22,7 +22,7 @@ import {
   ok,
   showError,
 } from "./utils/Error.js";
-import { safe } from "./utils/Util.js";
+import { unwrap } from "./utils/Util.js";
 
 /**
  * Use the current resample seed to sample all shapes in the State.
@@ -53,7 +53,10 @@ export const step = (
 ): Result<State, PenroseError> => {
   const { constraintSets, optStages, currentStageIndex } = state;
   const stage = optStages[currentStageIndex];
-  const masks = safe(constraintSets.get(stage), "missing stage");
+  const masks = unwrap(
+    constraintSets.get(stage),
+    () => `missing stage: ${stage}`,
+  );
   const xs = new Float64Array(state.varyingValues);
   const params = stepUntil(
     (x: Float64Array, weight: number, grad: Float64Array): number =>
@@ -312,7 +315,10 @@ export const finalStage = (state: State): boolean =>
 const evalGrad = (s: State): ad.OptOutputs => {
   const { constraintSets, optStages, currentStageIndex } = s;
   const stage = optStages[currentStageIndex];
-  const masks = safe(constraintSets.get(stage), "missing stage");
+  const masks = unwrap(
+    constraintSets.get(stage),
+    () => `missing stage: ${stage}`,
+  );
   const x = new Float64Array(s.varyingValues);
   // we constructed `x` to throw away, so it's OK to update it in-place with the
   // gradient after computing the energy

--- a/packages/core/src/lib/Minkowski.ts
+++ b/packages/core/src/lib/Minkowski.ts
@@ -18,7 +18,7 @@ import {
   sub,
 } from "../engine/AutodiffFunctions.js";
 import * as ad from "../types/ad.js";
-import { safe } from "../utils/Util.js";
+import { unwrap } from "../utils/Util.js";
 import {
   ImplicitEllipse,
   ImplicitHalfPlane,
@@ -156,9 +156,10 @@ export const convexPartitions = (p: ad.Num[][]): ad.Num[][][] => {
 
   return convexPolygons.map((poly) =>
     poly.map((point) =>
-      safe(
+      unwrap(
         pointMap.get(point),
-        "polygon decomposition unexpectedly created a new point",
+        () =>
+          `polygon decomposition unexpectedly created a new point { x: ${point.x}, y: ${point.y} }`,
       ),
     ),
   );

--- a/packages/core/src/shapes/Shapes.ts
+++ b/packages/core/src/shapes/Shapes.ts
@@ -1,6 +1,7 @@
 import { add, div, maxN, minN, sub } from "../engine/AutodiffFunctions.js";
 import * as BBox from "../engine/BBox.js";
 import * as ad from "../types/ad.js";
+import { unwrap } from "../utils/Util.js";
 import { Circle, CircleProps, sampleCircle } from "./Circle.js";
 import { Ellipse, EllipseProps, sampleEllipse } from "./Ellipse.js";
 import { Equation, EquationProps, sampleEquation } from "./Equation.js";
@@ -128,11 +129,11 @@ export const sampleShape = (
   context: Context,
   canvas: Canvas,
 ): ShapeProps<ad.Num> => {
-  const sampler = shapeSampler.get(shapeType);
-  if (sampler) {
-    return sampler(context, canvas);
-  }
-  throw new Error("shapeType not in sampler");
+  const sampler = unwrap(
+    shapeSampler.get(shapeType),
+    () => `shapeType not in sampler: ${shapeType}`,
+  );
+  return sampler(context, canvas);
 };
 
 // TODO: don't use a type predicate for this

--- a/packages/core/src/utils/CollectLabels.ts
+++ b/packages/core/src/utils/CollectLabels.ts
@@ -13,7 +13,7 @@ import { PenroseError } from "../types/errors.js";
 import { EquationData, LabelCache, State, TextData } from "../types/state.js";
 import { FloatV } from "../types/value.js";
 import { Result, err, ok } from "./Error.js";
-import { getAdValueAsString, getValueAsShapeList, safe } from "./Util.js";
+import { getAdValueAsString, getValueAsShapeList, unwrap } from "./Util.js";
 
 export const mathjaxInit = (): ((
   input: string,
@@ -351,7 +351,10 @@ const setPendingProperty = (
   after: FloatV<number>,
 ) => {
   if (typeof before.contents !== "number" && before.contents.tag === "Var") {
-    const { index, meta } = safe(inputs.get(before.contents), "missing input");
+    const { index, meta } = unwrap(
+      inputs.get(before.contents),
+      () => "missing input",
+    );
     if (meta.init.tag === "Pending") xs[index] = after.contents;
   }
 };
@@ -367,7 +370,10 @@ const insertPendingHelper = (
       const subShapes = getValueAsShapeList(s.shapes);
       insertPendingHelper(subShapes, xs, labelCache, inputs);
     } else if (s.shapeType === "Equation") {
-      const labelData = safe(labelCache.get(s.name.contents), "missing label");
+      const labelData = unwrap(
+        labelCache.get(s.name.contents),
+        () => `missing label: ${s.name.contents}`,
+      );
       if (labelData.tag !== "EquationData")
         throw Error(
           `for ${s.shapeType} ${s.name.contents} got unexpected ${labelData.tag}`,
@@ -377,7 +383,10 @@ const insertPendingHelper = (
       setPendingProperty(xs, inputs, s.ascent, labelData.ascent);
       setPendingProperty(xs, inputs, s.descent, labelData.descent);
     } else if (s.shapeType === "Text") {
-      const labelData = safe(labelCache.get(s.name.contents), "missing label");
+      const labelData = unwrap(
+        labelCache.get(s.name.contents),
+        () => `missing label: ${s.name.contents}`,
+      );
       if (labelData.tag !== "TextData")
         throw Error(
           `for ${s.shapeType} ${s.name.contents} got unexpected ${labelData.tag}`,

--- a/packages/core/src/utils/Graph.ts
+++ b/packages/core/src/utils/Graph.ts
@@ -1,3 +1,5 @@
+import { unwrap } from "./Util.js";
+
 // `i` and `I` stand for "index" or "ID", since we use them for node keys
 
 /** internal: half of an edge, where direction and one node are implicit */
@@ -33,9 +35,7 @@ export default class Graph<I, L = undefined, E = undefined> {
   private g = new Map<I, Vert<I, L, E>>();
 
   private get(i: I): Vert<I, L, E> {
-    const v = this.g.get(i);
-    if (v === undefined) throw Error(`node ID not found: ${i}`);
-    return v;
+    return unwrap(this.g.get(i), () => `node ID not found: ${i}`);
   }
 
   /** set `i`'s label to `l`, adding `i` to the graph if not already present */

--- a/packages/core/src/utils/GroupGraph.ts
+++ b/packages/core/src/utils/GroupGraph.ts
@@ -1,7 +1,7 @@
 import { Shape } from "../shapes/Shapes.js";
 import * as ad from "../types/ad.js";
 import Graph from "./Graph.js";
-import { shapeListV } from "./Util.js";
+import { shapeListV, unwrap } from "./Util.js";
 
 export type GroupGraph = Graph<string, number>; // shape name and index
 
@@ -76,10 +76,10 @@ export const buildRenderGraphNode = (
   groupGraph: GroupGraph,
   nameShapeMap: Map<string, Shape<ad.Num>>,
 ): RenderGraphNode => {
-  const shape = nameShapeMap.get(name);
-  if (!shape) {
-    throw new Error("Cannot find shape name in name-shape map");
-  }
+  const shape = unwrap(
+    nameShapeMap.get(name),
+    () => `Cannot find shape name in name-shape map: ${name}`,
+  );
 
   // If shape is non-group, return it as the node.
 

--- a/packages/core/src/utils/Util.ts
+++ b/packages/core/src/utils/Util.ts
@@ -79,16 +79,14 @@ export const combinations2 = <T>(list: T[]): [T, T][] =>
   }, []);
 
 /**
- * Safe wrapper for any function that might return `undefined`.
- * @borrows https://stackoverflow.com/questions/54738221/typescript-array-find-possibly-undefind
- * @param argument Possible unsafe function call
- * @param message Error message
+ * Throws if `x === undefined`.
+ * @returns `x`
+ * @param f called if `x === undefined`, to produce error message
  */
-export const safe = <T>(argument: T | undefined, message: string): T => {
-  if (argument === undefined) {
-    throw new TypeError(message);
-  }
-  return argument;
+export const unwrap = <T>(x: T | undefined, f?: () => string): T => {
+  if (x === undefined)
+    throw Error((f ?? (() => "called `unwrap` with `undefined`"))());
+  return x;
 };
 
 // Repeat `x`, `i` times


### PR DESCRIPTION
# Description

#412 added a utility function called `safe` which guards against `null` and `undefined` values, then #873 changed it to only handle `undefined`. The function takes a mandatory `message: string`, which it uses to construct a `TypeError`. This has a couple disadvantages:

1. it discourages usage with non-constant error messages, because the message string is always constructed regardless of whether the value is `undefined`
2. it discourages usage in general, because having to come up with an error message every time takes effort and adds verbosity, especially since often the chosen error message actually adds no value; making [`!`](https://www.typescriptlang.org/docs/handbook/2/everyday-types.html#non-null-assertion-operator-postfix-) attractive in comparison

To address those downsides, this PR changes the mandatory `message` parameter to an optional function `f` that returns a `string`, and updates usage accordingly to take advantage of this.

I also renamed it to `unwrap` (borrowing the name of Rust's [`Option::unwrap`](https://doc.rust-lang.org/std/option/enum.Option.html#method.unwrap)) which I think is clearer than `safe`.

# Checklist

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have reviewed any generated registry diagram changes

# Open questions

Now that we have the one-argument version of `unwrap`, should we follow up with a PR that replaces all (or at least most) instances of `!` with `unwrap` for better quality assurance, to see if it causes any noticeable slowdown?