### PR TITLE
feat: Added copy trio to clipboard feature

### DIFF
--- a/packages/editor/src/components/ExportButton.tsx
+++ b/packages/editor/src/components/ExportButton.tsx
@@ -1,4 +1,5 @@
 import {
+  useCopyToClipboard,
   useDownloadPdf,
   useDownloadPng,
   useDownloadSvgTex,
@@ -12,6 +13,7 @@ export default function ExportButton() {
     { label: "as PNG", onClick: useDownloadPng() },
     { label: "as PDF", onClick: useDownloadPdf() },
     { label: "as Penrose trio", onClick: useDownloadTrio() },
+    { label: "Copy to Clipboard", onClick: useCopyToClipboard() },
   ];
 
   return (

--- a/packages/editor/src/state/callbacks.ts
+++ b/packages/editor/src/state/callbacks.ts
@@ -222,6 +222,21 @@ export const useDownloadTrio = () =>
     }
   });
 
+export const useCopyToClipboard = () =>
+  useRecoilCallback(({ set, snapshot }) => async () => {
+    const workspace = snapshot.getLoadable(currentWorkspaceState)
+      .contents as Workspace;
+    const dsl = workspace.files.domain.contents;
+    const sub = workspace.files.substance.contents;
+    const sty = workspace.files.style.contents;
+    const concatenated = `-- .substance \n ${sub} \n 
+    -- .style \n ${sty} \n 
+    -- .domain \n ${dsl} \n`;
+
+    navigator.clipboard.writeText(concatenated);
+    toast.success("Copied trio to clipboard!");
+  });
+
 export const useDownloadSvg = () =>
   useRecoilCallback(({ set, snapshot }) => async () => {
     const diagram = snapshot.getLoadable(diagramMetadataSelector)

--- a/packages/editor/src/state/callbacks.ts
+++ b/packages/editor/src/state/callbacks.ts
@@ -229,9 +229,7 @@ export const useCopyToClipboard = () =>
     const sub = workspace.files.substance.contents;
     const sty = workspace.files.style.contents;
     const dsl = workspace.files.domain.contents;
-    const concatenated = `-- .substance \n ${sub} \n 
-    -- .style \n ${sty} \n 
-    -- .domain \n ${dsl} \n`;
+    const concatenated = `-- .substance\n${sub}\n-- .style\n${sty}\n-- .domain\n${dsl}\n`;
 
     navigator.clipboard
       .writeText(concatenated)

--- a/packages/editor/src/state/callbacks.ts
+++ b/packages/editor/src/state/callbacks.ts
@@ -226,15 +226,21 @@ export const useCopyToClipboard = () =>
   useRecoilCallback(({ set, snapshot }) => async () => {
     const workspace = snapshot.getLoadable(currentWorkspaceState)
       .contents as Workspace;
-    const dsl = workspace.files.domain.contents;
     const sub = workspace.files.substance.contents;
     const sty = workspace.files.style.contents;
+    const dsl = workspace.files.domain.contents;
     const concatenated = `-- .substance \n ${sub} \n 
     -- .style \n ${sty} \n 
     -- .domain \n ${dsl} \n`;
 
-    navigator.clipboard.writeText(concatenated);
-    toast.success("Copied trio to clipboard!");
+    navigator.clipboard
+      .writeText(concatenated)
+      .then(() => {
+        toast.success("Copied trio to clipboard!");
+      })
+      .catch(() => {
+        toast.error("Error could not copy");
+      });
   });
 
 export const useDownloadSvg = () =>


### PR DESCRIPTION
# Description

Resolves #1761 

Previously if a user wanted to copy a trio to their clipboard they would have to copy and paste each piece individually which feels time consuming and clunky. 

As a solution, I added a "Copy to Clipboard" option beneath the Export button in the ide. Clicking this option copies each element of the trio separated by a -- .(file name)