### PR TITLE
fix: default vim keybindings

### DIFF
--- a/packages/components/src/editing/EditorPane.tsx
+++ b/packages/components/src/editing/EditorPane.tsx
@@ -92,7 +92,6 @@ export default function EditorPane({
   );
 
   const defaultExtensions = [
-    vim(),
     EditorView.lineWrapping,
     ResponsiveStyles,
     lintObject,


### PR DESCRIPTION
# Description

Follow up on #1828 to fix the mistake of adding vim bindings by default