### PR TITLE
feat: Making gist sharing clearer (editor ux)

### DIFF
--- a/packages/editor/src/state/callbacks.ts
+++ b/packages/editor/src/state/callbacks.ts
@@ -678,8 +678,18 @@ export const usePublishGist = () =>
       toast.error(`Could not publish gist: ${res.statusText} ${json.message}`);
       return;
     }
-    toast.success(`Published gist, redirecting...`);
-    window.location.search = queryString.stringify({ gist: json.id });
+    const queryParameter = queryString.stringify({ gist: json.id });
+    const redirectURL = `https://penrose.cs.cmu.edu/try/?${queryParameter}`;
+    navigator.clipboard
+      .writeText(redirectURL)
+      .then(() => {
+        toast.success("Copied sharable link to clipboard");
+      })
+      .catch(() => {
+        toast.success("Redirecting to gist...");
+      });
+
+    window.location.search = queryParameter;
   });
 
 const REDIRECT_URL =

--- a/packages/editor/src/state/callbacks.ts
+++ b/packages/editor/src/state/callbacks.ts
@@ -563,6 +563,15 @@ export const useCheckURL = () =>
         files,
       };
       set(currentWorkspaceState, workspace);
+
+      // Notification + save to clipboard if redirected from clicking share
+      if ("pub" in parsed) {
+        const gistParameter = queryString.stringify({ gist: parsed["gist"] });
+        const shareableURL = `https://penrose.cs.cmu.edu/try/?${gistParameter}`;
+        navigator.clipboard.writeText(shareableURL).then(() => {
+          toast.success("Copied shareable link to clipboard");
+        });
+      }
     } else if ("examples" in parsed) {
       const t = toast.loading("Loading example...");
       const id = parsed["examples"];
@@ -678,18 +687,10 @@ export const usePublishGist = () =>
       toast.error(`Could not publish gist: ${res.statusText} ${json.message}`);
       return;
     }
-    const queryParameter = queryString.stringify({ gist: json.id });
-    const redirectURL = `https://penrose.cs.cmu.edu/try/?${queryParameter}`;
-    navigator.clipboard
-      .writeText(redirectURL)
-      .then(() => {
-        toast.success("Copied sharable link to clipboard");
-      })
-      .catch(() => {
-        toast.success("Redirecting to gist...");
-      });
-
-    window.location.search = queryParameter;
+    // Use query string (pub) to pass state to display notification on next page
+    const gistParameter = queryString.stringify({ gist: json.id, pub: true });
+    toast.success("Redirecting to gist...");
+    window.location.search = gistParameter;
   });
 
 const REDIRECT_URL =

--- a/packages/editor/src/state/callbacks.ts
+++ b/packages/editor/src/state/callbacks.ts
@@ -511,7 +511,11 @@ export const useCheckURL = () =>
       }));
     } else if ("gist" in parsed) {
       // Loading a gist
-      const id = toast.loading("Loading gist...");
+      // Show loading notification only if not redirected from share
+      var id!: string;
+      if (!("pub" in parsed)) {
+        id = toast.loading("Loading gist...");
+      }
       const res = await fetch(
         `https://api.github.com/gists/${parsed["gist"]}`,
         {
@@ -520,7 +524,9 @@ export const useCheckURL = () =>
           },
         },
       );
-      toast.dismiss(id);
+      if (!("pub" in parsed)) {
+        toast.dismiss(id);
+      }
       if (res.status !== 200) {
         console.error(res);
         toast.error(`Could not load gist: ${res.statusText}`);
@@ -567,10 +573,12 @@ export const useCheckURL = () =>
       // Notification + save to clipboard if redirected from clicking share
       if ("pub" in parsed) {
         const gistParameter = queryString.stringify({ gist: parsed["gist"] });
-        const shareableURL = `https://penrose.cs.cmu.edu/try/?${gistParameter}`;
+        const shareableURL = `${window.location.origin}${window.location.pathname}?${gistParameter}`;
         navigator.clipboard.writeText(shareableURL).then(() => {
           toast.success("Copied shareable link to clipboard");
         });
+        // Hide pub query parameter from displayed URL
+        window.history.replaceState({}, document.title, shareableURL);
       }
     } else if ("examples" in parsed) {
       const t = toast.loading("Loading example...");


### PR DESCRIPTION
# Description

Resolves #1760

Problem: Previously, it was not clear that the link the share button redirected the user to is a shareable link. 
Solution: Once the user clicks share, the shareable link is automatically copied to the user's clipboard and after redirecting, a notification saying "Copied shareable link to clipboard" is shown. See video below for behavior. 

https://github.com/penrose/penrose/assets/85892844/288a4780-86e3-4192-be96-ed75597581ff

# Implementation strategy and design decisions

The copy link and display notification is triggered by a url parameter. The way the share button flow works is once the user clicks share, they are redirected to a page with the gist id as a url parameter. Since we don't have explicit routing setup, the only way to pass state from the page the share button was clicked on to the page the user is redirected to is by adding a query parameter.

The downside of this, is that if the user copies the link manually that link will include the copy to clipboard query parameter so anyone who clicks that link will have the link copied to their clipboard and see the notification even if they weren't the ones who clicked share.

I do not see this as a major disadvantage, since the notification text isn't specific to sharing, this behavior won't feel like a bug.