### PR TITLE
chore: fix typo in L-BFGS docstring

### DIFF
--- a/packages/core/src/engine/Lbfgs.ts
+++ b/packages/core/src/engine/Lbfgs.ts
@@ -129,7 +129,7 @@ export interface Info {
   /** Data about previous steps. */
   state: State;
 
-  /** The objective value at the current point. */
+  /** The objective value at the previous point. */
   fx: number;
 
   /** The preconditioned descent direction. */


### PR DESCRIPTION
# Description

This PR corrects an error in a docstring in our current implementation of L-BFGS, introduced in #1355.

# Checklist

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have reviewed any generated registry diagram changes