### PR TITLE
fix: regression of TeX SVG download

### DIFF
--- a/packages/editor/src/components/DiagramPanel.tsx
+++ b/packages/editor/src/components/DiagramPanel.tsx
@@ -36,6 +36,7 @@ export default function DiagramPanel() {
             pathResolver(path, rogerState, workspace),
           width: "100%",
           height: "100%",
+          texLabels: false,
         });
         rendered.setAttribute("width", "100%");
         rendered.setAttribute("height", "100%");

--- a/packages/editor/src/state/callbacks.ts
+++ b/packages/editor/src/state/callbacks.ts
@@ -274,6 +274,7 @@ export const useDownloadSvgTex = () =>
             pathResolver(path, rogerState, metadata),
           width: state.canvas.width.toString(),
           height: state.canvas.height.toString(),
+          texLabels: true,
         });
         const domain = snapshot.getLoadable(fileContentsSelector("domain"))
           .contents as ProgramFile;

--- a/packages/editor/src/utils/renderUtils.ts
+++ b/packages/editor/src/utils/renderUtils.ts
@@ -7,6 +7,7 @@ export const stateToSVG = async (
     pathResolver: PathResolver;
     width: string;
     height: string;
+    texLabels: boolean;
   },
 ): Promise<SVGSVGElement> => {
   const { canvas, shapes, labelCache, variation } = state;
@@ -23,7 +24,7 @@ export const stateToSVG = async (
     canvasSize: canvas.size,
     variation,
     namespace: "editor",
-    texLabels: false,
+    texLabels: config.texLabels,
     pathResolver: config.pathResolver,
   });
   rendered.setAttribute("width", config.width);


### PR DESCRIPTION
# Description

#1678 refactored the download callbacks in `editor`, but accidentally hard-coded the `texLabels` option in `toSVG`, causing the "SVG (TeX)" option to download SVGs with rendered labels. This PR restores the expected behavior, where `Equation`s are rendered as plain text labels in TeX syntax.
