### PR TITLE
fix: Fixed traversal for recover all when exists string content file

### DIFF
--- a/packages/editor/src/state/callbacks.ts
+++ b/packages/editor/src/state/callbacks.ts
@@ -1086,7 +1086,11 @@ export const useRecoverAll = () =>
 
     Object.keys(results).forEach((key) => {
       // Ignore non diagrams and diagrams already saved
-      if ("metadata" in results[key] && !(key in savedDiagrams)) {
+      if (
+        results[key].constructor.name == "Object" &&
+        "metadata" in results[key] &&
+        !(key in savedDiagrams)
+      ) {
         data[key] = results[key];
 
         const name = results[key]["metadata"]["name"];
@@ -1131,7 +1135,11 @@ export async function countLegacyDiagrams(savedDiagrams: SavedWorkspaces) {
     let counter = 0;
 
     Object.keys(results).forEach((key) => {
-      if ("metadata" in results[key] && !(key in savedDiagrams)) {
+      if (
+        results[key].constructor.name == "Object" &&
+        "metadata" in results[key] &&
+        !(key in savedDiagrams)
+      ) {
         counter += 1;
       }
     });


### PR DESCRIPTION
# Description
Previously for recover all if user had in their localstorage a non dictionary object as a value, the button would fail

Example:
<img width="724" alt="Screenshot 2024-07-22 at 3 55 57 PM" src="https://github.com/user-attachments/assets/d58ed609-394a-4b7b-a999-a33d7c50e662">

<img width="879" alt="Screenshot 2024-07-22 at 3 56 01 PM" src="https://github.com/user-attachments/assets/b4c05699-4efc-4330-bd28-237dccb36c85">

We now check object is dictionary before checking for key in dict 