### PR TITLE
refactor: `Bond` constructor names in the chemistry domain

### DIFF
--- a/packages/examples/src/molecules/ammonia.substance
+++ b/packages/examples/src/molecules/ammonia.substance
@@ -1,8 +1,8 @@
 Nitrogen n
 Hydrogen h1, h2, h3
-Bond b1 := MakeSingleBond(n, h1)
-Bond b2 := MakeSingleBond(n, h2)
-Bond b3 := MakeSingleBond(n, h3)
+Bond b1 := SingleBond(n, h1)
+Bond b2 := SingleBond(n, h2)
+Bond b3 := SingleBond(n, h3)
 TwoDots(n)
 ZeroDots(h1)
 ZeroDots(h2)

--- a/packages/examples/src/molecules/bromateanion.substance
+++ b/packages/examples/src/molecules/bromateanion.substance
@@ -3,11 +3,11 @@ Oxygen o1, o2, o3
 -- bromine 
 TwoDots(br)
 -- single bond
-Bond b1 := MakeSingleBond(o1, br)
+Bond b1 := SingleBond(o1, br)
 SixDots(o1)
 -- double bond 1
-Bond b2 := MakeSingleBond(o2, br)
+Bond b2 := SingleBond(o2, br)
 SixDots(o2)
 -- double bond 2
-Bond b3 := MakeSingleBond(o3, br)
+Bond b3 := SingleBond(o3, br)
 SixDots(o3)

--- a/packages/examples/src/molecules/caffeine.substance
+++ b/packages/examples/src/molecules/caffeine.substance
@@ -7,37 +7,37 @@ Nitrogen N1, N2, N3, N4
 
 -- C-C Bonds
 
-DoubleBond C3C4 := MakeDoubleBond(C3, C4)
-SingleBond C4C5 := MakeSingleBond(C4, C5)
+DoubleBond C3C4 := DoubleBond(C3, C4)
+SingleBond C4C5 := SingleBond(C4, C5)
 
 -- C-H Bonds
 
-SingleBond C1H1 := MakeSingleBond(C1, H1)
-SingleBond C1H2 := MakeSingleBond(C1, H2)
-SingleBond C1H3 := MakeSingleBond(C1, H3)
-SingleBond C2H4 := MakeSingleBond(C2, H4)
-SingleBond C7H8 := MakeSingleBond(C7, H8)
-SingleBond C7H9 := MakeSingleBond(C7, H9)
-SingleBond C7H10 := MakeSingleBond(C7, H10)
-SingleBond C8H5 := MakeSingleBond(C8, H5)
-SingleBond C8H6 := MakeSingleBond(C8, H6)
-SingleBond C8H7 := MakeSingleBond(C8, H7)
+SingleBond C1H1 := SingleBond(C1, H1)
+SingleBond C1H2 := SingleBond(C1, H2)
+SingleBond C1H3 := SingleBond(C1, H3)
+SingleBond C2H4 := SingleBond(C2, H4)
+SingleBond C7H8 := SingleBond(C7, H8)
+SingleBond C7H9 := SingleBond(C7, H9)
+SingleBond C7H10 := SingleBond(C7, H10)
+SingleBond C8H5 := SingleBond(C8, H5)
+SingleBond C8H6 := SingleBond(C8, H6)
+SingleBond C8H7 := SingleBond(C8, H7)
 
 -- C-O Bonds
 
-DoubleBond C5O2 := MakeDoubleBond(C5, O2)
-DoubleBond C6O1 := MakeDoubleBond(C6, O1)
+DoubleBond C5O2 := DoubleBond(C5, O2)
+DoubleBond C6O1 := DoubleBond(C6, O1)
 
 -- C-N Bonds
 
-SingleBond C1N3 := MakeSingleBond(C1, N3)
-DoubleBond C2N2 := MakeDoubleBond(C2, N2)
-SingleBond C2N3 := MakeSingleBond(C2, N3)
-SingleBond C3N1 := MakeSingleBond(C3, N1)
-SingleBond C3N2 := MakeSingleBond(C3, N2)
-SingleBond C4N3 := MakeSingleBond(C4, N3)
-SingleBond C5N4 := MakeSingleBond(C5, N4)
-SingleBond C6N1 := MakeSingleBond(C6, N1)
-SingleBond C6N4 := MakeSingleBond(C6, N4)
-SingleBond C7N4 := MakeSingleBond(C7, N4)
-SingleBond C8N1 := MakeSingleBond(C8, N1)
+SingleBond C1N3 := SingleBond(C1, N3)
+DoubleBond C2N2 := DoubleBond(C2, N2)
+SingleBond C2N3 := SingleBond(C2, N3)
+SingleBond C3N1 := SingleBond(C3, N1)
+SingleBond C3N2 := SingleBond(C3, N2)
+SingleBond C4N3 := SingleBond(C4, N3)
+SingleBond C5N4 := SingleBond(C5, N4)
+SingleBond C6N1 := SingleBond(C6, N1)
+SingleBond C6N4 := SingleBond(C6, N4)
+SingleBond C7N4 := SingleBond(C7, N4)
+SingleBond C8N1 := SingleBond(C8, N1)

--- a/packages/examples/src/molecules/carbontetrachloride.substance
+++ b/packages/examples/src/molecules/carbontetrachloride.substance
@@ -1,9 +1,9 @@
 Carbon c
 Chlorine cl1, cl2, cl3, cl4
-Bond b1 := MakeSingleBond(c, cl1)
-Bond b2 := MakeSingleBond(c, cl2)
-Bond b3 := MakeSingleBond(c, cl3)
-Bond b4 := MakeSingleBond(c, cl4)
+Bond b1 := SingleBond(c, cl1)
+Bond b2 := SingleBond(c, cl2)
+Bond b3 := SingleBond(c, cl3)
+Bond b4 := SingleBond(c, cl4)
 ZeroDots(c)
 SixDots(cl1)
 SixDots(cl2)

--- a/packages/examples/src/molecules/glutamine.substance
+++ b/packages/examples/src/molecules/glutamine.substance
@@ -7,35 +7,35 @@ Nitrogen N1, N2
 
 -- C-C Bonds
 
-Bond C1C2 := MakeSingleBond(C1, C2)
-Bond C2C3 := MakeSingleBond(C2, C3)
-Bond C3C4 := MakeSingleBond(C3, C4)
-Bond C4C5 := MakeSingleBond(C4, C5)
+Bond C1C2 := SingleBond(C1, C2)
+Bond C2C3 := SingleBond(C2, C3)
+Bond C3C4 := SingleBond(C3, C4)
+Bond C4C5 := SingleBond(C4, C5)
 
 -- C-H Bonds
 
-Bond C2H3 := MakeSingleBond(C2, H3)
-Bond C2H4 := MakeSingleBond(C2, H4)
-Bond C3H5 := MakeSingleBond(C3, H5)
-Bond C3H6 := MakeSingleBond(C3, H6)
+Bond C2H3 := SingleBond(C2, H3)
+Bond C2H4 := SingleBond(C2, H4)
+Bond C3H5 := SingleBond(C3, H5)
+Bond C3H6 := SingleBond(C3, H6)
 
 -- C-O Bonds
 
-Bond C1O1 := MakeDoubleBond(C1, O1)
-Bond C5O2 := MakeDoubleBond(C5, O2)
-Bond C5O3 := MakeSingleBond(C5, O3)
+Bond C1O1 := DoubleBond(C1, O1)
+Bond C5O2 := DoubleBond(C5, O2)
+Bond C5O3 := SingleBond(C5, O3)
 
 -- C-N Bonds
 
-Bond C1N1 := MakeSingleBond(C1, N1)
-Bond C4N2 := MakeSingleBond(C4, N2)
+Bond C1N1 := SingleBond(C1, N1)
+Bond C4N2 := SingleBond(C4, N2)
 
 -- O-H Bonds
 
-Bond O3H9 := MakeSingleBond(O3, H9)
+Bond O3H9 := SingleBond(O3, H9)
 
 -- N-H Bonds
-Bond N1H1 := MakeSingleBond(N1, H1)
-Bond N1H2 := MakeSingleBond(N1, H2)
-Bond N2H7 := MakeSingleBond(N2, H7)
-Bond N2H8 := MakeSingleBond(N2, H8)
+Bond N1H1 := SingleBond(N1, H1)
+Bond N1H2 := SingleBond(N1, H2)
+Bond N2H7 := SingleBond(N2, H7)
+Bond N2H8 := SingleBond(N2, H8)

--- a/packages/examples/src/molecules/hydrazine.substance
+++ b/packages/examples/src/molecules/hydrazine.substance
@@ -1,11 +1,11 @@
 Nitrogen n1, n2
 Hydrogen h1, h2, h3, h4
 -- bonds
-Bond b1 := MakeSingleBond(n1, n2)
-Bond b2 := MakeSingleBond(n1, h1)
-Bond b3 := MakeSingleBond(n1, h2)
-Bond b4 := MakeSingleBond(n2, h3)
-Bond b5 := MakeSingleBond(n2, h4)
+Bond b1 := SingleBond(n1, n2)
+Bond b2 := SingleBond(n1, h1)
+Bond b3 := SingleBond(n1, h2)
+Bond b4 := SingleBond(n2, h3)
+Bond b5 := SingleBond(n2, h4)
 -- electrons
 ZeroDots(h1)
 ZeroDots(h2)

--- a/packages/examples/src/molecules/hydrogencyanide.substance
+++ b/packages/examples/src/molecules/hydrogencyanide.substance
@@ -1,8 +1,8 @@
 Hydrogen h
 Carbon c
 Nitrogen n
-Bond b1 := MakeSingleBond(c, h)
-Bond b2 := MakeTripleBond(c, n)
+Bond b1 := SingleBond(c, h)
+Bond b2 := TripleBond(c, n)
 ZeroDots(h)
 ZeroDots(c)
 TwoDots(n)

--- a/packages/examples/src/molecules/lewis.style
+++ b/packages/examples/src/molecules/lewis.style
@@ -615,7 +615,7 @@ forall Bond b {
 }
 
 forall Bond b
-where b := MakeSingleBond(x, y)
+where b := SingleBond(x, y)
 with Atom x; Atom y {
     vec2 b.vec = y.icon.center - x.icon.center
     vec2 b.dir = normalize(b.vec)
@@ -631,7 +631,7 @@ with Atom x; Atom y {
 }
 
 forall Bond b
-where b := MakeDoubleBond(x, y)
+where b := DoubleBond(x, y)
 with Atom x; Atom y {
     vec2 b.vec = y.icon.center - x.icon.center
     vec2 b.dir = normalize(b.vec)
@@ -653,7 +653,7 @@ with Atom x; Atom y {
 }
 
 forall Bond b
-where b := MakeTripleBond(x, y)
+where b := TripleBond(x, y)
 with Atom x; Atom y {
     vec2 b.vec = y.icon.center - x.icon.center
     vec2 b.dir = normalize(b.vec)
@@ -875,7 +875,7 @@ where SixDots(a) as e {
 
 -- single bond
 forall Bond b
-where TwoDots(x) as e; b := MakeSingleBond(x, y)
+where TwoDots(x) as e; b := SingleBond(x, y)
 with Atom x, y {
   -- attract all electrons to the opposite of the bond
   weight = const.bondAvoidWeight
@@ -891,7 +891,7 @@ with Atom x, y {
   -- }
 }
 forall Bond b
-where TwoDots(y) as e; b := MakeSingleBond(x, y)
+where TwoDots(y) as e; b := SingleBond(x, y)
 with Atom x, y {
   -- attract all electrons to the opposite of the bond
   weight = const.bondAvoidWeight
@@ -903,7 +903,7 @@ with Atom x, y {
 }
 
 forall Bond b
-where FourDots(x) as e; b := MakeSingleBond(x, y)
+where FourDots(x) as e; b := SingleBond(x, y)
 with Atom x, y {
   -- attract all electrons to the opposite of the bond
   weight = const.bondAvoidWeight
@@ -929,7 +929,7 @@ with Atom x, y {
   -- }
 }
 forall Bond b
-where FourDots(y) as e; b := MakeSingleBond(x, y)
+where FourDots(y) as e; b := SingleBond(x, y)
 with Atom x, y {
   -- attract all electrons to the opposite of the bond
   weight = const.bondAvoidWeight
@@ -946,7 +946,7 @@ with Atom x, y {
 }
 
 forall Bond b
-where SixDots(x) as e; b := MakeSingleBond(x, y)
+where SixDots(x) as e; b := SingleBond(x, y)
 with Atom x, y {
   -- attract all electrons to the opposite of the bond
   weight = const.bondAvoidWeight
@@ -982,7 +982,7 @@ with Atom x, y {
   -- }
 }
 forall Bond b
-where SixDots(y) as e; b := MakeSingleBond(x, y)
+where SixDots(y) as e; b := SingleBond(x, y)
 with Atom x, y {
   -- attract all electrons to the opposite of the bond
   weight = const.bondAvoidWeight
@@ -1006,7 +1006,7 @@ with Atom x, y {
 
 -- double bond
 forall Bond b
-where TwoDots(x) as e; b := MakeDoubleBond(x, y)
+where TwoDots(x) as e; b := DoubleBond(x, y)
 with Atom x, y {
   -- attract all electrons to the opposite of the bond
   weight = const.bondAvoidWeight
@@ -1016,7 +1016,7 @@ with Atom x, y {
   encourage weight * const.k*(d1 - const.L)*(d1 - const.L)/2 == weight in electron -- minimize ½ k(d-L)²
 }
 forall Bond b
-where TwoDots(y) as e; b := MakeDoubleBond(x, y)
+where TwoDots(y) as e; b := DoubleBond(x, y)
 with Atom x, y {
   -- attract all electrons to the opposite of the bond
   weight = const.bondAvoidWeight
@@ -1027,7 +1027,7 @@ with Atom x, y {
 }
 
 forall Bond b
-where FourDots(x) as e; b := MakeDoubleBond(x, y)
+where FourDots(x) as e; b := DoubleBond(x, y)
 with Atom x, y {
   -- attract all electrons to the opposite of the bond
   weight = const.bondAvoidWeight
@@ -1043,7 +1043,7 @@ with Atom x, y {
   encourage weight * const.k*(d2 - const.L)*(d2 - const.L)/2 == weight in electron -- minimize ½ k(d-L)²
 }
 forall Bond b
-where FourDots(y) as e; b := MakeDoubleBond(x, y)
+where FourDots(y) as e; b := DoubleBond(x, y)
 with Atom x, y {
   -- attract all electrons to the opposite of the bond
   weight = const.bondAvoidWeight
@@ -1060,7 +1060,7 @@ with Atom x, y {
 }
 
 forall Bond b
-where SixDots(x) as e; b := MakeDoubleBond(x, y)
+where SixDots(x) as e; b := DoubleBond(x, y)
 with Atom x, y {
   -- attract all electrons to the opposite of the bond
   weight = const.bondAvoidWeight
@@ -1081,7 +1081,7 @@ with Atom x, y {
   encourage weight * const.k*(d3 - const.L)*(d3 - const.L)/2 == weight in electron -- minimize ½ k(d-L)²
 }
 forall Bond b
-where SixDots(y) as e; b := MakeDoubleBond(x, y)
+where SixDots(y) as e; b := DoubleBond(x, y)
 with Atom x, y {
   -- attract all electrons to the opposite of the bond
   weight = const.bondAvoidWeight
@@ -1105,7 +1105,7 @@ with Atom x, y {
 
 -- triple bond
 forall Bond b
-where TwoDots(x) as e; b := MakeTripleBond(x, y)
+where TwoDots(x) as e; b := TripleBond(x, y)
 with Atom x, y {
   -- attract all electrons to the opposite of the bond
   weight = const.bondAvoidWeight
@@ -1115,7 +1115,7 @@ with Atom x, y {
   encourage weight * const.k*(d1 - const.L)*(d1 - const.L)/2 == weight in electron -- minimize ½ k(d-L)²
 }
 forall Bond b
-where TwoDots(y) as e; b := MakeTripleBond(x, y)
+where TwoDots(y) as e; b := TripleBond(x, y)
 with Atom x, y {
   -- attract all electrons to the opposite of the bond
   weight = const.bondAvoidWeight
@@ -1126,7 +1126,7 @@ with Atom x, y {
 }
 
 forall Bond b
-where FourDots(x) as e; b := MakeTripleBond(x, y)
+where FourDots(x) as e; b := TripleBond(x, y)
 with Atom x, y {
   -- attract all electrons to the opposite of the bond
   weight = const.bondAvoidWeight
@@ -1142,7 +1142,7 @@ with Atom x, y {
   encourage weight * const.k*(d2 - const.L)*(d2 - const.L)/2 == weight in electron -- minimize ½ k(d-L)²
 }
 forall Bond b
-where FourDots(y) as e; b := MakeTripleBond(x, y)
+where FourDots(y) as e; b := TripleBond(x, y)
 with Atom x, y {
   -- attract all electrons to the opposite of the bond
   weight = const.bondAvoidWeight
@@ -1159,7 +1159,7 @@ with Atom x, y {
 }
 
 forall Bond b
-where SixDots(x) as e; b := MakeTripleBond(x, y)
+where SixDots(x) as e; b := TripleBond(x, y)
 with Atom x, y {
   -- attract all electrons to the opposite of the bond
   weight = const.bondAvoidWeight
@@ -1180,7 +1180,7 @@ with Atom x, y {
   encourage weight * const.k*(d3 - const.L)*(d3 - const.L)/2 == weight in electron -- minimize ½ k(d-L)²
 }
 forall Bond b
-where SixDots(y) as e; b := MakeTripleBond(x, y)
+where SixDots(y) as e; b := TripleBond(x, y)
 with Atom x, y {
   -- attract all electrons to the opposite of the bond
   weight = const.bondAvoidWeight
@@ -1208,7 +1208,7 @@ layout = [general, symmetry, electron]
 
 -- layout directives
 forall Bond b
-where b := MakeSingleBond(x, y) 
+where b := SingleBond(x, y) 
 with Atom x, y {
   scalar weight = const.symmetryWeight
   scalar k = const.symmetryDegree
@@ -1218,7 +1218,7 @@ with Atom x, y {
 }
 
 forall Bond b
-where b := MakeDoubleBond(x, y) 
+where b := DoubleBond(x, y) 
 with Atom x, y {
   scalar weight = const.symmetryWeight
   scalar k = const.symmetryDegree
@@ -1228,7 +1228,7 @@ with Atom x, y {
 }
 
 forall Bond b
-where b := MakeTripleBond(x, y) 
+where b := TripleBond(x, y) 
 with Atom x, y {
   scalar weight = const.symmetryWeight
   scalar k = const.symmetryDegree

--- a/packages/examples/src/molecules/methane.substance
+++ b/packages/examples/src/molecules/methane.substance
@@ -1,9 +1,9 @@
 Hydrogen h1, h2, h3, h4
 Carbon c
-Bond b1 := MakeSingleBond(h1, c)
-Bond b2 := MakeSingleBond(h2, c)
-Bond b3 := MakeSingleBond(h3, c)
-Bond b4 := MakeSingleBond(h4, c)
+Bond b1 := SingleBond(h1, c)
+Bond b2 := SingleBond(h2, c)
+Bond b3 := SingleBond(h3, c)
+Bond b4 := SingleBond(h4, c)
 ZeroDots(h1)
 ZeroDots(h2)
 ZeroDots(h3)

--- a/packages/examples/src/molecules/molecules-basic.style
+++ b/packages/examples/src/molecules/molecules-basic.style
@@ -39,7 +39,7 @@ forall Nitrogen x {
 -- Bonds
 
 forall Bond b
-where b := MakeSingleBond(x, y)
+where b := SingleBond(x, y)
 with Atom x; Atom y {
     shape b.icon = Line {
         start : x.icon.center
@@ -52,7 +52,7 @@ with Atom x; Atom y {
 }
 
 forall Bond b
-where b := MakeDoubleBond(x, y)
+where b := DoubleBond(x, y)
 with Atom x; Atom y {
     shape b.icon = Line {
         start : x.icon.center
@@ -71,7 +71,7 @@ with Atom x; Atom y {
 }
 
 forall Bond b
-where b := MakeTripleBond(x, y)
+where b := TripleBond(x, y)
 with Atom x; Atom y {
     shape b.icon = Line {
         start : x.icon.center

--- a/packages/examples/src/molecules/molecules-elegant.style
+++ b/packages/examples/src/molecules/molecules-elegant.style
@@ -40,19 +40,19 @@ forall Nitrogen x {
 -- Bonds
 
 forall Bond b
-where b := MakeSingleBond(x, y)
+where b := SingleBond(x, y)
 with Atom x; Atom y {
     encourage equal(vdist(x.icon.center, y.icon.center), 60.0)
 }
 
 forall Bond b
-where b := MakeDoubleBond(x, y)
+where b := DoubleBond(x, y)
 with Atom x; Atom y {
     encourage equal(vdist(x.icon.center, y.icon.center), 60.0)
 }
 
 forall Bond b
-where b := MakeTripleBond(x, y)
+where b := TripleBond(x, y)
 with Atom x; Atom y {
     encourage equal(vdist(x.icon.center, y.icon.center), 60.0)
 }

--- a/packages/examples/src/molecules/molecules.domain
+++ b/packages/examples/src/molecules/molecules.domain
@@ -119,9 +119,9 @@ type Copernicium <: Atom
 
 type Bond
 
-constructor MakeSingleBond(Atom a, Atom b) -> Bond
-constructor MakeDoubleBond(Atom a, Atom b) -> Bond
-constructor MakeTripleBond(Atom a, Atom b) -> Bond
+constructor SingleBond(Atom a, Atom b) -> Bond
+constructor DoubleBond(Atom a, Atom b) -> Bond
+constructor TripleBond(Atom a, Atom b) -> Bond
 
 -- Electrons 
 

--- a/packages/examples/src/molecules/molecules.style
+++ b/packages/examples/src/molecules/molecules.style
@@ -40,7 +40,7 @@ forall Nitrogen x {
 -- Bonds
 
 forall Bond b
-where b := MakeSingleBond(x, y)
+where b := SingleBond(x, y)
 with Atom x; Atom y {
     shape b.line1 = Line {
         start : x.icon.center
@@ -52,7 +52,7 @@ with Atom x; Atom y {
 }
 
 forall Bond b
-where b := MakeDoubleBond(x, y)
+where b := DoubleBond(x, y)
 with Atom x; Atom y {
     shape b.line1 = Line {
         start : x.icon.center
@@ -71,7 +71,7 @@ with Atom x; Atom y {
 }
 
 forall Bond b
-where b := MakeTripleBond(x, y)
+where b := TripleBond(x, y)
 with Atom x; Atom y {
     shape b.line1 = Line {
         start : x.icon.center

--- a/packages/examples/src/molecules/nitricacid.substance
+++ b/packages/examples/src/molecules/nitricacid.substance
@@ -2,10 +2,10 @@ Hydrogen h
 Nitrogen n
 Oxygen o1, o2, o3
 -- bonds
-Bond b1 := MakeSingleBond(h, o1)
-Bond b2 := MakeSingleBond(o1, n)
-Bond b3 := MakeDoubleBond(n, o2)
-Bond b4 := MakeSingleBond(o3, n)
+Bond b1 := SingleBond(h, o1)
+Bond b2 := SingleBond(o1, n)
+Bond b3 := DoubleBond(n, o2)
+Bond b4 := SingleBond(o3, n)
 -- electrons
 ZeroDots(h)
 ZeroDots(n)

--- a/packages/examples/src/molecules/nitrogen.substance
+++ b/packages/examples/src/molecules/nitrogen.substance
@@ -1,4 +1,4 @@
 Nitrogen n1, n2
-Bond b := MakeTripleBond(n1, n2)
+Bond b := TripleBond(n1, n2)
 TwoDots(n1)
 TwoDots(n2)

--- a/packages/examples/src/molecules/nitrousacid0.substance
+++ b/packages/examples/src/molecules/nitrousacid0.substance
@@ -2,9 +2,9 @@ Hydrogen h
 Nitrogen n
 Oxygen o1, o2
 -- bonds
-Bond b1 := MakeSingleBond(h, o1)
-Bond b2 := MakeSingleBond(o1, n)
-Bond b3 := MakeDoubleBond(n, o2)
+Bond b1 := SingleBond(h, o1)
+Bond b2 := SingleBond(o1, n)
+Bond b3 := DoubleBond(n, o2)
 -- electrons
 ZeroDots(h)
 FourDots(o1)

--- a/packages/examples/src/molecules/phosgene.substance
+++ b/packages/examples/src/molecules/phosgene.substance
@@ -2,9 +2,9 @@ Carbon c
 Oxygen o
 Chlorine cl1, cl2
 -- bonds
-Bond b1 := MakeSingleBond(c, cl1)
-Bond b2 := MakeSingleBond(c, cl2)
-Bond b3 := MakeDoubleBond(c, o)
+Bond b1 := SingleBond(c, cl1)
+Bond b2 := SingleBond(c, cl2)
+Bond b3 := DoubleBond(c, o)
 -- electrons
 ZeroDots(c)
 FourDots(o)

--- a/packages/examples/src/molecules/phosphorustrichloride.substance
+++ b/packages/examples/src/molecules/phosphorustrichloride.substance
@@ -3,11 +3,11 @@ Chlorine cl1, cl2, cl3
 -- bromine 
 TwoDots(p)
 -- single bond
-Bond b1 := MakeSingleBond(cl1, p)
+Bond b1 := SingleBond(cl1, p)
 SixDots(cl1)
 -- double bond 1
-Bond b2 := MakeSingleBond(cl2, p)
+Bond b2 := SingleBond(cl2, p)
 SixDots(cl2)
 -- double bond 2
-Bond b3 := MakeSingleBond(cl3, p)
+Bond b3 := SingleBond(cl3, p)
 SixDots(cl3)

--- a/packages/examples/src/molecules/water.substance
+++ b/packages/examples/src/molecules/water.substance
@@ -1,7 +1,7 @@
 Hydrogen h1, h2
 Oxygen o
-Bond b1 := MakeSingleBond(h1, o)
-Bond b2 := MakeSingleBond(h2, o)
+Bond b1 := SingleBond(h1, o)
+Bond b2 := SingleBond(h2, o)
 ZeroDots(h1)
 ZeroDots(h2)
 FourDots(o)

--- a/packages/examples/src/molecules/xenontetroxide.substance
+++ b/packages/examples/src/molecules/xenontetroxide.substance
@@ -1,10 +1,10 @@
 Xenon xe
 Oxygen o1, o2, o3, o4
 -- bonds
-Bond b1 := MakeDoubleBond(xe, o1)
-Bond b2 := MakeDoubleBond(xe, o2)
-Bond b3 := MakeDoubleBond(xe, o3)
-Bond b4 := MakeDoubleBond(xe, o4)
+Bond b1 := DoubleBond(xe, o1)
+Bond b2 := DoubleBond(xe, o2)
+Bond b3 := DoubleBond(xe, o3)
+Bond b4 := DoubleBond(xe, o4)
 -- electrons
 ZeroDots(xe)
 FourDots(o1)


### PR DESCRIPTION
# Description

Changed chemistry Domain program and example Substance programs to make predicates shorter — `MakeSingleBond`, `MakeDoubleBond`, and `MakeTripleBond` have been changed to `SingleBond`, `DoubleBond`, `TripleBond`. 

# Checklist

- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have reviewed any generated registry diagram changes
