### PR TITLE
fix: off-by-one error in time-travel slider

### DIFF
--- a/packages/editor/src/components/LayoutTimelineSlider.tsx
+++ b/packages/editor/src/components/LayoutTimelineSlider.tsx
@@ -9,27 +9,31 @@ import SegmentedSlider from "./SegmentedSlider";
 export const LayoutTimelineSlider: React.FC<{}> = (props) => {
   const [diagram, setDiagram] = useRecoilState(diagramState);
   const min = 0;
-  const [max, setMax] = useState(100);
+  const [max, setMax] = useState(0);
   const stats = optimizer.getStats();
-  const [index, setIndex] = useState(100);
+  const [index, setIndex] = useState(0);
   const { running } = useRecoilValue(diagramWorkerState);
 
   useEffect(() => {
     setMax(stats.reduce((acc, stat) => acc + stat.steps, 0));
   }, [diagram]);
 
+  // useEffect(() => {
+  //   setIndex(max);
+  // }, [max]);
+
   const onChange = (i: number) => {
-    // update current index
-    setIndex(i);
     // request shapes from worker
     async function requestShapes() {
-      const state = await optimizer.computeShapes(index, min, max);
+      const state = await optimizer.computeShapes(i);
       setDiagram((diagram) => ({
         ...diagram,
         state: state,
       }));
     }
     requestShapes();
+    // update current index
+    setIndex(i);
   };
   return (
     <div

--- a/packages/editor/src/worker/OptimizerWorker.ts
+++ b/packages/editor/src/worker/OptimizerWorker.ts
@@ -51,18 +51,12 @@ export default class OptimizerWorker {
     return this.stats;
   }
 
-  async computeShapes(
-    index: number,
-    min: number,
-    max: number,
-  ): Promise<RenderState> {
+  async computeShapes(index: number): Promise<RenderState> {
     return new Promise((resolve, reject) => {
       log.debug("Worker computing shapes...");
       this.request({
         tag: "ComputeShapes",
         index,
-        min,
-        max,
       });
       const messageHandler = async ({ data }: MessageEvent<Resp>) => {
         if (data.tag === "Update") {

--- a/packages/editor/src/worker/message.ts
+++ b/packages/editor/src/worker/message.ts
@@ -25,8 +25,6 @@ export type Resample = {
 
 export type ComputeShapes = {
   tag: "ComputeShapes";
-  min: number;
-  max: number;
   index: number;
 };
 

--- a/packages/editor/src/worker/worker.ts
+++ b/packages/editor/src/worker/worker.ts
@@ -71,11 +71,7 @@ onmessage = async ({ data }: MessageEvent<Req>) => {
       break;
     }
     case "ComputeShapes": {
-      const range = data.max - data.min;
-      // normalize the index to the length of the history array
-      const index = Math.floor(
-        ((data.index - data.min) / range) * (history.length - 1),
-      );
+      const index = data.index;
       const newShapes = {
         ...currentState,
         varyingValues: history[index],
@@ -150,6 +146,7 @@ const optimize = (state: PenroseState) => {
   let i = 0;
   while (!isOptimized(state)) {
     let j = 0;
+    history.push(state.varyingValues);
     const steppedState = step(state, { until: (): boolean => j++ >= numSteps });
     if (steppedState.isErr()) {
       respondError(steppedState.error);
@@ -181,7 +178,6 @@ const optimize = (state: PenroseState) => {
       respondReady();
       return;
     }
-    history.push(state.varyingValues);
     i++;
   }
   respondFinished(state);


### PR DESCRIPTION
# Description

This PR fixes an issue introduced by #1681. The slider always lags by 1 when the user drags it around. This is caused by an error in the update effect, where I mistakenly used the state variable instead of the fresh value immediately. State updates later than the worker request, causing the off-by-one.

I also simplified the `ComputeShapes` message to remove `min` and `max`. I think it's premature optimization at the moment and also the client now should have the information to sample the layout timeline.
