### PR TITLE
docs: add a Nix flake for reproducibility with direnv

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,1 @@
+use flake

--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 *.log
 *#
 *~
+/.direnv/
 /target/
 dist/
 node_modules/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -31,7 +31,9 @@
 
 ## Prerequisites
 
-Be sure you have these tools installed:
+If you're using [Nix][] (with [flakes][] enabled) and [direnv][], you can skip this whole section, because the `flake.nix` file at the root of this repo contains everything you need and will automatically activate once you enter your clone of this repository and run `direnv allow`.
+
+Otherwise, be sure you have these tools installed:
 
 - [Git][]
 
@@ -42,7 +44,7 @@ Be sure you have these tools installed:
 
   - [Yarn][] v1.x
 
-Depending on your platform, here are some extra instructions:
+And then depending on your platform, here are some extra instructions:
 
 ### Apple Silicon
 
@@ -443,6 +445,8 @@ yarn lerna publish from-package --pre-dist-tag develop
 [commit]: https://github.com/git-guides/git-commit
 [conventional commit guidelines]: https://www.conventionalcommits.org/en/v1.0.0/
 [create a fork]: https://docs.github.com/en/get-started/quickstart/fork-a-repo
+[direnv]: https://direnv.net/
+[flakes]: https://wiki.nixos.org/wiki/Flakes
 [git]: https://git-scm.com/downloads
 [good first issues]: https://github.com/penrose/penrose/issues?q=is%3Aopen+is%3Aissue+label%3A%22kind%3Agood+first+issue%22
 [guide for installing nvm and node.js]: https://logfetch.com/install-node-npm-wsl2/
@@ -450,6 +454,7 @@ yarn lerna publish from-package --pre-dist-tag develop
 [homebrew]: https://brew.sh/
 [install dependencies]: https://classic.yarnpkg.com/en/docs/installing-dependencies
 [merge conflicts]: https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/addressing-merge-conflicts/resolving-a-merge-conflict-using-the-command-line
+[nix]: https://nixos.org/
 [node-canvas]: https://www.npmjs.com/package/canvas
 [node.js]: https://nodejs.org/en/download/
 [npm]: https://www.npmjs.com/

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,61 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1742169275,
+        "narHash": "sha256-nkH2Edu9rClcsQp2PYBe8E6fp8LDPi2uDBQ6wyMdeXI=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "5d9b5431f967007b3952c057fc92af49a4c5f3b2",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,36 @@
+{
+  description = "Create beautiful diagrams just by typing notation in plain text";
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
+    flake-utils.url = "github:numtide/flake-utils";
+  };
+  outputs =
+    {
+      self,
+      nixpkgs,
+      flake-utils,
+    }:
+    flake-utils.lib.eachDefaultSystem (
+      system:
+      let
+        pkgs = import nixpkgs { inherit system; };
+      in
+      {
+        devShell =
+          with pkgs;
+          mkShell {
+            buildInputs = [
+              cairo
+              giflib
+              libpng
+              librsvg
+              pango
+              pixman
+              pkg-config
+              python310
+              (yarn.override { nodejs = nodejs_18; })
+            ];
+          };
+      }
+    );
+}


### PR DESCRIPTION
Recently I tried to dust off Penrose to build on my machine, and I had a lot of difficulty getting it to work, because it has a _very_ tight set of constraints on all the dependencies before you can even run `yarn`. This PR helps with that a bit by adding a Nix environment that includes the right versions of all the dependencies.