### PR TITLE
fix: fixed SVG upload 

### DIFF
--- a/packages/editor/src/components/SvgUploader.tsx
+++ b/packages/editor/src/components/SvgUploader.tsx
@@ -17,9 +17,15 @@ export default function SvgUploader() {
   );
 
   const handleChange = (svg: File) => {
-    if (!isCleanWorkspace(currentWorkspace)) {
+    if (
+      !isCleanWorkspace(currentWorkspace) &&
+      !confirm(
+        "You have unsaved changes. Are you sure you want to load this SVG?",
+      )
+    ) {
       return;
     }
+
     const reader = new FileReader();
     reader.readAsText(svg);
     reader.onabort = () => console.log("file reading was aborted");


### PR DESCRIPTION
# Description

Resolves #1751 

SVG Upload logic works properly. However, currently SVG Upload exits silently when user is on an unsaved workspace. Solved this by adding a confirmation box that lets the user know SVG Upload will only continue if they click confirm. 

# Checklist

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have reviewed any generated registry diagram changes