### PR TITLE
fix: Better Hover + info box type names

### DIFF
--- a/packages/components/src/editing/hooks/hooksUtils.ts
+++ b/packages/components/src/editing/hooks/hooksUtils.ts
@@ -5,6 +5,7 @@ import {
   sampleShape,
   shapeTypes,
   simpleContext,
+  valueTypeDesc,
 } from "@penrose/core";
 import { ShapeDefinitions } from "../types";
 
@@ -37,8 +38,9 @@ export const getShapeDefs = (): ShapeDefinitions => {
 };
 
 /**
- * Dict should be constrDict[key] or compDict[key]. Takes a function name and
- * returns a string functionName(param1:type1, param2:type2,...)
+ * Dict should be constrDict[key], compDict[key], or objDict[key].
+ * Takes a function name and returns a string
+ * functionName(param1:type1, param2:type2,...)
  */
 export const toParamString = (dict: any, name: string) => {
   if (!dict.params || !Array.isArray(dict.params)) {
@@ -46,9 +48,40 @@ export const toParamString = (dict: any, name: string) => {
   }
 
   const formattedParams = dict.params
-    .map((param: any) => `${param.name}: ${param.type.type}`)
+    .map((param: any) => {
+      let typeName = param.type.type;
+
+      if (typeName in valueTypeDesc) {
+        return `${param.name}: ${
+          valueTypeDesc[typeName as keyof typeof valueTypeDesc].symbol
+        }`;
+      }
+
+      return `${param.name}: ${typeName}`;
+    })
+
     .join(", ");
   return `${name}(${formattedParams})`;
+};
+
+// map is meant to conform to valueTypeDesc as closely as possible
+// VectorV is only used for center, start, and end. Hence R^2
+export const convertShapeProps = (prop: string): string => {
+  let map = {
+    StrV: "String",
+    ColorV: '"rgb" | "hsv"',
+    FloatV: "ℝ",
+    BoolV: "true | false",
+    VectorV: "ℝ²",
+    PathDataV: "PathData[]",
+    PtListV: "(ℝ²)ⁿ",
+  };
+
+  if (prop in map) {
+    return map[prop as keyof typeof map];
+  }
+
+  return prop;
 };
 
 export const goToParentX = (node: SyntaxNode, x: number) => {

--- a/packages/components/src/editing/hooks/style/styleTooltips.ts
+++ b/packages/components/src/editing/hooks/style/styleTooltips.ts
@@ -4,6 +4,7 @@ import { compDict, constrDict, isKeyOf, objDict } from "@penrose/core";
 import Markdown from "markdown-it";
 import markdownItKatex from "markdown-it-katex";
 import {
+  convertShapeProps,
   extractText,
   getShapeDefs,
   toParamString,
@@ -122,7 +123,10 @@ export const wordHover = hoverTooltip((view, pos, side) => {
       );
 
       if (shapeName in shapeDefs && word in shapeDefs[shapeName]) {
-        let domElt = createShapePropDOM(word, shapeDefs[shapeName][word]);
+        let domElt = createShapePropDOM(
+          word,
+          convertShapeProps(shapeDefs[shapeName][word]),
+        );
         return createTooltip(start, end, domElt);
       }
     }

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -407,3 +407,4 @@ export {
 } from "./utils/Util.js";
 
 export type { Shape } from "./shapes/Shapes.js";
+export { valueTypeDesc } from "./types/types.js";


### PR DESCRIPTION
# Description

Uses valueTypeDesc object to map function parameter types to more intuitive names
Creates a map for shape prop type names with names similar to those used in valueTypeDesc