### PR TITLE
fix: Solves deletion override and diagram panel not updating

### DIFF
--- a/packages/editor/src/state/callbacks.ts
+++ b/packages/editor/src/state/callbacks.ts
@@ -717,7 +717,9 @@ export const useDeleteLocalFile = () =>
         });
         await localforage.removeItem(id);
         if (currentWorkspace.metadata.id === id) {
-          reset(currentWorkspaceState);
+          // set rather than reset to generate new id to avoid id conflicts
+          set(currentWorkspaceState, () => defaultWorkspaceState());
+          reset(diagramState);
         }
         toast.success(`Removed ${name}`);
       },


### PR DESCRIPTION
# Description
Resolves #1740 

Previously, when a workspace was deleted, sometimes another saved workspace would be highlighted and if "save" was clicked on the new workspace, this would override the highlighted space.

The overriding bug was because in useDeleteLocalFile in state/callbacks.ts previously the currentWorkspaceState was only reset to the default. This caused the id in the metadata to be identical to the default result of the uuid() call which could conflict with an existing saved file. Thus on deletion, the currentWorkspaceState would be reset with "blank" substance, style, and domain files, but the metadata id of another existing saved file. 

I solved this by setting the currentWorkspaceState metadata id to a new randomly generated uuid, thus avoiding collision.

The diagram panel previously would continue to show the deleted diagram even after deletion. I solved this by resetting the diagramState. 

The current flow is that upon deletion of a saved diagram if the diagram selected is the same as the diagram deleted, the user will be brought to a fresh new unsaved workspace. 

# Note
Assumes PR feat: workspace button is merged first