### PR TITLE
chore: fix `no-non-null-assertion` lint rule name

### DIFF
--- a/packages/core/.eslintrc.json
+++ b/packages/core/.eslintrc.json
@@ -19,7 +19,7 @@
     "@typescript-eslint/no-unnecessary-boolean-literal-compare": "error",
     "@typescript-eslint/no-unnecessary-condition": "warn",
     "@typescript-eslint/no-unused-vars": "warn",
-    "@typescript-eslint/non-nullable-type-assertion-style": "warn",
+    "@typescript-eslint/no-non-null-assertion": "warn",
     "@typescript-eslint/prefer-ts-expect-error": "error",
     "eqeqeq": "error",
     "eslint-comments/no-use": "error",


### PR DESCRIPTION
# Description

While working on #1662 I noticed that we were using the wrong name for typescript-eslint's [no-non-null-assertion](https://typescript-eslint.io/rules/no-non-null-assertion/) rule, causing those warnings to be hidden. Not sure when this changed; maybe when we upgraded typescript-eslint to v6?

# Checklist

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have reviewed any generated registry diagram changes