### PR TITLE
feat: Update variation for caffeine example

### DIFF
--- a/packages/examples/src/structural-formula/molecules/caffeine.trio.json
+++ b/packages/examples/src/structural-formula/molecules/caffeine.trio.json
@@ -2,5 +2,5 @@
   "substance": "./caffeine.substance",
   "style": ["../pseudo-3d.style"],
   "domain": "../structural-formula.domain",
-  "variation": "GreybeardChinchilla991"
+  "variation": "WaterslideBarracuda2752"
 }


### PR DESCRIPTION
> The caffeine example is laughable.

This PR fixes the caffeine example to be less laughable.