### PR TITLE
docs: added vite plugin note to bloom tutorial

### DIFF
--- a/packages/docs-site/docs/bloom/tutorial/getting_started.md
+++ b/packages/docs-site/docs/bloom/tutorial/getting_started.md
@@ -30,6 +30,28 @@ template above.
 npm install @penrose/bloom
 ```
 
+### Vite Plugins
+
+If you're using vite with Bloom (like in this tutorial), you'll need the `vite-plugin-top-level-await` plugin to
+support our automatic differentiation engine, [Rose](https://github.com/rose-lang/rose):
+
+```bash
+npm install vite-plugin-top-level-await
+```
+
+You must also update your `vite.config.ts`:
+
+```typescript
+import { defineConfig } from "vite";
+import topLevelAwait from "vite-plugin-top-level-await";
+
+export default defineConfig({
+  // ...
+  plugins: [/*...,*/ topLevelAwait()],
+  optimizeDeps: { exclude: ["rose"] },
+});
+```
+
 ### Creating a component
 
 At this point you'll probably want to remove all the template nonsense from your directory:

--- a/packages/docs-site/docs/bloom/tutorial/hello_diagram.md
+++ b/packages/docs-site/docs/bloom/tutorial/hello_diagram.md
@@ -21,6 +21,16 @@ Youâ€™ll almost certainly want to wrap the process of building your diagram itâ€
 when we render the diagram:
 
 ```ts
+import {
+  DiagramBuilder,
+  Renderer,
+  Vec2,
+  canvas,
+  constraints,
+  ops,
+  useDiagram,
+} from "@penrose/bloom";
+
 const buildMyDiagram = async () => {
   const db = new DiagramBuilder(canvas(400, 200), "abcd", 1);
 


### PR DESCRIPTION
# Description

Added a note to Bloom tutorial instructing the user to install `vite-plugin-top-level-await` when using vite.
