### PR TITLE
fix: queue and resolve pending requests in optimizer worker

### DIFF
--- a/packages/editor/src/worker/OptimizerWorker.ts
+++ b/packages/editor/src/worker/OptimizerWorker.ts
@@ -144,6 +144,7 @@ export default class OptimizerWorker {
       } else if (data.tag === "Error") {
         this.running = false;
         this.onError(data.error);
+        return;
       } else if (data.tag === "Ready") {
         log.info("Worker ready for new input");
         this.onComplete();
@@ -162,6 +163,7 @@ export default class OptimizerWorker {
         const labelCache = await collectLabels(data.shapes, convert);
         if (labelCache.isErr()) {
           this.onError(labelCache.error);
+          return;
         }
         const { optLabelCache, svgCache } = separateRenderedLabels(
           labelCache.value,

--- a/packages/editor/src/worker/OptimizerWorker.ts
+++ b/packages/editor/src/worker/OptimizerWorker.ts
@@ -11,7 +11,7 @@ import {
 } from "./message.js";
 
 const log = (consola as any)
-  .create({ level: (consola as any).LogLevel.Debug })
+  .create({ level: (consola as any).LogLevel.Warn })
   .withScope("worker:client");
 
 export type onComplete = () => void;


### PR DESCRIPTION
# Description

Resolves #1721.

The IDE shows unresolved toasts because it requests to compile the cached diagram on start, before the worker is loaded sometimes. Once the worker gets loaded, however, the IDE only resolves the most recent pending request, losing the earlier ones.

# Implementation strategy and design decisions

Implement a simple queue of requests along with their callbacks for cleanup and resolve them once the worker is loaded.

# Checklist

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have reviewed any generated registry diagram changes
