### PR TITLE
docs: update links to the technical roadmap

### DIFF
--- a/packages/docs-site/community.md
+++ b/packages/docs-site/community.md
@@ -129,7 +129,7 @@ We maintain a [blog][] and a [mailing list][] on Penrose and diagramming in gene
 [using penrose]: /docs/ref/using
 [contributing PR]: https://github.com/penrose/penrose/blob/main/CONTRIBUTING.md#contributing
 [rose]: https://rosejs.dev/
-[roadmap]: #technical-roadmap
+[roadmap]: https://github.com/orgs/penrose/projects/10
 [`obsidian-penrose-plugin`]: https://github.com/wodeni/obsidian-penrose-plugin
 [team]: /docs/team
 [`ob-penrose`]: https://github.com/weavermarquez/ob-penrose


### PR DESCRIPTION
# Description

It's a bit more convenient to maintain a GitHub project than a webpage on the site for our current technical roadmap (https://github.com/orgs/penrose/projects/10). This PR updates the links to the roadmap to point to the GH project instead of a section on https://penrose.cs.cmu.edu/community. 
