### PR TITLE
fix: load gallery examples asynchronously

### DIFF
--- a/packages/docs-site/src/components/Gallery.vue
+++ b/packages/docs-site/src/components/Gallery.vue
@@ -65,17 +65,21 @@ export default {
             encodeURI(
               `https://raw.githubusercontent.com/penrose/penrose/ci/refs/heads/main/${id}.svg`,
             ),
-          ).then((svg) => {
-            if (svg.ok) {
-              svg.text().then((preview) => {
-                const croppedPreview = cropSVG(preview);
-                const trio = { id, preview: croppedPreview };
-                examples.value = examples.value.map((e) =>
-                  e.id === id ? { ...trio, preview: croppedPreview } : e,
-                );
-              });
-            }
-          });
+          )
+            .then((svg) => {
+              if (svg.ok) {
+                return svg.text();
+              } else {
+                return Promise.reject("Failed to fetch SVG");
+              }
+            })
+            .then((preview) => {
+              const croppedPreview = cropSVG(preview);
+              const trio = { id, preview: croppedPreview };
+              examples.value = examples.value.map((e) =>
+                e.id === id ? { ...trio, preview: croppedPreview } : e,
+              );
+            });
         }
       };
       load();

--- a/packages/docs-site/src/components/Gallery.vue
+++ b/packages/docs-site/src/components/Gallery.vue
@@ -61,19 +61,21 @@ export default {
     onMounted(async () => {
       const load = async () => {
         for (const id of props.trios) {
-          const svg = await fetch(
+          fetch(
             encodeURI(
               `https://raw.githubusercontent.com/penrose/penrose/ci/refs/heads/main/${id}.svg`,
             ),
-          );
-          if (svg.ok) {
-            const preview = await svg.text();
-            const croppedPreview = cropSVG(preview);
-            const trio = { id, preview: croppedPreview };
-            examples.value = examples.value.map((e) =>
-              e.id === id ? { ...trio, preview: croppedPreview } : e,
-            );
-          }
+          ).then((svg) => {
+            if (svg.ok) {
+              svg.text().then((preview) => {
+                const croppedPreview = cropSVG(preview);
+                const trio = { id, preview: croppedPreview };
+                examples.value = examples.value.map((e) =>
+                  e.id === id ? { ...trio, preview: croppedPreview } : e,
+                );
+              });
+            }
+          });
         }
       };
       load();


### PR DESCRIPTION
# Description

`Gallery.vue` currently loads the preview SVGs sequentially, which is unnecessary and slows down pageload. This PR changes it to an async approach.

