### PR TITLE
fix: improper handling of flipped index ranges

### DIFF
--- a/packages/core/src/compiler/Substance.test.ts
+++ b/packages/core/src/compiler/Substance.test.ts
@@ -304,7 +304,7 @@ NoLabel B, C
       }
 
       const env2 = envOrError(domainProg);
-      const prog2 = `Set a_i for i in [11, 10]`;
+      const prog2 = `Set a_i for i in [20, 10]`;
       const res2 = compileSubstance(prog2, env2);
       expect(res2.isOk()).toBe(true);
       if (res2.isOk()) {

--- a/packages/core/src/compiler/Substance.test.ts
+++ b/packages/core/src/compiler/Substance.test.ts
@@ -310,6 +310,14 @@ NoLabel B, C
       if (res2.isOk()) {
         expect(res2.value[1].vars.size).toBe(0);
       }
+
+      const env3 = envOrError(domainProg);
+      const prog3 = `Set a_i, b_j for i in [20, 1], j in [1, 20]`;
+      const res3 = compileSubstance(prog3, env3);
+      expect(res3.isOk()).toBe(true);
+      if (res3.isOk()) {
+        expect(res3.value[1].vars.size).toBe(0);
+      }
     });
 
     test("indexed set decllist", () => {

--- a/packages/core/src/compiler/Substance.ts
+++ b/packages/core/src/compiler/Substance.ts
@@ -447,6 +447,10 @@ const evalISet = (iset: IndexSet<A>): Result<ISetSubst[], SubstanceError> => {
       });
     }
 
+    if (high.value < low.value) {
+      return ok([]);
+    }
+
     // a list of [[name, value]]
     const possVals = im
       .Range(low.value, high.value + 1)


### PR DESCRIPTION
# Description

Resolves #1685.

This PR adds a check to `evalISet` - for a range `i in [low, high]`, if `high < low`, then return empty set since there are no valid `i`s.

# Examples with steps to reproduce them

We modified the test `indexed set decl - no satisfying indices`. The modified test would fail in the current version but will pass in this PR.

 
# Checklist

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have reviewed any generated registry diagram changes
