### PR TITLE
feat: added cntrl/cmd+enter and :w to compile diagram

### DIFF
--- a/packages/editor/src/components/ProgramEditor.tsx
+++ b/packages/editor/src/components/ProgramEditor.tsx
@@ -57,6 +57,7 @@ export default function ProgramEditor({ kind }: { kind: ProgramType }) {
       showCompileErrs={showCompileErrs}
       codemirrorHistoryState={codemirrorHistoryState}
       readOnly={false}
+      onWrite={compileDiagram}
     />
   );
 }


### PR DESCRIPTION
# Description
Feature existed prior to Codemirror migration. This PR adds it back in. 
1) In Vim mode, :w will compile diagram. 

https://github.com/penrose/penrose/assets/85892844/79b776c8-a747-4acd-b399-ae2704d62773

2) Cntrl/Cmd+Enter will compile diagram

**Notes**
Listing uses EditorPane and does not pass in an onWrite property. In this case onWrite will be undefined and thus no keymaps will be added. 