### PR TITLE
build: fix `yarn start` for top-level `await`

### DIFF
--- a/packages/editor/vite.config.ts
+++ b/packages/editor/vite.config.ts
@@ -8,7 +8,8 @@ export default defineConfig({
   plugins: [react({ jsxRuntime: "classic" })],
   build: { target: "esnext" },
   optimizeDeps: {
-    exclude: ["@penrose/examples"],
+    esbuildOptions: { target: "esnext" },
+    exclude: ["@penrose/examples", "rose"],
   },
   server: {
     port: 3000,


### PR DESCRIPTION
# Description

This PR fixes the `yarn start` issue @hsharriman and @liangyiliang have been running into since #1636 was merged.

# Examples with steps to reproduce them

```sh
yarn
yarn start
```

# Checklist

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have reviewed any generated registry diagram changes