### PR TITLE
test: wait until the end to write the text chart

### DIFF
--- a/packages/examples/src/registry.test.ts
+++ b/packages/examples/src/registry.test.ts
@@ -7,7 +7,7 @@ import * as fs from "fs/promises";
 import rawFetch, { RequestInit, Response } from "node-fetch";
 import * as path from "path";
 import prettier from "prettier";
-import { describe, test } from "vitest";
+import { afterAll, describe, test } from "vitest";
 import { Trio } from "./index.js";
 import registry from "./registry.js";
 
@@ -280,9 +280,12 @@ describe("registry", () => {
           path.join(out, "data.json"),
           `${JSON.stringify(Object.fromEntries(datas), null, 2)}\n`,
         );
-        await fs.writeFile(path.join(out, "stats.md"), textChart(datas));
       },
       { timeout: MAX_SECONDS * 1000 },
     );
   }
+
+  afterAll(async () => {
+    await fs.writeFile(path.join(out, "stats.md"), textChart(datas));
+  });
 });


### PR DESCRIPTION
# Description

Followup to #1664, since the `data.json` file size should be linear in the number of tests, but the `stats.md` file can also grow according to `MAX_SECONDS`, configured in #1657 for example.

# Checklist

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have reviewed any generated registry diagram changes