### PR TITLE
fix: optimizer entering error state on compile error from init

### DIFF
--- a/packages/editor/src/worker/OptimizerWorker.ts
+++ b/packages/editor/src/worker/OptimizerWorker.ts
@@ -290,8 +290,7 @@ export default class OptimizerWorker {
         case "CompileError":
           if (
             "previous" in this.state &&
-            this.state.previous.tag === data.error.nextWorkerState &&
-            this.state.previous.tag === "Compiled"
+            this.state.previous.tag === data.error.nextWorkerState
           ) {
             callRejects();
             this.setState(this.state.previous);


### PR DESCRIPTION
# Description

Resolves #1799.

Fixes an issue where compiler errors may enter the optimizer worker into an error state if there were no previosuly successful compiles.

# Checklist

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have reviewed any generated registry diagram changes
