### PR TITLE
fix: no error markers

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -428,7 +428,12 @@ export {
   insertLabelMeasurements as insertPending,
   mathjaxInit,
 } from "./utils/CollectLabels.js";
-export { errLocs, runtimeError, showError } from "./utils/Error.js";
+export {
+  errLocs,
+  isPenroseError,
+  runtimeError,
+  showError,
+} from "./utils/Error.js";
 export type { Result } from "./utils/Error.js";
 export {
   allWarnings,

--- a/packages/core/src/utils/Error.ts
+++ b/packages/core/src/utils/Error.ts
@@ -1172,6 +1172,17 @@ const loc = (node: AbstractNode): string => {
   }
 };
 
+export const isPenroseError = (error: unknown): error is PenroseError => {
+  return (
+    error instanceof Object &&
+    "errorType" in error &&
+    (error.errorType === "DomainError" ||
+      error.errorType === "SubstanceError" ||
+      error.errorType === "StyleError" ||
+      error.errorType === "RuntimeError")
+  );
+};
+
 // #endregion
 
 // #region Either monad

--- a/packages/editor/src/worker/OptimizerWorker.ts
+++ b/packages/editor/src/worker/OptimizerWorker.ts
@@ -648,7 +648,7 @@ export default class OptimizerWorker {
             onFinish.then(finishResolve, finishReject);
             await onStart;
             startResolve();
-          } catch (error: any) {
+          } catch (error: unknown) {
             startReject(error);
           }
           break;


### PR DESCRIPTION
# Description

As noted by @liangyiliang, #1765 broke error markers in the editor (by not properly updating the diagram state on compilation errors). This change addresses that.

# Checklist

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have reviewed any generated registry diagram changes
