### PR TITLE
fix: public links and build config in `docs-site`

### DIFF
--- a/packages/docs-site/.vitepress/config.ts
+++ b/packages/docs-site/.vitepress/config.ts
@@ -58,7 +58,6 @@ const indexableFunctionDocs = () => {
     "## Computation\nn",
     ...compFuncs,
   ].join("\n\n");
-  console.log(markdown);
 
   return markdown;
 };

--- a/packages/docs-site/blog/v3.md
+++ b/packages/docs-site/blog/v3.md
@@ -41,7 +41,7 @@ Keenan Crane recently made [a tutorial of the walk-on-stars algorithm fully
 illustrated by Penrose][wost]. This is the first LaTeX document made with
 Penrose, made possible by these new features:
 
-- "SVG (TeX)" export: now you can export a Penrose diagram from the [IDE][] as
+- "SVG (TeX)" export: now you can export a Penrose diagram from the <a href="/try/index.html" target="blank">IDE</a> as
   an SVG with labels optimized for imports using [the LaTeX `svg`
   package][tex-svg]. Keenan made the label font style and size consistent with
   the rest of his document.
@@ -125,7 +125,6 @@ Penrose itself.
 [discord]: https://discord.gg/a7VXJU4dfR
 [functions]: /docs/ref/style/functions
 [gallery page]: /examples
-[ide]: pathname:///try/index.html
 [language api]: /docs/ref/api
 [optimization api]: /docs/ref/optimization-api
 [roger pr]: https://github.com/penrose/penrose/pull/1387

--- a/packages/docs-site/blog/v3.md
+++ b/packages/docs-site/blog/v3.md
@@ -41,7 +41,7 @@ Keenan Crane recently made [a tutorial of the walk-on-stars algorithm fully
 illustrated by Penrose][wost]. This is the first LaTeX document made with
 Penrose, made possible by these new features:
 
-- "SVG (TeX)" export: now you can export a Penrose diagram from the <a href="/try/index.html" target="blank">IDE</a> as
+- "SVG (TeX)" export: now you can export a Penrose diagram from the <a href="/try/index.html" target="_blank">IDE</a> as
   an SVG with labels optimized for imports using [the LaTeX `svg`
   package][tex-svg]. Keenan made the label font style and size consistent with
   the rest of his document.

--- a/packages/docs-site/docs/ref/using.md
+++ b/packages/docs-site/docs/ref/using.md
@@ -1,10 +1,10 @@
 # Using Penrose
 
-Use our [online editor](pathname:///try/index.html) to start making diagrams in your browser now. To make diagrams locally, use [`roger`](#command-line-interface-roger), the command-line interface for Penrose.
+Use our <a href="/try/index.html" target="blank">online editor</a> to start making diagrams in your browser now. To make diagrams locally, use [`roger`](#command-line-interface-roger), the command-line interface for Penrose.
 
 ## Online editor
 
-You can start creating diagrams by visiting the [online editor](pathname:///try/index.html).
+You can start creating diagrams by visiting the <a href="/try/index.html" target="blank">online editor</a>.
 
 ![Penrose editor](/img/docs/editor.png)
 

--- a/packages/docs-site/docs/ref/using.md
+++ b/packages/docs-site/docs/ref/using.md
@@ -1,10 +1,10 @@
 # Using Penrose
 
-Use our <a href="/try/index.html" target="blank">online editor</a> to start making diagrams in your browser now. To make diagrams locally, use [`roger`](#command-line-interface-roger), the command-line interface for Penrose.
+Use our <a href="/try/index.html" target="_blank">online editor</a> to start making diagrams in your browser now. To make diagrams locally, use [`roger`](#command-line-interface-roger), the command-line interface for Penrose.
 
 ## Online editor
 
-You can start creating diagrams by visiting the <a href="/try/index.html" target="blank">online editor</a>.
+You can start creating diagrams by visiting the <a href="/try/index.html" target="_blank">online editor</a>.
 
 ![Penrose editor](/img/docs/editor.png)
 

--- a/packages/docs-site/docs/ref/vanilla-js.md
+++ b/packages/docs-site/docs/ref/vanilla-js.md
@@ -16,7 +16,7 @@ To run this example, copy the code above into an HTML file (e.g. `index.html`) a
 npx http-server .
 ```
 
-You can also check out this example live <a href="/vanilla-js-demo.html" target="blank">here</a>.
+You can also check out this example live <a href="/vanilla-js-demo.html" target="_blank">here</a>.
 
 ## Experimental bundled ESM
 

--- a/packages/docs-site/docs/ref/vanilla-js.md
+++ b/packages/docs-site/docs/ref/vanilla-js.md
@@ -16,7 +16,7 @@ To run this example, copy the code above into an HTML file (e.g. `index.html`) a
 npx http-server .
 ```
 
-You can also check out this example live [here](pathname:///vanilla-js-demo.html).
+You can also check out this example live <a href="/vanilla-js-demo.html" target="blank">here</a>.
 
 ## Experimental bundled ESM
 
@@ -41,8 +41,6 @@ if (compile && optimize) {
 ```
 
 :::
-
-<!--@include: pathname:///vanilla-js-demo.html-->
 
 [ECMAScript module]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Modules
 [JSPM]: https://jspm.org/

--- a/packages/docs-site/docs/tutorial/basics.md
+++ b/packages/docs-site/docs/tutorial/basics.md
@@ -2,7 +2,7 @@
 
 This is the first diagram we will make together. This is the equivalent of the `print("Hello World")` program for Penrose. To make any mathematical diagram, we first need to visualize some **shapes** that we want. In this tutorial, we will learn about how to build a triple (`.domain`, `.substance`, `.style`) for a simple diagram containing two circles.
 
-👉 [**Open this online workspace**](pathname:///try/index.html?examples=tutorials%2Ftutorial1) in a separate tab to follow along!
+👉 <a href="/try/index.html?examples=tutorials%2Ftutorial1" target="blank">**Open this online workspace**</a> in a separate tab to follow along!
 
 ## Goal
 

--- a/packages/docs-site/docs/tutorial/basics.md
+++ b/packages/docs-site/docs/tutorial/basics.md
@@ -2,7 +2,7 @@
 
 This is the first diagram we will make together. This is the equivalent of the `print("Hello World")` program for Penrose. To make any mathematical diagram, we first need to visualize some **shapes** that we want. In this tutorial, we will learn about how to build a triple (`.domain`, `.substance`, `.style`) for a simple diagram containing two circles.
 
-👉 <a href="/try/index.html?examples=tutorials%2Ftutorial1" target="blank">**Open this online workspace**</a> in a separate tab to follow along!
+👉 <a href="/try/index.html?examples=tutorials%2Ftutorial1" target="_blank">**Open this online workspace**</a> in a separate tab to follow along!
 
 ## Goal
 

--- a/packages/docs-site/docs/tutorial/functions.md
+++ b/packages/docs-site/docs/tutorial/functions.md
@@ -14,7 +14,7 @@ In particular, we are visualizing vector addition. Below is the goal diagram for
 
 ## Starter Code
 
-👉 <a href="/try/index.html?examples=tutorials%2Ftutorial3" target="blank">**Open this online workspace**</a> in a separate tab to follow along!
+👉 <a href="/try/index.html?examples=tutorials%2Ftutorial3" target="_blank">**Open this online workspace**</a> in a separate tab to follow along!
 
 If everything is working, when you compile, you should see a vector space labeled `U` with its x-axis and y-axis in your Penrose window. It should look something like this:
 

--- a/packages/docs-site/docs/tutorial/functions.md
+++ b/packages/docs-site/docs/tutorial/functions.md
@@ -14,7 +14,7 @@ In particular, we are visualizing vector addition. Below is the goal diagram for
 
 ## Starter Code
 
-👉 [**Open this online workspace**](pathname:///try/index.html?examples=tutorials%2Ftutorial3) in a separate tab to follow along!
+👉 <a href="/try/index.html?examples=tutorials%2Ftutorial3" target="blank">**Open this online workspace**</a> in a separate tab to follow along!
 
 If everything is working, when you compile, you should see a vector space labeled `U` with its x-axis and y-axis in your Penrose window. It should look something like this:
 

--- a/packages/docs-site/docs/tutorial/predicates.md
+++ b/packages/docs-site/docs/tutorial/predicates.md
@@ -2,7 +2,7 @@
 
 In Penrose, we are not only given the power to represent mathematical objects with shapes, but we are also able to represent complicated relationships between the objects. In this tutorial, we will learn about defining **predicates**, and visually representing them with the constraint keyword `ensure`. After this tutorial, you should be equipped to create diagrams with relationships between objects in Penrose.
 
-👉 <a href="/try/index.html?examples=tutorials%2Ftutorial2" target="blank">**Open this online workspace**</a> in a separate tab to follow along!
+👉 <a href="/try/index.html?examples=tutorials%2Ftutorial2" target="_blank">**Open this online workspace**</a> in a separate tab to follow along!
 
 ## Goal
 

--- a/packages/docs-site/docs/tutorial/predicates.md
+++ b/packages/docs-site/docs/tutorial/predicates.md
@@ -2,7 +2,7 @@
 
 In Penrose, we are not only given the power to represent mathematical objects with shapes, but we are also able to represent complicated relationships between the objects. In this tutorial, we will learn about defining **predicates**, and visually representing them with the constraint keyword `ensure`. After this tutorial, you should be equipped to create diagrams with relationships between objects in Penrose.
 
-👉 [**Open this online workspace**](pathname:///try/index.html?examples=tutorials%2Ftutorial2) in a separate tab to follow along!
+👉 <a href="/try/index.html?examples=tutorials%2Ftutorial2" target="blank">**Open this online workspace**</a> in a separate tab to follow along!
 
 ## Goal
 

--- a/packages/docs-site/vite.config.ts
+++ b/packages/docs-site/vite.config.ts
@@ -9,4 +9,16 @@ export default defineConfig({
     esbuildOptions: { target: "esnext" },
     exclude: ["@penrose/examples", "rose"],
   },
+  server: {
+    headers: {
+      "Cross-Origin-Embedder-Policy": "require-corp",
+      "Cross-Origin-Opener-Policy": "same-origin",
+    },
+  },
+  preview: {
+    headers: {
+      "Cross-Origin-Embedder-Policy": "require-corp",
+      "Cross-Origin-Opener-Policy": "same-origin",
+    },
+  },
 });


### PR DESCRIPTION
# Description

_Originally reported by `WormEmperor` on discord (thanks!)_

This PR replaces all `pathname://` links on `docs-site` with `<a href="..." target="blank">` to fix broken links. For context, we updated vitepress in #1704, the new version of which removed `pathname://` support. 

# Implementation strategy and design decisions

* In addition to the `pathname://` fixes, this PR also updates the vite config to match `editor`'s to include the following for web worker support:
```js
{
  server: {
    headers: {
      "Cross-Origin-Embedder-Policy": "require-corp",
      "Cross-Origin-Opener-Policy": "same-origin",
    },
  },
  preview: {
    headers: {
      "Cross-Origin-Embedder-Policy": "require-corp",
      "Cross-Origin-Opener-Policy": "same-origin",
    },
  },
}
```

# Examples with steps to reproduce them

Test the first link to the IDE in `/docs/ref/using`, and all other links to workspaces in the tutorial in the preview deployment. These links should all open the IDE in a new tab.

# Checklist

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have reviewed any generated registry diagram changes
