### PR TITLE
feat: added recover button to Settings

### DIFF
--- a/packages/editor/package.json
+++ b/packages/editor/package.json
@@ -49,6 +49,7 @@
     "color-name-list": "^8.38.0",
     "flexlayout-react": "^0.7.3",
     "localforage": "^1.10.0",
+    "localforage-getitems": "^1.4.2",
     "lodash": "^4.17.21",
     "query-string": "^7.1.1",
     "react": "^18.2.0",

--- a/packages/editor/src/components/SavedBrowser.tsx
+++ b/packages/editor/src/components/SavedBrowser.tsx
@@ -47,14 +47,21 @@ export default function SavedFilesBrowser() {
             {(currentWorkspace.metadata.location.kind !== "stored" ||
               !currentWorkspace.metadata.location.saved) && (
               <BlueButton
-                onClick={() => saveNewWorkspace(currentWorkspace.metadata.id)}
+                onClick={() =>
+                  saveNewWorkspace(
+                    currentWorkspace.metadata.id,
+                    currentWorkspace,
+                  )
+                }
               >
                 save current workspace
               </BlueButton>
             )}
             {currentWorkspace.metadata.location.kind === "stored" &&
               currentWorkspace.metadata.location.saved && (
-                <BlueButton onClick={() => saveNewWorkspace(uuid())}>
+                <BlueButton
+                  onClick={() => saveNewWorkspace(uuid(), currentWorkspace)}
+                >
                   duplicate workspace
                 </BlueButton>
               )}

--- a/packages/editor/src/components/Settings.tsx
+++ b/packages/editor/src/components/Settings.tsx
@@ -1,5 +1,6 @@
 import { useRecoilStateLoadable, useRecoilValue } from "recoil";
 import { currentAppUser, settingsState } from "../state/atoms.js";
+import { useRecoverAll } from "../state/callbacks.js";
 import { logInWrapper, signOutWrapper } from "../utils/firebaseUtils.js";
 import BlueButton from "./BlueButton.js";
 
@@ -8,6 +9,7 @@ export default function Settings() {
   const currentUser = useRecoilValue(currentAppUser);
   const useLogin = logInWrapper();
   const useLogout = signOutWrapper();
+  const recoverAll = useRecoverAll();
 
   if (settings.state !== "hasValue") {
     return <div>loading...</div>;
@@ -86,6 +88,11 @@ export default function Settings() {
       {currentUser != null ? (
         <div style={{ margin: "10px" }}>
           <BlueButton onClick={useLogout}>Sign Out</BlueButton>
+          <p>
+            We've migrated to cloud storage! Recover all legacy locally stored
+            diagrams:
+          </p>
+          <BlueButton onClick={recoverAll}>Recover All</BlueButton>
         </div>
       ) : (
         <div style={{ margin: "10px" }}>

--- a/packages/editor/src/components/Settings.tsx
+++ b/packages/editor/src/components/Settings.tsx
@@ -1,15 +1,30 @@
+import { useEffect, useState } from "react";
 import { useRecoilStateLoadable, useRecoilValue } from "recoil";
-import { currentAppUser, settingsState } from "../state/atoms.js";
-import { useRecoverAll } from "../state/callbacks.js";
+import {
+  currentAppUser,
+  savedFilesState,
+  settingsState,
+} from "../state/atoms.js";
+import { countLegacyDiagrams, useRecoverAll } from "../state/callbacks.js";
 import { logInWrapper, signOutWrapper } from "../utils/firebaseUtils.js";
 import BlueButton from "./BlueButton.js";
 
 export default function Settings() {
   const [settings, setSettings] = useRecoilStateLoadable(settingsState);
+  const [numLegacyDiagrams, setNumLegacyDiagrams] = useState<number>(0);
   const currentUser = useRecoilValue(currentAppUser);
   const useLogin = logInWrapper();
   const useLogout = signOutWrapper();
   const recoverAll = useRecoverAll();
+  const savedDiagrams = useRecoilValue(savedFilesState);
+
+  useEffect(() => {
+    const set = async () => {
+      let num = await countLegacyDiagrams(savedDiagrams);
+      setNumLegacyDiagrams(num);
+    };
+    set();
+  }, [savedDiagrams]);
 
   if (settings.state !== "hasValue") {
     return <div>loading...</div>;
@@ -89,10 +104,12 @@ export default function Settings() {
         <div style={{ margin: "10px" }}>
           <BlueButton onClick={useLogout}>Sign Out</BlueButton>
           <p>
-            We've migrated to cloud storage! Recover all legacy locally stored
-            diagrams:
+            We've migrated to cloud storage! You have {numLegacyDiagrams}{" "}
+            unrestored locally stored diagrams.
           </p>
-          <BlueButton onClick={recoverAll}>Recover All</BlueButton>
+          {numLegacyDiagrams > 0 && (
+            <BlueButton onClick={recoverAll}>Recover All</BlueButton>
+          )}
         </div>
       ) : (
         <div style={{ margin: "10px" }}>

--- a/packages/editor/src/components/TopBar.tsx
+++ b/packages/editor/src/components/TopBar.tsx
@@ -189,13 +189,19 @@ export default function TopBar() {
               </AuthorBox>
             </a>
           )}
-          {currentWorkspace.metadata.location.kind == "local" && (
-            <BlueButton
-              onClick={() => saveNewWorkspace(currentWorkspace.metadata.id)}
-            >
-              save
-            </BlueButton>
-          )}
+          {currentWorkspace.metadata.location.kind == "local" &&
+            currentWorkspace.metadata.location.changesMade && (
+              <BlueButton
+                onClick={() =>
+                  saveNewWorkspace(
+                    currentWorkspace.metadata.id,
+                    currentWorkspace,
+                  )
+                }
+              >
+                save
+              </BlueButton>
+            )}
           {currentWorkspace.metadata.location.kind === "stored" &&
             !currentWorkspace.metadata.location.saved && (
               <BlueButton onClick={() => saveWorkspace()}>save</BlueButton>

--- a/packages/editor/src/state/callbacks.ts
+++ b/packages/editor/src/state/callbacks.ts
@@ -2,6 +2,8 @@ import { runtimeError } from "@penrose/core";
 import { Style } from "@penrose/examples/dist/index.js";
 import registry from "@penrose/examples/dist/registry.js";
 import { deleteDoc, doc, getDoc, setDoc, updateDoc } from "firebase/firestore";
+import localforage from "localforage";
+import "localforage-getitems";
 import { debounce } from "lodash";
 import queryString from "query-string";
 import { useCallback, useEffect, useRef } from "react";
@@ -809,67 +811,82 @@ export const useDeleteWorkspace = () =>
   );
 
 /**
+ * Helper function outside of recoil callback function for use in
+ * multiple callbacks. Saves currentWorkspace under diagramId to cloud
+ * storage and propogates to local state
+ */
+async function saveNewLogic(
+  diagramId: string,
+  currentWorkspace: Workspace,
+  set: any,
+) {
+  if (
+    authObject.currentUser != null &&
+    authObject.currentUser.uid != undefined
+  ) {
+    const modificationTime = Date.parse(new Date().toISOString());
+    // Save to cloud
+    const notif = toast.loading("saving...");
+    await setDoc(doc(db, authObject.currentUser.uid, diagramId), {
+      diagramId: diagramId,
+      name: currentWorkspace.metadata.name,
+      lastModified: modificationTime,
+      editorVersion: currentWorkspace.metadata.editorVersion,
+      substance: currentWorkspace.files.substance.contents,
+      style: currentWorkspace.files.style.contents,
+      domain: currentWorkspace.files.domain.contents,
+    })
+      .catch((error) => {
+        console.log(
+          `Error code: ${error.code}, Error message: ${error.message}`,
+        );
+        toast.error("Encountered an error");
+      })
+      // Update local state
+      .then(() => {
+        set(savedFilesState, (prevState: any) => ({
+          ...prevState,
+          [diagramId]: createWorkspaceObject(
+            currentWorkspace.metadata.name,
+            modificationTime,
+            diagramId,
+            currentWorkspace.metadata.editorVersion,
+            true,
+            currentWorkspace.files.substance.contents,
+            currentWorkspace.files.style.contents,
+            currentWorkspace.files.domain.contents,
+          ),
+        }));
+        set(currentWorkspaceState, (prevState: any) => ({
+          ...prevState,
+          metadata: {
+            ...prevState.metadata,
+            id: diagramId,
+            lastModified: modificationTime,
+            location: {
+              kind: "stored",
+              saved: true,
+            } as WorkspaceLocation,
+          },
+        }));
+        toast.dismiss(notif);
+      });
+  } else {
+    toast.error("Could not save workspace, please check login credentials");
+  }
+}
+
+/**
  * Used when a "local" workspace is saved for the first time
  * Also used for duplicate diagram, diagramId passed in as fresh uuid
  */
 export const useSaveNewWorkspace = () =>
-  useRecoilCallback(({ snapshot, set }) => async (diagramId: string) => {
-    if (
-      authObject.currentUser != null &&
-      authObject.currentUser.uid != undefined
-    ) {
-      const currentWorkspace = snapshot.getLoadable(
-        currentWorkspaceState,
-      ).contents;
-
-      const modificationTime = Date.parse(new Date().toISOString());
-      // Save to cloud
-      const notif = toast.loading("saving...");
-      await setDoc(doc(db, authObject.currentUser.uid, diagramId), {
-        diagramId: diagramId,
-        name: currentWorkspace.metadata.name,
-        lastModified: modificationTime,
-        editorVersion: currentWorkspace.metadata.editorVersion,
-        substance: currentWorkspace.files.substance.contents,
-        style: currentWorkspace.files.style.contents,
-        domain: currentWorkspace.files.domain.contents,
-      })
-        .catch((error) => {
-          console.log(
-            `Error code: ${error.code}, Error message: ${error.message}`,
-          );
-          toast.error("Encountered an error");
-        })
-        // Update local state
-        .then(() => {
-          set(savedFilesState, (prevState) => ({
-            ...prevState,
-            [diagramId]: createWorkspaceObject(
-              currentWorkspace.metadata.name,
-              modificationTime,
-              diagramId,
-              currentWorkspace.metadata.editorVersion,
-              true,
-              currentWorkspace.files.substance.contents,
-              currentWorkspace.files.style.contents,
-              currentWorkspace.files.domain.contents,
-            ),
-          }));
-          set(currentWorkspaceState, (prevState) => ({
-            ...prevState,
-            metadata: {
-              ...prevState.metadata,
-              id: diagramId,
-              lastModified: modificationTime,
-              location: { kind: "stored", saved: true } as WorkspaceLocation,
-            },
-          }));
-          toast.dismiss(notif);
-        });
-    } else {
-      toast.error("Could not save workspace, please check login credentials");
-    }
-  });
+  useRecoilCallback(
+    ({ set }) =>
+      async (diagramId: string, currentWorkspace: Workspace) => {
+        saveNewLogic(diagramId, currentWorkspace, set);
+      },
+  );
 
 export const useSaveWorkspace = () =>
   useRecoilCallback(({ snapshot, set }) => async () => {
@@ -978,9 +995,8 @@ export const saveShortcutHook = () => {
   const handleShortcut = useRecoilCallback(
     ({ snapshot }) =>
       async (event: KeyboardEvent) => {
-        const currentWorkspace = snapshot.getLoadable(
-          currentWorkspaceState,
-        ).contents;
+        const currentWorkspace = snapshot.getLoadable(currentWorkspaceState)
+          .contents as Workspace;
         if (event.repeat) return;
         // Cmd+s or Ctrl+s
         if ((event.metaKey || event.ctrlKey) && event.key === "s") {
@@ -992,7 +1008,7 @@ export const saveShortcutHook = () => {
             saveWorkspace();
           } else if (currentWorkspace.metadata.location.kind == "local") {
             event.preventDefault();
-            saveNewWorkspace(uuid());
+            saveNewWorkspace(uuid(), currentWorkspace);
           }
         }
       },
@@ -1052,3 +1068,24 @@ export const autosaveHook = () => {
     currentWorkspace.files.domain.contents,
   ]);
 };
+
+/**
+ * Traverse local storage and save to cloud storage
+ */
+export const useRecoverAll = () =>
+  useRecoilCallback(({ set, snapshot }) => async () => {
+    // Get all cloud storage saved diagrams
+    const savedDiagrams = snapshot.getLoadable(savedFilesState)
+      .contents as SavedWorkspaces;
+
+    // Get all locally saved items
+    localforage.getItems().then(function (results) {
+      // Loop over all results
+      Object.keys(results).forEach((key) => {
+        // Ignore non diagrams and diagrams already saved
+        if ("metadata" in results[key] && !(key in savedDiagrams)) {
+          saveNewLogic(key, results[key], set);
+        }
+      });
+    });
+  });

--- a/yarn.lock
+++ b/yarn.lock
@@ -5215,7 +5215,7 @@
   version "3.0.0-beta.54"
   resolved "https://registry.yarnpkg.com/@tanstack/virtual-core/-/virtual-core-3.0.0-beta.54.tgz#12259d007911ad9fce1388385c54a9141f4ecdc4"
   integrity sha512-jtkwqdP2rY2iCCDVAFuaNBH3fiEi29aTn2RhtIoky8DTTiCdc48plpHHreLwmv1PICJ4AJUUESaq3xa8fZH8+g==
-  
+
 "@testing-library/dom@10.1.0":
   version "10.1.0"
   resolved "https://registry.npmjs.org/@testing-library/dom/-/dom-10.1.0.tgz"
@@ -12145,7 +12145,14 @@ local-pkg@^0.5.0:
     mlly "^1.4.2"
     pkg-types "^1.0.3"
 
-localforage@^1.10.0:
+localforage-getitems@^1.4.2:
+  version "1.4.2"
+  resolved "https://registry.yarnpkg.com/localforage-getitems/-/localforage-getitems-1.4.2.tgz#bddd3e716e7df339dc5a5cc26e2dd1decec76606"
+  integrity sha512-3Y1DAAlRjGlhWAXoD1DR8M+7WF9DC6t8CvYZ7YKVnIJBpima8j4RsWUv1ryJKB+fTPozfDxeqrN7ooqzBPyB4g==
+  dependencies:
+    localforage ">=1.4.0"
+
+localforage@>=1.4.0, localforage@^1.10.0:
   version "1.10.0"
   resolved "https://registry.npmjs.org/localforage/-/localforage-1.10.0.tgz"
   integrity sha512-14/H1aX7hzBBmmh7sGPd+AOMkkIrHM3Z1PAyGgZigA1H1p5O5ANnMyWzvpAETtG68/dC4pC0ncy3+PPGzXZHPg==


### PR DESCRIPTION
# Description

Post cloud storage merge, users no longer see their old locally saved diagrams. This adds a button to settings which automatically traverses local storage and saves all locally saved diagrams to cloud storage and syncs the system.

https://github.com/user-attachments/assets/44dbc551-f3b7-47ce-817e-fff76141f9cd


# Implementation strategy and design decisions

Function loops over all locally saved file ids and saves diagrams whose ids are not in the cloud storage saved list. This required adding the package ["localForage-getItems"](https://github.com/localForage/localForage-getItems/tree/master) which traverses local storage with a driver. localForage did not have this capability built in.

This strategy has two implications:
1 - If a user deletes some of these diagrams from cloud storage, clicking this button a second time will restore the ones they deleted 
2 - If somehow the user created another diagram that miraculously has the same id as a legacy locally saved diagram, that legacy locally saved diagram won't be restored. Diagram id strings are very long, the probability of this is negligible. 

Additionally, this required refactoring useSaveNewWorkspace. I created a helper function saveNewLogic which is now used by both useSaveNewWorkspace and useRecoverAll.

Transparency:
1 - In Settings users is displayed a count of how many unrestored legacy diagrams they have
2 - User is given a confirmation box listing the names of all diagrams to restore upon clicking "Recover"

Regarding 1: This requires us calling a function to traverse local storage to get ids every time the savedFiles recoil object is updated (otherwise once the diagrams get restored, the number remains the same in this view, which is misleading). This doesn't seem to cause any noticeable performance decrease, but if performance suffers unexpectedly, come back to this useEffect

# Open questions
The help string I display in settings is: "We've migrated to cloud storage! Recover all legacy locally stored diagrams:" is this good?

