### PR TITLE
fix: failed handling of optimizer errors

### DIFF
--- a/packages/editor/src/components/DiagramPanel.tsx
+++ b/packages/editor/src/components/DiagramPanel.tsx
@@ -66,17 +66,16 @@ export default function DiagramPanel() {
       try {
         const info = await optimizer.pollForUpdate();
         if (info !== null) {
-          setDiagram({
-            ...diagram,
-            error: null,
+          setDiagram((state) => ({
+            ...state,
             state: info.state,
-          });
+          }));
         }
       } catch (error: any) {
-        setDiagram({
-          ...diagram,
+        setDiagram((state) => ({
+          ...state,
           error,
-        });
+        }));
       }
     }
   };

--- a/packages/editor/src/state/callbacks.ts
+++ b/packages/editor/src/state/callbacks.ts
@@ -219,6 +219,8 @@ export const useResampleDiagram = () =>
         ...state,
         metadata: { ...state.metadata, variation },
         state: info.state,
+        // keep compile errors on resample, but clear runtime errors
+        error: state.error?.errorType === "RuntimeError" ? null : state.error,
       }));
       // update grid state too
       set(diagramGridState, ({ gridSize }) => ({

--- a/packages/editor/src/worker/worker.ts
+++ b/packages/editor/src/worker/worker.ts
@@ -332,7 +332,11 @@ const optimize = async (state: PenroseState) => {
       log.info("Optimization failed. Quitting without finishing...");
       workerState = WorkerState.Compiled;
       optState = null;
-      respondError(err);
+      respondError({
+        tag: "OptimizationError",
+        error: err,
+        nextWorkerState: WorkerState.Compiled,
+      });
       return;
     }
   };


### PR DESCRIPTION
# Description

Resolves #1790 

Optimizer errors were not correctly propagated from the web worker to the main thread due to a typo. Additionally, errors were cleared prematurely on resampling by being default cleared on diagram update. Both of these issues have been corrected.

# Checklist

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have reviewed any generated registry diagram changes
