### PR TITLE
fix: style canvas default indent error

### DIFF
--- a/packages/editor/src/state/atoms.ts
+++ b/packages/editor/src/state/atoms.ts
@@ -206,8 +206,8 @@ export const defaultWorkspaceState = (): Workspace => ({
     style: {
       name: ".style",
       contents: `canvas {
-width = 400
-height = 400
+  width = 400
+  height = 400
 }`,
     },
     domain: {


### PR DESCRIPTION
# Description
After new button was added, in the .style file the canvas width and height lacked indentation. This is a minor fix to have the auto indent. 
