### PR TITLE
chore: add `.envrc` to `.gitignore`

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,1 +1,0 @@
-use flake

--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@
 *#
 *~
 /.direnv/
+/.envrc
 /target/
 dist/
 node_modules/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -31,7 +31,7 @@
 
 ## Prerequisites
 
-If you're using [Nix][] (with [flakes][] enabled) and [direnv][], you can skip this whole section, because the `flake.nix` file at the root of this repo contains everything you need and will automatically activate once you enter your clone of this repository and run `direnv allow`.
+If you're using [Nix][], this repository provides a [flake][] with all these prerequisites, letting you skip this whole section.
 
 Otherwise, be sure you have these tools installed:
 
@@ -445,8 +445,7 @@ yarn lerna publish from-package --pre-dist-tag develop
 [commit]: https://github.com/git-guides/git-commit
 [conventional commit guidelines]: https://www.conventionalcommits.org/en/v1.0.0/
 [create a fork]: https://docs.github.com/en/get-started/quickstart/fork-a-repo
-[direnv]: https://direnv.net/
-[flakes]: https://wiki.nixos.org/wiki/Flakes
+[flake]: https://wiki.nixos.org/wiki/Flakes
 [git]: https://git-scm.com/downloads
 [good first issues]: https://github.com/penrose/penrose/issues?q=is%3Aopen+is%3Aissue+label%3A%22kind%3Agood+first+issue%22
 [guide for installing nvm and node.js]: https://logfetch.com/install-node-npm-wsl2/


### PR DESCRIPTION
Followup on #1886, since I've realized that checking a one-line `.envrc` into Git is bad practice for a couple reasons:

1. It messes up people who use direnv but want a different setup, e.g. configuring extra environment variables or pointing to an out-of-tree flake instead.
2. The "default" or "recommended" `use flake` is just one line, so it's easy to create that `.envrc` manually after cloning the repo.