### PR TITLE
fix: fixed mod err in substance

### DIFF
--- a/packages/components/src/editing/parser/substance/substance.grammar
+++ b/packages/components/src/editing/parser/substance/substance.grammar
@@ -75,7 +75,7 @@ NumericExpression {
     Number |
     Identifier |
     (ArithOp<"-">) NumericExpression |
-    NumericExpression !times (ArithOp<"/"> | ArithOp<"%"> | ArithOp<"*"> | ArithOp<"^">) NumericExpression |
+    NumericExpression !times (ArithOp<"/"> | ArithOp<"%"> | ArithOp<"mod"> | ArithOp<"*"> | ArithOp<"^">) NumericExpression |
     NumericExpression !plus (ArithOp<"+" | "-">) NumericExpression |
     "(" NumericExpression ")"
 }


### PR DESCRIPTION
# Description
Shoutout Leo for finding this bug 

In Mobius Strip, the parser throws an error on the "mod" statements in substance

<img width="1256" alt="Screenshot 2024-07-19 at 3 06 50 PM" src="https://github.com/user-attachments/assets/28c5f7c5-7920-45f7-991e-ea6e9ffd0aa9">

This adds mod as a arithmetic operator to the lezer parser

<img width="1278" alt="Screenshot 2024-07-19 at 3 09 29 PM" src="https://github.com/user-attachments/assets/d6507208-c2ae-458c-a72b-b59912f1b00e">