### PR TITLE
fix: prohibiting inline subtyping on literal types

### DIFF
--- a/packages/core/src/compiler/Domain.test.ts
+++ b/packages/core/src/compiler/Domain.test.ts
@@ -268,5 +268,9 @@ type Set
 function F(Set s) -> String
     `;
     expectErrorOf(prog4, "OutputLiteralTypeError");
+    const prog5 = `
+type Set <: Number
+        `;
+    expectErrorOf(prog5, "SubOrSuperLiteralTypeError");
   });
 });

--- a/packages/core/src/compiler/Domain.ts
+++ b/packages/core/src/compiler/Domain.ts
@@ -229,10 +229,8 @@ const checkStmt = (stmt: DomainStmt<C>, env: DomainEnv): CheckerResult => {
     }
     case "SubTypeDecl": {
       const { subType, superType } = stmt;
-      const subOk = checkSubSupType(subType, env);
-      const supOk = checkSubSupType(superType, env);
       const updatedEnv = addSubtype(subType, superType, env);
-      return everyResult(subOk, supOk, updatedEnv);
+      return updatedEnv;
     }
   }
 };
@@ -345,16 +343,17 @@ const areSameTypes = (
 };
 
 const addSubtype = (
-  subType: Type<C>, // assume already checked
+  subType: Type<C>,
   superType: Type<C>,
   env: DomainEnv,
 ): CheckerResult => {
-  const superOk = checkType(superType, env);
+  const subOk = checkSubSupType(subType, env);
+  const superOk = checkSubSupType(superType, env);
   const updatedEnv: CheckerResult = ok({
     ...env,
     subTypes: [...env.subTypes, [subType, superType]],
   });
-  return everyResult(superOk, updatedEnv);
+  return everyResult(subOk, superOk, updatedEnv);
 };
 
 const computeTypeGraph = (env: DomainEnv): CheckerResult => {


### PR DESCRIPTION
# Description

Resolves #1818.

This PR moves the check on prohibiting literal types to whenever a subtyping relation is registered. That way, no matter where the subtyping relation appears (in `TypeDecl` or in `SubtypeDecl`), the checker will prohibit subtyping on literal types.

A test has been added.

# Checklist

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have reviewed any generated registry diagram changes
