### PR TITLE
fix: Substance parsing of floating-point numbers

### DIFF
--- a/packages/core/src/compiler/Substance.test.ts
+++ b/packages/core/src/compiler/Substance.test.ts
@@ -584,6 +584,13 @@ Label D $\\vec{d}$
     expectErrorOf(res2, "InvalidSetIndexingError");
   });
 
+  test("invalid range", () => {
+    const env1 = envOrError(domainProg);
+    const prog1 = `Set a_i for i in [1.234, 10]`;
+    const res1 = compileSubstance(prog1, env1);
+    expectErrorOf(res1, "BadSetIndexRangeError");
+  });
+
   test("duplicate index", () => {
     const env = envOrError(domainProg);
     const prog = `Set a_i for i in [1, 10], j in [2, 10], i in [1, 10]`;

--- a/packages/core/src/compiler/Substance.ts
+++ b/packages/core/src/compiler/Substance.ts
@@ -428,6 +428,24 @@ const evalISet = (iset: IndexSet<A>): Result<ISetSubst[], SubstanceError> => {
   for (const { variable, range } of indices) {
     const name = variable.value;
     const { high, low } = range;
+    const highVal = high.value,
+      lowVal = low.value;
+
+    if (!Number.isInteger(lowVal)) {
+      return err({
+        tag: "BadSetIndexRangeError",
+        index: lowVal,
+        location: low,
+      });
+    }
+
+    if (!Number.isInteger(highVal)) {
+      return err({
+        tag: "BadSetIndexRangeError",
+        index: highVal,
+        location: high,
+      });
+    }
 
     // a list of [[name, value]]
     const possVals = im

--- a/packages/core/src/parser/Substance.ne
+++ b/packages/core/src/parser/Substance.ne
@@ -16,7 +16,6 @@ import { IndexSet, RangeAssign, Range, NumberConstant, BinaryExpr, UnaryExpr, Co
 const lexer = moo.compile({
   tex_literal: /\$.*?\$/, // TeX string enclosed by dollar signs
   double_arrow: "<->",
-  int_literal: /[+-]?[1-9][0-9]*|0(?!\.[0-9])/,
   float_literal: /([+-]?([0-9]*[.])?[0-9]+)/,
   ...basicSymbols,
   identifier: {
@@ -115,19 +114,11 @@ range_assign -> identifier _ "in" _ int_range {%
   })
 %}
 
-int_range -> "[" _ integer _ "," _ integer _ "]" {%
+int_range -> "[" _ number _ "," _ number _ "]" {%
   ([lbracket, , low, , , , high, , rbracket]): Range<C> => ({
     ...nodeData,
     ...rangeBetween(lbracket, rbracket),
     tag: "Range", low, high
-  })
-%}
-
-integer -> %int_literal {% 
-  ([d]): NumberConstant<C> => ({
-    ...nodeData,
-    ...rangeOf(d),
-    tag: "NumberConstant", value: +d.value
   })
 %}
 
@@ -139,9 +130,7 @@ float -> %float_literal {%
     })
   %}
 
-number 
-  -> integer {%id%}
-  |  float {%id%}
+number -> float {%id%}
 
 stmt 
   -> decl            {% id %}

--- a/packages/core/src/types/errors.ts
+++ b/packages/core/src/types/errors.ts
@@ -61,6 +61,7 @@ export type SubstanceError =
   | DeconstructNonconstructor
   | UnexpectedExprForNestedPred
   | InvalidSetIndexingError
+  | BadSetIndexRangeError
   | DuplicateIndexError
   | DivideByZeroError
   | InvalidArithmeticValueError
@@ -92,6 +93,12 @@ export interface InvalidSetIndexingError {
   index: string;
   location: AbstractNode;
   suggestions: string[];
+}
+
+export interface BadSetIndexRangeError {
+  tag: "BadSetIndexRangeError";
+  index: number;
+  location: AbstractNode;
 }
 
 export interface DuplicateIndexError {

--- a/packages/core/src/utils/Error.ts
+++ b/packages/core/src/utils/Error.ts
@@ -262,9 +262,9 @@ export const showError = (
     }
     case "BadSetIndexRangeError": {
       const { index, location } = error;
-      return `Number ${index} (at ${loc(
+      return `A indexed-set range must consist of integers, but value ${index} (at ${loc(
         location,
-      )}) is not a valid upper or lower bound of a range.`;
+      )}) is not an integer.`;
     }
     case "DuplicateIndexError": {
       const { index, location } = error;

--- a/packages/core/src/utils/Error.ts
+++ b/packages/core/src/utils/Error.ts
@@ -260,6 +260,12 @@ export const showError = (
         ", ",
       )}`;
     }
+    case "BadSetIndexRangeError": {
+      const { index, location } = error;
+      return `Number ${index} (at ${loc(
+        location,
+      )}) is not a valid upper or lower bound of a range.`;
+    }
     case "DuplicateIndexError": {
       const { index, location } = error;
       return `Index variable \`${index}\` has been declared multiple times at ${loc(
@@ -733,6 +739,7 @@ export const errLocs = (
       return locOrNone(e.deconstructor);
     }
     case "InvalidSetIndexingError":
+    case "BadSetIndexRangeError":
     case "DuplicateIndexError":
     case "DivideByZeroError":
     case "InvalidArithmeticValueError": {


### PR DESCRIPTION
# Description

Resolves #1671 .

This PR addresses the issue by removing separate parse rules for `int_literal` and adding a compile-time check for integer.

# Checklist

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have reviewed any generated registry diagram changes
