### PR TITLE
ci: omit `.git` from `diagrams` artifact

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -93,10 +93,12 @@ jobs:
       - name: Generate diagrams and metadata
         run: yarn registry
       - name: Upload generated diagrams and metadata
-        uses: actions/upload-artifact@v4.1.0
+        uses: actions/upload-artifact@v4
         with:
           name: diagrams
-          path: packages/examples/diagrams/
+          path: |
+            packages/examples/diagrams
+            !packages/examples/diagrams/.git
       - name: Record performance summary
         working-directory: packages/examples/diagrams/
         run: |


### PR DESCRIPTION
# Description

This PR omits the `.git` directory which has been included in our uploaded `diagrams` artifact since #1418.

# Examples with steps to reproduce them

Download the artifact and check to see whether it contains a `.git` directory.

# Checklist

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have reviewed any generated registry diagram changes