### PR TITLE
chore: add `nixfmt` to flake

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -19,5 +19,6 @@
   "files.insertFinalNewline": false,
   "files.trimFinalNewlines": false,
   "files.trimTrailingWhitespace": false,
+  "nix.formatterPath": "nixfmt",
   "search.useParentIgnoreFiles": true
 }

--- a/flake.nix
+++ b/flake.nix
@@ -24,6 +24,7 @@
               giflib
               libpng
               librsvg
+              nixfmt-rfc-style
               pango
               pixman
               pkg-config


### PR DESCRIPTION
This PR follows up on #1886 by installing `nixfmt` in `flake.nix`, e.g. for people using the [Nix IDE](https://marketplace.visualstudio.com/items?itemName=jnoortheen.nix-ide) VS Code extension to edit that file.