### PR TITLE
docs: warn about Homebrew Python

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -54,6 +54,14 @@ don't already have it, then run this command:
 brew install pkg-config cairo pango libpng jpeg giflib librsvg pixman
 ```
 
+Note that, because some of these packages depend on Python, your Python version
+may be wrong after this step even if it was correct earlier; for instance, if
+you've never installed Python before so you just have the Python 3.9 that your
+Mac comes preinstalled with, you may think you're OK but then after this step
+you may run `python3 --version` again and find that you now have Python 3.12
+installed. Using [Pyenv][] is a great way to prevent these shenanigans from
+messing with your Penrose setup!
+
 ### Windows WSL
 
 Here are some WSL-specific guides:


### PR DESCRIPTION
# Description

Following up on #1777 and #1778, this PR adds a warning note about how Homebrew can adjust the Python version on one's `PATH` even if it's correct before running any `brew install` commands.

# Checklist

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have reviewed any generated registry diagram changes