### PR TITLE
chore: add default canvas block to `editor`

### DIFF
--- a/packages/components/src/editing/languages/StyleConfig.ts
+++ b/packages/components/src/editing/languages/StyleConfig.ts
@@ -127,6 +127,11 @@ export const StyleLanguageTokens: languages.IMonarchLanguage = {
   },
 };
 
+const defaultCanvas = `canvas {
+  width = \${1:400}
+  height = \${2:400}
+}`;
+
 export const StyleCompletions = (range: IRange): languages.CompletionItem[] => [
   ...styleCustoms.keywords.map((keyword: string) => ({
     label: keyword,
@@ -175,6 +180,14 @@ export const StyleCompletions = (range: IRange): languages.CompletionItem[] => [
     detail: "type",
     range,
   })),
+  {
+    insertTextRules: languages.CompletionItemInsertTextRule.InsertAsSnippet,
+    label: "canvas",
+    insertText: defaultCanvas,
+    kind: languages.CompletionItemKind.Snippet,
+    detail: "canvas settings",
+    range,
+  },
 ];
 
 export const SetupStyleMonaco = (monaco: Monaco) => {

--- a/packages/editor/src/state/atoms.ts
+++ b/packages/editor/src/state/atoms.ts
@@ -200,7 +200,10 @@ export const currentWorkspaceState = atom<Workspace>({
       },
       style: {
         name: ".style",
-        contents: "",
+        contents: `canvas {
+  width = 400
+  height = 400
+}`,
       },
       domain: {
         name: ".domain",


### PR DESCRIPTION
# Description

On start, `editor` starts the trio with empty strings, and it's a bit tedious to type `canvas { ... }` every time. This PR inserts a default canvas block to the Style pane by default and exposes a code snippet `canvas` that inserts a template for the canvas block:

```
canvas {
  width = 400
  height = 400
}
```

# Examples with steps to reproduce them

* Go to deployment IDE
* Hit "compile"
* Observe no errors are thrown because the canvas is already pre-populated.

# Checklist

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have reviewed any generated registry diagram changes

# Open questions

Questions that require more discussion or to be addressed in future development:
