### PR TITLE
fix: compilation errors not displaying properly

### DIFF
--- a/packages/editor/src/state/callbacks.ts
+++ b/packages/editor/src/state/callbacks.ts
@@ -1,3 +1,4 @@
+import { showError } from "@penrose/core";
 import { Style } from "@penrose/examples/dist/index.js";
 import registry from "@penrose/examples/dist/registry.js";
 import localforage from "localforage";
@@ -88,7 +89,7 @@ const _compileDiagram = async (
 
   const onError = (error: any) => {
     toast.dismiss(compiling);
-    toast.error(error.message);
+    toast.error(showError(error));
     set(diagramWorkerState, {
       ...diagramWorkerState,
       optimizing: false,
@@ -176,7 +177,7 @@ export const useResampleDiagram = () =>
     const resamplingLoading = toast.loading("Resampling...");
     const onError = (error: any) => {
       toast.dismiss(resamplingLoading);
-      toast.error(error.message);
+      toast.error(showError(error));
       set(diagramWorkerState, (state) => ({
         ...state,
         optimizing: false,


### PR DESCRIPTION
# Description

Resolves #1768

Recent OptimizationWorker refactor (#1765) incorrectly displays certain errors. This has been corrected.

# Checklist

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have reviewed any generated registry diagram changes
