### PR TITLE
feat: help button and keybinding cheatsheet in `editor`

### DIFF
--- a/packages/editor/package.json
+++ b/packages/editor/package.json
@@ -48,6 +48,7 @@
     "animals": "^0.0.3",
     "color-name-list": "^8.38.0",
     "flexlayout-react": "^0.7.3",
+    "keycap": "^1.0.2",
     "localforage": "^1.10.0",
     "localforage-getitems": "^1.4.2",
     "lodash": "^4.17.21",

--- a/packages/editor/src/components/BlueButton.tsx
+++ b/packages/editor/src/components/BlueButton.tsx
@@ -10,7 +10,6 @@ const BlueButton = styled.button<{}>`
   color: #ffffff;
   background-color: #40b4f7;
   padding: 0.25em 0.3em 0.3em 0.3em;
-  margin: 0 0.3em 0 0.3em;
   user-select: none;
   border-radius: 6px;
   transition: 0.2s;

--- a/packages/editor/src/components/Dropdown.tsx
+++ b/packages/editor/src/components/Dropdown.tsx
@@ -1,0 +1,111 @@
+import { useEffect, useRef, useState } from "react";
+import styled from "styled-components";
+
+const Help = styled.button`
+  background-color: #c9c9c9;
+  border: solid 0.5px;
+  color: #ffffff;
+  border-radius: 100%;
+  font-weight: bold;
+  width: 1.5rem;
+  height: 1.5rem;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  font-size: 1rem;
+  cursor: pointer;
+  :hover {
+    background-color: #d9d9d9;
+    transition: 0.2s;
+  }
+`;
+
+export const DropdownMenu = styled.div`
+  z-index: 10;
+  background-color: white;
+  margin-top: 0.5rem;
+  border-radius: 0.5rem; /* Tailwind's rounded-lg */
+  box-shadow: 0 0.25rem 0.5rem rgba(0, 0, 0, 0.1); /* Tailwind's shadow */
+  width: 10.5rem;
+  position: absolute; /* Adjust position based on needs */
+`;
+
+// Dropdown menu items list
+export const DropdownList = styled.ul`
+  margin-block-start: 0.4rem;
+  margin-block-end: 0.4rem;
+  padding: 0 0.05rem;
+  font-size: 0.875rem; /* Tailwind's text-sm */
+  list-style-type: none;
+  color: #4b5563; /* Tailwind's text-gray-700 */
+`;
+
+// Dropdown menu item
+export const DropdownItem = styled.li`
+  cursor: pointer;
+  &:hover {
+    background-color: #f3f4f6; /* Tailwind's hover:bg-gray-100 */
+  }
+`;
+
+// Link styled-component within dropdown
+export const DropdownLink = styled.a`
+  display: flex;
+  padding: 0.5rem 1rem; /* Tailwind's px-4 py-2 */
+  text-decoration: none;
+  gap: 0.5rem;
+  color: inherit;
+`;
+
+export type DropDownItem = {
+  text: string;
+  link?: string;
+  icon: JSX.Element;
+  onClick?: () => void;
+};
+
+export default ({ items }: { items: DropDownItem[] }) => {
+  const [isOpen, setIsOpen] = useState(false);
+  const dropdownRef = useRef<HTMLDivElement>(null);
+
+  const handleClickOutside = (event: MouseEvent) => {
+    if (
+      dropdownRef.current &&
+      !dropdownRef.current.contains(event.target as Node)
+    ) {
+      setIsOpen(false);
+    }
+  };
+
+  useEffect(() => {
+    document.addEventListener("mousedown", handleClickOutside);
+    return () => {
+      document.removeEventListener("mousedown", handleClickOutside);
+    };
+  }, []);
+  return (
+    <div>
+      <Help onClick={() => setIsOpen(!isOpen)}>?</Help>
+      {isOpen && (
+        <DropdownMenu ref={dropdownRef}>
+          <DropdownList aria-labelledby="dropdownDefaultButton">
+            {items.map((item) => (
+              <DropdownItem
+                key={item.text}
+                onClick={(e) => {
+                  setIsOpen(false);
+                  if (item.onClick) item.onClick();
+                }}
+              >
+                <DropdownLink href={item.link} target="_blank">
+                  {item.icon}
+                  {item.text}
+                </DropdownLink>
+              </DropdownItem>
+            ))}
+          </DropdownList>
+        </DropdownMenu>
+      )}
+    </div>
+  );
+};

--- a/packages/editor/src/components/Icons.tsx
+++ b/packages/editor/src/components/Icons.tsx
@@ -1,0 +1,84 @@
+export const Tutorial = () => (
+  <svg
+    aria-hidden="true"
+    xmlns="http://www.w3.org/2000/svg"
+    width="18"
+    height="18"
+    fill="currentColor"
+    viewBox="0 0 24 24"
+  >
+    <path
+      fill-rule="evenodd"
+      d="M17.44 3a1 1 0 0 1 .707.293l2.56 2.56a1 1 0 0 1 0 1.414L18.194 9.78 14.22 5.806l2.513-2.513A1 1 0 0 1 17.44 3Zm-4.634 4.22-9.513 9.513a1 1 0 0 0 0 1.414l2.56 2.56a1 1 0 0 0 1.414 0l9.513-9.513-3.974-3.974ZM6 6a1 1 0 0 1 1 1v1h1a1 1 0 0 1 0 2H7v1a1 1 0 1 1-2 0v-1H4a1 1 0 0 1 0-2h1V7a1 1 0 0 1 1-1Zm9 9a1 1 0 0 1 1 1v1h1a1 1 0 1 1 0 2h-1v1a1 1 0 1 1-2 0v-1h-1a1 1 0 1 1 0-2h1v-1a1 1 0 0 1 1-1Z"
+      clip-rule="evenodd"
+    />
+    <path d="M19 13h-2v2h2v-2ZM13 3h-2v2h2V3Zm-2 2H9v2h2V5ZM9 3H7v2h2V3Zm12 8h-2v2h2v-2Zm0 4h-2v2h2v-2Z" />
+  </svg>
+);
+
+export const Docs = () => (
+  <svg
+    aria-hidden="true"
+    xmlns="http://www.w3.org/2000/svg"
+    width="18"
+    height="18"
+    fill="currentColor"
+    viewBox="0 0 24 24"
+  >
+    <path
+      fill-rule="evenodd"
+      d="M11 4.717c-2.286-.58-4.16-.756-7.045-.71A1.99 1.99 0 0 0 2 6v11c0 1.133.934 2.022 2.044 2.007 2.759-.038 4.5.16 6.956.791V4.717Zm2 15.081c2.456-.631 4.198-.829 6.956-.791A2.013 2.013 0 0 0 22 16.999V6a1.99 1.99 0 0 0-1.955-1.993c-2.885-.046-4.76.13-7.045.71v15.081Z"
+      clip-rule="evenodd"
+    />
+  </svg>
+);
+
+export const Keyboard = () => (
+  <svg
+    aria-hidden="true"
+    xmlns="http://www.w3.org/2000/svg"
+    width="18"
+    height="18"
+    fill="currentColor"
+    viewBox="0 0 24 24"
+  >
+    <path
+      fill-rule="evenodd"
+      d="M2 7a2 2 0 0 1 2-2h16a2 2 0 0 1 2 2v10a2 2 0 0 1-2 2H4a2 2 0 0 1-2-2V7Zm5.01 1H5v2.01h2.01V8Zm3 0H8v2.01h2.01V8Zm3 0H11v2.01h2.01V8Zm3 0H14v2.01h2.01V8Zm3 0H17v2.01h2.01V8Zm-12 3H5v2.01h2.01V11Zm3 0H8v2.01h2.01V11Zm3 0H11v2.01h2.01V11Zm3 0H14v2.01h2.01V11Zm3 0H17v2.01h2.01V11Zm-12 3H5v2.01h2.01V14ZM8 14l-.001 2 8.011.01V14H8Zm11.01 0H17v2.01h2.01V14Z"
+      clip-rule="evenodd"
+    />
+  </svg>
+);
+
+export const Discord = () => (
+  <svg
+    aria-hidden="true"
+    xmlns="http://www.w3.org/2000/svg"
+    width="18"
+    height="18"
+    fill="currentColor"
+    viewBox="0 0 24 24"
+  >
+    <path d="M18.942 5.556a16.3 16.3 0 0 0-4.126-1.3 12.04 12.04 0 0 0-.529 1.1 15.175 15.175 0 0 0-4.573 0 11.586 11.586 0 0 0-.535-1.1 16.274 16.274 0 0 0-4.129 1.3 17.392 17.392 0 0 0-2.868 11.662 15.785 15.785 0 0 0 4.963 2.521c.41-.564.773-1.16 1.084-1.785a10.638 10.638 0 0 1-1.706-.83c.143-.106.283-.217.418-.331a11.664 11.664 0 0 0 10.118 0c.137.114.277.225.418.331-.544.328-1.116.606-1.71.832a12.58 12.58 0 0 0 1.084 1.785 16.46 16.46 0 0 0 5.064-2.595 17.286 17.286 0 0 0-2.973-11.59ZM8.678 14.813a1.94 1.94 0 0 1-1.8-2.045 1.93 1.93 0 0 1 1.8-2.047 1.918 1.918 0 0 1 1.8 2.047 1.929 1.929 0 0 1-1.8 2.045Zm6.644 0a1.94 1.94 0 0 1-1.8-2.045 1.93 1.93 0 0 1 1.8-2.047 1.919 1.919 0 0 1 1.8 2.047 1.93 1.93 0 0 1-1.8 2.045Z" />
+  </svg>
+);
+
+export const Plus = () => (
+  <svg
+    className="w-6 h-6 text-gray-800 dark:text-white"
+    aria-hidden="true"
+    xmlns="http://www.w3.org/2000/svg"
+    width="20"
+    height="20"
+    fill="none"
+    viewBox="0 0 24 24"
+  >
+    <path
+      stroke="currentColor"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      strokeWidth="2"
+      d="M5 12h14m-7 7V5"
+    />
+  </svg>
+);

--- a/packages/editor/src/components/Keybindings.tsx
+++ b/packages/editor/src/components/Keybindings.tsx
@@ -1,0 +1,237 @@
+import { Keycap } from "keycap";
+import { Fragment, useEffect, useRef } from "react";
+import { useRecoilState } from "recoil";
+import styled, { ThemeProvider } from "styled-components";
+import { showKeybindingsState } from "../state/atoms";
+import { Plus } from "./Icons";
+
+const CmdCtrl = () => (
+  <>
+    <Keycap activeKey="Meta">⌘</Keycap>
+    <Keycap activeKey="Ctrl">⌃</Keycap>
+  </>
+);
+
+const Container = styled.div`
+  position: absolute;
+  z-index: 1000;
+  padding: 1rem 2rem;
+  // centered in page
+  // width: 30rem;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  background-color: #ffffff;
+  border-radius: 10px;
+  // shadow
+  box-shadow: 0 0.25rem 0.5rem rgba(0, 0, 0, 0.1); /* Tailwind's shadow */
+  color: ${({ theme }) => theme.textGray};
+  font-size: 0.875rem;
+`;
+
+// Wrapper for the table container
+const TableContainer = styled.div`
+  position: relative;
+  overflow-x: auto;
+  // box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1);
+  border-radius: 0.5rem;
+`;
+
+// Table element with responsive and text styling
+const StyledTable = styled.table`
+  width: 100%;
+  text-align: left;
+  border-spacing: 0px;
+`;
+
+// Body section of the table
+const TableBody = styled.tbody``;
+
+// Row styling for table body
+const TableRow = styled.tr`
+  &:nth-child(odd) {
+    background-color: ${({ theme }) => theme.bgWhite};
+  }
+  &:nth-child(even) {
+    background-color: ${({ theme }) => theme.bgGrayLight};
+  }
+  border-bottom: 1px solid ${({ theme }) => theme.borderGray};
+`;
+
+// Cell styling for table rows
+const TableCell = styled.td`
+  padding: 0.75rem 1.5rem;
+  border: none;
+`;
+
+// Special styling for header cells
+const HeaderCellSpecial = styled.th`
+  padding: 0.75rem 1.5rem;
+  font-weight: 500;
+  // color: ${({ theme }) => theme.textGrayDark};
+  white-space: nowrap;
+`;
+
+// Link styling inside table cells
+const TableLink = styled.a`
+  font-weight: 500;
+  color: ${({ theme }) => theme.linkBlue};
+  text-decoration: underline;
+  &:hover {
+    color: ${({ theme }) => theme.linkBlueHover};
+  }
+`;
+
+const KeyBind = styled.span`
+  display: flex;
+`;
+
+const theme = {
+  textGray: "#4b5563",
+  textGrayDark: "#1a202c",
+  bgWhite: "#ffffff",
+  bgGrayLight: "#f3f4f6",
+  borderGray: "#e2e8f0",
+  linkBlue: "#3490dc",
+  linkBlueHover: "#2779bd",
+};
+
+type HotKey = {
+  keys: string[];
+  name: string;
+  description: string;
+};
+
+const generalKeys: HotKey[] = [
+  {
+    keys: ["CmdCtrl", "Enter"],
+    name: "Compile",
+    description: "Compile the current Penrose Trio",
+  },
+  {
+    keys: ["CmdCtrl", "S"],
+    name: "Save",
+    description: "Save the current Penrose Trio",
+  },
+];
+
+const editorKeys: HotKey[] = [
+  {
+    keys: ["CmdCtrl", "Shift", "["],
+    name: "Fold block",
+    description: "Fold the current Style block",
+  },
+  {
+    keys: ["CmdCtrl", "Shift", "]"],
+    name: "Unfold block",
+    description: "Unfold the current Style block",
+  },
+  {
+    keys: ["CmdCtrl", "Alt", "["],
+    name: "Fold all blocks",
+    description: "Fold all Style blocks",
+  },
+  {
+    keys: ["CmdCtrl", "Alt", "]"],
+    name: "Unfold all blocks",
+    description: "Unfold all Style blocks",
+  },
+];
+
+const keyUnicode: { [key: string]: string } = {
+  Enter: "↵",
+  Tab: "⇥",
+  Space: "␣",
+  Shift: "⇧",
+  Backspace: "⌫",
+  ArrowUp: "↑",
+  ArrowDown: "↓",
+  ArrowLeft: "←",
+  ArrowRight: "→",
+  Escape: "⎋",
+  Control: "Ctrl",
+  Meta: "⌘",
+  Alt: "⌥",
+};
+
+const renderKey = (key: string) => {
+  if (key === "CmdCtrl") {
+    return <CmdCtrl />;
+  } else
+    return (
+      <Keycap style={{ marginLeft: ".4em" }} activeKey={key}>
+        {Object.keys(keyUnicode).includes(key) ? keyUnicode[key] : key}
+      </Keycap>
+    );
+};
+
+const KeyTable = ({ hotkeys }: { hotkeys: HotKey[] }) => (
+  <TableContainer>
+    <StyledTable>
+      <TableBody>
+        {hotkeys.map(({ keys, name, description }) => (
+          <TableRow>
+            <HeaderCellSpecial>
+              <KeyBind>
+                {keys.map(renderKey).map((key, index) => (
+                  <Fragment key={index}>
+                    {key}
+                    {index < keys.length - 1 && <Plus />}
+                  </Fragment>
+                ))}
+              </KeyBind>
+            </HeaderCellSpecial>
+            <TableCell>{name}</TableCell>
+            <TableCell>{description}</TableCell>
+          </TableRow>
+        ))}
+      </TableBody>
+    </StyledTable>
+  </TableContainer>
+);
+
+export default () => {
+  const overlayRef = useRef<HTMLDivElement>(null);
+  const [showKeybindings, setShowKeybindings] =
+    useRecoilState(showKeybindingsState);
+
+  const handleClickOutside = (event: MouseEvent) => {
+    if (
+      overlayRef.current &&
+      !overlayRef.current.contains(event.target as Node)
+    ) {
+      setShowKeybindings(false);
+    }
+  };
+
+  useEffect(() => {
+    document.addEventListener("mousedown", handleClickOutside);
+    return () => {
+      document.removeEventListener("mousedown", handleClickOutside);
+    };
+  }, []);
+  return (
+    <ThemeProvider theme={theme}>
+      <Container ref={overlayRef}>
+        <h1>General</h1>
+        <KeyTable hotkeys={generalKeys} />
+        <h1>Program Editor</h1>
+        <p>
+          Check out <code>defaultKeymap</code> and <code>standardKeymap</code>{" "}
+          in the{" "}
+          <TableLink href="https://codemirror.net/docs/ref/#commands">
+            CodeMirror editor docs
+          </TableLink>{" "}
+          to see the full list of supported key bindings.
+        </p>
+        <KeyTable hotkeys={editorKeys} />
+        <h1>Vim Mode</h1>
+        Go to "settings" to enable Vim mode. Penrose's Vim mode is enabled by{" "}
+        <TableLink href="https://codemirror.net/doc/manual.html#vim">
+          codemirror-vim
+        </TableLink>
+        .
+      </Container>
+    </ThemeProvider>
+  );
+};

--- a/packages/editor/src/components/TopBar.tsx
+++ b/packages/editor/src/components/TopBar.tsx
@@ -1,11 +1,12 @@
 import { useCallback, useState } from "react";
 import { useMediaQuery } from "react-responsive";
-import { useRecoilCallback, useRecoilValue } from "recoil";
+import { useRecoilCallback, useRecoilState, useRecoilValue } from "recoil";
 import styled from "styled-components";
 import {
   currentWorkspaceState,
   diagramWorkerState,
   settingsState,
+  showKeybindingsState,
 } from "../state/atoms.js";
 import {
   autosaveHook,
@@ -19,7 +20,9 @@ import {
   useSaveWorkspace,
 } from "../state/callbacks.js";
 import BlueButton from "./BlueButton.js";
-
+import Dropdown from "./Dropdown.js";
+import { Discord, Docs, Keyboard, Tutorial } from "./Icons.js";
+import Keybindings from "./Keybindings.js";
 const UnsavedIcon = styled.div`
   background-color: #dddddd;
   padding: 2px 4px;
@@ -66,6 +69,7 @@ const HeaderButtonContainer = styled.div`
   display: flex;
   flex-direction: row;
   align-items: center;
+  gap: 0.3em;
 `;
 
 const ButtonsAlignment = styled.div<{ isMobile: boolean }>`
@@ -143,6 +147,8 @@ export default function TopBar() {
   const newWorkspace = useNewWorkspace();
   const saveWorkspace = useSaveWorkspace();
   const saveNewWorkspace = useSaveNewWorkspace();
+  const [showKeybindings, setShowKeybindings] =
+    useRecoilState(showKeybindingsState);
   const isMobile = useMediaQuery({ query: "(max-width: 768px)" });
 
   /**
@@ -232,6 +238,30 @@ export default function TopBar() {
       )}
       {!isMobile && (
         <HeaderButtonContainer>
+          <Dropdown
+            items={[
+              {
+                text: "Do the tutorial",
+                link: "https://penrose.cs.cmu.edu/docs/tutorial/welcome",
+                icon: <Tutorial />,
+              },
+              {
+                text: "Read the docs",
+                link: "https://penrose.cs.cmu.edu/docs/ref",
+                icon: <Docs />,
+              },
+              {
+                text: "Community help",
+                link: "https://discord.gg/a7VXJU4dfR",
+                icon: <Discord />,
+              },
+              {
+                text: "View hotkeys",
+                icon: <Keyboard />,
+                onClick: () => setShowKeybindings(true),
+              },
+            ]}
+          />
           <BlueButton disabled={compiling} onClick={resampleDiagram}>
             resample
           </BlueButton>
@@ -240,6 +270,7 @@ export default function TopBar() {
           </BlueButton>
         </HeaderButtonContainer>
       )}
+      {showKeybindings && <Keybindings />}
     </nav>
   );
 }

--- a/packages/editor/src/state/atoms.ts
+++ b/packages/editor/src/state/atoms.ts
@@ -137,6 +137,11 @@ export const autosaveTimerState = atom<AutosaveTimer>({
   default: null,
 });
 
+export const showKeybindingsState = atom<boolean>({
+  key: "showKeybindingsState",
+  default: false,
+});
+
 /**
  * On any state change to a stored workspace, mark it as unsaved (debounced)
  * On any state change to an example workspace (i.e. title or content edit),

--- a/packages/editor/src/state/callbacks.ts
+++ b/packages/editor/src/state/callbacks.ts
@@ -184,6 +184,7 @@ export const useClearAutosave = (set: any, snapshot: any) => {
     set(autosaveTimerState, null);
   }
 };
+
 /*
  * See: https://github.com/uiwjs/react-codemirror/issues/405
  * Summary: Utilizing React Codemirror provides useful abstractions that

--- a/yarn.lock
+++ b/yarn.lock
@@ -4275,7 +4275,7 @@
   resolved "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.18.0.tgz"
   integrity sha512-IWfdwU7KDSm07Ty0PuA/W2JYoZ4iTj3TUQjkVsO/6U+4I1jN5lcR71ZEvRh52sDOERdnNhhHU57UITXz5jC1/w==
 
-"@rollup/rollup-darwin-arm64@4.9.5":
+"@rollup/rollup-darwin-arm64@4.9.5", "@rollup/rollup-win32-x64-msvc@4.9.5":
   version "4.9.5"
   resolved "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.9.5.tgz"
   integrity sha512-ndoXeLx455FffL68OIUrVr89Xu1WLzAG4n65R8roDlCoYiQcGGg6MALvs2Ap9zs7AHg8mpHtMpwC8jBBjZrT/w==
@@ -4389,11 +4389,6 @@
   version "4.18.0"
   resolved "https://registry.yarnpkg.com/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.18.0.tgz#5d694d345ce36b6ecf657349e03eb87297e68da4"
   integrity sha512-UOo5FdvOL0+eIVTgS4tIdbW+TtnBLWg1YBCcU2KWM7nuNwRz9bksDX1bekJJCpu25N1DVWaCwnT39dVQxzqS8g==
-
-"@rollup/rollup-win32-x64-msvc@4.9.5":
-  version "4.9.5"
-  resolved "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.9.5.tgz"
-  integrity sha512-ndoXeLx455FffL68OIUrVr89Xu1WLzAG4n65R8roDlCoYiQcGGg6MALvs2Ap9zs7AHg8mpHtMpwC8jBBjZrT/w==
 
 "@rose-lang/wasm@0.4.9":
   version "0.4.9"
@@ -11943,6 +11938,11 @@ katex@^0.6.0:
   dependencies:
     match-at "^0.1.0"
 
+keycap@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/keycap/-/keycap-1.0.2.tgz#0a31be0383cc1be47be63fa961153304ac5c6ce2"
+  integrity sha512-XBFaz1p2JFvGZFiBA2RaytzqXCkkZ/VpfTPJm8p/VtugdGQhmM0A76GAtn23Aa3CKqOJvxweEaotRm2rqIeATQ==
+
 keytar@^7.7.0:
   version "7.9.0"
   resolved "https://registry.npmjs.org/keytar/-/keytar-7.9.0.tgz"
@@ -16129,7 +16129,7 @@ strict-uri-encode@^2.0.0:
   resolved "https://registry.npmjs.org/strict-uri-encode/-/strict-uri-encode-2.0.0.tgz"
   integrity sha512-QwiXZgpRcKkhTj2Scnn++4PKtWsH0kpzZ62L2R6c/LUVYv7hVnZqcg2+sMuT6R7Jusu1vviK/MFsu6kNJfWlEQ==
 
-"string-width-cjs@npm:string-width@^4.2.0":
+"string-width-cjs@npm:string-width@^4.2.0", "string-width@^1.0.2 || 2 || 3 || 4", string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
   version "4.2.3"
   resolved "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
@@ -16146,15 +16146,6 @@ string-width@^1.0.1:
     code-point-at "^1.0.0"
     is-fullwidth-code-point "^1.0.0"
     strip-ansi "^3.0.0"
-
-"string-width@^1.0.2 || 2 || 3 || 4", string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
-  version "4.2.3"
-  resolved "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz"
-  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
-  dependencies:
-    emoji-regex "^8.0.0"
-    is-fullwidth-code-point "^3.0.0"
-    strip-ansi "^6.0.1"
 
 string-width@^2.1.0:
   version "2.1.1"
@@ -16239,7 +16230,7 @@ string_decoder@~1.1.1:
   dependencies:
     safe-buffer "~5.1.0"
 
-"strip-ansi-cjs@npm:strip-ansi@^6.0.1":
+"strip-ansi-cjs@npm:strip-ansi@^6.0.1", strip-ansi@^6.0.0, strip-ansi@^6.0.1:
   version "6.0.1"
   resolved "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz"
   integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
@@ -16266,13 +16257,6 @@ strip-ansi@^5.0.0, strip-ansi@^5.1.0, strip-ansi@^5.2.0:
   integrity sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==
   dependencies:
     ansi-regex "^4.1.0"
-
-strip-ansi@^6.0.0, strip-ansi@^6.0.1:
-  version "6.0.1"
-  resolved "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz"
-  integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
-  dependencies:
-    ansi-regex "^5.0.1"
 
 strip-ansi@^7.0.1:
   version "7.1.0"
@@ -17824,7 +17808,7 @@ wordwrap@^1.0.0:
   resolved "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz"
   integrity sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus=
 
-"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0":
+"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0", wrap-ansi@^7.0.0:
   version "7.0.0"
   resolved "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz"
   integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
@@ -17841,15 +17825,6 @@ wrap-ansi@^5.1.0:
     ansi-styles "^3.2.0"
     string-width "^3.0.0"
     strip-ansi "^5.0.0"
-
-wrap-ansi@^7.0.0:
-  version "7.0.0"
-  resolved "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz"
-  integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
-  dependencies:
-    ansi-styles "^4.0.0"
-    string-width "^4.1.0"
-    strip-ansi "^6.0.0"
 
 wrap-ansi@^8.1.0:
   version "8.1.0"


### PR DESCRIPTION
# Description

This PR adds a "?" button in the top bar of `editor`, which refers the user to good resources to get help on using Penrose, including: tutorial and official documentation from our site, an invite to the Discord server, and a list of supported keybindings.

On the last item: `editor` supports a small set of keyboard shortcuts, but they are never displayed anywhere. This PR adds an overlay that displays everything keybinding related.

# Examples with steps to reproduce them

https://github.com/user-attachments/assets/60038faa-395c-4210-bf8f-0e8471aef2d2


# Checklist

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have reviewed any generated registry diagram changes

# Open questions

Any other keybindings we need to add?
