### PR TITLE
chore: bump version to 4.0.0-alpha.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,125 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [v4.0.0-alpha.1] (2024-07-11)
+
+### :warning: BREAKING CHANGE
+
+- separate Substance environment and remove unused features (#1677)
+
+### :rocket: New Feature
+
+- Add array-manipulation diagram to gallery ([#1716](https://github.com/penrose/penrose/issues/1716)) ([7f08c63](https://github.com/penrose/penrose/commit/7f08c636bfbcdf09c465bf5e244f31a42a3cf6e7))
+- Added copy trio to clipboard feature ([#1763](https://github.com/penrose/penrose/issues/1763)) ([e4193ab](https://github.com/penrose/penrose/commit/e4193ab64e7433b7c61e44ae3d250d5c70683090))
+- Arc mesh example ([#1789](https://github.com/penrose/penrose/issues/1789)) ([edd0a04](https://github.com/penrose/penrose/commit/edd0a041068f00e059fa2dfd5b70dd76a5a3df99))
+- LSP-style optimization worker(s) ([#1801](https://github.com/penrose/penrose/issues/1801)) ([cff021a](https://github.com/penrose/penrose/commit/cff021a613cf1f796efce92e4a58f1dc34d66c65))
+- Layout stage autocomplete + corresponding tests ([#1823](https://github.com/penrose/penrose/issues/1823)) ([d3a9369](https://github.com/penrose/penrose/commit/d3a93691e6d781e03d17a66e844d8444d316e993))
+- Lsp-style worker + editor vite upgrade ([#1804](https://github.com/penrose/penrose/issues/1804)) ([f711e9d](https://github.com/penrose/penrose/commit/f711e9dff1120ccd799d2544c983be8df26ebafa))
+- Making gist sharing clearer (editor ux) ([#1764](https://github.com/penrose/penrose/issues/1764)) ([0ad9f39](https://github.com/penrose/penrose/commit/0ad9f39cd57a8a722241cb89811787a1b6ad236e))
+- More fractals ([#1644](https://github.com/penrose/penrose/issues/1644)) ([4862055](https://github.com/penrose/penrose/commit/4862055cb61891e7e55a2e910582fb4fbbb9f205))
+- Nephroid as Envelope ([#1647](https://github.com/penrose/penrose/issues/1647)) ([09119bd](https://github.com/penrose/penrose/commit/09119bd26895fa015d3c4864eadb05b1d72f8f9d))
+- Random Index Style Function & Chaos Game ([#1643](https://github.com/penrose/penrose/issues/1643)) ([36d4299](https://github.com/penrose/penrose/commit/36d4299a03c965b27b611dbb8c3fee941bbfbb4a))
+- Update spectral graph examples ([#1642](https://github.com/penrose/penrose/issues/1642)) ([97daca2](https://github.com/penrose/penrose/commit/97daca2af38db7d7ded95caa754d6e74b8d8e274))
+- Update variation for caffeine example ([#1700](https://github.com/penrose/penrose/issues/1700)) ([cd68afa](https://github.com/penrose/penrose/commit/cd68afa950f1471fe05a9fd6f113686aee3a4841))
+- `--dump-metadata` in `roger` ([#1717](https://github.com/penrose/penrose/issues/1717)) ([98b96a5](https://github.com/penrose/penrose/commit/98b96a51a123d69e9525beda7f4b887f359be956))
+- `DraggablePoint` in `solids` ([#1485](https://github.com/penrose/penrose/issues/1485)) ([165adfb](https://github.com/penrose/penrose/commit/165adfb170c87a44dd967a7e2d28f46b2e230935))
+- added cntrl/cmd+enter and :w to compile diagram ([#1822](https://github.com/penrose/penrose/issues/1822)) ([30ff1d6](https://github.com/penrose/penrose/commit/30ff1d621d83db680c3013b49f82aa4df934fc43))
+- codemirror migration ([#1798](https://github.com/penrose/penrose/issues/1798)) ([59d77f2](https://github.com/penrose/penrose/commit/59d77f22822cc28a32daf812f0b8c4b9e791786c))
+- distribute horizontal and vertical constraint functions ([#1794](https://github.com/penrose/penrose/issues/1794)) ([939f5fe](https://github.com/penrose/penrose/commit/939f5fea1019cc6d0adf8968188fb1e598aab757))
+- dump SVG option in `roger` ([#1697](https://github.com/penrose/penrose/issues/1697)) ([243b306](https://github.com/penrose/penrose/commit/243b306946045e306180390303aff3347d037006))
+- initial values for unknown variables ([#1638](https://github.com/penrose/penrose/issues/1638)) ([61f2ad7](https://github.com/penrose/penrose/commit/61f2ad766efc471bf552a6cfc3d9fcf9c2f3779a))
+- interactive widgets + programatically constrained dragging (experiemental) ([#1796](https://github.com/penrose/penrose/issues/1796)) ([d5f269e](https://github.com/penrose/penrose/commit/d5f269e9fd60740997033b93c2c99cf3a6926bdb))
+- join paths ([#1770](https://github.com/penrose/penrose/issues/1770)) ([42ea8ec](https://github.com/penrose/penrose/commit/42ea8ec954655fabdd0eea0e208cd2f4810afeca))
+- run the compiler and optimizer in a web worker ([#1681](https://github.com/penrose/penrose/issues/1681)) ([42a657d](https://github.com/penrose/penrose/commit/42a657dcb32e565ebd8923df671f673b6b6436d5))
+- substance literal values ([#1682](https://github.com/penrose/penrose/issues/1682)) ([7c1978f](https://github.com/penrose/penrose/commit/7c1978f4e33498828d6893d7d8f9257d2f1f839b))
+- update upload-artifact action to latest version ([#1699](https://github.com/penrose/penrose/issues/1699)) ([3516985](https://github.com/penrose/penrose/commit/351698531a1d59f87da74756ca295d0edb3c7db5))
+- warn `editor` users to save local changes ([#1734](https://github.com/penrose/penrose/issues/1734)) ([c088040](https://github.com/penrose/penrose/commit/c088040a604034e6776b8dcf8dd8a8b39180ca0c))
+- workspace button ([#1741](https://github.com/penrose/penrose/issues/1741)) ([09bbd05](https://github.com/penrose/penrose/commit/09bbd0592d28d3aa318f79a10d19a8ad6ca4378a))
+
+### :bug: Bug Fix
+
+- Revert "feat: LSP-style optimization worker(s)" ([#1803](https://github.com/penrose/penrose/issues/1803)) ([9dc8968](https://github.com/penrose/penrose/commit/9dc8968716c4ac4584a152de81744bb0b555785e))
+- Solves deletion override and diagram panel not updating ([#1742](https://github.com/penrose/penrose/issues/1742)) ([a7a303f](https://github.com/penrose/penrose/commit/a7a303fb7f38269f889a6994d4dfce117f78ad9d))
+- Style function body should not be in errors ([#1746](https://github.com/penrose/penrose/issues/1746)) ([ed89d2b](https://github.com/penrose/penrose/commit/ed89d2b5815100f529604a5949c6dec17ddcf295))
+- Substance parsing of floating-point numbers ([#1672](https://github.com/penrose/penrose/issues/1672)) ([e6e271a](https://github.com/penrose/penrose/commit/e6e271a7cab45bd5b2efa77155c050a9271a6c37))
+- UI bugs in `edgeworth` ([#1706](https://github.com/penrose/penrose/issues/1706)) ([c255e39](https://github.com/penrose/penrose/commit/c255e39176c118662f91108ac9ab59682966acc6))
+- Update api.md ([#1670](https://github.com/penrose/penrose/issues/1670)) ([97c8679](https://github.com/penrose/penrose/commit/97c8679a76b3dbcda9bec44bb3e81eee1f1ccb82))
+- a better path resolution algorithm ([#1795](https://github.com/penrose/penrose/issues/1795)) ([922004a](https://github.com/penrose/penrose/commit/922004ae0055087790b5f8eed335e9fe8e0e5da9))
+- comment shortcut ([#1817](https://github.com/penrose/penrose/issues/1817)) ([d1ea504](https://github.com/penrose/penrose/commit/d1ea50448c5a835fdfeee0a0638342d07b5032e4))
+- compilation errors not displaying properly ([#1769](https://github.com/penrose/penrose/issues/1769)) ([284a324](https://github.com/penrose/penrose/commit/284a32488d87294e3223b6c8b863d48c57dc6e8d))
+- download functionality in the editor ([#1678](https://github.com/penrose/penrose/issues/1678)) ([6401b84](https://github.com/penrose/penrose/commit/6401b841d7413ef1c6a878c84927c737dff80858))
+- duplicate `<penrose>` tags in exported SVGs ([#1652](https://github.com/penrose/penrose/issues/1652)) ([1da2cab](https://github.com/penrose/penrose/commit/1da2cabc1ec11d1fdba101dedc0cff5f63ed5880))
+- exclude function body from `FunctionInternalError` ([#1714](https://github.com/penrose/penrose/issues/1714)) ([0f96b30](https://github.com/penrose/penrose/commit/0f96b30b3d1e628024327eb53f68a2b625054c31))
+- failed handling of optimizer errors ([#1792](https://github.com/penrose/penrose/issues/1792)) ([4076594](https://github.com/penrose/penrose/commit/4076594b3b23510cb13698e8b005304ee636a372))
+- fixed SVG upload ([#1753](https://github.com/penrose/penrose/issues/1753)) ([58eccb9](https://github.com/penrose/penrose/commit/58eccb9e756dbccd826a2b62c14773dcebee7be2))
+- improper Style matching of functions without parameters ([#1679](https://github.com/penrose/penrose/issues/1679)) ([171110c](https://github.com/penrose/penrose/commit/171110c60179a46fbd5cb790ebcab7cf9898fce4))
+- improper handling of flipped index ranges ([#1687](https://github.com/penrose/penrose/issues/1687)) ([f4c5675](https://github.com/penrose/penrose/commit/f4c5675bfe3b6195a9b101fe04d52589a94b8cf9))
+- misc. webworker + IDE fixes ([#1774](https://github.com/penrose/penrose/issues/1774)) ([74c49f8](https://github.com/penrose/penrose/commit/74c49f812869f9ad78e126914edf8ebca0a4902e))
+- no error markers ([#1771](https://github.com/penrose/penrose/issues/1771)) ([fbe8a81](https://github.com/penrose/penrose/commit/fbe8a8124f2be25202cd84ec02d7317f40da6d59))
+- off-by-one error in time-travel slider ([#1698](https://github.com/penrose/penrose/issues/1698)) ([bcb0c6c](https://github.com/penrose/penrose/commit/bcb0c6caff00d7c95220161d07f00e6b7840e8d4))
+- optimizer entering error state on compile error from init ([#1800](https://github.com/penrose/penrose/issues/1800)) ([6a7ce9a](https://github.com/penrose/penrose/commit/6a7ce9ac254a5b04c2981e20aa6051596f32fc9f))
+- parse empty predicates ([#1827](https://github.com/penrose/penrose/issues/1827)) ([7a207f6](https://github.com/penrose/penrose/commit/7a207f62b9d9e12b502da9848bfa52cab567c24e))
+- pretty-printed paths use dots consistently ([#1825](https://github.com/penrose/penrose/issues/1825)) ([3a6c0a8](https://github.com/penrose/penrose/commit/3a6c0a8ddf32e5b05a24bcccfe0fa4865f4ca142))
+- prioritize vim keymaps in vim mode ([#1828](https://github.com/penrose/penrose/issues/1828)) ([39f88c4](https://github.com/penrose/penrose/commit/39f88c473ad09cb17c70e99606e2edb936a2a471))
+- prohibiting inline subtyping on literal types ([#1820](https://github.com/penrose/penrose/issues/1820)) ([53dc10f](https://github.com/penrose/penrose/commit/53dc10f9e6d123ab5810c1adb4c20aa75071476b))
+- public links and build config in `docs-site` ([#1731](https://github.com/penrose/penrose/issues/1731)) ([a66cd72](https://github.com/penrose/penrose/commit/a66cd72b1217d51351512d6c273596dd00cbd5bd))
+- queue and resolve pending requests in optimizer worker ([#1722](https://github.com/penrose/penrose/issues/1722)) ([357b1da](https://github.com/penrose/penrose/commit/357b1da0d53abb39408863ce78a28f45150d6716))
+- regression of TeX SVG download ([#1759](https://github.com/penrose/penrose/issues/1759)) ([8f6f0b8](https://github.com/penrose/penrose/commit/8f6f0b80e01969348206ab143cfdb91ee2d37d32))
+- resolve state-related bugs in the editor ([#1696](https://github.com/penrose/penrose/issues/1696)) ([b9e08d4](https://github.com/penrose/penrose/commit/b9e08d4f8897efd194a0ee843ebcdad26eaa91da))
+- separate Substance environment and remove unused features ([#1677](https://github.com/penrose/penrose/issues/1677)) ([7ad14e7](https://github.com/penrose/penrose/commit/7ad14e7d819d1ddedc03a75eb17f17532430b3aa))
+- show `roger` version ([#1736](https://github.com/penrose/penrose/issues/1736)) ([11ff419](https://github.com/penrose/penrose/commit/11ff41901aa176c32f15c436cf44c17d7d0ce495))
+- style canvas default indent error ([#1747](https://github.com/penrose/penrose/issues/1747)) ([5c92e62](https://github.com/penrose/penrose/commit/5c92e62f455de6514593d3985e94985c0573f8be))
+- vector subtraction in tutorial3.md ([#1701](https://github.com/penrose/penrose/issues/1701)) ([2680e34](https://github.com/penrose/penrose/commit/2680e346c80cf67cbb402b8d45e800c80f22c5c7))
+
+### :nail_care: Polish
+
+- OptimizerWorker/worker ([#1765](https://github.com/penrose/penrose/issues/1765)) ([4110f80](https://github.com/penrose/penrose/commit/4110f80092aa6b4c1f199a22a7144ab1220dceeb))
+- `Bond` constructor names in the chemistry domain ([#1712](https://github.com/penrose/penrose/issues/1712)) ([11ae235](https://github.com/penrose/penrose/commit/11ae2352279c18fb116a5dfa195a72fa9ef642a3))
+- commented geometry domain ([#1728](https://github.com/penrose/penrose/issues/1728)) ([2a335ee](https://github.com/penrose/penrose/commit/2a335ee1f2825b482766677001ad3dd3f280da9e))
+- integrate Rose ([#1636](https://github.com/penrose/penrose/issues/1636)) ([d7c1ef4](https://github.com/penrose/penrose/commit/d7c1ef4be11ac0251f026c755039bccc05818303))
+- replace `safe` util with nicer `unwrap` ([#1662](https://github.com/penrose/penrose/issues/1662)) ([4621bb5](https://github.com/penrose/penrose/commit/4621bb5f502b7e14bf70c828176f282ca2acd9af))
+- simplified shared `Grid` and custom `Grid` in Edgeworth ([#1729](https://github.com/penrose/penrose/issues/1729)) ([a7c9d4d](https://github.com/penrose/penrose/commit/a7c9d4d5d8cc44b3544afb826da3a7002ef55cff))
+
+### :memo: Documentation
+
+- "getting involved" page ([#1639](https://github.com/penrose/penrose/issues/1639)) ([192b363](https://github.com/penrose/penrose/commit/192b363fc6620aeb00ba4f51f1aa80dc766bdc01))
+- add `ob-penrose` to tool integration section ([#1668](https://github.com/penrose/penrose/issues/1668)) ([617ebd3](https://github.com/penrose/penrose/commit/617ebd38589e6c4bfcb83418ee781d3cfdd17002))
+- add documentation and an example of arrowhead styles ([#1702](https://github.com/penrose/penrose/issues/1702)) ([13fe8a0](https://github.com/penrose/penrose/commit/13fe8a0b11bd6caf1eeb574581acf8221ac48bd0))
+- clarify that only Node v18 works ([#1785](https://github.com/penrose/penrose/issues/1785)) ([6946cfb](https://github.com/penrose/penrose/commit/6946cfb3352bc0e497482c29b741270d13d88cbd))
+- comment SolidJS `sample` function ([#1656](https://github.com/penrose/penrose/issues/1656)) ([68975e5](https://github.com/penrose/penrose/commit/68975e5519ee3ad9ba0e5b50bd9b2766fff2c543))
+- recommend Pyenv ([#1778](https://github.com/penrose/penrose/issues/1778)) ([38ea517](https://github.com/penrose/penrose/commit/38ea517a302d997141675df896768ce76c313472))
+- remove `wasm-bindgen` instructions ([#1791](https://github.com/penrose/penrose/issues/1791)) ([101ad4f](https://github.com/penrose/penrose/commit/101ad4f7a1b6fe3770e540185e97d2f88b12a39d))
+- remove link to planned subsection on the contributing page ([#1719](https://github.com/penrose/penrose/issues/1719)) ([3c66163](https://github.com/penrose/penrose/commit/3c661637d8f9ab4855a345fcd45767dac7d61a55))
+- split up language reference docs ([#1703](https://github.com/penrose/penrose/issues/1703)) ([1126038](https://github.com/penrose/penrose/commit/11260385d5215a8d6d64eba9f29c901148c0fdd8))
+- summer 24 team ([#1807](https://github.com/penrose/penrose/issues/1807)) ([03195cf](https://github.com/penrose/penrose/commit/03195cfc05f725864122bc97ddb22e595ef746da))
+- typo in staged layout blog post ([#1720](https://github.com/penrose/penrose/issues/1720)) ([caf797b](https://github.com/penrose/penrose/commit/caf797bcb22e0dede0bbc580783070d877beae01))
+- update CONTRIBUTING.md to require Node 18+ ([#1710](https://github.com/penrose/penrose/issues/1710)) ([6d31981](https://github.com/penrose/penrose/commit/6d3198196b56761e52a60c57635f5555f75075ce))
+- update links to the technical roadmap ([#1718](https://github.com/penrose/penrose/issues/1718)) ([af5de7d](https://github.com/penrose/penrose/commit/af5de7daf223fee85f221f937b738dcdfe5b04b1))
+- update vitepress and index function library ([#1704](https://github.com/penrose/penrose/issues/1704)) ([12b0442](https://github.com/penrose/penrose/commit/12b0442f78603fb619d615133acebfde8d319337))
+- warn about Homebrew Python ([#1784](https://github.com/penrose/penrose/issues/1784)) ([d85620e](https://github.com/penrose/penrose/commit/d85620ee8de518d316f00ef69ebbd311d1814458))
+
+### :house: Internal
+
+- add default canvas block to `editor` ([#1674](https://github.com/penrose/penrose/issues/1674)) ([52f8fd2](https://github.com/penrose/penrose/commit/52f8fd28e1cfc22e0c9750f3c9cdc61e5f9a6591))
+- bump version to 4.0.0-alpha.0 ([#1735](https://github.com/penrose/penrose/issues/1735)) ([da1343d](https://github.com/penrose/penrose/commit/da1343dca34cb1291894b754b7f7ac3aed672df5))
+- delete deprecated file extensions from Roger ([#1675](https://github.com/penrose/penrose/issues/1675)) ([12ff3d0](https://github.com/penrose/penrose/commit/12ff3d069ed7b4478642a23e126cc08c45a32e7f))
+- fix `no-non-null-assertion` lint rule name ([#1663](https://github.com/penrose/penrose/issues/1663)) ([b8b18b3](https://github.com/penrose/penrose/commit/b8b18b34ede45e06426c9704ae1820a790b31a76))
+- fix labeling objective in ray tracing Style ([#1660](https://github.com/penrose/penrose/issues/1660)) ([4f9ed8e](https://github.com/penrose/penrose/commit/4f9ed8ec5e78869f5577e8598a23b401a6a691b8))
+- fix typo in L-BFGS docstring ([#1809](https://github.com/penrose/penrose/issues/1809)) ([806d1a0](https://github.com/penrose/penrose/commit/806d1a021056eb36e2bf7970ae9c73b5171aaf98))
+- obviate custom unary-minus ESLint package ([#1673](https://github.com/penrose/penrose/issues/1673)) ([3ffb9e8](https://github.com/penrose/penrose/commit/3ffb9e8bd4942ab331d63c332ebaebba4d0d1444))
+- rename `contrib` to `lib` in `core` ([#1651](https://github.com/penrose/penrose/issues/1651)) ([f909232](https://github.com/penrose/penrose/commit/f9092321d591497cd398bafb6f5fa761e933dcfb))
+- rename venn to euler diagrams ([#1756](https://github.com/penrose/penrose/issues/1756)) ([355b130](https://github.com/penrose/penrose/commit/355b130e044f613a6fab7abe55681ab5f0df4fee))
+- run components tests in CI ([#1815](https://github.com/penrose/penrose/issues/1815)) ([e164486](https://github.com/penrose/penrose/commit/e164486e4121e07f75fe816c138d2cf660073cd7))
+- simplify names of `IsSubset` and `NotIntersecting` ([#1724](https://github.com/penrose/penrose/issues/1724)) ([b5e8cb8](https://github.com/penrose/penrose/commit/b5e8cb8675c63f279e9e769913b24c1ec8055b23))
+- wait until the end to write the text chart ([#1665](https://github.com/penrose/penrose/issues/1665)) ([31492d0](https://github.com/penrose/penrose/commit/31492d0d29a8310f1782ea4a5b252a162f6ab285))
+- write out registry stats after every diagram ([#1664](https://github.com/penrose/penrose/issues/1664)) ([c16e63f](https://github.com/penrose/penrose/commit/c16e63f93bacf65e161264982af250a83b3b0d38))
+
+### :running_woman: Performance
+
+- CI workflow for comparing registry performance ([#1637](https://github.com/penrose/penrose/issues/1637)) ([8ef997e](https://github.com/penrose/penrose/commit/8ef997e782402a5f0185d95cfd3fed5aaab9a86f))
+- optimizer worker speed up ([#1772](https://github.com/penrose/penrose/issues/1772)) ([3383139](https://github.com/penrose/penrose/commit/3383139ca526b2f991b78c984b8a2ef5717aca74))
+- share memory across all Rose compilations ([#1725](https://github.com/penrose/penrose/issues/1725)) ([10869e2](https://github.com/penrose/penrose/commit/10869e2e5269857a1b01a00b0282e42d886dc04a))
+
 ## [v4.0.0-alpha.0] (2024-05-07)
 
 ### :warning: BREAKING CHANGE

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -415,6 +415,27 @@ Our repo uses [semantic versioning][] and maintains the same version number for 
 - Create a new [GitHub release][].
 - CI will run after the new release is created, automatically publishing packages to npm.
 
+### Pre-release
+
+To publish development releases:
+
+- Make sure all PRs for the upcoming release are merged. Switch to `main` and check `git status` to make sure it's clean and up-to-date.
+- Create the pre-release version without tagging or committing:
+
+```shell
+yarn lerna version --conventional-commits --conventional-prerelease --no-git-tag-version --no-push
+```
+
+- Run `yarn format` to clean up auto-generated file changes.
+- Create a new branch (`git switch --create release-X.Y.Z`) from main and commit the changes.
+- Publish the pre-release version:
+
+```
+yarn lerna publish from-package --pre-dist-tag develop
+```
+
+- Open a new PR with a title `chore: bump version to X.Y.Z` and merge after CI passes.
+
 [branch]: https://git-scm.com/book/en/v2/Git-Branching-Basic-Branching-and-Merging
 [ci]: https://docs.github.com/en/actions
 [clone]: https://docs.github.com/en/repositories/creating-and-managing-repositories/cloning-a-repository

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -25,6 +25,7 @@
   - [Adding tests](#adding-tests)
   - [Opening a pull request (PR)](#opening-a-pull-request-pr)
 - [Release](#release)
+  - [Pre-release](#pre-release)
 
 <!-- tocstop -->
 

--- a/lerna.json
+++ b/lerna.json
@@ -1,7 +1,7 @@
 {
   "packages": ["packages/*"],
   "npmClient": "yarn",
-  "version": "4.0.0-alpha.0",
+  "version": "4.0.0-alpha.1",
   "useWorkspaces": true,
   "changelogPreset": {
     "name": "@spyke/conventional-changelog-preset"

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -3,6 +3,42 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [v4.0.0-alpha.1] (2024-07-11)
+
+### :warning: BREAKING CHANGE
+
+- separate Substance environment and remove unused features (#1677)
+
+### :rocket: New Feature
+
+- Layout stage autocomplete + corresponding tests ([#1823](https://github.com/penrose/penrose/issues/1823)) ([d3a9369](https://github.com/penrose/penrose/commit/d3a93691e6d781e03d17a66e844d8444d316e993))
+- added cntrl/cmd+enter and :w to compile diagram ([#1822](https://github.com/penrose/penrose/issues/1822)) ([30ff1d6](https://github.com/penrose/penrose/commit/30ff1d621d83db680c3013b49f82aa4df934fc43))
+- codemirror migration ([#1798](https://github.com/penrose/penrose/issues/1798)) ([59d77f2](https://github.com/penrose/penrose/commit/59d77f22822cc28a32daf812f0b8c4b9e791786c))
+- initial values for unknown variables ([#1638](https://github.com/penrose/penrose/issues/1638)) ([61f2ad7](https://github.com/penrose/penrose/commit/61f2ad766efc471bf552a6cfc3d9fcf9c2f3779a))
+- interactive widgets + programatically constrained dragging (experiemental) ([#1796](https://github.com/penrose/penrose/issues/1796)) ([d5f269e](https://github.com/penrose/penrose/commit/d5f269e9fd60740997033b93c2c99cf3a6926bdb))
+
+### :bug: Bug Fix
+
+- UI bugs in `edgeworth` ([#1706](https://github.com/penrose/penrose/issues/1706)) ([c255e39](https://github.com/penrose/penrose/commit/c255e39176c118662f91108ac9ab59682966acc6))
+- comment shortcut ([#1817](https://github.com/penrose/penrose/issues/1817)) ([d1ea504](https://github.com/penrose/penrose/commit/d1ea50448c5a835fdfeee0a0638342d07b5032e4))
+- prioritize vim keymaps in vim mode ([#1828](https://github.com/penrose/penrose/issues/1828)) ([39f88c4](https://github.com/penrose/penrose/commit/39f88c473ad09cb17c70e99606e2edb936a2a471))
+- separate Substance environment and remove unused features ([#1677](https://github.com/penrose/penrose/issues/1677)) ([7ad14e7](https://github.com/penrose/penrose/commit/7ad14e7d819d1ddedc03a75eb17f17532430b3aa))
+
+### :nail_care: Polish
+
+- simplified shared `Grid` and custom `Grid` in Edgeworth ([#1729](https://github.com/penrose/penrose/issues/1729)) ([a7c9d4d](https://github.com/penrose/penrose/commit/a7c9d4d5d8cc44b3544afb826da3a7002ef55cff))
+
+### :memo: Documentation
+
+- update vitepress and index function library ([#1704](https://github.com/penrose/penrose/issues/1704)) ([12b0442](https://github.com/penrose/penrose/commit/12b0442f78603fb619d615133acebfde8d319337))
+
+### :house: Internal
+
+- add default canvas block to `editor` ([#1674](https://github.com/penrose/penrose/issues/1674)) ([52f8fd2](https://github.com/penrose/penrose/commit/52f8fd28e1cfc22e0c9750f3c9cdc61e5f9a6591))
+- bump version to 4.0.0-alpha.0 ([#1735](https://github.com/penrose/penrose/issues/1735)) ([da1343d](https://github.com/penrose/penrose/commit/da1343dca34cb1291894b754b7f7ac3aed672df5))
+- rename venn to euler diagrams ([#1756](https://github.com/penrose/penrose/issues/1756)) ([355b130](https://github.com/penrose/penrose/commit/355b130e044f613a6fab7abe55681ab5f0df4fee))
+- run components tests in CI ([#1815](https://github.com/penrose/penrose/issues/1815)) ([e164486](https://github.com/penrose/penrose/commit/e164486e4121e07f75fe816c138d2cf660073cd7))
+
 ## [v4.0.0-alpha.0] (2024-05-07)
 
 ### :warning: BREAKING CHANGE

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@penrose/components",
-  "version": "4.0.0-alpha.0",
+  "version": "4.0.0-alpha.1",
   "license": "MIT",
   "type": "module",
   "main": "dist/index.js",
@@ -60,7 +60,7 @@
   "dependencies": {
     "@lezer-unofficial/printer": "^1.0.1",
     "@lezer/generator": "^1.7.0",
-    "@penrose/core": "^4.0.0-alpha.0",
+    "@penrose/core": "^4.0.0-alpha.1",
     "@replit/codemirror-css-color-picker": "^6.1.1",
     "@replit/codemirror-vim": "^6.2.1",
     "@uiw/codemirror-extensions-color": "^4.22.2",
@@ -74,7 +74,7 @@
   "devDependencies": {
     "@babel/core": "^7.18.0",
     "@mdx-js/preact": "^2.1.5",
-    "@penrose/examples": "^4.0.0-alpha.0",
+    "@penrose/examples": "^4.0.0-alpha.1",
     "@storybook/addon-actions": "^8.1.11",
     "@storybook/addon-essentials": "^8.1.11",
     "@storybook/addon-interactions": "^8.1.11",

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -3,6 +3,61 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [v4.0.0-alpha.1] (2024-07-11)
+
+### :warning: BREAKING CHANGE
+
+- separate Substance environment and remove unused features (#1677)
+
+### :rocket: New Feature
+
+- Arc mesh example ([#1789](https://github.com/penrose/penrose/issues/1789)) ([edd0a04](https://github.com/penrose/penrose/commit/edd0a041068f00e059fa2dfd5b70dd76a5a3df99))
+- LSP-style optimization worker(s) ([#1801](https://github.com/penrose/penrose/issues/1801)) ([cff021a](https://github.com/penrose/penrose/commit/cff021a613cf1f796efce92e4a58f1dc34d66c65))
+- Lsp-style worker + editor vite upgrade ([#1804](https://github.com/penrose/penrose/issues/1804)) ([f711e9d](https://github.com/penrose/penrose/commit/f711e9dff1120ccd799d2544c983be8df26ebafa))
+- Random Index Style Function & Chaos Game ([#1643](https://github.com/penrose/penrose/issues/1643)) ([36d4299](https://github.com/penrose/penrose/commit/36d4299a03c965b27b611dbb8c3fee941bbfbb4a))
+- codemirror migration ([#1798](https://github.com/penrose/penrose/issues/1798)) ([59d77f2](https://github.com/penrose/penrose/commit/59d77f22822cc28a32daf812f0b8c4b9e791786c))
+- distribute horizontal and vertical constraint functions ([#1794](https://github.com/penrose/penrose/issues/1794)) ([939f5fe](https://github.com/penrose/penrose/commit/939f5fea1019cc6d0adf8968188fb1e598aab757))
+- initial values for unknown variables ([#1638](https://github.com/penrose/penrose/issues/1638)) ([61f2ad7](https://github.com/penrose/penrose/commit/61f2ad766efc471bf552a6cfc3d9fcf9c2f3779a))
+- interactive widgets + programatically constrained dragging (experiemental) ([#1796](https://github.com/penrose/penrose/issues/1796)) ([d5f269e](https://github.com/penrose/penrose/commit/d5f269e9fd60740997033b93c2c99cf3a6926bdb))
+- join paths ([#1770](https://github.com/penrose/penrose/issues/1770)) ([42ea8ec](https://github.com/penrose/penrose/commit/42ea8ec954655fabdd0eea0e208cd2f4810afeca))
+- run the compiler and optimizer in a web worker ([#1681](https://github.com/penrose/penrose/issues/1681)) ([42a657d](https://github.com/penrose/penrose/commit/42a657dcb32e565ebd8923df671f673b6b6436d5))
+- substance literal values ([#1682](https://github.com/penrose/penrose/issues/1682)) ([7c1978f](https://github.com/penrose/penrose/commit/7c1978f4e33498828d6893d7d8f9257d2f1f839b))
+
+### :bug: Bug Fix
+
+- Revert "feat: LSP-style optimization worker(s)" ([#1803](https://github.com/penrose/penrose/issues/1803)) ([9dc8968](https://github.com/penrose/penrose/commit/9dc8968716c4ac4584a152de81744bb0b555785e))
+- Style function body should not be in errors ([#1746](https://github.com/penrose/penrose/issues/1746)) ([ed89d2b](https://github.com/penrose/penrose/commit/ed89d2b5815100f529604a5949c6dec17ddcf295))
+- Substance parsing of floating-point numbers ([#1672](https://github.com/penrose/penrose/issues/1672)) ([e6e271a](https://github.com/penrose/penrose/commit/e6e271a7cab45bd5b2efa77155c050a9271a6c37))
+- a better path resolution algorithm ([#1795](https://github.com/penrose/penrose/issues/1795)) ([922004a](https://github.com/penrose/penrose/commit/922004ae0055087790b5f8eed335e9fe8e0e5da9))
+- exclude function body from `FunctionInternalError` ([#1714](https://github.com/penrose/penrose/issues/1714)) ([0f96b30](https://github.com/penrose/penrose/commit/0f96b30b3d1e628024327eb53f68a2b625054c31))
+- improper Style matching of functions without parameters ([#1679](https://github.com/penrose/penrose/issues/1679)) ([171110c](https://github.com/penrose/penrose/commit/171110c60179a46fbd5cb790ebcab7cf9898fce4))
+- improper handling of flipped index ranges ([#1687](https://github.com/penrose/penrose/issues/1687)) ([f4c5675](https://github.com/penrose/penrose/commit/f4c5675bfe3b6195a9b101fe04d52589a94b8cf9))
+- no error markers ([#1771](https://github.com/penrose/penrose/issues/1771)) ([fbe8a81](https://github.com/penrose/penrose/commit/fbe8a8124f2be25202cd84ec02d7317f40da6d59))
+- parse empty predicates ([#1827](https://github.com/penrose/penrose/issues/1827)) ([7a207f6](https://github.com/penrose/penrose/commit/7a207f62b9d9e12b502da9848bfa52cab567c24e))
+- pretty-printed paths use dots consistently ([#1825](https://github.com/penrose/penrose/issues/1825)) ([3a6c0a8](https://github.com/penrose/penrose/commit/3a6c0a8ddf32e5b05a24bcccfe0fa4865f4ca142))
+- prohibiting inline subtyping on literal types ([#1820](https://github.com/penrose/penrose/issues/1820)) ([53dc10f](https://github.com/penrose/penrose/commit/53dc10f9e6d123ab5810c1adb4c20aa75071476b))
+- separate Substance environment and remove unused features ([#1677](https://github.com/penrose/penrose/issues/1677)) ([7ad14e7](https://github.com/penrose/penrose/commit/7ad14e7d819d1ddedc03a75eb17f17532430b3aa))
+
+### :nail_care: Polish
+
+- OptimizerWorker/worker ([#1765](https://github.com/penrose/penrose/issues/1765)) ([4110f80](https://github.com/penrose/penrose/commit/4110f80092aa6b4c1f199a22a7144ab1220dceeb))
+- integrate Rose ([#1636](https://github.com/penrose/penrose/issues/1636)) ([d7c1ef4](https://github.com/penrose/penrose/commit/d7c1ef4be11ac0251f026c755039bccc05818303))
+- replace `safe` util with nicer `unwrap` ([#1662](https://github.com/penrose/penrose/issues/1662)) ([4621bb5](https://github.com/penrose/penrose/commit/4621bb5f502b7e14bf70c828176f282ca2acd9af))
+
+### :house: Internal
+
+- bump version to 4.0.0-alpha.0 ([#1735](https://github.com/penrose/penrose/issues/1735)) ([da1343d](https://github.com/penrose/penrose/commit/da1343dca34cb1291894b754b7f7ac3aed672df5))
+- fix `no-non-null-assertion` lint rule name ([#1663](https://github.com/penrose/penrose/issues/1663)) ([b8b18b3](https://github.com/penrose/penrose/commit/b8b18b34ede45e06426c9704ae1820a790b31a76))
+- fix typo in L-BFGS docstring ([#1809](https://github.com/penrose/penrose/issues/1809)) ([806d1a0](https://github.com/penrose/penrose/commit/806d1a021056eb36e2bf7970ae9c73b5171aaf98))
+- obviate custom unary-minus ESLint package ([#1673](https://github.com/penrose/penrose/issues/1673)) ([3ffb9e8](https://github.com/penrose/penrose/commit/3ffb9e8bd4942ab331d63c332ebaebba4d0d1444))
+- rename `contrib` to `lib` in `core` ([#1651](https://github.com/penrose/penrose/issues/1651)) ([f909232](https://github.com/penrose/penrose/commit/f9092321d591497cd398bafb6f5fa761e933dcfb))
+- rename venn to euler diagrams ([#1756](https://github.com/penrose/penrose/issues/1756)) ([355b130](https://github.com/penrose/penrose/commit/355b130e044f613a6fab7abe55681ab5f0df4fee))
+- simplify names of `IsSubset` and `NotIntersecting` ([#1724](https://github.com/penrose/penrose/issues/1724)) ([b5e8cb8](https://github.com/penrose/penrose/commit/b5e8cb8675c63f279e9e769913b24c1ec8055b23))
+
+### :running_woman: Performance
+
+- share memory across all Rose compilations ([#1725](https://github.com/penrose/penrose/issues/1725)) ([10869e2](https://github.com/penrose/penrose/commit/10869e2e5269857a1b01a00b0282e42d886dc04a))
+
 ## [v4.0.0-alpha.0] (2024-05-07)
 
 ### :warning: BREAKING CHANGE

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@penrose/core",
-  "version": "4.0.0-alpha.0",
+  "version": "4.0.0-alpha.1",
   "type": "module",
   "main": "dist/index.js",
   "module": "dist/index.js",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -33,7 +33,7 @@
     "docs": "typedoc --out docs",
     "docs:md": "typedoc --plugin typedoc-plugin-markdown --out docs/md",
     "lint": "eslint --ext js,ts,tsx src",
-    "prepack": "yarn bundle"
+    "prepack": "yarn build-parsers && yarn build && yarn bundle"
   },
   "nx": {
     "targets": {

--- a/packages/docs-site/CHANGELOG.md
+++ b/packages/docs-site/CHANGELOG.md
@@ -3,6 +3,42 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [v4.0.0-alpha.1] (2024-07-11)
+
+### :warning: BREAKING CHANGE
+
+- separate Substance environment and remove unused features (#1677)
+
+### :rocket: New Feature
+
+- initial values for unknown variables ([#1638](https://github.com/penrose/penrose/issues/1638)) ([61f2ad7](https://github.com/penrose/penrose/commit/61f2ad766efc471bf552a6cfc3d9fcf9c2f3779a))
+- run the compiler and optimizer in a web worker ([#1681](https://github.com/penrose/penrose/issues/1681)) ([42a657d](https://github.com/penrose/penrose/commit/42a657dcb32e565ebd8923df671f673b6b6436d5))
+- substance literal values ([#1682](https://github.com/penrose/penrose/issues/1682)) ([7c1978f](https://github.com/penrose/penrose/commit/7c1978f4e33498828d6893d7d8f9257d2f1f839b))
+
+### :bug: Bug Fix
+
+- Update api.md ([#1670](https://github.com/penrose/penrose/issues/1670)) ([97c8679](https://github.com/penrose/penrose/commit/97c8679a76b3dbcda9bec44bb3e81eee1f1ccb82))
+- public links and build config in `docs-site` ([#1731](https://github.com/penrose/penrose/issues/1731)) ([a66cd72](https://github.com/penrose/penrose/commit/a66cd72b1217d51351512d6c273596dd00cbd5bd))
+- separate Substance environment and remove unused features ([#1677](https://github.com/penrose/penrose/issues/1677)) ([7ad14e7](https://github.com/penrose/penrose/commit/7ad14e7d819d1ddedc03a75eb17f17532430b3aa))
+
+### :memo: Documentation
+
+- "getting involved" page ([#1639](https://github.com/penrose/penrose/issues/1639)) ([192b363](https://github.com/penrose/penrose/commit/192b363fc6620aeb00ba4f51f1aa80dc766bdc01))
+- add `ob-penrose` to tool integration section ([#1668](https://github.com/penrose/penrose/issues/1668)) ([617ebd3](https://github.com/penrose/penrose/commit/617ebd38589e6c4bfcb83418ee781d3cfdd17002))
+- add documentation and an example of arrowhead styles ([#1702](https://github.com/penrose/penrose/issues/1702)) ([13fe8a0](https://github.com/penrose/penrose/commit/13fe8a0b11bd6caf1eeb574581acf8221ac48bd0))
+- remove link to planned subsection on the contributing page ([#1719](https://github.com/penrose/penrose/issues/1719)) ([3c66163](https://github.com/penrose/penrose/commit/3c661637d8f9ab4855a345fcd45767dac7d61a55))
+- split up language reference docs ([#1703](https://github.com/penrose/penrose/issues/1703)) ([1126038](https://github.com/penrose/penrose/commit/11260385d5215a8d6d64eba9f29c901148c0fdd8))
+- summer 24 team ([#1807](https://github.com/penrose/penrose/issues/1807)) ([03195cf](https://github.com/penrose/penrose/commit/03195cfc05f725864122bc97ddb22e595ef746da))
+- typo in staged layout blog post ([#1720](https://github.com/penrose/penrose/issues/1720)) ([caf797b](https://github.com/penrose/penrose/commit/caf797bcb22e0dede0bbc580783070d877beae01))
+- update links to the technical roadmap ([#1718](https://github.com/penrose/penrose/issues/1718)) ([af5de7d](https://github.com/penrose/penrose/commit/af5de7daf223fee85f221f937b738dcdfe5b04b1))
+- update vitepress and index function library ([#1704](https://github.com/penrose/penrose/issues/1704)) ([12b0442](https://github.com/penrose/penrose/commit/12b0442f78603fb619d615133acebfde8d319337))
+
+### :house: Internal
+
+- bump version to 4.0.0-alpha.0 ([#1735](https://github.com/penrose/penrose/issues/1735)) ([da1343d](https://github.com/penrose/penrose/commit/da1343dca34cb1291894b754b7f7ac3aed672df5))
+- rename venn to euler diagrams ([#1756](https://github.com/penrose/penrose/issues/1756)) ([355b130](https://github.com/penrose/penrose/commit/355b130e044f613a6fab7abe55681ab5f0df4fee))
+- simplify names of `IsSubset` and `NotIntersecting` ([#1724](https://github.com/penrose/penrose/issues/1724)) ([b5e8cb8](https://github.com/penrose/penrose/commit/b5e8cb8675c63f279e9e769913b24c1ec8055b23))
+
 ## [v4.0.0-alpha.0] (2024-05-07)
 
 ### :warning: BREAKING CHANGE

--- a/packages/docs-site/package.json
+++ b/packages/docs-site/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@penrose/docs-site",
-  "version": "4.0.0-alpha.0",
+  "version": "4.0.0-alpha.1",
   "type": "module",
   "private": true,
   "scripts": {
@@ -46,14 +46,14 @@
     }
   },
   "dependencies": {
-    "@penrose/components": "^4.0.0-alpha.0",
-    "@penrose/examples": "^4.0.0-alpha.0",
+    "@penrose/components": "^4.0.0-alpha.1",
+    "@penrose/examples": "^4.0.0-alpha.1",
     "veaury": "^2.3.11"
   },
   "devDependencies": {
-    "@penrose/core": "^4.0.0-alpha.0",
-    "@penrose/editor": "^4.0.0-alpha.0",
-    "@penrose/roger": "^4.0.0-alpha.0",
+    "@penrose/core": "^4.0.0-alpha.1",
+    "@penrose/editor": "^4.0.0-alpha.1",
+    "@penrose/roger": "^4.0.0-alpha.1",
     "@tailwindcss/typography": "^0.5.4",
     "@types/markdown-it": "^12.2.3",
     "chalk": "^3.0.0",

--- a/packages/edgeworth/CHANGELOG.md
+++ b/packages/edgeworth/CHANGELOG.md
@@ -3,6 +3,32 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [v4.0.0-alpha.1] (2024-07-11)
+
+### :warning: BREAKING CHANGE
+
+- separate Substance environment and remove unused features (#1677)
+
+### :rocket: New Feature
+
+- codemirror migration ([#1798](https://github.com/penrose/penrose/issues/1798)) ([59d77f2](https://github.com/penrose/penrose/commit/59d77f22822cc28a32daf812f0b8c4b9e791786c))
+- initial values for unknown variables ([#1638](https://github.com/penrose/penrose/issues/1638)) ([61f2ad7](https://github.com/penrose/penrose/commit/61f2ad766efc471bf552a6cfc3d9fcf9c2f3779a))
+- substance literal values ([#1682](https://github.com/penrose/penrose/issues/1682)) ([7c1978f](https://github.com/penrose/penrose/commit/7c1978f4e33498828d6893d7d8f9257d2f1f839b))
+
+### :bug: Bug Fix
+
+- UI bugs in `edgeworth` ([#1706](https://github.com/penrose/penrose/issues/1706)) ([c255e39](https://github.com/penrose/penrose/commit/c255e39176c118662f91108ac9ab59682966acc6))
+- separate Substance environment and remove unused features ([#1677](https://github.com/penrose/penrose/issues/1677)) ([7ad14e7](https://github.com/penrose/penrose/commit/7ad14e7d819d1ddedc03a75eb17f17532430b3aa))
+
+### :nail_care: Polish
+
+- simplified shared `Grid` and custom `Grid` in Edgeworth ([#1729](https://github.com/penrose/penrose/issues/1729)) ([a7c9d4d](https://github.com/penrose/penrose/commit/a7c9d4d5d8cc44b3544afb826da3a7002ef55cff))
+
+### :house: Internal
+
+- bump version to 4.0.0-alpha.0 ([#1735](https://github.com/penrose/penrose/issues/1735)) ([da1343d](https://github.com/penrose/penrose/commit/da1343dca34cb1291894b754b7f7ac3aed672df5))
+- simplify names of `IsSubset` and `NotIntersecting` ([#1724](https://github.com/penrose/penrose/issues/1724)) ([b5e8cb8](https://github.com/penrose/penrose/commit/b5e8cb8675c63f279e9e769913b24c1ec8055b23))
+
 ## [v4.0.0-alpha.0] (2024-05-07)
 
 ### :warning: BREAKING CHANGE

--- a/packages/edgeworth/package.json
+++ b/packages/edgeworth/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@penrose/edgeworth",
   "private": true,
-  "version": "4.0.0-alpha.0",
+  "version": "4.0.0-alpha.1",
   "scripts": {
     "dev": "vite",
     "watch": "vite",
@@ -56,12 +56,12 @@
   },
   "dependencies": {
     "@material-ui/core": "^4.12.3",
-    "consola": "^3.2.3",
-    "@penrose/components": "^4.0.0-alpha.0",
-    "@penrose/core": "^4.0.0-alpha.0",
-    "@penrose/examples": "^4.0.0-alpha.0",
+    "@penrose/components": "^4.0.0-alpha.1",
+    "@penrose/core": "^4.0.0-alpha.1",
+    "@penrose/examples": "^4.0.0-alpha.1",
     "@types/file-saver": "^2.0.5",
     "@types/jszip": "^3.4.1",
+    "consola": "^3.2.3",
     "file-saver": "^2.0.5",
     "jszip": "^3.10.1",
     "react": "^18.2.0",
@@ -71,9 +71,9 @@
   },
   "devDependencies": {
     "@types/file-saver": "^2.0.5",
+    "@types/jszip": "^3.4.1",
     "@types/react": "^18.3.3",
     "@types/react-dom": "^18.3.0",
-    "@types/jszip": "^3.4.1",
     "@vitejs/plugin-react-swc": "^3.0.1",
     "canvas": "^2.8.0",
     "vite": "^4.0.4",

--- a/packages/editor/CHANGELOG.md
+++ b/packages/editor/CHANGELOG.md
@@ -3,6 +3,59 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [v4.0.0-alpha.1] (2024-07-11)
+
+### :warning: BREAKING CHANGE
+
+- separate Substance environment and remove unused features (#1677)
+
+### :rocket: New Feature
+
+- Added copy trio to clipboard feature ([#1763](https://github.com/penrose/penrose/issues/1763)) ([e4193ab](https://github.com/penrose/penrose/commit/e4193ab64e7433b7c61e44ae3d250d5c70683090))
+- LSP-style optimization worker(s) ([#1801](https://github.com/penrose/penrose/issues/1801)) ([cff021a](https://github.com/penrose/penrose/commit/cff021a613cf1f796efce92e4a58f1dc34d66c65))
+- Lsp-style worker + editor vite upgrade ([#1804](https://github.com/penrose/penrose/issues/1804)) ([f711e9d](https://github.com/penrose/penrose/commit/f711e9dff1120ccd799d2544c983be8df26ebafa))
+- Making gist sharing clearer (editor ux) ([#1764](https://github.com/penrose/penrose/issues/1764)) ([0ad9f39](https://github.com/penrose/penrose/commit/0ad9f39cd57a8a722241cb89811787a1b6ad236e))
+- added cntrl/cmd+enter and :w to compile diagram ([#1822](https://github.com/penrose/penrose/issues/1822)) ([30ff1d6](https://github.com/penrose/penrose/commit/30ff1d621d83db680c3013b49f82aa4df934fc43))
+- codemirror migration ([#1798](https://github.com/penrose/penrose/issues/1798)) ([59d77f2](https://github.com/penrose/penrose/commit/59d77f22822cc28a32daf812f0b8c4b9e791786c))
+- initial values for unknown variables ([#1638](https://github.com/penrose/penrose/issues/1638)) ([61f2ad7](https://github.com/penrose/penrose/commit/61f2ad766efc471bf552a6cfc3d9fcf9c2f3779a))
+- interactive widgets + programatically constrained dragging (experiemental) ([#1796](https://github.com/penrose/penrose/issues/1796)) ([d5f269e](https://github.com/penrose/penrose/commit/d5f269e9fd60740997033b93c2c99cf3a6926bdb))
+- run the compiler and optimizer in a web worker ([#1681](https://github.com/penrose/penrose/issues/1681)) ([42a657d](https://github.com/penrose/penrose/commit/42a657dcb32e565ebd8923df671f673b6b6436d5))
+- warn `editor` users to save local changes ([#1734](https://github.com/penrose/penrose/issues/1734)) ([c088040](https://github.com/penrose/penrose/commit/c088040a604034e6776b8dcf8dd8a8b39180ca0c))
+- workspace button ([#1741](https://github.com/penrose/penrose/issues/1741)) ([09bbd05](https://github.com/penrose/penrose/commit/09bbd0592d28d3aa318f79a10d19a8ad6ca4378a))
+
+### :bug: Bug Fix
+
+- Revert "feat: LSP-style optimization worker(s)" ([#1803](https://github.com/penrose/penrose/issues/1803)) ([9dc8968](https://github.com/penrose/penrose/commit/9dc8968716c4ac4584a152de81744bb0b555785e))
+- Solves deletion override and diagram panel not updating ([#1742](https://github.com/penrose/penrose/issues/1742)) ([a7a303f](https://github.com/penrose/penrose/commit/a7a303fb7f38269f889a6994d4dfce117f78ad9d))
+- compilation errors not displaying properly ([#1769](https://github.com/penrose/penrose/issues/1769)) ([284a324](https://github.com/penrose/penrose/commit/284a32488d87294e3223b6c8b863d48c57dc6e8d))
+- download functionality in the editor ([#1678](https://github.com/penrose/penrose/issues/1678)) ([6401b84](https://github.com/penrose/penrose/commit/6401b841d7413ef1c6a878c84927c737dff80858))
+- duplicate `<penrose>` tags in exported SVGs ([#1652](https://github.com/penrose/penrose/issues/1652)) ([1da2cab](https://github.com/penrose/penrose/commit/1da2cabc1ec11d1fdba101dedc0cff5f63ed5880))
+- failed handling of optimizer errors ([#1792](https://github.com/penrose/penrose/issues/1792)) ([4076594](https://github.com/penrose/penrose/commit/4076594b3b23510cb13698e8b005304ee636a372))
+- fixed SVG upload ([#1753](https://github.com/penrose/penrose/issues/1753)) ([58eccb9](https://github.com/penrose/penrose/commit/58eccb9e756dbccd826a2b62c14773dcebee7be2))
+- misc. webworker + IDE fixes ([#1774](https://github.com/penrose/penrose/issues/1774)) ([74c49f8](https://github.com/penrose/penrose/commit/74c49f812869f9ad78e126914edf8ebca0a4902e))
+- no error markers ([#1771](https://github.com/penrose/penrose/issues/1771)) ([fbe8a81](https://github.com/penrose/penrose/commit/fbe8a8124f2be25202cd84ec02d7317f40da6d59))
+- off-by-one error in time-travel slider ([#1698](https://github.com/penrose/penrose/issues/1698)) ([bcb0c6c](https://github.com/penrose/penrose/commit/bcb0c6caff00d7c95220161d07f00e6b7840e8d4))
+- optimizer entering error state on compile error from init ([#1800](https://github.com/penrose/penrose/issues/1800)) ([6a7ce9a](https://github.com/penrose/penrose/commit/6a7ce9ac254a5b04c2981e20aa6051596f32fc9f))
+- queue and resolve pending requests in optimizer worker ([#1722](https://github.com/penrose/penrose/issues/1722)) ([357b1da](https://github.com/penrose/penrose/commit/357b1da0d53abb39408863ce78a28f45150d6716))
+- regression of TeX SVG download ([#1759](https://github.com/penrose/penrose/issues/1759)) ([8f6f0b8](https://github.com/penrose/penrose/commit/8f6f0b80e01969348206ab143cfdb91ee2d37d32))
+- resolve state-related bugs in the editor ([#1696](https://github.com/penrose/penrose/issues/1696)) ([b9e08d4](https://github.com/penrose/penrose/commit/b9e08d4f8897efd194a0ee843ebcdad26eaa91da))
+- separate Substance environment and remove unused features ([#1677](https://github.com/penrose/penrose/issues/1677)) ([7ad14e7](https://github.com/penrose/penrose/commit/7ad14e7d819d1ddedc03a75eb17f17532430b3aa))
+- style canvas default indent error ([#1747](https://github.com/penrose/penrose/issues/1747)) ([5c92e62](https://github.com/penrose/penrose/commit/5c92e62f455de6514593d3985e94985c0573f8be))
+
+### :nail_care: Polish
+
+- OptimizerWorker/worker ([#1765](https://github.com/penrose/penrose/issues/1765)) ([4110f80](https://github.com/penrose/penrose/commit/4110f80092aa6b4c1f199a22a7144ab1220dceeb))
+- simplified shared `Grid` and custom `Grid` in Edgeworth ([#1729](https://github.com/penrose/penrose/issues/1729)) ([a7c9d4d](https://github.com/penrose/penrose/commit/a7c9d4d5d8cc44b3544afb826da3a7002ef55cff))
+
+### :house: Internal
+
+- add default canvas block to `editor` ([#1674](https://github.com/penrose/penrose/issues/1674)) ([52f8fd2](https://github.com/penrose/penrose/commit/52f8fd28e1cfc22e0c9750f3c9cdc61e5f9a6591))
+- bump version to 4.0.0-alpha.0 ([#1735](https://github.com/penrose/penrose/issues/1735)) ([da1343d](https://github.com/penrose/penrose/commit/da1343dca34cb1291894b754b7f7ac3aed672df5))
+
+### :running_woman: Performance
+
+- optimizer worker speed up ([#1772](https://github.com/penrose/penrose/issues/1772)) ([3383139](https://github.com/penrose/penrose/commit/3383139ca526b2f991b78c984b8a2ef5717aca74))
+
 ## [v4.0.0-alpha.0] (2024-05-07)
 
 ### :warning: BREAKING CHANGE

--- a/packages/editor/package.json
+++ b/packages/editor/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@penrose/editor",
   "private": true,
-  "version": "4.0.0-alpha.0",
+  "version": "4.0.0-alpha.1",
   "scripts": {
     "start": "cross-env NODE_OPTIONS='--max-old-space-size=8192' vite",
     "dev": "cross-env NODE_OPTIONS='--max-old-space-size=8192' vite",
@@ -41,9 +41,9 @@
     }
   },
   "dependencies": {
-    "@penrose/components": "^4.0.0-alpha.0",
-    "@penrose/core": "^4.0.0-alpha.0",
-    "@penrose/examples": "^4.0.0-alpha.0",
+    "@penrose/components": "^4.0.0-alpha.1",
+    "@penrose/core": "^4.0.0-alpha.1",
+    "@penrose/examples": "^4.0.0-alpha.1",
     "@uiw/react-codemirror": "^4.22.2",
     "animals": "^0.0.3",
     "color-name-list": "^8.38.0",

--- a/packages/examples/CHANGELOG.md
+++ b/packages/examples/CHANGELOG.md
@@ -3,6 +3,48 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [v4.0.0-alpha.1] (2024-07-11)
+
+### :warning: BREAKING CHANGE
+
+- separate Substance environment and remove unused features (#1677)
+
+### :rocket: New Feature
+
+- Add array-manipulation diagram to gallery ([#1716](https://github.com/penrose/penrose/issues/1716)) ([7f08c63](https://github.com/penrose/penrose/commit/7f08c636bfbcdf09c465bf5e244f31a42a3cf6e7))
+- Arc mesh example ([#1789](https://github.com/penrose/penrose/issues/1789)) ([edd0a04](https://github.com/penrose/penrose/commit/edd0a041068f00e059fa2dfd5b70dd76a5a3df99))
+- More fractals ([#1644](https://github.com/penrose/penrose/issues/1644)) ([4862055](https://github.com/penrose/penrose/commit/4862055cb61891e7e55a2e910582fb4fbbb9f205))
+- Nephroid as Envelope ([#1647](https://github.com/penrose/penrose/issues/1647)) ([09119bd](https://github.com/penrose/penrose/commit/09119bd26895fa015d3c4864eadb05b1d72f8f9d))
+- Random Index Style Function & Chaos Game ([#1643](https://github.com/penrose/penrose/issues/1643)) ([36d4299](https://github.com/penrose/penrose/commit/36d4299a03c965b27b611dbb8c3fee941bbfbb4a))
+- Update spectral graph examples ([#1642](https://github.com/penrose/penrose/issues/1642)) ([97daca2](https://github.com/penrose/penrose/commit/97daca2af38db7d7ded95caa754d6e74b8d8e274))
+- Update variation for caffeine example ([#1700](https://github.com/penrose/penrose/issues/1700)) ([cd68afa](https://github.com/penrose/penrose/commit/cd68afa950f1471fe05a9fd6f113686aee3a4841))
+- codemirror migration ([#1798](https://github.com/penrose/penrose/issues/1798)) ([59d77f2](https://github.com/penrose/penrose/commit/59d77f22822cc28a32daf812f0b8c4b9e791786c))
+- distribute horizontal and vertical constraint functions ([#1794](https://github.com/penrose/penrose/issues/1794)) ([939f5fe](https://github.com/penrose/penrose/commit/939f5fea1019cc6d0adf8968188fb1e598aab757))
+- initial values for unknown variables ([#1638](https://github.com/penrose/penrose/issues/1638)) ([61f2ad7](https://github.com/penrose/penrose/commit/61f2ad766efc471bf552a6cfc3d9fcf9c2f3779a))
+- interactive widgets + programatically constrained dragging (experiemental) ([#1796](https://github.com/penrose/penrose/issues/1796)) ([d5f269e](https://github.com/penrose/penrose/commit/d5f269e9fd60740997033b93c2c99cf3a6926bdb))
+- substance literal values ([#1682](https://github.com/penrose/penrose/issues/1682)) ([7c1978f](https://github.com/penrose/penrose/commit/7c1978f4e33498828d6893d7d8f9257d2f1f839b))
+
+### :bug: Bug Fix
+
+- a better path resolution algorithm ([#1795](https://github.com/penrose/penrose/issues/1795)) ([922004a](https://github.com/penrose/penrose/commit/922004ae0055087790b5f8eed335e9fe8e0e5da9))
+- separate Substance environment and remove unused features ([#1677](https://github.com/penrose/penrose/issues/1677)) ([7ad14e7](https://github.com/penrose/penrose/commit/7ad14e7d819d1ddedc03a75eb17f17532430b3aa))
+- vector subtraction in tutorial3.md ([#1701](https://github.com/penrose/penrose/issues/1701)) ([2680e34](https://github.com/penrose/penrose/commit/2680e346c80cf67cbb402b8d45e800c80f22c5c7))
+
+### :nail_care: Polish
+
+- `Bond` constructor names in the chemistry domain ([#1712](https://github.com/penrose/penrose/issues/1712)) ([11ae235](https://github.com/penrose/penrose/commit/11ae2352279c18fb116a5dfa195a72fa9ef642a3))
+- commented geometry domain ([#1728](https://github.com/penrose/penrose/issues/1728)) ([2a335ee](https://github.com/penrose/penrose/commit/2a335ee1f2825b482766677001ad3dd3f280da9e))
+- integrate Rose ([#1636](https://github.com/penrose/penrose/issues/1636)) ([d7c1ef4](https://github.com/penrose/penrose/commit/d7c1ef4be11ac0251f026c755039bccc05818303))
+
+### :house: Internal
+
+- bump version to 4.0.0-alpha.0 ([#1735](https://github.com/penrose/penrose/issues/1735)) ([da1343d](https://github.com/penrose/penrose/commit/da1343dca34cb1291894b754b7f7ac3aed672df5))
+- fix labeling objective in ray tracing Style ([#1660](https://github.com/penrose/penrose/issues/1660)) ([4f9ed8e](https://github.com/penrose/penrose/commit/4f9ed8ec5e78869f5577e8598a23b401a6a691b8))
+- rename venn to euler diagrams ([#1756](https://github.com/penrose/penrose/issues/1756)) ([355b130](https://github.com/penrose/penrose/commit/355b130e044f613a6fab7abe55681ab5f0df4fee))
+- simplify names of `IsSubset` and `NotIntersecting` ([#1724](https://github.com/penrose/penrose/issues/1724)) ([b5e8cb8](https://github.com/penrose/penrose/commit/b5e8cb8675c63f279e9e769913b24c1ec8055b23))
+- wait until the end to write the text chart ([#1665](https://github.com/penrose/penrose/issues/1665)) ([31492d0](https://github.com/penrose/penrose/commit/31492d0d29a8310f1782ea4a5b252a162f6ab285))
+- write out registry stats after every diagram ([#1664](https://github.com/penrose/penrose/issues/1664)) ([c16e63f](https://github.com/penrose/penrose/commit/c16e63f93bacf65e161264982af250a83b3b0d38))
+
 ## [v4.0.0-alpha.0] (2024-05-07)
 
 ### :warning: BREAKING CHANGE

--- a/packages/examples/package.json
+++ b/packages/examples/package.json
@@ -1,11 +1,11 @@
 {
   "name": "@penrose/examples",
-  "version": "4.0.0-alpha.0",
+  "version": "4.0.0-alpha.1",
   "private": true,
   "type": "module",
   "dependencies": {
-    "@penrose/core": "^4.0.0-alpha.0",
-    "@penrose/solids": "^4.0.0-alpha.0",
+    "@penrose/core": "^4.0.0-alpha.1",
+    "@penrose/solids": "^4.0.0-alpha.1",
     "solid-js": "^1"
   },
   "devDependencies": {

--- a/packages/roger/CHANGELOG.md
+++ b/packages/roger/CHANGELOG.md
@@ -3,6 +3,24 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [v4.0.0-alpha.1] (2024-07-11)
+
+### :rocket: New Feature
+
+- `--dump-metadata` in `roger` ([#1717](https://github.com/penrose/penrose/issues/1717)) ([98b96a5](https://github.com/penrose/penrose/commit/98b96a51a123d69e9525beda7f4b887f359be956))
+- dump SVG option in `roger` ([#1697](https://github.com/penrose/penrose/issues/1697)) ([243b306](https://github.com/penrose/penrose/commit/243b306946045e306180390303aff3347d037006))
+- initial values for unknown variables ([#1638](https://github.com/penrose/penrose/issues/1638)) ([61f2ad7](https://github.com/penrose/penrose/commit/61f2ad766efc471bf552a6cfc3d9fcf9c2f3779a))
+
+### :bug: Bug Fix
+
+- show `roger` version ([#1736](https://github.com/penrose/penrose/issues/1736)) ([11ff419](https://github.com/penrose/penrose/commit/11ff41901aa176c32f15c436cf44c17d7d0ce495))
+
+### :house: Internal
+
+- bump version to 4.0.0-alpha.0 ([#1735](https://github.com/penrose/penrose/issues/1735)) ([da1343d](https://github.com/penrose/penrose/commit/da1343dca34cb1291894b754b7f7ac3aed672df5))
+- delete deprecated file extensions from Roger ([#1675](https://github.com/penrose/penrose/issues/1675)) ([12ff3d0](https://github.com/penrose/penrose/commit/12ff3d069ed7b4478642a23e126cc08c45a32e7f))
+- rename venn to euler diagrams ([#1756](https://github.com/penrose/penrose/issues/1756)) ([355b130](https://github.com/penrose/penrose/commit/355b130e044f613a6fab7abe55681ab5f0df4fee))
+
 ## [v4.0.0-alpha.0] (2024-05-07)
 
 ### :rocket: New Feature

--- a/packages/roger/package.json
+++ b/packages/roger/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@penrose/roger",
-  "version": "4.0.0-alpha.0",
+  "version": "4.0.0-alpha.1",
   "description": "",
   "type": "module",
   "main": "dist/index.js",
@@ -30,7 +30,7 @@
   "author": "Penrose Team (https://penrose.cs.cmu.edu/)",
   "license": "MIT",
   "dependencies": {
-    "@penrose/core": "^4.0.0-alpha.0",
+    "@penrose/core": "^4.0.0-alpha.1",
     "canvas": "^2.8.0",
     "chalk": "^3.0.0",
     "chokidar": "^3.5.3",

--- a/packages/solids/CHANGELOG.md
+++ b/packages/solids/CHANGELOG.md
@@ -3,6 +3,25 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [v4.0.0-alpha.1] (2024-07-11)
+
+### :rocket: New Feature
+
+- `DraggablePoint` in `solids` ([#1485](https://github.com/penrose/penrose/issues/1485)) ([165adfb](https://github.com/penrose/penrose/commit/165adfb170c87a44dd967a7e2d28f46b2e230935))
+- initial values for unknown variables ([#1638](https://github.com/penrose/penrose/issues/1638)) ([61f2ad7](https://github.com/penrose/penrose/commit/61f2ad766efc471bf552a6cfc3d9fcf9c2f3779a))
+
+### :nail_care: Polish
+
+- integrate Rose ([#1636](https://github.com/penrose/penrose/issues/1636)) ([d7c1ef4](https://github.com/penrose/penrose/commit/d7c1ef4be11ac0251f026c755039bccc05818303))
+
+### :memo: Documentation
+
+- comment SolidJS `sample` function ([#1656](https://github.com/penrose/penrose/issues/1656)) ([68975e5](https://github.com/penrose/penrose/commit/68975e5519ee3ad9ba0e5b50bd9b2766fff2c543))
+
+### :house: Internal
+
+- bump version to 4.0.0-alpha.0 ([#1735](https://github.com/penrose/penrose/issues/1735)) ([da1343d](https://github.com/penrose/penrose/commit/da1343dca34cb1291894b754b7f7ac3aed672df5))
+
 ## [v4.0.0-alpha.0] (2024-05-07)
 
 ### :rocket: New Feature

--- a/packages/solids/package.json
+++ b/packages/solids/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@penrose/solids",
-  "version": "4.0.0-alpha.0",
+  "version": "4.0.0-alpha.1",
   "private": true,
   "type": "module",
   "exports": {
@@ -9,7 +9,7 @@
     "default": "./dist/ssr/index.js"
   },
   "dependencies": {
-    "@penrose/core": "^4.0.0-alpha.0",
+    "@penrose/core": "^4.0.0-alpha.1",
     "markdown-it": "^13.0.1",
     "markdown-it-mathjax3": "^4.3.2",
     "solid-js": "^1"

--- a/packages/vscode/CHANGELOG.md
+++ b/packages/vscode/CHANGELOG.md
@@ -3,6 +3,24 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [v4.0.0-alpha.1] (2024-07-11)
+
+### :warning: BREAKING CHANGE
+
+- separate Substance environment and remove unused features (#1677)
+
+### :rocket: New Feature
+
+- initial values for unknown variables ([#1638](https://github.com/penrose/penrose/issues/1638)) ([61f2ad7](https://github.com/penrose/penrose/commit/61f2ad766efc471bf552a6cfc3d9fcf9c2f3779a))
+
+### :bug: Bug Fix
+
+- separate Substance environment and remove unused features ([#1677](https://github.com/penrose/penrose/issues/1677)) ([7ad14e7](https://github.com/penrose/penrose/commit/7ad14e7d819d1ddedc03a75eb17f17532430b3aa))
+
+### :house: Internal
+
+- bump version to 4.0.0-alpha.0 ([#1735](https://github.com/penrose/penrose/issues/1735)) ([da1343d](https://github.com/penrose/penrose/commit/da1343dca34cb1291894b754b7f7ac3aed672df5))
+
 ## [v4.0.0-alpha.0] (2024-05-07)
 
 ### :warning: BREAKING CHANGE

--- a/packages/vscode/package.json
+++ b/packages/vscode/package.json
@@ -3,7 +3,7 @@
   "displayName": "Penrose",
   "publisher": "penrose",
   "description": "Penrose languages bundle",
-  "version": "4.0.0-alpha.0",
+  "version": "4.0.0-alpha.1",
   "author": "Penrose Team (https://penrose.cs.cmu.edu/)",
   "license": "MIT",
   "private": true,


### PR DESCRIPTION
# Description

bumps to `v4.0.0-alpha.1` for #1827 mainly. added docs for the pre-release process.