### PR TITLE
fix: prioritize vim keymaps in vim mode

### DIFF
--- a/packages/components/src/editing/EditorPane.tsx
+++ b/packages/components/src/editing/EditorPane.tsx
@@ -1,4 +1,5 @@
 import { autocompletion, completionKeymap } from "@codemirror/autocomplete";
+
 import { lintGutter, linter } from "@codemirror/lint";
 import { Prec } from "@codemirror/state";
 import { EditorView, keymap } from "@codemirror/view";
@@ -91,6 +92,7 @@ export default function EditorPane({
   );
 
   const defaultExtensions = [
+    vim(),
     EditorView.lineWrapping,
     ResponsiveStyles,
     lintObject,
@@ -158,7 +160,10 @@ export default function EditorPane({
     });
   }
 
-  if (vimMode) extensionsList.push(vim());
+  if (vimMode) {
+    // NOTE: need to make sure vim keybindings have the highest precedence whenever we're in vim mode
+    extensionsList.push(Prec.highest(vim()));
+  }
 
   return (
     <div style={{ width: "100%", height: "100%", position: "relative" }}>


### PR DESCRIPTION
# Description

Reported by @keenancrane: 

> It seems visual block selection in vim mode (ctrl-v) no longer works.  Maybe it got overriden with a higher-priority interpretation of ctrl-v? 
> Also, ctrl-u moves up, but ctrl-d deletes

codemirror, and by extension`@uiw/react-codemirror`, include emacs-style keymaps in its default settings: https://github.com/uiwjs/react-codemirror/issues/356#issuecomment-1180503509

This PR adds `Prec.highest` around the `vim` extension to force prioritize vim keybindings.
