### PR TITLE
docs: summer 24 team

### DIFF
--- a/packages/docs-site/docs/team.md
+++ b/packages/docs-site/docs/team.md
@@ -83,7 +83,7 @@ const members = [
   },
   {
     name: "Yiliang (Leo) Liang",
-    title: "Research engineer @ CMU",
+    title: "Ph.D. student @ CMU",
     avatar: "https://www.github.com/liangyiliang.png",
     links: [
       { icon: "github", link: "https://github.com/liangyiliang" },
@@ -107,6 +107,23 @@ const members = [
       { icon: "github", link: "https://github.com/hsharriman" },
     ],
   },
+	{
+		name: "Kyle Lee",
+		title: "Undergraduate student @ CMU",
+		avatar: "https://github.com/KyleleeSea.png",
+		links:[
+      { icon: "github", link: "https://github.com/KyleleeSea" },
+		]
+	},
+	{
+		name: "Griffin Teller",
+		title: "Undergraduate student @ CMU",
+		avatar: "https://github.com/griffinteller.png",
+    links: [
+      { icon: { svg: website }, link: "https://griffinteller.com/" },
+      { icon: "github", link: "https://github.com/griffinteller" },
+    ],
+	},
   {
     name: "Rijul Jain",
     title: "REUSE student",
@@ -114,15 +131,6 @@ const members = [
     links: [
       { icon: { svg: website }, link: "https://rijuljain.com" },
       { icon: "github", link: "https://github.com/rjainrjain" },
-    ],
-  },
-  {
-    name: "Raven Rothkopf",
-    title: "REUSE student",
-    avatar: "https://www.github.com/ravenrothkopf.png",
-    links: [
-      { icon: { svg: website }, link: "https://ravenrothkopf.github.io/" },
-      { icon: "github", link: "https://github.com/ravenrothkopf" },
     ],
   },
   {
@@ -157,6 +165,7 @@ in Pittsburgh, PA USA—and other locations around the world.
 
 ## Past Members
 
+- [Raven Rothkopf](https://ravenrothkopf.github.io/)
 - [Jonathan Aldrich](https://www.cs.cmu.edu/~aldrich/)
 - [Matt Davis](https://cmumatt.github.io/)
 - [Rain Du](https://miyehn.me/)


### PR DESCRIPTION
# Description

This PR updates the team page to include @KyleleeSea and @griffinteller, moves @ravenrothkopf to past members, and changes @liangyiliang's title to PhD student.