### PR TITLE
fix: vector subtraction in tutorial3.md

### DIFF
--- a/packages/examples/src/tutorials/solutions/tutorial3.md
+++ b/packages/examples/src/tutorials/solutions/tutorial3.md
@@ -206,7 +206,7 @@ where In(u,U) {
 -- Exercise 1 Changes:
 forall Vector u; Vector v; Vector w; VectorSpace U
 where u := subV(v,w); In(u, U); In(v, U); In(w, U){
-  override u.shape.end = v.shape.end - w.shape.end - U.origin
+  override u.shape.end = v.shape.end - w.shape.end + U.origin
   override u.shape.strokeColor = const.green
   override u.text.string = "difference"
 }


### PR DESCRIPTION
# Description

Vector subtraction should involve adding the origin, not subtracting. It will cause an offset when `vec2 U.origin` is not `(0., 0.)`.