### PR TITLE
fix: parse empty predicates

### DIFF
--- a/packages/core/src/parser/Substance.ne
+++ b/packages/core/src/parser/Substance.ne
@@ -196,7 +196,7 @@ let_bind -> "Let" __ identifier _ ":=" _ sub_expr {%
   }
 %}
 
-apply_predicate -> identifier _ "(" _ sepEndBy1[sub_arg_expr, ","] _ ")" {%
+apply_predicate -> identifier _ "(" _ sepEndBy[sub_arg_expr, ","] _ ")" {%
   ([name, , , , args]): ApplyPredicate<C> => ({
     ...nodeData,
     ...rangeFrom([name, ...args]),


### PR DESCRIPTION
# Description

@KyleleeSea reported that empty predicates aren't parsed by the substance nearley parser. This PR is a quick fix just to unblock him, knowing that we will deprecate the nearley parsers soon 