### PR TITLE
docs: add documentation and an example of arrowhead styles

### DIFF
--- a/packages/docs-site/docs/ref/style/shapes/line.md
+++ b/packages/docs-site/docs/ref/style/shapes/line.md
@@ -1,7 +1,24 @@
 <script setup>
 import ShapeProps from "../../../../src/components/ShapeProps.vue";
+import Embed from "../../../../src/components/Embed.vue";
+import arrowheads from "@penrose/examples/dist/shape-spec/arrowheads.trio.js"
+
+const arrows = {
+  trio: {
+    substance: arrowheads.substance,
+    style: arrowheads.style[0].contents,
+    domain: arrowheads.domain,
+    variation: arrowheads.variation,
+  },
+  imageResolver: arrowheads.style[0].resolver,
+}
+
 </script>
 
 # Line
 
 <ShapeProps shape-name="Line" />
+
+The `Line` shape allows a few styles of arrowheads arrowhead styles inspired by [quiver](https://q.uiver.app/). The arrowhead styles are given by `startArrowhead` and `endArrowhead`. The example below shows all the supported options:
+
+<Embed :trio=arrows.trio  />

--- a/packages/docs-site/src/components/PropValue.vue
+++ b/packages/docs-site/src/components/PropValue.vue
@@ -9,7 +9,7 @@ const showValue = (contents: any): { text: string; color?: string } => {
   if (typeof contents === "object") {
     switch (contents.tag) {
       case "NONE":
-        return { text: "NONE" };
+        return { text: "none()" };
       case "RGBA": {
         const c = contents.contents;
         return {
@@ -43,5 +43,7 @@ const { text, color } = showValue(contents);
     </div>
     <span style="margin-left: 1em">{{ text }}</span>
   </div>
-  <template v-else>{{ text }}</template>
+  <template v-else
+    ><code>{{ text }}</code></template
+  >
 </template>

--- a/packages/docs-site/vite.config.ts
+++ b/packages/docs-site/vite.config.ts
@@ -1,6 +1,12 @@
 import { defineConfig } from "vite";
+import topLevelAwait from "vite-plugin-top-level-await";
 
 // https://vitejs.dev/config/
 export default defineConfig({
   build: { target: "esnext" },
+  plugins: [topLevelAwait()],
+  optimizeDeps: {
+    esbuildOptions: { target: "esnext" },
+    exclude: ["@penrose/examples", "rose"],
+  },
 });


### PR DESCRIPTION
# Description

Resolves #1689.

# Implementation strategy and design decisions

Add an `Embed` component on the doc page to showcase all arrowhead styles.

# Examples with steps to reproduce them

https://arrowhead-docs.penrose-72l.pages.dev/docs/ref/style/shapes/line

# Checklist

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have reviewed any generated registry diagram changes

