### PR TITLE
fix: Style function body should not be in errors

### DIFF
--- a/packages/core/src/compiler/StyleFunctionCaller.ts
+++ b/packages/core/src/compiler/StyleFunctionCaller.ts
@@ -85,7 +85,17 @@ export const callObjConstrFunc = (
     });
   } catch (e) {
     if (e instanceof Error) {
-      return err(functionInternalError(func, range, e.message));
+      return err(
+        functionInternalError(
+          {
+            name: func.name,
+            description: func.description,
+            params: func.params,
+          },
+          range,
+          e.message,
+        ),
+      );
     } else {
       throw new Error("Function call resulted in exception not of Error type");
     }
@@ -98,7 +108,17 @@ export const checkArgs = (
   args: ArgValWithSourceLoc<ad.Num>[],
 ): Result<(Shape<ad.Num> | Value<ad.Num>["contents"])[], StyleError> => {
   if (args.length > func.params.length) {
-    return err(tooManyArgumentsError(func, range, args.length));
+    return err(
+      tooManyArgumentsError(
+        {
+          name: func.name,
+          description: func.description,
+          params: func.params,
+        },
+        range,
+        args.length,
+      ),
+    );
   }
   const vals: (Shape<ad.Num> | Value<ad.Num>["contents"])[] = [];
   for (let i = 0; i < func.params.length; i++) {

--- a/packages/core/src/types/errors.ts
+++ b/packages/core/src/types/errors.ts
@@ -525,7 +525,10 @@ export interface MissingArgumentError {
 
 export interface TooManyArgumentsError {
   tag: "TooManyArgumentsError";
-  func: CompFunc | ObjFunc | ConstrFunc;
+  func:
+    | Omit<CompFunc, "body">
+    | Omit<ObjFunc, "body">
+    | Omit<ConstrFunc, "body">;
   funcLocation: SourceRange;
   numProvided: number;
 }

--- a/packages/core/src/utils/Error.ts
+++ b/packages/core/src/utils/Error.ts
@@ -1069,7 +1069,10 @@ export const missingArgumentError = (
 });
 
 export const tooManyArgumentsError = (
-  func: CompFunc | ObjFunc | ConstrFunc,
+  func:
+    | Omit<CompFunc, "body">
+    | Omit<ObjFunc, "body">
+    | Omit<ConstrFunc, "body">,
   funcLocation: SourceRange,
   numProvided: number,
 ): TooManyArgumentsError => ({


### PR DESCRIPTION
# Description

Resolves #1745.

Like PR #1714, this PR removes the function bodies from `TooManyArgumentsError` so that it plays nicely with WebWorker.

# Checklist

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have reviewed any generated registry diagram changes

# Open questions

Questions that require more discussion or to be addressed in future development:
