### PR TITLE
fix: read-only flag in codemirror

### DIFF
--- a/packages/components/src/editing/EditorPane.tsx
+++ b/packages/components/src/editing/EditorPane.tsx
@@ -180,6 +180,7 @@ export default function EditorPane({
         maxWidth={maxWidth}
         minHeight={minHeight}
         minWidth={minWidth}
+        readOnly={readOnly}
       />
       <div
         ref={statusBarRef}


### PR DESCRIPTION
This PR correctly passes the `readOnly` flag for CodeMirror editors. 

