### PR TITLE
feat: distribute horizontal and vertical constraint functions

### DIFF
--- a/packages/core/src/lib/Constraints.ts
+++ b/packages/core/src/lib/Constraints.ts
@@ -1063,7 +1063,7 @@ const constrDictGeneral = {
   hSpacing: {
     name: "hSpacing",
     description:
-      "Requires that the bounding boxes for shapes within a shapeList are touching.",
+      "Requires that the bounding boxes for shapes within a shapeList are evenly spaced with a set padding.",
     params: [
       {
         name: "shapes",
@@ -1071,15 +1071,21 @@ const constrDictGeneral = {
           "List containing the top-left, top-right, bottom-right, bottom-left points (in that order) of the axis-aligned bounding box of a shape",
         type: shapeListT(),
       },
+      {
+        name: "padding",
+        description: "Margin between bounding boxes of shapes",
+        type: realT(),
+        default: 0,
+      },
     ],
-    body: noWarnFn((shapes: Shape<ad.Num>[]) => {
+    body: noWarnFn((shapes: Shape<ad.Num>[], padding: ad.Num) => {
       let spacingSum: ad.Num = 0;
 
       for (let i = 0; i < shapes.length - 1; i++) {
         const currShape = BBox.maxX(bboxFromShape(shapes[i]));
         const nextShape = BBox.minX(bboxFromShape(shapes[i + 1]));
 
-        const difference = absVal(sub(currShape, nextShape));
+        const difference = absVal(sub(add(currShape, padding), nextShape));
 
         spacingSum = add(spacingSum, difference);
 

--- a/packages/core/src/lib/Constraints.ts
+++ b/packages/core/src/lib/Constraints.ts
@@ -1063,7 +1063,7 @@ const constrDictGeneral = {
   hSpacing: {
     name: "hSpacing",
     description:
-      "Requires that the bounding boxes for shapes within a shapeList are evenly spaced with a set padding.",
+      "Requires that the bounding boxes for shapes within a shapeList are evenly spaced horizontally with a set padding.",
     params: [
       {
         name: "shapes",
@@ -1084,6 +1084,43 @@ const constrDictGeneral = {
       for (let i = 0; i < shapes.length - 1; i++) {
         const currShape = BBox.maxX(bboxFromShape(shapes[i]));
         const nextShape = BBox.minX(bboxFromShape(shapes[i + 1]));
+
+        const difference = absVal(sub(add(currShape, padding), nextShape));
+
+        spacingSum = add(spacingSum, difference);
+
+        //compare |currShapeRight - nextShapeLeft|
+      }
+
+      return spacingSum;
+    }),
+  },
+
+  vSpacing: {
+    name: "vSpacing",
+    description:
+      "Requires that the bounding boxes for shapes within a shapeList are evenly spaced vertically with a set padding.",
+
+    params: [
+      {
+        name: "shapes",
+        description:
+          "List containing the top-left, top-right, bottom-right, bottom-left points (in that order) of the axis-aligned bounding box of a shape",
+        type: shapeListT(),
+      },
+      {
+        name: "padding",
+        description: "Margin between bounding boxes of shapes",
+        type: realT(),
+        default: 0,
+      },
+    ],
+    body: noWarnFn((shapes: Shape<ad.Num>[], padding: ad.Num) => {
+      let spacingSum: ad.Num = 0;
+
+      for (let i = 0; i < shapes.length - 1; i++) {
+        const currShape = BBox.maxY(bboxFromShape(shapes[i]));
+        const nextShape = BBox.minY(bboxFromShape(shapes[i + 1]));
 
         const difference = absVal(sub(add(currShape, padding), nextShape));
 

--- a/packages/core/src/lib/Constraints.ts
+++ b/packages/core/src/lib/Constraints.ts
@@ -1089,7 +1089,7 @@ const constrDictGeneral = {
 
         spacingSum = add(spacingSum, difference);
 
-        //compare |currShapeRight - nextShapeLeft|
+        //compare difference between current shape + horizontal padding and next shape
       }
 
       return spacingSum;
@@ -1126,7 +1126,7 @@ const constrDictGeneral = {
 
         spacingSum = add(spacingSum, difference);
 
-        //compare |currShapeRight - nextShapeLeft|
+        //compare difference between current shape + vertical padding and next shape
       }
 
       return spacingSum;

--- a/packages/core/src/lib/Constraints.ts
+++ b/packages/core/src/lib/Constraints.ts
@@ -1060,8 +1060,8 @@ const constrDictGeneral = {
     body: noWarnFn(containsRects),
   },
 
-  hSpacing: {
-    name: "hSpacing",
+  distributeHorizontally: {
+    name: "distributeHorizontally",
     description:
       "Requires that the bounding boxes for shapes within a shapeList are evenly spaced horizontally with a set padding.",
     params: [
@@ -1096,8 +1096,8 @@ const constrDictGeneral = {
     }),
   },
 
-  vSpacing: {
-    name: "vSpacing",
+  distributeVertically: {
+    name: "distributeVertically",
     description:
       "Requires that the bounding boxes for shapes within a shapeList are evenly spaced vertically with a set padding.",
 

--- a/packages/core/src/lib/Constraints.ts
+++ b/packages/core/src/lib/Constraints.ts
@@ -30,6 +30,7 @@ import {
   real2T,
   realNT,
   realT,
+  shapeListT,
   shapeT,
 } from "../utils/Util.js";
 import { constrDictCurves } from "./Curves.js";
@@ -1057,6 +1058,36 @@ const constrDictGeneral = {
       },
     ],
     body: noWarnFn(containsRects),
+  },
+
+  hSpacing: {
+    name: "hSpacing",
+    description:
+      "Requires that the bounding boxes for shapes within a shapeList are touching.",
+    params: [
+      {
+        name: "shapes",
+        description:
+          "List containing the top-left, top-right, bottom-right, bottom-left points (in that order) of the axis-aligned bounding box of a shape",
+        type: shapeListT(),
+      },
+    ],
+    body: noWarnFn((shapes: Shape<ad.Num>[]) => {
+      let spacingSum: ad.Num = 0;
+
+      for (let i = 0; i < shapes.length - 1; i++) {
+        const currShape = BBox.maxX(bboxFromShape(shapes[i]));
+        const nextShape = BBox.minX(bboxFromShape(shapes[i + 1]));
+
+        const difference = absVal(sub(currShape, nextShape));
+
+        spacingSum = add(spacingSum, difference);
+
+        //compare |currShapeRight - nextShapeLeft|
+      }
+
+      return spacingSum;
+    }),
   },
 };
 

--- a/packages/examples/src/alloy-models/file-system/icicle-plot-file-system.domain
+++ b/packages/examples/src/alloy-models/file-system/icicle-plot-file-system.domain
@@ -1,0 +1,10 @@
+type Object
+type File <: Object
+type Dir <: Object
+type Root <: Dir
+type Entry
+type Name
+
+predicate name(Entry, Name)
+predicate object(Entry, Object)
+predicate entries(Dir, Entry)

--- a/packages/examples/src/alloy-models/file-system/icicle-plot-file-system.style
+++ b/packages/examples/src/alloy-models/file-system/icicle-plot-file-system.style
@@ -1,0 +1,177 @@
+canvas {
+  width = 800
+  height = 800
+}
+
+Color {
+  darkPurple = #76448A
+  mediumPurple = #AF7AC5
+  lightPurple = #D7BDE2
+  offWhite = #F9F2FE
+
+}
+
+config {
+  shapeHeight = 100
+  font = "15px"
+  minShapeWidth = 100
+
+}
+
+
+layout = [shapes, texts]
+
+
+forall Object x {
+
+  x.width = ?[20] in shapes
+  x.height = config.shapeHeight
+
+  x.center_x = ? in shapes 
+  x.center_y = ? in shapes
+
+  x.center = [x.center_x, x.center_y]
+
+  x.left = x.center_x - x.width/2
+  x.right = x.center_x + x.width/2
+  x.top = x.center_y + x.height/2
+  x.bottom = x.center_y - x.height/2
+
+
+  ensure x.width > config.minShapeWidth in shapes
+
+
+
+  x.icon = Rectangle {
+    fillColor : #808080
+    strokeColor : #000000
+    strokeWidth : 1
+    center: x.center
+    width: x.width
+    height: x.height
+  }
+
+
+
+  
+  x.text = Text {
+    string : x.label
+    center: x.center
+    fontSize: config.font
+    
+
+  }
+
+  x.g = Group {
+    shapes: [x.icon, x.text]
+  }
+  layer x.icon below x.text
+
+
+  ensure contains(x.icon, x.text, 10) in texts
+
+}
+
+forall Dir d {
+  override d.icon.fillColor = Color.lightPurple
+  
+}
+
+forall File f {
+  override f.icon.fillColor = Color.offWhite
+}
+
+forall Root r {
+  override r.icon.fillColor = Color.darkPurple
+  override r.text.fillColor = #F5EEF8
+
+}
+
+
+forall Entry e {
+
+  e.width = ?[20] in shapes
+  e.height = config.shapeHeight
+
+
+  e.center_x = ? in shapes 
+  e.center_y = ? in shapes
+
+  e.center = [e.center_x, e.center_y]
+
+  e.left = e.center_x - e.width/2
+  e.right = e.center_x + e.width/2
+  e.top = e.center_y + e.height/2
+  e.bottom = e.center_y - e.height/2
+
+  ensure e.width > config.minShapeWidth in shapes
+
+
+  
+  e.icon = Rectangle {
+    fillColor : Color.mediumPurple
+    strokeColor : #000000
+    strokeWidth : 0.5
+    center: e.center 
+    width: e.width
+    height: e.height
+  }
+
+  e.text = Text {
+    string : e.label
+    fontSize: config.font
+    center: e.center
+  }
+
+
+  e.g = Group {
+    shapes : [e.icon, e.text]
+  }
+
+  layer e.icon below e.text
+  ensure contains(e.icon, e.text, 10) in texts
+
+}
+
+
+
+
+forall Object o; Entry e 
+where object(e, o) {
+
+  override o.center_y = e.center_y - config.shapeHeight
+
+  ensure o.left > e.left
+  ensure  o.right < e.right
+
+
+}
+
+
+
+forall Dir d ; Entry e
+where entries (d, e) {
+
+  override e.center_y = d.center_y - config.shapeHeight
+
+  ensure e.left > d.left
+  ensure  e.right < d.right
+
+}
+
+
+collect Entry e into es
+where entries(d, e)
+foreach Dir d {
+  override d.width = sum(listof width from es)
+  ensure hSpacing(listof icon from es)
+}
+
+
+
+collect Object o into os
+where object(e, o)
+foreach Entry e {
+  override e.width = sum(listof width from os)
+  ensure hSpacing(listof icon from os)
+}

--- a/packages/examples/src/alloy-models/file-system/icicle-plot-file-system.style
+++ b/packages/examples/src/alloy-models/file-system/icicle-plot-file-system.style
@@ -164,7 +164,7 @@ collect Entry e into es
 where entries(d, e)
 foreach Dir d {
   override d.width = sum(listof width from es)
-  ensure hSpacing(listof icon from es)
+  ensure distributeHorizontally(listof icon from es)
 }
 
 
@@ -173,5 +173,5 @@ collect Object o into os
 where object(e, o)
 foreach Entry e {
   override e.width = sum(listof width from os)
-  ensure hSpacing(listof icon from os)
+  ensure distributeHorizontally(listof icon from os)
 }

--- a/packages/examples/src/alloy-models/file-system/icicle-plot-file-system.substance
+++ b/packages/examples/src/alloy-models/file-system/icicle-plot-file-system.substance
@@ -1,0 +1,42 @@
+Dir dir0, dir1, dir2
+Entry entry0, entry1, entry2, entry3, entry4
+File file0, file1
+Name name0, name1, name2
+Root root0
+
+name(entry0, name2)
+name(entry1, name2)
+name(entry2, name1)
+name(entry3, name2)
+name(entry4, name1)
+
+
+entries(dir1, entry1)
+entries(dir1, entry2)
+entries(dir2, entry0)
+entries(root0, entry3)
+entries(root0, entry4)
+
+
+object(entry0, file1)
+object(entry1, dir0)
+object(entry2, dir2)
+object(entry3, dir1)
+object(entry4, file0)
+
+
+Label dir0 "Directory 0"
+Label dir1 "Directory 1"
+Label dir2 "Directory 2"
+Label entry0 "Entry 0"
+Label entry1 "Entry 1"
+Label entry2 "Entry 2"
+Label entry3 "Entry 3"
+Label entry4 "Entry 4"
+Label file0 "File 0"
+Label file1 "File 1"
+Label name0 "Name 0"
+Label name1 "Name 1"
+Label name2 "Name 2"
+Label root0 "Root"
+

--- a/packages/examples/src/alloy-models/icicle-plot-file-system.trio.json
+++ b/packages/examples/src/alloy-models/icicle-plot-file-system.trio.json
@@ -1,0 +1,6 @@
+{
+  "substance": "./file-system/icicle-plot-file-system.substance",
+  "style": ["./file-system/icicle-plot-file-system.style"],
+  "domain": "./file-system/icicle-plot-file-system.domain",
+  "variation": "CeruleanFalcon14759"
+}

--- a/packages/examples/src/registry.json
+++ b/packages/examples/src/registry.json
@@ -566,5 +566,9 @@
   "dataviz/residual": {
     "name": "Linear Regression Residuals",
     "gallery": false
+  },
+  "alloy-models/icicle-plot-file-system": {
+    "name": "File System Icicle Plot",
+    "gallery": false
   }
 }


### PR DESCRIPTION
# Description

I added two additional constraint functions to the constraint function library. These functions, called distributeHorizontally and distributeVertically respectively, both take in a list of shapes and an optional padding margin as parameters. My original use case for this feature was for an icicle plot diagram I was making in Penrose. For context, icicle plots are one neat way to visualize file systems, or any general hierarchy-based system. Previously, I had to use the disjoint and touching functions in different instances to replicate what I was was envisioning. However, these constraints were difficult to balance and I ran into some consistency issues when resampling. This new constraint function simplified my work and allowed the more difficult alignments of my visualization to be computed instead of optimized. These two functions can be generalized to any collection of shapes. 


# Implementation strategy and design decisions

Both functions ensure that the bounding boxes of all shapes are touching each other by default, or separated by a margin specified by the padding. The padding parameter defaults to 0 if not specified. 

Here is a more in-depth look at how the functions work:

### distributeHorizontally

Require that the bounding boxes for `shapes` within a shape list are evenly spaced horizontally with optional padding `padding` . 

| Name     | Type | Type Description | Description | 
| ----------- | ----------- | ----------- | ----------- |
|      shapes        |      List of Shapes         |     Any list of shapes          |       Collection of shapes           |
| padding          |             ℝ                     |    Real Number        |         padding                                |



### distributeVertically

Require that the bounding boxes for `shapes` within a shape list are evenly spaced vertically with optional padding `padding` . 
| Name     | Type | Type Description | Description | 
| ----------- | ----------- | ----------- | ----------- |
|      shapes        |      List of Shapes         |     Any list of shapes          |       Collection of shapes           |
| padding          |             ℝ                     |    Real Number        |         padding                                |


---

For distributeHorizontally, the function works by iterating over all shapes in the list (collector) and summing the absolute values of the differences between the  sum of the right side of the current box plus padding and the left side of the next box. 

The optimization function that Penrose then solves is 

$$ \sum_{i=1}^{n-1} | (right_i + padding) -  left_{i+1} | = 0  $$


For distributeVertically, the function works similarly, but with different bounding box sides. Instead of the left and right bounds, the function uses the top and bottom bounds, summing the differences between the top bound of a current shape's bounding box and padding and the bottom bound of the next box's padding. 

The optimization function that Penrose solves here is 

$$ \sum_{i=1}^{n-1} | (top_i + padding) -  bottom_{i+1} | = 0 $$



# Examples with steps to reproduce them


distributeVertically example:

<img width="764" alt="image" src="https://github.com/penrose/penrose/assets/100004157/8735f73f-a632-4fae-b459-1adb9355835e">



distributeVertically test link:  https://6ef225de.penrose-72l.pages.dev/try/?gist=dd0371a1f9d571beb756596fd3e44ad3

---

distributeHorizontally example:

<img width="781" alt="image" src="https://github.com/penrose/penrose/assets/100004157/8e62627f-4b86-4593-82ea-9d63754bdc98">


distributeHorizontally test link: https://6ef225de.penrose-72l.pages.dev/try/?gist=94aae8ee3b747470fdbca682999b586a

---

file system example:


![image](https://github.com/penrose/penrose/assets/100004157/4c3079f5-b197-4069-9110-fe375afbbc96)

file system test link: https://6ef225de.penrose-72l.pages.dev/try/?gist=387d16129c47db9f81b2ae62cfc84260

---

# Checklist

- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have reviewed any generated registry diagram changes

# Open questions


