### PR TITLE
docs: clarify that only Node v18 works

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -38,7 +38,7 @@ Be sure you have these tools installed:
 - [Python][] 3.10 or below (if using Linux or Mac, we recommend installing via
   [Pyenv][])
 
-- [Node.js][] v18+ (if using Linux or Mac, we recommend installing via [nvm][])
+- [Node.js][] v18 (if using Linux or Mac, we recommend installing via [nvm][])
 
   - [Yarn][] v1.x
 


### PR DESCRIPTION
# Description

On commit 42ea8ec954655fabdd0eea0e208cd2f4810afeca, trying to install using Node v19 gives this error:

```
yarn install v1.22.19
[1/4] 🔍  Resolving packages...
[2/4] 🚚  Fetching packages...
warning penrose-vs@4.0.0-alpha.0: The engine "vscode" appears to be invalid.
error vitest@1.6.0: The engine "node" is incompatible with this module. Expected version "^18.0.0 || >=20.0.0". Got "19.9.0"
error Found incompatible module.
info Visit https://yarnpkg.com/en/docs/cli/install for documentation about this command.
```

And trying to install with Node v20 or v21 gives this error: https://pastebin.com/uUcHasWM

This PR modifies `CONTRIBUTING.md` to clarify that only Node v18 actually works.

# Checklist

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have reviewed any generated registry diagram changes