### PR TITLE
feat: update upload-artifact action to latest version

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Generate diagrams and metadata for the first commit
         run: yarn registry
       - name: Upload generated diagrams and metadata
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4.1.0
         with:
           name: diagrams-1
           path: packages/examples/diagrams/
@@ -41,7 +41,7 @@ jobs:
       - name: Generate diagrams and metadata for the second commit
         run: yarn registry
       - name: Upload generated diagrams and metadata
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4.1.0
         with:
           name: diagrams-2
           path: packages/examples/diagrams/

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -93,7 +93,7 @@ jobs:
       - name: Generate diagrams and metadata
         run: yarn registry
       - name: Upload generated diagrams and metadata
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4.1.0
         with:
           name: diagrams
           path: packages/examples/diagrams/


### PR DESCRIPTION
Updated GitHub Actions workflows to use the latest upload-artifact action v4.1.0
which According to GitHub 90% faster and storage efficient

Revised workflows
- bench.yml
- build.yml

[https://github.com/actions/upload-artifact#v4---whats-new](https://github.com/actions/upload-artifact#v4---whats-new)

