### PR TITLE
fix: improper Style matching of functions without parameters

### DIFF
--- a/packages/core/src/compiler/Style.ts
+++ b/packages/core/src/compiler/Style.ts
@@ -1271,7 +1271,7 @@ const matchStyArgsToSubArgs = (
     );
     return substs;
   } else {
-    return [];
+    return [{}];
   }
 };
 


### PR DESCRIPTION
# Description

The algorithm that matches Style selector function calls against Substance function calls don't work if the function take in zero arguments.

# Cause 

Suppose we have Style selector expression `MyFunc(a, b, c)` and Substance expression `MyFunc(A, B, C)`. Naturally, we have substitution `{a -> A, b -> B, c -> C}`. That is, the substitution contains one entry for each argument. This is a valid substitution.

What happens if `MyFunc` takes in no arguments? In other words, what happens if we match Style selector expression `MyFunc()` against Substance expression `MyFunc()`? Naturally, it should generate a valid substitution, but with no entries. That is, the substitution should be `{}`. This is a valid but empty substitution.

The bug occurs because instead of returning `{}` which is a valid substitution, we return nothing which would indicate that there are _no valid substitutions_.

[Here ](https://penrose.cs.cmu.edu/try/?gist=e518c77ba74b067b495b786364b47475)is the bug in action. A successful match (as it should be) should draw a circle on the canvas.

This PR fixes the bug by returning a valid, empty substitution when function has no arguments.

# Checklist

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have reviewed any generated registry diagram changes

# Open questions

Questions that require more discussion or to be addressed in future development:
