### PR TITLE
docs: consistent links to all functions

### DIFF
--- a/packages/docs-site/.vitepress/config.ts
+++ b/packages/docs-site/.vitepress/config.ts
@@ -34,14 +34,14 @@ const indexableFunctionDocs = () => {
     return `${t.symbol}: ${t.description}`;
   };
   const compFuncs = Object.entries(compDict).map(([k, v]: any) => {
-    return `### ${v.name} {#computation-${v.name}}\n\n${
+    return `### ${v.name} {#computation-${v.name.toLowerCase()}}\n\n${
       v.description
     }\n\n**Returns:** ${showReturn(
       v.returns,
     )}\n\n**Parameters:**\n\n${showParams(v.params)}`;
   });
   const objectives = Object.entries(objDict).map(([k, v]: any) => {
-    return `### ${v.name} {#objective-${v.name}}\n\n${
+    return `### ${v.name} {#objective-${v.name.toLowerCase()}}\n\n${
       v.description
     }\n\n**Parameters:**\n\n${showParams(v.params)}`;
   });

--- a/packages/docs-site/.vitepress/config.ts
+++ b/packages/docs-site/.vitepress/config.ts
@@ -34,19 +34,19 @@ const indexableFunctionDocs = () => {
     return `${t.symbol}: ${t.description}`;
   };
   const compFuncs = Object.entries(compDict).map(([k, v]: any) => {
-    return `### ${v.name} {#computation-${v.name.toLowerCase()}}\n\n${
+    return `### ${v.name} {#computation-${v.name}}\n\n${
       v.description
     }\n\n**Returns:** ${showReturn(
       v.returns,
     )}\n\n**Parameters:**\n\n${showParams(v.params)}`;
   });
   const objectives = Object.entries(objDict).map(([k, v]: any) => {
-    return `### ${v.name} {#objective-${v.name.toLowerCase()}}\n\n${
+    return `### ${v.name} {#objective-${v.name}}\n\n${
       v.description
     }\n\n**Parameters:**\n\n${showParams(v.params)}`;
   });
   const constraints = Object.entries(constrDict).map(([k, v]: any) => {
-    return `### ${v.name} {#constraint-${v.name.toLowerCase()}}\n\n${
+    return `### ${v.name} {#constraint-${v.name}}\n\n${
       v.description
     }\n\n**Parameters:**\n\n${showParams(v.params)}`;
   });

--- a/packages/docs-site/docs/ref/style/functions.md
+++ b/packages/docs-site/docs/ref/style/functions.md
@@ -14,9 +14,9 @@ const { objDict, compDict, constrDict } = data;
 
 <div v-for="f in constrDict">
 
-<h3 :id="`constraint-${f.name.toLowerCase()}`">
+<h3 :id="`constraint-${f.name}`">
   {{ f.name }}
-  <a class="header-anchor" :href="`#constraint-${f.name.toLowerCase()}`" :aria-label="`Permalink to constraint &quot;${f.name}&quot;`">&ZeroWidthSpace;</a>
+  <a class="header-anchor" :href="`#constraint-${f.name}`" :aria-label="`Permalink to constraint &quot;${f.name}&quot;`">&ZeroWidthSpace;</a>
 </h3>
 
 <Function :name="f.name" :description="f.description" :params="f.params" :returns="f.returns" />
@@ -27,9 +27,9 @@ const { objDict, compDict, constrDict } = data;
 
 <div v-for="f in objDict">
 
-<h3 :id="`objective-${f.name.toLowerCase()}`">
+<h3 :id="`objective-${f.name}`">
   {{ f.name }}
-  <a class="header-anchor" :href="`#objective-${f.name.toLowerCase()}`" :aria-label="`Permalink to objective &quot;${f.name}&quot;`">&ZeroWidthSpace;</a>
+  <a class="header-anchor" :href="`#objective-${f.name}`" :aria-label="`Permalink to objective &quot;${f.name}&quot;`">&ZeroWidthSpace;</a>
 </h3>
 
 <Function :name="f.name" :description="f.description" :params="f.params" :returns="f.returns" />
@@ -40,9 +40,9 @@ const { objDict, compDict, constrDict } = data;
 
 <div v-for="f in compDict">
 
-<h3 :id="`computation-${f.name.toLowerCase()}`">
+<h3 :id="`computation-${f.name}`">
   {{ f.name }}
-  <a class="header-anchor" :href="`#computation-${f.name.toLowerCase()}`" :aria-label="`Permalink to computation &quot;${f.name}&quot;`">&ZeroWidthSpace;</a>
+  <a class="header-anchor" :href="`#computation-${f.name}`" :aria-label="`Permalink to computation &quot;${f.name}&quot;`">&ZeroWidthSpace;</a>
 </h3>
 
 <Function :name="f.name" :description="f.description" :params="f.params" :returns="f.returns" />

--- a/packages/docs-site/docs/ref/style/functions.md
+++ b/packages/docs-site/docs/ref/style/functions.md
@@ -14,7 +14,7 @@ const { objDict, compDict, constrDict } = data;
 
 <div v-for="f in constrDict">
 
-<h3 :id="`constraint-${f.name}`">
+<h3 :id="`constraint-${f.name.toLowerCase()}`">
   {{ f.name }}
   <a class="header-anchor" :href="`#constraint-${f.name.toLowerCase()}`" :aria-label="`Permalink to constraint &quot;${f.name}&quot;`">&ZeroWidthSpace;</a>
 </h3>
@@ -27,9 +27,9 @@ const { objDict, compDict, constrDict } = data;
 
 <div v-for="f in objDict">
 
-<h3 :id="`objective-${f.name}`">
+<h3 :id="`objective-${f.name.toLowerCase()}`">
   {{ f.name }}
-  <a class="header-anchor" :href="`#objective-${f.name}`" :aria-label="`Permalink to objective &quot;${f.name}&quot;`">&ZeroWidthSpace;</a>
+  <a class="header-anchor" :href="`#objective-${f.name.toLowerCase()}`" :aria-label="`Permalink to objective &quot;${f.name}&quot;`">&ZeroWidthSpace;</a>
 </h3>
 
 <Function :name="f.name" :description="f.description" :params="f.params" :returns="f.returns" />
@@ -40,9 +40,9 @@ const { objDict, compDict, constrDict } = data;
 
 <div v-for="f in compDict">
 
-<h3 :id="`computation-${f.name}`">
+<h3 :id="`computation-${f.name.toLowerCase()}`">
   {{ f.name }}
-  <a class="header-anchor" :href="`#computation-${f.name}`" :aria-label="`Permalink to computation &quot;${f.name}&quot;`">&ZeroWidthSpace;</a>
+  <a class="header-anchor" :href="`#computation-${f.name.toLowerCase()}`" :aria-label="`Permalink to computation &quot;${f.name}&quot;`">&ZeroWidthSpace;</a>
 </h3>
 
 <Function :name="f.name" :description="f.description" :params="f.params" :returns="f.returns" />


### PR DESCRIPTION
# Description

Related: https://github.com/penrose/penrose/pull/1704

In #1704 we hacked the vitepress config to have anchor links to functions in the generated [functions docs page](https://penrose.cs.cmu.edu/docs/ref/style/functions). While search will show the functions now, the links to constraints don't jump to the actual `h3` of the function docs entry. The cause was inconsistent casing of the links, e.g. `#constraint-distributeVertically` vs. `#constraint-distributevertically`. This PR removes `toLowerCase` to constraints to make sure the links are consistent.


