### PR TITLE
feat: `--dump-metadata` in `roger`

### DIFF
--- a/packages/roger/index.ts
+++ b/packages/roger/index.ts
@@ -266,6 +266,10 @@ yargs(hideBin(process.argv))
           type: "boolean",
           default: false,
         })
+        .option("dump-metadata", {
+          desc: "Output collected metadata to a JSON file. Needs --out to be specified.",
+          type: "string",
+        })
         .options("dump-prefix", {
           desc: "Prefix for the dumped SVGs.",
           type: "string",
@@ -306,7 +310,7 @@ yargs(hideBin(process.argv))
 
       const { substance, style, domain } = readTrio(sub, sty, dom, prefix);
       // draw diagram and get metadata
-      const { diagram, state } = await render(
+      const { diagram, state, metadata } = await render(
         variation ?? "",
         substance,
         style,
@@ -350,6 +354,17 @@ yargs(hideBin(process.argv))
         console.log(
           chalk.green(`The diagram has been saved as ${resolve(options.out)}`),
         );
+        if (options.dumpMetadata) {
+          fs.writeFileSync(
+            options.dumpMetadata,
+            JSON.stringify(metadata, null, 2),
+          );
+          console.log(
+            chalk.green(
+              `The metadata has been saved as ${resolve(options.dumpMetadata)}`,
+            ),
+          );
+        }
       } else {
         console.log(diagram);
         for (const warning of state.warnings) {


### PR DESCRIPTION
# Description

Related: #1697 

Requested by @keenancrane for collecting timing information for diagrams. `roger` internally collects timing for compilation, optimization, and rendering. This PR adds a `--dump-metadata` option in `roger` for writing the metadata as a JSON file to disc.

# Examples with steps to reproduce them

Running `roger trio exterior-algebra.domain exterior-algebra.style  vector-wedge.substance --dump-metadata  meta.json --out diagram.svg` in `examples/src/exterior-algebra` produces:


![diagram](https://github.com/penrose/penrose/assets/11740102/2e166dcc-71c5-4761-9757-e353eb7db1b2)
[meta.json](https://github.com/penrose/penrose/files/14589470/meta.json)

# Checklist

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have reviewed any generated registry diagram changes
