### PR TITLE
fix: exclude function body from `FunctionInternalError`

### DIFF
--- a/packages/core/src/compiler/StyleFunctionCaller.ts
+++ b/packages/core/src/compiler/StyleFunctionCaller.ts
@@ -46,7 +46,17 @@ export const callCompFunc = (
     });
   } catch (e) {
     if (e instanceof Error) {
-      return err(functionInternalError(func, range, e.message));
+      return err(
+        functionInternalError(
+          {
+            name: func.name,
+            description: func.description,
+            params: func.params,
+          },
+          range,
+          e.message,
+        ),
+      );
     } else {
       throw new Error("Function call resulted in exception not of Error type");
     }

--- a/packages/core/src/shapes/Samplers.ts
+++ b/packages/core/src/shapes/Samplers.ts
@@ -99,6 +99,7 @@ export const sampleWidth = (
 ): FloatV<ad.Num> =>
   floatV(
     makeInput({
+      // BUG: when canvas width is too small this will error out
       init: { tag: "Sampled", sampler: uniform(3, canvas.width / 6) },
       stages: "All",
     }),
@@ -110,6 +111,7 @@ export const sampleHeight = (
 ): FloatV<ad.Num> =>
   floatV(
     makeInput({
+      // BUG: when canvas width is too small this will error out
       init: { tag: "Sampled", sampler: uniform(3, canvas.height / 6) },
       stages: "All",
     }),

--- a/packages/core/src/types/errors.ts
+++ b/packages/core/src/types/errors.ts
@@ -532,7 +532,11 @@ export interface TooManyArgumentsError {
 
 export interface FunctionInternalError {
   tag: "FunctionInternalError";
-  func: CompFunc | ObjFunc | ConstrFunc;
+  // NOTE: to be compatible with webworkers, the function body cannot be cloned and can be therefore excluded.
+  func:
+    | Omit<CompFunc, "body">
+    | Omit<ObjFunc, "body">
+    | Omit<ConstrFunc, "body">;
   location: SourceRange;
   message: string;
 }

--- a/packages/core/src/utils/Error.ts
+++ b/packages/core/src/utils/Error.ts
@@ -862,6 +862,7 @@ export const errLocs = (
       ];
     }
 
+    case "FunctionInternalError":
     case "RedeclareNamespaceError":
     case "NotSubstanceCollectionError":
     case "NotStyleVariableError":

--- a/packages/core/src/utils/Error.ts
+++ b/packages/core/src/utils/Error.ts
@@ -862,7 +862,6 @@ export const errLocs = (
       ];
     }
 
-    case "FunctionInternalError":
     case "RedeclareNamespaceError":
     case "NotSubstanceCollectionError":
     case "NotStyleVariableError":
@@ -1080,7 +1079,10 @@ export const tooManyArgumentsError = (
 });
 
 export const functionInternalError = (
-  func: CompFunc | ObjFunc | ConstrFunc,
+  func:
+    | Omit<CompFunc, "body">
+    | Omit<ObjFunc, "body">
+    | Omit<ConstrFunc, "body">,
   location: SourceRange,
   message: string,
 ): FunctionInternalError => ({

--- a/packages/core/src/utils/Util.ts
+++ b/packages/core/src/utils/Util.ts
@@ -207,7 +207,7 @@ export const randFloat = (
   // TODO: better error reporting
   console.assert(
     max > min,
-    "min should be smaller than max for random number generation!",
+    `min should be smaller than max for random number generation! min ${min}, max ${max}`,
   );
   return rng() * (max - min) + min;
 };


### PR DESCRIPTION
# Description

Resolves #1713.

When there's an internal error in computation functions, the compiler adds the entire function including its body as metadata for the error. This is fine on the main thread but not ok in webworkers because functions are not clonable. This PR omits the function body in the `FunctionInteralError` type.

