### PR TITLE
feat: no unsaved notif on unedited workspace

### DIFF
--- a/packages/editor/src/components/SvgUploader.tsx
+++ b/packages/editor/src/components/SvgUploader.tsx
@@ -61,7 +61,7 @@ export default function SvgUploader() {
         ...currentWorkspace,
         metadata: {
           ...currentWorkspace.metadata,
-          location: { kind: "local" } as WorkspaceLocation,
+          location: { kind: "local", changesMade: false } as WorkspaceLocation,
           id: uuid(),
           name: svg.name.replace(".svg", ""),
         },

--- a/packages/editor/src/state/atoms.ts
+++ b/packages/editor/src/state/atoms.ts
@@ -51,7 +51,10 @@ export type WorkspaceLocation =
    * "local" used for unstored non-example workspaces, to distinguish for
    * save button functionality
    */
-  | { kind: "local" }
+  | {
+      kind: "local";
+      changesMade: boolean;
+    }
   | {
       /**
        * If file is explicitly saved to cloud storage
@@ -176,7 +179,18 @@ const markWorkspaceUnsavedEffect: AtomEffect<Workspace> = ({
               ...workspace,
               metadata: {
                 ...workspace.metadata,
-                location: { kind: "local" },
+                location: { kind: "local", changesMade: false },
+              } as WorkspaceMetadata,
+            };
+          });
+        } else if (newValue.metadata.location.kind == "local") {
+          setSelf((workspaceOrDefault) => {
+            const workspace = workspaceOrDefault as Workspace;
+            return {
+              ...workspace,
+              metadata: {
+                ...workspace.metadata,
+                location: { kind: "local", changesMade: true },
               } as WorkspaceMetadata,
             };
           });
@@ -213,7 +227,7 @@ export const defaultWorkspaceState = (): Workspace => ({
     id: uuid(),
     lastModified: Date.parse(new Date().toISOString()),
     editorVersion: 0.1,
-    location: { kind: "local" },
+    location: { kind: "local", changesMade: false },
     forkedFromGist: null,
   },
   files: {

--- a/packages/editor/src/state/callbacks.ts
+++ b/packages/editor/src/state/callbacks.ts
@@ -435,7 +435,8 @@ export const isCleanWorkspace = (workspace: Workspace): boolean => {
   if (
     (workspace.metadata.location.kind === "stored" &&
       !workspace.metadata.location.saved) ||
-    workspace.metadata.location.kind == "local"
+    (workspace.metadata.location.kind == "local" &&
+      workspace.metadata.location.changesMade)
   ) {
     return false;
   } else {


### PR DESCRIPTION
# Description
by request of overlord sam

- Unedited unstored workspaces will not trigger a "unsaved" notification anymore (example: on example click or tab exit)
- This also applies to unedited SVG uploaded workspaces 
