### PR TITLE
feat: Layout stage autocomplete + corresponding tests

### DIFF
--- a/packages/components/src/editing/hooks/style/styleAutocomplete.ts
+++ b/packages/components/src/editing/hooks/style/styleAutocomplete.ts
@@ -1,5 +1,6 @@
 import { Completion, CompletionContext } from "@codemirror/autocomplete";
 import { syntaxTree } from "@codemirror/language";
+// import { printTree } from "@lezer-unofficial/printer";
 import { useCallback } from "react";
 import { DomainCache, ShapeDefinitions } from "../../types";
 import {
@@ -19,6 +20,7 @@ import {
   getPredOptions,
   getShapeNames,
   getShapeProps,
+  getStageNameOpts,
   getTypeOptions,
   headerOptions,
   selectorHeaderOptions,
@@ -34,6 +36,19 @@ export const createStyleAutocomplete = (
     let nodeBefore = syntaxTree(context.state).resolveInner(context.pos, -1);
     let parentNode = nodeBefore.parent;
     let word = context.matchBefore(/\w*/);
+
+    // console.log(
+    //   printTree(
+    //     syntaxTree(context.state).topNode,
+    //     context.state.doc.toString(),
+    //   ),
+    // );
+    // console.log(
+    //   getStageNameOpts(
+    //     syntaxTree(context.state).topNode,
+    //     context.state.doc.toString(),
+    //   ),
+    // );
 
     if (word == null) {
       return null;
@@ -131,6 +146,21 @@ export const createStyleAutocomplete = (
           };
         }
       }
+    }
+
+    // Stage Name autocomplete
+    if (
+      goUpToTarget(nodeBefore, "StageSpecifier") &&
+      // Avoid suggesting where "in"/"except" go
+      parentNode?.prevSibling != null
+    ) {
+      const topNode = syntaxTree(context.state).topNode;
+      const styleProg = context.state.doc.toString();
+
+      return {
+        from: word.from,
+        options: getStageNameOpts(topNode, styleProg),
+      };
     }
 
     // Top level kw completion (forall, collect, layout)

--- a/packages/components/src/editing/hooks/style/styleAutocomplete.ts
+++ b/packages/components/src/editing/hooks/style/styleAutocomplete.ts
@@ -1,6 +1,5 @@
 import { Completion, CompletionContext } from "@codemirror/autocomplete";
 import { syntaxTree } from "@codemirror/language";
-// import { printTree } from "@lezer-unofficial/printer";
 import { useCallback } from "react";
 import { DomainCache, ShapeDefinitions } from "../../types";
 import {
@@ -36,19 +35,6 @@ export const createStyleAutocomplete = (
     let nodeBefore = syntaxTree(context.state).resolveInner(context.pos, -1);
     let parentNode = nodeBefore.parent;
     let word = context.matchBefore(/\w*/);
-
-    // console.log(
-    //   printTree(
-    //     syntaxTree(context.state).topNode,
-    //     context.state.doc.toString(),
-    //   ),
-    // );
-    // console.log(
-    //   getStageNameOpts(
-    //     syntaxTree(context.state).topNode,
-    //     context.state.doc.toString(),
-    //   ),
-    // );
 
     if (word == null) {
       return null;

--- a/packages/components/src/editing/hooks/style/styleAutocompleteUtils.ts
+++ b/packages/components/src/editing/hooks/style/styleAutocompleteUtils.ts
@@ -143,6 +143,45 @@ export const getNamespaceProps = (
   return [];
 };
 
+/*
+ * Returns an array of every stage name defined in style
+ */
+export const getStageNames = (
+  topNode: SyntaxNode,
+  styleProg: string,
+): string[] => {
+  // topNode is type input, walk down into items
+  const itemsNode = topNode.getChild("Items");
+  if (itemsNode === null) return [];
+  const itemNodes = itemsNode.getChildren("Item");
+  let stageNames = [] as string[];
+
+  itemNodes.forEach((node: SyntaxNode) => {
+    // Will shortcircuit if any not found
+    let stages = node
+      .getChild("LayoutStages")
+      ?.getChild("StageList")
+      ?.getChildren("Stage");
+
+    if (stages) {
+      stages.forEach((stageNode: SyntaxNode) => {
+        stageNames.push(extractText(styleProg, stageNode.to, stageNode.from));
+      });
+    }
+  });
+
+  return stageNames;
+};
+
+export const getStageNameOpts = (topNode: SyntaxNode, styleProg: string) => {
+  let stageNames = getStageNames(topNode, styleProg);
+  return stageNames.map((name) => ({
+    label: `${name}`,
+    type: "text",
+    info: "",
+  }));
+};
+
 export const exprKws = ["true", "false", "listof"].map((name) => ({
   label: `${name}`,
   type: "keyword",

--- a/packages/components/src/editing/tests/styleTests.test.ts
+++ b/packages/components/src/editing/tests/styleTests.test.ts
@@ -13,6 +13,7 @@ import { parser } from "../parser/style/style";
 import {
   hasErrors,
   hasNoErrors,
+  testLayoutStages,
   testNamespaceProps,
   testNamespaces,
   testStyleAutocomplete,
@@ -738,6 +739,46 @@ where InTri( p, t ); t := Triangle(q0, q1, q2) {
   });
 });
 
+describe("Stage name Caching", () => {
+  test("Stage names 1", async () => {
+    const input = `layout = [ walkStage, nestStage, labelStage, legendStage ]
+
+-- diagram dimensions (in px; multiply by 96/72 to convert to pt)
+canvas {
+   width = 200 -- ==150pt
+   height = 200 -- ==150pt
+}`;
+
+    testLayoutStages(input, [
+      "walkStage",
+      "nestStage",
+      "labelStage",
+      "legendStage",
+    ]);
+  });
+
+  test("Stage names 2", async () => {
+    const input = `canvas {
+   width = 200 -- ==150pt
+   height = 200 -- ==150pt
+}
+   forall Set x {
+  shape x.icon = Circle { }
+  shape x.text = Equation {
+    string : x.label
+    fontSize : "32px"
+  }
+  ensure contains(x.icon, x.text)
+  encourage norm(x.text.center - x.icon.center) == 0
+  layer x.text above x.icon
+}
+
+layout = [A, B, C, D]
+`;
+    testLayoutStages(input, ["A", "B", "C", "D"]);
+  });
+});
+
 describe("Autocomplete", () => {
   const shapeDefns = getShapeDefs();
   const shapeNames = getShapeNames(shapeDefns).map((cmp) => cmp.label.trim());
@@ -877,6 +918,36 @@ describe("Autocomplete", () => {
     
     c`;
     await testStyleAutocomplete(input, "", styleHeaderKws);
+  });
+
+  test("Stage Names after ?", async () => {
+    const input = `layout = [ stageA, stageB, stageC ]
+
+-- diagram dimensions (in px; multiply by 96/72 to convert to pt)
+canvas {
+   width = 200 -- ==150pt
+   height = 200 -- ==150pt
+}
+
+forall Points p {
+scalar d = ? in s}`;
+
+    await testStyleAutocomplete(input, "", ["stageA", "stageB", "stageC"], 1);
+  });
+
+  test("Stage Names in Objective", async () => {
+    const input = `layout = [ stage1, stage2, stage3 ]
+
+-- diagram dimensions (in px; multiply by 96/72 to convert to pt)
+canvas {
+   width = 200 -- ==150pt
+   height = 200 -- ==150pt
+}
+
+forall Points p {
+ensure norm(p) == 5 in s}`;
+
+    await testStyleAutocomplete(input, "", ["stage1", "stage2", "stage3"], 1);
   });
 
   // Tests assume computation functions suggested in expressions.

--- a/packages/components/src/editing/tests/testUtils.ts
+++ b/packages/components/src/editing/tests/testUtils.ts
@@ -9,6 +9,7 @@ import { createStyleAutocomplete } from "../hooks/style/styleAutocomplete";
 import {
   getNamespaceDict,
   getNamespaceProps,
+  getStageNames,
 } from "../hooks/style/styleAutocompleteUtils";
 import { getSubstanceCache } from "../hooks/substance/getSubstanceCache";
 import { createSubstanceAutocomplete } from "../hooks/substance/substanceAutocomplete";
@@ -137,7 +138,23 @@ export function testNamespaceProps(
     );
   }
 }
+/*
+ * Takes an input program and gets all the declared layout stages.
+ * Then compares it to an expected array of stage names
+ */
+export function testLayoutStages(input: string, expected: string[]) {
+  const parsedTree = parser.parse(input);
+  const stageCompletions = getStageNames(parsedTree.topNode, input);
 
+  if (!sameItems(expected, stageCompletions)) {
+    assert.fail(
+      `"Failed stage completions caching test. 
+      Expected: ${expected}
+      Recieved: ${stageCompletions}
+      Program: ${input}`,
+    );
+  }
+}
 // Converts CompletionResult object to array of labels (strings)
 export function CompletionsToLabels(
   completions: CompletionResult | null,


### PR DESCRIPTION
# Description
Adds stage name autocomplete based on the names users defines after `layout = [...]`

Adds four tests to test suite both testing layout stage names obtained correctly and autocomplete fires for stage names. 

<img width="60%" alt="Screenshot 2024-07-03 at 4 40 16 PM" src="https://github.com/penrose/penrose/assets/85892844/12a3609a-e92d-4bac-aa30-0f73b65381fa">
