### PR TITLE
feat: join paths

### DIFF
--- a/packages/core/src/compiler/StyleTypeChecker.ts
+++ b/packages/core/src/compiler/StyleTypeChecker.ts
@@ -87,6 +87,8 @@ export const checkValueAgainstValueType = (
   } else if (expected === "PathType") {
     if (tag === "StrV" && (contents === "open" || contents === "closed"))
       return contents;
+  } else if (expected === "PathDataList") {
+    if (tag === "PathDataListV") return contents;
   } else if (expected === "ShapeList") {
     if (tag === "ShapeListV") return contents;
   } else if (expected === "PathCmd") {

--- a/packages/core/src/engine/EngineUtils.ts
+++ b/packages/core/src/engine/EngineUtils.ts
@@ -48,6 +48,7 @@ import {
   ListV,
   MatrixV,
   PathCmd,
+  PathDataListV,
   PathDataV,
   PtListV,
   ShapeListV,
@@ -159,6 +160,21 @@ function mapPathData<T, S>(f: (arg: T) => S, v: PathDataV<T>): PathDataV<S> {
           };
         }),
       };
+    }),
+  };
+}
+
+function mapPathDataList<T, S>(
+  f: (arg: T) => S,
+  v: PathDataListV<T>,
+): PathDataListV<S> {
+  return {
+    tag: "PathDataListV",
+    contents: v.contents.map((cmds) => {
+      return mapPathData(f, {
+        tag: "PathDataV",
+        contents: cmds,
+      }).contents;
     }),
   };
 }
@@ -481,6 +497,8 @@ export function mapValueNumeric<T, S>(f: (arg: T) => S, v: Value<T>): Value<S> {
       return mapPathData(f, v);
     case "ShapeListV":
       return mapShapeList(f, v);
+    case "PathDataListV":
+      return mapPathDataList(f, v);
     case "ClipDataV":
       return mapClipData(f, v);
     // non-numeric Value types

--- a/packages/core/src/lib/Functions.ts
+++ b/packages/core/src/lib/Functions.ts
@@ -2066,6 +2066,30 @@ export const compDict = {
     returns: valueT("PathCmd"),
   },
 
+  joinPaths: {
+    name: "joinPaths",
+    description:
+      "Given a list of `PathData`s, join them into one SVG path. For correct results, the end points and start points" +
+      "of each path must already coincide.",
+
+    params: [
+      {
+        type: pathDataListT(),
+        name: "pathDataList",
+        description: "List of path data",
+      },
+    ],
+    body: (
+      _context: Context,
+      pathDataList: PathCmd<ad.Num>[][],
+    ): MayWarn<PathDataV<ad.Num>> => {
+      const connect = () => null;
+      const resPathData = PathBuilder.concatPaths(pathDataList, connect);
+      return noWarn(pathDataV(resPathData));
+    },
+    returns: valueT("PathCmd"),
+  },
+
   Penrose: {
     name: "Penrose",
     description: `Return path data describing an "impossible polygon."`,

--- a/packages/core/src/lib/__tests__/Functions.test.ts
+++ b/packages/core/src/lib/__tests__/Functions.test.ts
@@ -1,13 +1,11 @@
 import { describe, expect, test } from "vitest";
-import { compDict } from "../Functions.js";
-import { makePath } from "../../shapes/Path.js";
-import { makeCanvas, simpleContext } from "../../shapes/Samplers.js";
+import { toPathString } from "../../renderer/Path.js";
 import { PathBuilder } from "../../renderer/PathBuilder.js";
-import Path, { toPathString } from "../../renderer/Path.js";
-import { PathCmd, PathDataV } from "../../types/value.js";
+import { makeCanvas, simpleContext } from "../../shapes/Samplers.js";
+import { PathCmd } from "../../types/value.js";
+import { compDict } from "../Functions.js";
 
 const canvas = makeCanvas(800, 700);
-
 
 describe("key-name equality", () => {
   test("each function's key and name should be equal", () => {
@@ -17,13 +15,10 @@ describe("key-name equality", () => {
   });
 
   describe("join path variants", () => {
-    const context = simpleContext('join path variants');
+    const context = simpleContext("join path variants");
 
     const buildPath1 = (builder: PathBuilder) => {
-      return builder
-        .moveTo([0, 0])
-        .lineTo([1, 1])
-        .lineTo([2, 2]);
+      return builder.moveTo([0, 0]).lineTo([1, 1]).lineTo([2, 2]);
     };
 
     const buildPath2 = (builder: PathBuilder) => {
@@ -34,99 +29,111 @@ describe("key-name equality", () => {
     };
 
     const buildPath3 = (builder: PathBuilder) => {
-      return builder
-        .moveTo([0, 1])
-        .lineTo([1, 0]);
-    }
+      return builder.moveTo([0, 1]).lineTo([1, 0]);
+    };
 
     const buildPath4 = (builder: PathBuilder) => {
-      return builder
-        .moveTo([0, 0]);
-    }
+      return builder.moveTo([0, 0]);
+    };
 
-    const path1 = buildPath1(new PathBuilder()).getPath().contents as PathCmd<number>[];
-    const path2 = buildPath2(new PathBuilder()).getPath().contents as PathCmd<number>[];
-    const path3 = buildPath3(new PathBuilder()).getPath().contents as PathCmd<number>[];
-    const path4 = buildPath4(new PathBuilder()).getPath().contents as PathCmd<number>[];
+    const path1 = buildPath1(new PathBuilder()).getPath()
+      .contents as PathCmd<number>[];
+    const path2 = buildPath2(new PathBuilder()).getPath()
+      .contents as PathCmd<number>[];
+    const path3 = buildPath3(new PathBuilder()).getPath()
+      .contents as PathCmd<number>[];
+    const path4 = buildPath4(new PathBuilder()).getPath()
+      .contents as PathCmd<number>[];
 
-    const concat123 = buildPath3(buildPath2(buildPath1(new PathBuilder()))).getPath().contents as PathCmd<number>[];
+    const concat123 = buildPath3(
+      buildPath2(buildPath1(new PathBuilder())),
+    ).getPath().contents as PathCmd<number>[];
     const connect123 = buildPath1(new PathBuilder())
       .lineTo([2, 2])
       .lineTo([3, 0])
       .quadraticCurveTo([1, 1], [0, 1])
       .lineTo([0, 1])
       .lineTo([1, 0])
-      .getPath()
-      .contents as PathCmd<number>[];
+      .getPath().contents as PathCmd<number>[];
     const join123 = buildPath1(new PathBuilder())
       .lineTo([3, 0])
       .quadraticCurveTo([1, 1], [0, 1])
       .lineTo([1, 0])
-      .getPath()
-      .contents as PathCmd<number>[];
+      .getPath().contents as PathCmd<number>[];
 
     test("concatenate paths simple", () => {
-      expect(toPathString(concat123, canvas.size)).toEqual(toPathString(
-        compDict.concatenatePaths.body(context, [path1, path2, path3])
-          .value.contents as PathCmd<number>[],
-        canvas.size
-      ));
+      expect(toPathString(concat123, canvas.size)).toEqual(
+        toPathString(
+          compDict.concatenatePaths.body(context, [path1, path2, path3]).value
+            .contents as PathCmd<number>[],
+          canvas.size,
+        ),
+      );
     });
 
     test("connect paths simple", () => {
-      expect(toPathString(connect123, canvas.size)).toEqual(toPathString(
-        compDict.connectPaths.body(context, "open", [path1, path2, path3])
-          .value.contents as PathCmd<number>[],
-        canvas.size
-      ));
+      expect(toPathString(connect123, canvas.size)).toEqual(
+        toPathString(
+          compDict.connectPaths.body(context, "open", [path1, path2, path3])
+            .value.contents as PathCmd<number>[],
+          canvas.size,
+        ),
+      );
     });
 
     test("join paths simple", () => {
-      expect(toPathString(join123, canvas.size)).toEqual(toPathString(
-        compDict.joinPaths.body(context, [path1, path2, path3])
-          .value.contents as PathCmd<number>[],
-        canvas.size
-      ));
+      expect(toPathString(join123, canvas.size)).toEqual(
+        toPathString(
+          compDict.joinPaths.body(context, [path1, path2, path3]).value
+            .contents as PathCmd<number>[],
+          canvas.size,
+        ),
+      );
     });
 
-
-    const concat124 = buildPath4(buildPath2(buildPath1(new PathBuilder()))).getPath().contents as PathCmd<number>[];
+    const concat124 = buildPath4(
+      buildPath2(buildPath1(new PathBuilder())),
+    ).getPath().contents as PathCmd<number>[];
     const connect124 = buildPath1(new PathBuilder())
       .lineTo([2, 2])
       .lineTo([3, 0])
       .quadraticCurveTo([1, 1], [0, 1])
       .lineTo([0, 0])
       .lineTo([0, 0])
-      .getPath()
-      .contents as PathCmd<number>[];
+      .getPath().contents as PathCmd<number>[];
     const join124 = buildPath1(new PathBuilder())
       .lineTo([3, 0])
       .quadraticCurveTo([1, 1], [0, 1])
-      .getPath()
-      .contents as PathCmd<number>[];
+      .getPath().contents as PathCmd<number>[];
 
     test("concatenate paths empty ending", () => {
-      expect(toPathString(concat124, canvas.size)).toEqual(toPathString(
-        compDict.concatenatePaths.body(context, [path1, path2, path4])
-          .value.contents as PathCmd<number>[],
-        canvas.size
-      ));
+      expect(toPathString(concat124, canvas.size)).toEqual(
+        toPathString(
+          compDict.concatenatePaths.body(context, [path1, path2, path4]).value
+            .contents as PathCmd<number>[],
+          canvas.size,
+        ),
+      );
     });
 
     test("connect paths empty ending", () => {
-      expect(toPathString(connect124, canvas.size)).toEqual(toPathString(
-        compDict.connectPaths.body(context, "closed", [path1, path2, path4])
-          .value.contents as PathCmd<number>[],
-        canvas.size
-      ));
+      expect(toPathString(connect124, canvas.size)).toEqual(
+        toPathString(
+          compDict.connectPaths.body(context, "closed", [path1, path2, path4])
+            .value.contents as PathCmd<number>[],
+          canvas.size,
+        ),
+      );
     });
 
     test("join paths empty ending", () => {
-      expect(toPathString(join124, canvas.size)).toEqual(toPathString(
-        compDict.joinPaths.body(context, [path1, path2, path4])
-          .value.contents as PathCmd<number>[],
-        canvas.size
-      ));
+      expect(toPathString(join124, canvas.size)).toEqual(
+        toPathString(
+          compDict.joinPaths.body(context, [path1, path2, path4]).value
+            .contents as PathCmd<number>[],
+          canvas.size,
+        ),
+      );
     });
   });
 });

--- a/packages/core/src/lib/__tests__/Functions.test.ts
+++ b/packages/core/src/lib/__tests__/Functions.test.ts
@@ -1,10 +1,132 @@
 import { describe, expect, test } from "vitest";
 import { compDict } from "../Functions.js";
+import { makePath } from "../../shapes/Path.js";
+import { makeCanvas, simpleContext } from "../../shapes/Samplers.js";
+import { PathBuilder } from "../../renderer/PathBuilder.js";
+import Path, { toPathString } from "../../renderer/Path.js";
+import { PathCmd, PathDataV } from "../../types/value.js";
+
+const canvas = makeCanvas(800, 700);
+
 
 describe("key-name equality", () => {
   test("each function's key and name should be equal", () => {
     for (const [name, func] of Object.entries(compDict)) {
       expect(name).toEqual(func.name);
     }
+  });
+
+  describe("join path variants", () => {
+    const context = simpleContext('join path variants');
+
+    const buildPath1 = (builder: PathBuilder) => {
+      return builder
+        .moveTo([0, 0])
+        .lineTo([1, 1])
+        .lineTo([2, 2]);
+    };
+
+    const buildPath2 = (builder: PathBuilder) => {
+      return builder
+        .moveTo([2, 2])
+        .lineTo([3, 0])
+        .quadraticCurveTo([1, 1], [0, 1]);
+    };
+
+    const buildPath3 = (builder: PathBuilder) => {
+      return builder
+        .moveTo([0, 1])
+        .lineTo([1, 0]);
+    }
+
+    const buildPath4 = (builder: PathBuilder) => {
+      return builder
+        .moveTo([0, 0]);
+    }
+
+    const path1 = buildPath1(new PathBuilder()).getPath().contents as PathCmd<number>[];
+    const path2 = buildPath2(new PathBuilder()).getPath().contents as PathCmd<number>[];
+    const path3 = buildPath3(new PathBuilder()).getPath().contents as PathCmd<number>[];
+    const path4 = buildPath4(new PathBuilder()).getPath().contents as PathCmd<number>[];
+
+    const concat123 = buildPath3(buildPath2(buildPath1(new PathBuilder()))).getPath().contents as PathCmd<number>[];
+    const connect123 = buildPath1(new PathBuilder())
+      .lineTo([2, 2])
+      .lineTo([3, 0])
+      .quadraticCurveTo([1, 1], [0, 1])
+      .lineTo([0, 1])
+      .lineTo([1, 0])
+      .getPath()
+      .contents as PathCmd<number>[];
+    const join123 = buildPath1(new PathBuilder())
+      .lineTo([3, 0])
+      .quadraticCurveTo([1, 1], [0, 1])
+      .lineTo([1, 0])
+      .getPath()
+      .contents as PathCmd<number>[];
+
+    test("concatenate paths simple", () => {
+      expect(toPathString(concat123, canvas.size)).toEqual(toPathString(
+        compDict.concatenatePaths.body(context, [path1, path2, path3])
+          .value.contents as PathCmd<number>[],
+        canvas.size
+      ));
+    });
+
+    test("connect paths simple", () => {
+      expect(toPathString(connect123, canvas.size)).toEqual(toPathString(
+        compDict.connectPaths.body(context, "open", [path1, path2, path3])
+          .value.contents as PathCmd<number>[],
+        canvas.size
+      ));
+    });
+
+    test("join paths simple", () => {
+      expect(toPathString(join123, canvas.size)).toEqual(toPathString(
+        compDict.joinPaths.body(context, [path1, path2, path3])
+          .value.contents as PathCmd<number>[],
+        canvas.size
+      ));
+    });
+
+
+    const concat124 = buildPath4(buildPath2(buildPath1(new PathBuilder()))).getPath().contents as PathCmd<number>[];
+    const connect124 = buildPath1(new PathBuilder())
+      .lineTo([2, 2])
+      .lineTo([3, 0])
+      .quadraticCurveTo([1, 1], [0, 1])
+      .lineTo([0, 0])
+      .lineTo([0, 0])
+      .getPath()
+      .contents as PathCmd<number>[];
+    const join124 = buildPath1(new PathBuilder())
+      .lineTo([3, 0])
+      .quadraticCurveTo([1, 1], [0, 1])
+      .getPath()
+      .contents as PathCmd<number>[];
+
+    test("concatenate paths empty ending", () => {
+      expect(toPathString(concat124, canvas.size)).toEqual(toPathString(
+        compDict.concatenatePaths.body(context, [path1, path2, path4])
+          .value.contents as PathCmd<number>[],
+        canvas.size
+      ));
+    });
+
+    test("connect paths empty ending", () => {
+      expect(toPathString(connect124, canvas.size)).toEqual(toPathString(
+        compDict.connectPaths.body(context, "closed", [path1, path2, path4])
+          .value.contents as PathCmd<number>[],
+        canvas.size
+      ));
+    });
+
+    test("join paths empty ending", () => {
+      expect(toPathString(join124, canvas.size)).toEqual(toPathString(
+        compDict.joinPaths.body(context, [path1, path2, path4])
+          .value.contents as PathCmd<number>[],
+        canvas.size
+      ));
+    });
   });
 });

--- a/packages/core/src/renderer/Path.ts
+++ b/packages/core/src/renderer/Path.ts
@@ -16,7 +16,7 @@ import {
 import { arrowHead } from "./Line.js";
 import { RenderProps } from "./Renderer.js";
 
-const toPathString = (
+export const toPathString = (
   pathData: PathCmd<number>[],
   canvasSize: [number, number],
 ) =>

--- a/packages/core/src/renderer/PathBuilder.ts
+++ b/packages/core/src/renderer/PathBuilder.ts
@@ -137,7 +137,7 @@ export class PathBuilder {
    * Concatenate paths according to the specified connection policy.
    * @param pathDataList List of paths, given as lists of path commands (a list of lists)
    * @param connect Given start command, transform it to a new command (or lack thereof)
-   * @param connectEnd Should the ends of the paths be connected according to `connect`?
+   * @param connectLast Should the ends of the paths be connected according to `connect`?
    */
   static concatPaths(
     pathDataList: PathCmd<ad.Num>[][],

--- a/packages/core/src/renderer/PathBuilder.ts
+++ b/packages/core/src/renderer/PathBuilder.ts
@@ -1,5 +1,5 @@
 import * as ad from "../types/ad.js";
-import { PathDataV, SubPath } from "../types/value.js";
+import { PathCmd, PathDataV, SubPath } from "../types/value.js";
 
 /**
  * Class for building SVG paths
@@ -132,4 +132,48 @@ export class PathBuilder {
     });
     return this;
   };
+
+  /**
+   * Concatenate paths according to the specified connection policy.
+   * @param pathDataList List of paths, given as lists of path commands (a list of lists)
+   * @param connect Given start command, transform it to a new command (or lack thereof)
+   * @param connectEnd Should the ends of the paths be connected according to `connect`?
+   */
+  static concatPaths(
+    pathDataList: PathCmd<ad.Num>[][],
+    connect?: (startCmd: PathCmd<ad.Num>) => PathCmd<ad.Num> | null,
+    connectLast: boolean = false,
+  ): PathCmd<ad.Num>[] {
+    if (pathDataList.length === 0) {
+      return [];
+    }
+
+    let resPathData: PathCmd<ad.Num>[] = [];
+    for (let i = 0; i < pathDataList.length; i++) {
+      // shallow copy
+      const pathData = pathDataList[i].map((x) => x);
+      if (pathData.length === 0) {
+        continue;
+      }
+      if (connect && i > 0) {
+        const oldStart: PathCmd<ad.Num> | null = pathData[0];
+        const newStart = connect(oldStart);
+        if (newStart) {
+          pathData[0] = newStart;
+        } else {
+          pathData.shift();
+        }
+      }
+      resPathData = resPathData.concat(pathData);
+    }
+    if (connect && connectLast) {
+      const start: PathCmd<ad.Num> | null = resPathData[0];
+      const newEnd = connect(start);
+      if (newEnd) {
+        resPathData.push(newEnd);
+      }
+    }
+
+    return resPathData;
+  }
 }

--- a/packages/core/src/types/types.ts
+++ b/packages/core/src/types/types.ts
@@ -20,6 +20,7 @@ export const valueTypeDesc = {
   ColorType: { description: "Color Type", symbol: `"rgb" | "hsv"` },
   PathType: { description: "Path Type", symbol: `"open" | "closed"` },
   ShapeList: { description: "List of shapes", symbol: "Shape[]" },
+  PathDataList: { description: "List of paths", symbol: "PathData[]" },
   PathCmd: { description: "Path Command", symbol: "PathCmd" },
   Boolean: { description: "Boolean Value", symbol: `true | false` },
   ClipData: { description: "Shape clip data", symbol: "ClipData" },

--- a/packages/core/src/types/value.ts
+++ b/packages/core/src/types/value.ts
@@ -43,6 +43,7 @@ export type Value<T> =
   | TupV<T>
   | LListV<T>
   | ShapeListV<T>
+  | PathDataListV<T>
   | ClipDataV<T>;
 
 /** A floating point number **/
@@ -109,6 +110,12 @@ export interface TupV<T> {
 export interface LListV<T> {
   tag: "LListV";
   contents: T[][];
+}
+
+/** A list of SVG paths */
+export interface PathDataListV<T> {
+  tag: "PathDataListV";
+  contents: PathCmd<T>[][];
 }
 
 export type Color<T> = RGBA<T> | HSVA<T> | NoPaint;

--- a/packages/core/src/utils/Util.ts
+++ b/packages/core/src/utils/Util.ts
@@ -40,6 +40,7 @@ import {
   MatrixV,
   NoClip,
   PathCmd,
+  PathDataListV,
   PathDataV,
   PtListV,
   ShapeListV,
@@ -668,6 +669,13 @@ export const shapeListV = (contents: Shape<ad.Num>[]): ShapeListV<ad.Num> => ({
   contents,
 });
 
+export const pathDataListV = (
+  contents: PathCmd<ad.Num>[][],
+): PathDataListV<ad.Num> => ({
+  tag: "PathDataListV",
+  contents,
+});
+
 export const black = (): ColorV<ad.Num> =>
   colorV({ tag: "RGBA", contents: [0, 0, 0, 1] });
 export const white = (): ColorV<ad.Num> =>
@@ -743,6 +751,7 @@ export const posIntT = (): ValueT => valueT("PosInt");
 export const booleanT = (): ValueT => valueT("Boolean");
 export const realNMT = (): ValueT => valueT("RealNM");
 export const shapeListT = (): ValueT => valueT("ShapeList");
+export const pathDataListT = (): ValueT => valueT("PathDataList");
 
 export const shapeT = (type: ShapeType | "AnyShape"): ShapeT => ({
   tag: "ShapeT",

--- a/packages/editor/src/state/callbacks.ts
+++ b/packages/editor/src/state/callbacks.ts
@@ -1,3 +1,4 @@
+import { showError } from "@penrose/core";
 import { Style } from "@penrose/examples/dist/index.js";
 import registry from "@penrose/examples/dist/registry.js";
 import localforage from "localforage";
@@ -88,7 +89,7 @@ const _compileDiagram = async (
 
   const onError = (error: any) => {
     toast.dismiss(compiling);
-    toast.error(error.message);
+    toast.error(showError(error));
     set(diagramWorkerState, {
       ...diagramWorkerState,
       optimizing: false,
@@ -176,7 +177,7 @@ export const useResampleDiagram = () =>
     const resamplingLoading = toast.loading("Resampling...");
     const onError = (error: any) => {
       toast.dismiss(resamplingLoading);
-      toast.error(error.message);
+      toast.error(showError(error));
       set(diagramWorkerState, (state) => ({
         ...state,
         optimizing: false,


### PR DESCRIPTION
# Description

**Draft**

(Partially) resolves #1767.

This implements two style functions, `concatenatePaths` and `connectPaths` which both turn a list of `PathDataV` into one `PathDataV`, according to different connection policies

# Implementation strategy and design decisions
- Added `PathDataListV` as a style list type
- New style functions mirror the format of existing path factory functions
## New Functions
```
concatenatePaths : (PathDataListV) => PathDataV
```
Connect a list of paths by exactly concatenating their SVG commands. Visually, this has the effect of taking the union of the paths.

```
connectPaths : (PathTypeV, PathDataListV) => PathDataV
```
Connect a list of paths by drawing a line between the end and start point of each path. If "closed" is passed as the path type, a line is drawn from the end of the last path to the start of the first.

```
joinPaths: (PathDataListV) => PathDataV
``` 
Connect a list of paths by removing the beginning 'M' command from all but the first path. This has the effect of closing the path, allowing for filling, etc. However, the start and end points of each path must already coincide to give correct results.

# Examples 

<img width="1307" alt="Screenshot 2024-05-31 at 7 33 01 PM" src="https://github.com/penrose/penrose/assets/13922490/8bde73b3-a231-4ac7-9acd-8d52315e870e">

<img width="1337" alt="Screenshot 2024-05-31 at 7 33 29 PM" src="https://github.com/penrose/penrose/assets/13922490/50c56f05-75d4-4b17-9edf-e04cd0aff78c">

# Checklist

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have reviewed any generated registry diagram changes

# Open questions/Next steps

- ~~A `joinPaths` function where each start point is made to coincide with the previous endpoint would be an obvious next step, as Prof. Crane suggested. But since certain path coordinates may be absolutely specified, we likely couldn't use relative SVG commands. Additionally, it's not clear what should happen if a start point is absolutely specified to be different from the previous endpoint. But it wouldn't be hard to just delete the 'M' command from the beginning of each path, and make the coincidence of start and end points a precondition for the function.~~ implemented, as above.
