### PR TITLE
fix: UI bugs in `edgeworth`

### DIFF
--- a/packages/components/src/Gridbox.tsx
+++ b/packages/components/src/Gridbox.tsx
@@ -202,7 +202,7 @@ export class Gridbox extends React.Component<GridboxProps, GridboxState> {
 
         <div
           onClick={this.toggleView}
-          style={{ height: "calc(100% - 2.5rem)", position: "relative" }}
+          style={{ height: "calc(100% - 2.75rem)", position: "relative" }}
         >
           {this.state.showDiagramInfo && (
             <Body>

--- a/packages/components/src/Simple.tsx
+++ b/packages/components/src/Simple.tsx
@@ -157,6 +157,8 @@ class Simple extends React.Component<SimpleProps, SimpleState> {
               this.props.imageResolver ?? fetchResolver,
               this.props.name ?? "",
             ));
+        renderedState.setAttribute("width", "100%");
+        renderedState.setAttribute("height", "100%");
         if (node.firstChild !== null) {
           node.replaceChild(renderedState, node.firstChild);
         } else {
@@ -175,7 +177,7 @@ class Simple extends React.Component<SimpleProps, SimpleState> {
   render = () => {
     const { error } = this.state;
     return (
-      <div style={{ width: "100%", height: "100%" }}>
+      <>
         {!error && (
           <div style={{ width: "100%", height: "100%" }} ref={this.canvasRef} />
         )}
@@ -194,7 +196,7 @@ class Simple extends React.Component<SimpleProps, SimpleState> {
             </div>
           </div>
         )}
-      </div>
+      </>
     );
   };
 }

--- a/packages/edgeworth/src/components/Settings.tsx
+++ b/packages/edgeworth/src/components/Settings.tsx
@@ -19,7 +19,6 @@ import {
 import { Listing } from "@penrose/components";
 import { compileDomain, showError } from "@penrose/core";
 import { DomainEnv } from "@penrose/core/dist/types/domain";
-import c04p01 from "@penrose/examples/dist/geometry-domain/textbook_problems/c04p01.substance";
 import React from "react";
 import Latex from "react-latex-next";
 import { Preset, domains, presets } from "../examples.js";
@@ -167,9 +166,9 @@ export class Settings extends React.Component<SettingsProps, SettingState> {
   constructor(props: SettingsProps) {
     super(props);
     this.state = {
-      substance: c04p01,
+      substance: "",
       setting: undefined,
-      numPrograms: 10,
+      numPrograms: 0,
       seed: "test0", // default seed
       domainEnv: defaultEnv,
       domain: this.props.defaultDomain,
@@ -178,8 +177,8 @@ export class Settings extends React.Component<SettingsProps, SettingState> {
       llmInput: "",
       llmRunning: false,
       currentTab: 0,
-      domainSelect: "moleculesDomain",
-      presetSelect: "lewis_0",
+      domainSelect: "",
+      presetSelect: "",
     };
   }
 
@@ -561,7 +560,8 @@ To write comments, begin with \`--\`. Return only the Substance program; explain
 
   componentDidMount = () => {
     // this.handlePreset("c04p01");
-    this.handlePreset("lewis_0");
+    // this.handlePreset("lewis_0");
+    this.handleDomain("moleculesDomain");
   };
 
   render() {
@@ -592,7 +592,7 @@ To write comments, begin with \`--\`. Return only the Substance program; explain
           </SettingDiv>
           <SettingDiv>{this.displayNaturalLangOrPresetTabs()}</SettingDiv>
           <br />
-          <Accordion key="substance" elevation={0}>
+          <Accordion key="substance" elevation={0} defaultExpanded>
             <AccordionHeaderStyled>{`Input Scenario`}</AccordionHeaderStyled>
             <AccordionBodyStyled style={{ padding: 0 }}>
               <Listing
@@ -605,7 +605,7 @@ To write comments, begin with \`--\`. Return only the Substance program; explain
                 }
                 width={"100%"}
                 height={"400px"}
-                monacoOptions={{ theme: "vs" }}
+                monacoOptions={{ theme: "vs", lineNumbers: "on" }}
                 readOnly={false}
               />
             </AccordionBodyStyled>
@@ -627,7 +627,7 @@ To write comments, begin with \`--\`. Return only the Substance program; explain
               valueLabelDisplay="auto"
               step={1}
               marks={[
-                { value: 1, label: "1" },
+                { value: 0, label: "0" },
                 { value: 10, label: "10" },
                 { value: 20, label: "20" },
                 { value: 30, label: "30" },
@@ -635,7 +635,7 @@ To write comments, begin with \`--\`. Return only the Substance program; explain
                 { value: 50, label: "50" },
               ]}
               value={this.state.numPrograms}
-              min={1}
+              min={0}
               max={50}
               onChange={this.onProgCountChange}
             />
@@ -695,7 +695,7 @@ To write comments, begin with \`--\`. Return only the Substance program; explain
                   <AccordionHeaderStyled>{`Domain Program`}</AccordionHeaderStyled>
                   <AccordionBodyStyled style={{ padding: 0 }}>
                     <TextField
-                      rows={20}
+                      minRows={20}
                       name="dsl"
                       multiline
                       variant="outlined"
@@ -711,7 +711,7 @@ To write comments, begin with \`--\`. Return only the Substance program; explain
                   <AccordionHeaderStyled>Style Program</AccordionHeaderStyled>
                   <AccordionBodyStyled style={{ padding: 0 }}>
                     <TextField
-                      rows={20}
+                      minRows={20}
                       name="sty"
                       multiline
                       fullWidth

--- a/packages/edgeworth/src/problems/all.tsx
+++ b/packages/edgeworth/src/problems/all.tsx
@@ -1,133 +1,133 @@
 import { presets } from "../examples.js";
 import { multipleChoiceProblem } from "./util.js";
 
-const problems = [
-  multipleChoiceProblem(presets["lewis_0"], "test0", 10, {
-    correct: [0],
-    incorrect: [1, 6, 8],
-  }),
-  multipleChoiceProblem(presets["lewis_1"], "test0", 10, {
-    correct: [0],
-    incorrect: [3, 4, 5],
-  }),
-  multipleChoiceProblem(presets["lewis_2"], "test0", 10, {
-    correct: [0],
-    incorrect: [2, 5, 7],
-  }),
-  multipleChoiceProblem(presets["lewis_3"], "test0", 10, {
-    correct: [0],
-    incorrect: [1, 3, 5],
-  }),
-  multipleChoiceProblem(presets["lewis_4"], "test0", 10, {
-    correct: [0],
-    incorrect: [2, 6, 7],
-  }),
-  multipleChoiceProblem(presets["lewis_5"], "test0", 10, {
-    correct: [0],
-    incorrect: [2, 3, 4],
-  }),
-  multipleChoiceProblem(presets["lewis_6"], "test0", 10, {
-    correct: [0],
-    incorrect: [1, 2, 3],
-  }),
-  multipleChoiceProblem(presets["c01p01"], "test0", 10, {
-    correct: [0],
-    incorrect: [1, 4, 6],
-  }),
-  multipleChoiceProblem(presets["c01p10"], "test0", 10, {
-    correct: [0],
-    incorrect: [7, 2, 3],
-  }),
-  multipleChoiceProblem(presets["c02p01"], "test0", 10, {
-    correct: [0],
-    incorrect: [4, 2, 3],
-  }),
-  multipleChoiceProblem(presets["c03p01"], "test0", 10, {
-    correct: [0],
-    incorrect: [1, 5, 3],
-  }),
-  multipleChoiceProblem(presets["c04p01"], "test0", 10, {
-    correct: [0],
-    incorrect: [1, 2, 4],
-  }),
-  multipleChoiceProblem(presets["c04p12"], "test0", 10, {
-    correct: [0, 4, 5],
-    incorrect: [1],
-  }),
-  multipleChoiceProblem(presets["c05p01"], "test0", 10, {
-    correct: [0, 1, 5, 7],
-    incorrect: [],
-  }),
-
-  multipleChoiceProblem(presets["c05p13"], "test0", 10, {
-    correct: [0],
-    incorrect: [1, 2, 7],
-  }),
-  multipleChoiceProblem(presets["c06p06"], "test0", 10, {
-    correct: [0, 1, 2],
-    incorrect: [10],
-  }),
-  multipleChoiceProblem(presets["c07p06"], "test0", 10, {
-    correct: [0, 3],
-    incorrect: [6, 10],
-  }),
-  multipleChoiceProblem(presets["c07p10"], "test0", 10, {
-    correct: [0, 1, 2, 3],
-    incorrect: [],
-  }),
-  multipleChoiceProblem(presets["c07p22"], "test0", 10, {
-    correct: [0],
-    incorrect: [5, 2, 3],
-  }),
-  multipleChoiceProblem(presets["c08p08"], "test0", 10, {
-    correct: [0],
-    incorrect: [8, 9, 3],
-  }),
-  multipleChoiceProblem(presets["c10p08"], "test0", 10, {
-    correct: [0],
-    incorrect: [1, 2, 5],
-  }),
-  multipleChoiceProblem(presets["c11p07"], "test0", 10, {
-    correct: [0],
-    incorrect: [6, 7, 3],
-  }),
-  multipleChoiceProblem(presets["c11p25"], "test0", 10, {
-    correct: [0, 1],
-    incorrect: [6, 8],
-  }),
-  multipleChoiceProblem(presets["c12p20"], "test0", 10, {
-    correct: [0],
-    incorrect: [6, 7, 8],
-  }),
-  multipleChoiceProblem(presets["graph_0"], "test0", 10, {
-    correct: [0, 8],
-    incorrect: [1, 5],
-  }),
-  multipleChoiceProblem(presets["graph_1"], "test0", 10, {
-    correct: [0],
-    incorrect: [4, 2, 7],
-  }),
-  multipleChoiceProblem(presets["graph_2"], "test0", 10, {
-    correct: [2],
-    incorrect: [4, 3, 7],
-  }),
-  multipleChoiceProblem(presets["graph_3"], "test0", 10, {
-    correct: [3],
-    incorrect: [1, 4, 5],
-  }),
-  multipleChoiceProblem(presets["graph_4"], "test0", 10, {
-    correct: [1, 3, 4, 7],
-    incorrect: [],
-  }),
-  multipleChoiceProblem(presets["graph_5"], "test0", 10, {
-    correct: [0, 1],
-    incorrect: [3, 5],
-  }),
-  multipleChoiceProblem(presets["graph_6"], "test0", 10, {
-    correct: [0],
-    incorrect: [2, 4, 5],
-  }),
-];
 export default function () {
+  const problems = [
+    multipleChoiceProblem(presets["lewis_0"], "test0", 10, {
+      correct: [0],
+      incorrect: [1, 6, 8],
+    }),
+    multipleChoiceProblem(presets["lewis_1"], "test0", 10, {
+      correct: [0],
+      incorrect: [3, 4, 5],
+    }),
+    multipleChoiceProblem(presets["lewis_2"], "test0", 10, {
+      correct: [0],
+      incorrect: [2, 5, 7],
+    }),
+    multipleChoiceProblem(presets["lewis_3"], "test0", 10, {
+      correct: [0],
+      incorrect: [1, 3, 5],
+    }),
+    multipleChoiceProblem(presets["lewis_4"], "test0", 10, {
+      correct: [0],
+      incorrect: [2, 6, 7],
+    }),
+    multipleChoiceProblem(presets["lewis_5"], "test0", 10, {
+      correct: [0],
+      incorrect: [2, 3, 4],
+    }),
+    multipleChoiceProblem(presets["lewis_6"], "test0", 10, {
+      correct: [0],
+      incorrect: [1, 2, 3],
+    }),
+    multipleChoiceProblem(presets["c01p01"], "test0", 10, {
+      correct: [0],
+      incorrect: [1, 4, 6],
+    }),
+    multipleChoiceProblem(presets["c01p10"], "test0", 10, {
+      correct: [0],
+      incorrect: [7, 2, 3],
+    }),
+    multipleChoiceProblem(presets["c02p01"], "test0", 10, {
+      correct: [0],
+      incorrect: [4, 2, 3],
+    }),
+    multipleChoiceProblem(presets["c03p01"], "test0", 10, {
+      correct: [0],
+      incorrect: [1, 5, 3],
+    }),
+    multipleChoiceProblem(presets["c04p01"], "test0", 10, {
+      correct: [0],
+      incorrect: [1, 2, 4],
+    }),
+    multipleChoiceProblem(presets["c04p12"], "test0", 10, {
+      correct: [0, 4, 5],
+      incorrect: [1],
+    }),
+    multipleChoiceProblem(presets["c05p01"], "test0", 10, {
+      correct: [0, 1, 5, 7],
+      incorrect: [],
+    }),
+
+    multipleChoiceProblem(presets["c05p13"], "test0", 10, {
+      correct: [0],
+      incorrect: [1, 2, 7],
+    }),
+    multipleChoiceProblem(presets["c06p06"], "test0", 10, {
+      correct: [0, 1, 2],
+      incorrect: [10],
+    }),
+    multipleChoiceProblem(presets["c07p06"], "test0", 10, {
+      correct: [0, 3],
+      incorrect: [6, 10],
+    }),
+    multipleChoiceProblem(presets["c07p10"], "test0", 10, {
+      correct: [0, 1, 2, 3],
+      incorrect: [],
+    }),
+    multipleChoiceProblem(presets["c07p22"], "test0", 10, {
+      correct: [0],
+      incorrect: [5, 2, 3],
+    }),
+    multipleChoiceProblem(presets["c08p08"], "test0", 10, {
+      correct: [0],
+      incorrect: [8, 9, 3],
+    }),
+    multipleChoiceProblem(presets["c10p08"], "test0", 10, {
+      correct: [0],
+      incorrect: [1, 2, 5],
+    }),
+    multipleChoiceProblem(presets["c11p07"], "test0", 10, {
+      correct: [0],
+      incorrect: [6, 7, 3],
+    }),
+    multipleChoiceProblem(presets["c11p25"], "test0", 10, {
+      correct: [0, 1],
+      incorrect: [6, 8],
+    }),
+    multipleChoiceProblem(presets["c12p20"], "test0", 10, {
+      correct: [0],
+      incorrect: [6, 7, 8],
+    }),
+    multipleChoiceProblem(presets["graph_0"], "test0", 10, {
+      correct: [0, 8],
+      incorrect: [1, 5],
+    }),
+    multipleChoiceProblem(presets["graph_1"], "test0", 10, {
+      correct: [0],
+      incorrect: [4, 2, 7],
+    }),
+    multipleChoiceProblem(presets["graph_2"], "test0", 10, {
+      correct: [2],
+      incorrect: [4, 3, 7],
+    }),
+    multipleChoiceProblem(presets["graph_3"], "test0", 10, {
+      correct: [3],
+      incorrect: [1, 4, 5],
+    }),
+    multipleChoiceProblem(presets["graph_4"], "test0", 10, {
+      correct: [1, 3, 4, 7],
+      incorrect: [],
+    }),
+    multipleChoiceProblem(presets["graph_5"], "test0", 10, {
+      correct: [0, 1],
+      incorrect: [3, 5],
+    }),
+    multipleChoiceProblem(presets["graph_6"], "test0", 10, {
+      correct: [0],
+      incorrect: [2, 4, 5],
+    }),
+  ];
   return <div>{problems}</div>;
 }

--- a/packages/edgeworth/src/problems/chemistry.tsx
+++ b/packages/edgeworth/src/problems/chemistry.tsx
@@ -1,64 +1,64 @@
 import { presets } from "../examples.js";
 import { multipleChoiceProblem } from "./util.js";
 
-const problems = [
-  multipleChoiceProblem(presets["lewis_0"], "test0", 10, {
-    correct: [0],
-    incorrect: [1, 6, 8],
-  }),
-  multipleChoiceProblem(presets["lewis_1"], "test0", 10, {
-    correct: [0],
-    incorrect: [1, 2, 3],
-  }),
-  multipleChoiceProblem(presets["lewis_2"], "test0", 10, {
-    correct: [0],
-    incorrect: [1, 3, 7],
-  }),
-  multipleChoiceProblem(presets["lewis_3"], "test0", 10, {
-    correct: [0],
-    incorrect: [3, 6, 7],
-  }),
-  multipleChoiceProblem(presets["lewis_4"], "test0", 10, {
-    correct: [0],
-    incorrect: [1, 2, 3],
-  }),
-  multipleChoiceProblem(presets["lewis_5"], "test0", 10, {
-    correct: [0],
-    incorrect: [2, 3, 4],
-  }),
-  multipleChoiceProblem(presets["lewis_6"], "test0", 10, {
-    correct: [0],
-    incorrect: [1, 6, 10],
-  }),
-  multipleChoiceProblem(presets["graph_0"], "test0", 10, {
-    correct: [0],
-    incorrect: [1, 6, 8],
-  }),
-  multipleChoiceProblem(presets["graph_1"], "test0", 10, {
-    correct: [0],
-    incorrect: [1, 2, 3],
-  }),
-  multipleChoiceProblem(presets["graph_2"], "test0", 10, {
-    correct: [0],
-    incorrect: [1, 3, 7],
-  }),
-  multipleChoiceProblem(presets["graph_3"], "test0", 10, {
-    correct: [0],
-    incorrect: [3, 6, 7],
-  }),
-  multipleChoiceProblem(presets["graph_4"], "test0", 10, {
-    correct: [0],
-    incorrect: [1, 2, 3],
-  }),
-  multipleChoiceProblem(presets["graph_5"], "test0", 10, {
-    correct: [0],
-    incorrect: [2, 3, 4],
-  }),
-  multipleChoiceProblem(presets["graph_6"], "test0", 10, {
-    correct: [0],
-    incorrect: [1, 6, 10],
-  }),
-];
 export default function () {
+  const problems = [
+    multipleChoiceProblem(presets["lewis_0"], "test0", 10, {
+      correct: [0],
+      incorrect: [1, 6, 8],
+    }),
+    multipleChoiceProblem(presets["lewis_1"], "test0", 10, {
+      correct: [0],
+      incorrect: [1, 2, 3],
+    }),
+    multipleChoiceProblem(presets["lewis_2"], "test0", 10, {
+      correct: [0],
+      incorrect: [1, 3, 7],
+    }),
+    multipleChoiceProblem(presets["lewis_3"], "test0", 10, {
+      correct: [0],
+      incorrect: [3, 6, 7],
+    }),
+    multipleChoiceProblem(presets["lewis_4"], "test0", 10, {
+      correct: [0],
+      incorrect: [1, 2, 3],
+    }),
+    multipleChoiceProblem(presets["lewis_5"], "test0", 10, {
+      correct: [0],
+      incorrect: [2, 3, 4],
+    }),
+    multipleChoiceProblem(presets["lewis_6"], "test0", 10, {
+      correct: [0],
+      incorrect: [1, 6, 10],
+    }),
+    multipleChoiceProblem(presets["graph_0"], "test0", 10, {
+      correct: [0],
+      incorrect: [1, 6, 8],
+    }),
+    multipleChoiceProblem(presets["graph_1"], "test0", 10, {
+      correct: [0],
+      incorrect: [1, 2, 3],
+    }),
+    multipleChoiceProblem(presets["graph_2"], "test0", 10, {
+      correct: [0],
+      incorrect: [1, 3, 7],
+    }),
+    multipleChoiceProblem(presets["graph_3"], "test0", 10, {
+      correct: [0],
+      incorrect: [3, 6, 7],
+    }),
+    multipleChoiceProblem(presets["graph_4"], "test0", 10, {
+      correct: [0],
+      incorrect: [1, 2, 3],
+    }),
+    multipleChoiceProblem(presets["graph_5"], "test0", 10, {
+      correct: [0],
+      incorrect: [2, 3, 4],
+    }),
+    multipleChoiceProblem(presets["graph_6"], "test0", 10, {
+      correct: [0],
+      incorrect: [1, 6, 10],
+    }),
+  ];
   return <div>{problems}</div>;
 }

--- a/packages/edgeworth/src/problems/geometry.tsx
+++ b/packages/edgeworth/src/problems/geometry.tsx
@@ -1,61 +1,61 @@
 import { presets } from "../examples.js";
 import { multipleChoiceProblem } from "./util.js";
 
-const problems = [
-  multipleChoiceProblem(presets["c01p01"], "test0", 10, {
-    correct: [0],
-    incorrect: [2, 7, 8],
-  }),
-  multipleChoiceProblem(presets["c01p10"], "test0", 10, {
-    correct: [0],
-    incorrect: [1, 2, 3],
-  }),
-  multipleChoiceProblem(presets["c02p01"], "test0", 10, {
-    correct: [0],
-    incorrect: [1, 2, 3],
-  }),
-  multipleChoiceProblem(presets["c03p01"], "test0", 10, {
-    correct: [0],
-    incorrect: [1, 2, 3],
-  }),
-  multipleChoiceProblem(presets["c04p01"], "test0", 10, {
-    correct: [0],
-    incorrect: [1, 2, 3],
-  }),
-  multipleChoiceProblem(presets["c04p12"], "test0", 10, {
-    correct: [0],
-    incorrect: [1, 2, 3],
-  }),
-  multipleChoiceProblem(presets["c05p01"], "test0", 10, {
-    correct: [0],
-    incorrect: [1, 2, 3],
-  }),
-
-  multipleChoiceProblem(presets["c05p13"], "test0", 10, {
-    correct: [0],
-    incorrect: [1, 2, 3],
-  }),
-  multipleChoiceProblem(presets["c06p06"], "test0", 10, {
-    correct: [0],
-    incorrect: [1, 2, 3],
-  }),
-  multipleChoiceProblem(presets["c07p10"], "test0", 10, {
-    correct: [0],
-    incorrect: [1, 2, 3],
-  }),
-  multipleChoiceProblem(presets["c07p22"], "test0", 10, {
-    correct: [0],
-    incorrect: [1, 2, 3],
-  }),
-  multipleChoiceProblem(presets["c08p08"], "test0", 10, {
-    correct: [0],
-    incorrect: [1, 2, 3],
-  }),
-  multipleChoiceProblem(presets["c11p07"], "test0", 10, {
-    correct: [0],
-    incorrect: [1, 2, 3],
-  }),
-];
 export default function () {
+  const problems = [
+    multipleChoiceProblem(presets["c01p01"], "test0", 10, {
+      correct: [0],
+      incorrect: [2, 7, 8],
+    }),
+    multipleChoiceProblem(presets["c01p10"], "test0", 10, {
+      correct: [0],
+      incorrect: [1, 2, 3],
+    }),
+    multipleChoiceProblem(presets["c02p01"], "test0", 10, {
+      correct: [0],
+      incorrect: [1, 2, 3],
+    }),
+    multipleChoiceProblem(presets["c03p01"], "test0", 10, {
+      correct: [0],
+      incorrect: [1, 2, 3],
+    }),
+    multipleChoiceProblem(presets["c04p01"], "test0", 10, {
+      correct: [0],
+      incorrect: [1, 2, 3],
+    }),
+    multipleChoiceProblem(presets["c04p12"], "test0", 10, {
+      correct: [0],
+      incorrect: [1, 2, 3],
+    }),
+    multipleChoiceProblem(presets["c05p01"], "test0", 10, {
+      correct: [0],
+      incorrect: [1, 2, 3],
+    }),
+
+    multipleChoiceProblem(presets["c05p13"], "test0", 10, {
+      correct: [0],
+      incorrect: [1, 2, 3],
+    }),
+    multipleChoiceProblem(presets["c06p06"], "test0", 10, {
+      correct: [0],
+      incorrect: [1, 2, 3],
+    }),
+    multipleChoiceProblem(presets["c07p10"], "test0", 10, {
+      correct: [0],
+      incorrect: [1, 2, 3],
+    }),
+    multipleChoiceProblem(presets["c07p22"], "test0", 10, {
+      correct: [0],
+      incorrect: [1, 2, 3],
+    }),
+    multipleChoiceProblem(presets["c08p08"], "test0", 10, {
+      correct: [0],
+      incorrect: [1, 2, 3],
+    }),
+    multipleChoiceProblem(presets["c11p07"], "test0", 10, {
+      correct: [0],
+      incorrect: [1, 2, 3],
+    }),
+  ];
   return <div>{problems}</div>;
 }

--- a/packages/edgeworth/src/problems/graphs.tsx
+++ b/packages/edgeworth/src/problems/graphs.tsx
@@ -1,36 +1,36 @@
 import { presets } from "../examples.js";
 import { multipleChoiceProblem } from "./util.js";
 
-const problems = [
-  multipleChoiceProblem(presets["graph_0"], "test0", 10, {
-    correct: [0],
-    incorrect: [1, 6, 8],
-  }),
-  multipleChoiceProblem(presets["graph_1"], "test0", 10, {
-    correct: [0],
-    incorrect: [1, 2, 3],
-  }),
-  multipleChoiceProblem(presets["graph_2"], "test0", 10, {
-    correct: [0],
-    incorrect: [1, 3, 7],
-  }),
-  multipleChoiceProblem(presets["graph_3"], "test0", 10, {
-    correct: [0],
-    incorrect: [3, 6, 7],
-  }),
-  multipleChoiceProblem(presets["graph_4"], "test0", 10, {
-    correct: [0],
-    incorrect: [1, 2, 3],
-  }),
-  multipleChoiceProblem(presets["graph_5"], "test0", 10, {
-    correct: [0],
-    incorrect: [2, 3, 4],
-  }),
-  multipleChoiceProblem(presets["graph_6"], "test0", 10, {
-    correct: [0],
-    incorrect: [1, 6, 10],
-  }),
-];
 export default function () {
+  const problems = [
+    multipleChoiceProblem(presets["graph_0"], "test0", 10, {
+      correct: [0],
+      incorrect: [1, 6, 8],
+    }),
+    multipleChoiceProblem(presets["graph_1"], "test0", 10, {
+      correct: [0],
+      incorrect: [1, 2, 3],
+    }),
+    multipleChoiceProblem(presets["graph_2"], "test0", 10, {
+      correct: [0],
+      incorrect: [1, 3, 7],
+    }),
+    multipleChoiceProblem(presets["graph_3"], "test0", 10, {
+      correct: [0],
+      incorrect: [3, 6, 7],
+    }),
+    multipleChoiceProblem(presets["graph_4"], "test0", 10, {
+      correct: [0],
+      incorrect: [1, 2, 3],
+    }),
+    multipleChoiceProblem(presets["graph_5"], "test0", 10, {
+      correct: [0],
+      incorrect: [2, 3, 4],
+    }),
+    multipleChoiceProblem(presets["graph_6"], "test0", 10, {
+      correct: [0],
+      incorrect: [1, 6, 10],
+    }),
+  ];
   return <div>{problems}</div>;
 }

--- a/packages/edgeworth/src/synthesis/Synthesizer.ts
+++ b/packages/edgeworth/src/synthesis/Synthesizer.ts
@@ -85,7 +85,7 @@ import {
 type RandomFunction = (min: number, max: number) => number;
 
 const log = consola
-  .create({ level: (consola as any).LogLevel.Warn })
+  .create({ level: (consola as any).LogLevel.Info })
   .withScope("Substance Synthesizer");
 
 //#region Synthesizer setting types

--- a/packages/edgeworth/vite.config.ts
+++ b/packages/edgeworth/vite.config.ts
@@ -2,13 +2,18 @@
 
 import react from "@vitejs/plugin-react-swc";
 import { defineConfig } from "vite";
+import topLevelAwait from "vite-plugin-top-level-await";
 
 // https://vitejs.dev/config/
 export default defineConfig({
   base: "./",
-  plugins: [react()],
+  plugins: [react(), topLevelAwait()],
   build: { target: "esnext" },
   server: {
     port: 3001,
+  },
+  optimizeDeps: {
+    esbuildOptions: { target: "esnext" },
+    exclude: ["@penrose/examples", "rose"],
   },
 });


### PR DESCRIPTION
# Description

This PR fixes a few superficial bugs in Edgeworth that impacted the first-use experience.

# Implementation strategy and design decisions

* [x] long load-time due to unnecessary synthesizer runs before page load
* [x] default "input scenario" drawer not empty on load
* [x] configuration to support `rose`
* [x] grid container overflow 

# Examples with steps to reproduce them

# Checklist

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have reviewed any generated registry diagram changes

# Open questions

Questions that require more discussion or to be addressed in future development:
