### PR TITLE
fix: misc. webworker + IDE fixes

### DIFF
--- a/packages/editor/src/components/DiagramPanel.tsx
+++ b/packages/editor/src/components/DiagramPanel.tsx
@@ -82,6 +82,9 @@ export default function DiagramPanel() {
   };
 
   const layoutTimeline = useRecoilValue(layoutTimelineState);
+  const unexcludedWarnings = warnings.filter(
+    (w) => metadata.excludeWarnings.find((s) => w.tag === s) === undefined,
+  );
 
   return (
     <div style={{ display: "flex", flexDirection: "row", height: "100%" }}>
@@ -121,7 +124,7 @@ export default function DiagramPanel() {
             </pre>
           </div>
         )}
-        {warnings.length > 0 && (
+        {unexcludedWarnings.length > 0 && (
           <div
             style={{
               bottom: 0,
@@ -140,7 +143,9 @@ export default function DiagramPanel() {
               warnings
             </span>
             <pre style={{ whiteSpace: "pre-wrap" }}>
-              {warnings.map((w) => showError(w).toString()).join("\n")}
+              {unexcludedWarnings
+                .map((w) => showError(w).toString())
+                .join("\n")}
             </pre>
           </div>
         )}

--- a/packages/editor/src/components/LayoutTimelineSlider.tsx
+++ b/packages/editor/src/components/LayoutTimelineSlider.tsx
@@ -1,6 +1,7 @@
 // a slider that shows the history of the diagram layout optimization, requesting shapes from the worker and rendering them on demand
 
 import { penroseBlue } from "@penrose/components";
+import { useState } from "react";
 import { useRecoilState, useRecoilValue } from "recoil";
 import { diagramState, diagramWorkerState, optimizer } from "../state/atoms.js";
 import SegmentedSlider from "./SegmentedSlider.js";
@@ -8,17 +9,27 @@ import SegmentedSlider from "./SegmentedSlider.js";
 export const LayoutTimelineSlider: React.FC<{}> = (props) => {
   const [diagram, setDiagram] = useRecoilState(diagramState);
   const { optimizing } = useRecoilValue(diagramWorkerState);
+  const [waiting, setWaiting] = useState(false);
 
   const onChange = (i: number) => {
     // request shapes from worker
     async function requestShapes() {
+      setWaiting(true);
       const state = await optimizer.computeShapesAtIndex(i);
       setDiagram((diagram) => ({
         ...diagram,
         state: state,
       }));
+      setWaiting(false);
     }
-    requestShapes();
+
+    if (!waiting) {
+      // may not be able to request shapes if recompiled, resampled, etc between
+      // call and receive
+      requestShapes().catch(() => {
+        setWaiting(false);
+      });
+    }
   };
   return (
     <div

--- a/packages/editor/src/components/SegmentedSlider.tsx
+++ b/packages/editor/src/components/SegmentedSlider.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React, { useEffect, useState } from "react";
 import styled from "styled-components";
 
 interface Segment {
@@ -47,9 +47,8 @@ const SegmentedSlider: React.FC<SegmentedSliderProps> = ({
   disabled,
   onChange,
 }) => {
-  if (stages.length === 0) return null;
   // compute the step ranges for each stage
-  const stageRanges = stages.reduce(
+  let stageRanges = stages.reduce(
     (acc, stage, i) => [
       ...acc,
       {
@@ -59,10 +58,12 @@ const SegmentedSlider: React.FC<SegmentedSliderProps> = ({
     ],
     [] as { start: number; end: number }[],
   );
+  if (stageRanges.length === 0) {
+    stageRanges = [{ start: 0, end: 0 }];
+  }
 
-  const totalSteps = stageRanges[stageRanges.length - 1].end;
   const [dragged, setDragged] = useState<boolean>(false);
-  const [value, setValue] = useState<number>(totalSteps - 1);
+  const [value, setValue] = useState<number>(0);
   const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     setDragged(true);
     const newValue = parseInt(e.target.value, 10);
@@ -70,6 +71,13 @@ const SegmentedSlider: React.FC<SegmentedSliderProps> = ({
     onChange(newValue);
   };
 
+  useEffect(() => {
+    if (disabled) {
+      setDragged(false);
+    }
+  }, [disabled]);
+
+  const totalSteps = stageRanges[stageRanges.length - 1].end;
   const currValue = dragged ? value : totalSteps;
 
   return (

--- a/packages/editor/src/components/TopBar.tsx
+++ b/packages/editor/src/components/TopBar.tsx
@@ -117,7 +117,7 @@ export default function TopBar() {
   const settings = useRecoilValue(settingsState);
   const saveLocally = useSaveLocally();
   const publishGist = usePublishGist();
-  const { optimizing } = useRecoilValue(diagramWorkerState);
+  const { optimizing, compiling } = useRecoilValue(diagramWorkerState);
   const isUnsaved = useIsUnsaved();
   const newWorkspace = useNewWorkspace();
 
@@ -179,12 +179,16 @@ export default function TopBar() {
         </div>
       )}
       <HeaderButtonContainer>
-        <BlueButton disabled={optimizing} onClick={useDownloadSvg()}>
+        <BlueButton disabled={compiling} onClick={useDownloadSvg()}>
           save Penrose SVG
         </BlueButton>
         <ExportButton />
-        <BlueButton onClick={compileDiagram}>compile ▶</BlueButton>
-        <BlueButton onClick={resampleDiagram}>resample</BlueButton>
+        <BlueButton disabled={compiling} onClick={compileDiagram}>
+          compile ▶
+        </BlueButton>
+        <BlueButton disabled={compiling} onClick={resampleDiagram}>
+          resample
+        </BlueButton>
       </HeaderButtonContainer>
     </nav>
   );

--- a/packages/editor/src/state/atoms.ts
+++ b/packages/editor/src/state/atoms.ts
@@ -350,12 +350,14 @@ export const layoutTimelineState = atom<LayoutTimeline>({
 export const diagramWorkerState = atom<{
   id: string;
   init: boolean;
+  compiling: boolean;
   optimizing: boolean;
 }>({
   key: "diagramWorkerState",
   default: {
     id: "",
     init: false,
+    compiling: false,
     optimizing: false,
   },
 });

--- a/packages/editor/src/state/callbacks.ts
+++ b/packages/editor/src/state/callbacks.ts
@@ -59,6 +59,7 @@ const _onError = (
   }
   set(diagramState, (state) => ({
     ...state,
+    warnings: [],
     error,
   }));
   set(diagramWorkerState, (state) => ({
@@ -84,8 +85,6 @@ const _compileDiagram = async (
       return {
         ...state,
         error: null,
-        // TODO: warnings
-        // warnings: initialState.warnings,
         metadata: {
           ...state.metadata,
           variation,
@@ -119,11 +118,20 @@ const _compileDiagram = async (
       ...state,
       compiling: true,
     }));
-    const id = await optimizer.compile(domain, style, substance, variation);
+    const { id, warnings } = await optimizer.compile(
+      domain,
+      style,
+      substance,
+      variation,
+    );
     set(diagramWorkerState, (state) => ({
       ...state,
       id,
       compiling: false,
+    }));
+    set(diagramState, (state) => ({
+      ...state,
+      warnings: warnings,
     }));
     toast.dismiss(compiling);
 

--- a/packages/editor/src/state/callbacks.ts
+++ b/packages/editor/src/state/callbacks.ts
@@ -63,6 +63,7 @@ const _onError = (
   }));
   set(diagramWorkerState, (state) => ({
     ...state,
+    compiling: false,
     optimizing: false,
   }));
 };
@@ -114,17 +115,21 @@ const _compileDiagram = async (
   };
 
   try {
+    set(diagramWorkerState, (state) => ({
+      ...state,
+      compiling: true,
+    }));
     const id = await optimizer.compile(domain, style, substance, variation);
     set(diagramWorkerState, (state) => ({
       ...state,
       id,
-      optimizing: false,
+      compiling: false,
     }));
+    toast.dismiss(compiling);
 
     const { onStart, onFinish } = await optimizer.startOptimizing();
     onFinish
       .then((info) => {
-        toast.dismiss(compiling);
         set(diagramWorkerState, (state) => ({
           ...state,
           optimizing: false,
@@ -215,9 +220,9 @@ export const useResampleDiagram = () =>
 
     try {
       const { onStart, onFinish } = await optimizer.resample(id, variation);
+      toast.dismiss(resamplingLoading);
       onFinish
         .then((info) => {
-          toast.dismiss(resamplingLoading);
           set(diagramWorkerState, (state) => ({
             ...state,
             optimizing: false,

--- a/packages/editor/src/state/callbacks.ts
+++ b/packages/editor/src/state/callbacks.ts
@@ -114,21 +114,14 @@ const _compileDiagram = async (
   };
 
   try {
-    const {
-      id,
-      promises: { onStart, onFinish },
-    } = await optimizer.compileAndStartOptimizing(
-      domain,
-      style,
-      substance,
-      variation,
-    );
+    const id = await optimizer.compile(domain, style, substance, variation);
     set(diagramWorkerState, (state) => ({
       ...state,
       id,
       optimizing: false,
     }));
 
+    const { onStart, onFinish } = await optimizer.startOptimizing();
     onFinish
       .then((info) => {
         toast.dismiss(compiling);

--- a/packages/editor/src/state/callbacks.ts
+++ b/packages/editor/src/state/callbacks.ts
@@ -84,17 +84,6 @@ const _compileDiagram = async (
     set(diagramState, (state) => {
       return {
         ...state,
-        error: null,
-        metadata: {
-          ...state.metadata,
-          variation,
-          excludeWarnings,
-          source: {
-            domain,
-            substance,
-            style,
-          },
-        },
         state: updatedState,
       };
     });
@@ -114,6 +103,19 @@ const _compileDiagram = async (
   };
 
   try {
+    set(diagramState, (state) => ({
+      ...state,
+      metadata: {
+        ...state.metadata,
+        variation,
+        excludeWarnings,
+        source: {
+          substance,
+          style,
+          domain,
+        },
+      },
+    }));
     set(diagramWorkerState, (state) => ({
       ...state,
       compiling: true,
@@ -132,6 +134,7 @@ const _compileDiagram = async (
     set(diagramState, (state) => ({
       ...state,
       warnings: warnings,
+      error: null,
     }));
     toast.dismiss(compiling);
 

--- a/packages/editor/src/worker/OptimizerWorker.test.ts
+++ b/packages/editor/src/worker/OptimizerWorker.test.ts
@@ -94,7 +94,12 @@ const fuzz = async (ops: number, expect: any) => {
   };
 
   const compile = async () => {
-    const { id: id_, warnings } = await optimizer.compile(domain, style, substance, variation);
+    const { id: id_, warnings } = await optimizer.compile(
+      domain,
+      style,
+      substance,
+      variation,
+    );
     id = id_;
     expect(state === "Compiled");
   };

--- a/packages/editor/src/worker/OptimizerWorker.test.ts
+++ b/packages/editor/src/worker/OptimizerWorker.test.ts
@@ -94,7 +94,8 @@ const fuzz = async (ops: number, expect: any) => {
   };
 
   const compile = async () => {
-    id = await optimizer.compile(domain, style, substance, variation);
+    const { id: id_, warnings } = await optimizer.compile(domain, style, substance, variation);
+    id = id_;
     expect(state === "Compiled");
   };
 

--- a/packages/editor/src/worker/OptimizerWorker.ts
+++ b/packages/editor/src/worker/OptimizerWorker.ts
@@ -114,7 +114,7 @@ export type OWState = StableState | WaitingState;
 /* Module helpers */
 
 const log = (consola as any)
-  .create({ level: (consola as any).LogLevel.Info })
+  .create({ level: (consola as any).LogLevel.Warn })
   .withScope("worker:client");
 
 const isWaiting = (state: OWState): state is WaitingState => {

--- a/packages/editor/src/worker/common.ts
+++ b/packages/editor/src/worker/common.ts
@@ -4,6 +4,7 @@ import {
   LabelData,
   LabelMeasurements,
   Num,
+  PenroseWarning,
   Shape,
   State,
 } from "@penrose/core";
@@ -23,6 +24,7 @@ export type InitResp = {
 export type CompiledResp = {
   tag: "CompiledResp";
   jobId: string;
+  warnings: PenroseWarning[];
   shapes: Shape<Num>[];
 };
 

--- a/packages/editor/src/worker/common.ts
+++ b/packages/editor/src/worker/common.ts
@@ -4,15 +4,16 @@ import {
   LabelData,
   LabelMeasurements,
   Num,
-  PenroseError,
   Shape,
   State,
 } from "@penrose/core";
+import { WorkerError } from "./errors.js";
 
 export enum WorkerState {
   Init = "Init",
   Compiled = "Compiled",
   Optimizing = "Optimizing",
+  Error = "Error",
 }
 
 export type InitResp = {
@@ -43,7 +44,7 @@ export type UpdateResp = {
 
 export type ErrorResp = {
   tag: "ErrorResp";
-  error: PenroseError;
+  error: WorkerError;
 };
 
 export type Resp =

--- a/packages/editor/src/worker/errors.ts
+++ b/packages/editor/src/worker/errors.ts
@@ -1,0 +1,80 @@
+import { PenroseError, runtimeError, showError } from "@penrose/core";
+import { WorkerState } from "./common.js";
+
+export type BadStateError = {
+  tag: "BadStateError";
+  request: string;
+  workerState: WorkerState;
+};
+
+export type HistoryIndexOutOfRangeError = {
+  tag: "HistoryIndexOutOfRangeError";
+  index: number;
+  historyLength: number;
+};
+
+export type FatalWorkerError = {
+  tag: "FatalWorkerError";
+  error: unknown;
+};
+
+export type CompileError = {
+  tag: "CompileError";
+  error: PenroseError;
+};
+
+export type OptimizationError = {
+  tag: "OptimizationError";
+  error: unknown;
+  nextWorkerState: WorkerState.Compiled;
+};
+
+export type WorkerError =
+  | ((
+      | BadStateError
+      | HistoryIndexOutOfRangeError
+      | CompileError
+      | OptimizationError
+    ) & {
+      nextWorkerState: WorkerState;
+    })
+  | FatalWorkerError;
+
+export const showWorkerError = (error: WorkerError): string => {
+  switch (error.tag) {
+    case "BadStateError":
+      return `Cannot receive ${error.request} in worker state ${error.workerState}`;
+
+    case "HistoryIndexOutOfRangeError":
+      return `History index ${error.index} is out of range for length ${error.historyLength}`;
+
+    case "CompileError":
+      return showError(error.error);
+
+    case "OptimizationError":
+      return `Error during optimization: ${error.error}`;
+
+    case "FatalWorkerError":
+      return `Fatal worker error: ${error.error}`;
+  }
+};
+
+export const isWorkerError = (error: unknown): error is WorkerError => {
+  return (
+    error instanceof Object &&
+    "tag" in error &&
+    (error.tag === "BadStateError" ||
+      error.tag === "HistoryIndexOutOfRangeError" ||
+      error.tag === "CompileError" ||
+      error.tag === "OptimizationError" ||
+      error.tag === "FatalWorkerError")
+  );
+};
+
+export const toPenroseError = (error: WorkerError) => {
+  if (error.tag === "CompileError") {
+    return error.error;
+  } else {
+    return runtimeError(showWorkerError(error));
+  }
+};

--- a/packages/editor/src/worker/worker.ts
+++ b/packages/editor/src/worker/worker.ts
@@ -6,7 +6,6 @@ import {
   isOptimized,
   LabelMeasurements,
   nextStage,
-  PenroseError,
   PenroseState,
   resample,
   runtimeError,
@@ -23,6 +22,7 @@ import {
   stateToLayoutState,
   WorkerState,
 } from "./common.js";
+import { WorkerError } from "./errors.js";
 
 type Frame = number[];
 
@@ -55,7 +55,7 @@ const respond = (response: Resp) => {
   postMessage(response);
 };
 
-const respondError = (error: PenroseError) => {
+const respondError = (error: WorkerError) => {
   respond({
     tag: "ErrorResp",
     error,
@@ -64,10 +64,14 @@ const respondError = (error: PenroseError) => {
 
 self.onmessage = async ({ data }: MessageEvent<Req>) => {
   const badStateError = () => {
-    respondError(
-      runtimeError(`Cannot receive ${data.tag} in worker state ${workerState}`),
-    );
+    respondError({
+      tag: "BadStateError",
+      request: data.tag,
+      workerState: workerState,
+      nextWorkerState: workerState,
+    });
   };
+
   switch (workerState) {
     case WorkerState.Init:
       switch (data.tag) {
@@ -105,20 +109,7 @@ self.onmessage = async ({ data }: MessageEvent<Req>) => {
 
         case "ComputeShapesReq":
           log.info("Received ComputeShapesReq in state Compiled");
-          if (data.index >= history.length) {
-            respondError(
-              runtimeError(`Index ${data.index} too large for history`),
-            );
-            break;
-          }
-          {
-            const state = optState ?? unoptState;
-            const newShapes: LayoutState = stateToLayoutState({
-              ...state,
-              varyingValues: history[data.index],
-            });
-            respondUpdate(newShapes, stats);
-          }
+          respondShapes(data.index);
           break;
 
         case "CompiledReq":
@@ -132,6 +123,7 @@ self.onmessage = async ({ data }: MessageEvent<Req>) => {
           // resample can fail, but doesn't return a result. Hence, try/catch
           try {
             const resampled = resample({ ...unoptState, variation });
+            workerState = WorkerState.Optimizing;
             respondOptimizing();
             optimize(insertPending(resampled));
           } catch (err: any) {
@@ -154,9 +146,10 @@ self.onmessage = async ({ data }: MessageEvent<Req>) => {
       log.info("Received request during optimization");
 
       if (optState === null) {
-        respondError(
-          runtimeError(`OptState was null on request during optimizing`),
-        );
+        respondError({
+          tag: "FatalWorkerError",
+          error: runtimeError("OptState was null during optimization"),
+        });
         return;
       }
 
@@ -168,11 +161,7 @@ self.onmessage = async ({ data }: MessageEvent<Req>) => {
 
         case "ComputeShapesReq":
           log.info("Received ComputeShapesReq in state Optimizing");
-          const newShapes: LayoutState = stateToLayoutState({
-            ...unoptState,
-            varyingValues: history[data.index],
-          });
-          respondUpdate(newShapes, stats);
+          respondShapes(data.index);
           break;
 
         case "InterruptReq":
@@ -191,8 +180,6 @@ self.onmessage = async ({ data }: MessageEvent<Req>) => {
 const compileAndRespond = async (data: CompiledReq) => {
   const { domain, substance, style, variation, jobId } = data;
 
-  // save the id for the current task
-  currentTask = jobId;
   const compileResult = await compileTrio({
     domain,
     substance,
@@ -201,11 +188,37 @@ const compileAndRespond = async (data: CompiledReq) => {
   });
 
   if (compileResult.isErr()) {
-    respondError(compileResult.error);
+    respondError({
+      tag: "CompileError",
+      error: compileResult.error,
+      nextWorkerState: workerState,
+    });
   } else {
+    // save the id for the current task
+    currentTask = jobId;
     unoptState = compileResult.value;
     workerState = WorkerState.Compiled;
     respondCompiled(jobId, unoptState);
+  }
+};
+
+const respondShapes = (index: number) => {
+  if (index >= history.length) {
+    respondError({
+      tag: "HistoryIndexOutOfRangeError",
+      index: index,
+      historyLength: history.length,
+      nextWorkerState: workerState,
+    });
+    return;
+  }
+  {
+    const state = optState ?? unoptState;
+    const newShapes: LayoutState = stateToLayoutState({
+      ...state,
+      varyingValues: history[index],
+    });
+    respondUpdate(newShapes, stats);
   }
 };
 
@@ -271,6 +284,8 @@ const optimize = async (state: PenroseState) => {
         // set by onmessage if we need to stop
         log.info("Optimization finishing early");
         shouldFinish = false;
+        workerState = WorkerState.Compiled;
+        respondFinished(state, stats);
         return;
       }
 

--- a/packages/editor/src/worker/worker.ts
+++ b/packages/editor/src/worker/worker.ts
@@ -233,6 +233,7 @@ const respondCompiled = (id: string, state: PenroseState) => {
     tag: "CompiledResp",
     jobId: id,
     shapes: state.shapes,
+    warnings: state.warnings,
   });
 };
 


### PR DESCRIPTION
# Description

Many small bugfixes and improvements

- Worker no longer errors on stale update responses (simply ignores)
- Created `WorkerError` type to distinguish recoverable errors more cleanly
- ~~Editor no longer hangs when several compiles are queued quickly~~ **Disabled recompilation before compilation has finished** (in accordance with previous behavior)
- Slider no longer throws out of range error when compiled immediately after a drag
- Slider no longer "falls behind" after a drag + resample 
- Allow `startOptimize` to interrupt ongoing optimization instead of erroring
- Display compiler warnings properly
- Hide excluded warnings

# Checklist

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have reviewed any generated registry diagram changes
