### PR TITLE
fix: avoid non-finite values in  L-BFGS line search

### DIFF
--- a/.idea/workspace.xml
+++ b/.idea/workspace.xml
@@ -1,0 +1,147 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="AutoImportSettings">
+    <option name="autoReloadType" value="SELECTIVE" />
+  </component>
+  <component name="ChangeListManager">
+    <list default="true" id="a6cd53c9-20d3-4c19-8cad-cc7e561c8adf" name="Changes" comment="">
+      <change beforePath="$PROJECT_DIR$/packages/core/src/engine/Lbfgs.ts" beforeDir="false" afterPath="$PROJECT_DIR$/packages/core/src/engine/Lbfgs.ts" afterDir="false" />
+    </list>
+    <option name="SHOW_DIALOG" value="false" />
+    <option name="HIGHLIGHT_CONFLICTS" value="true" />
+    <option name="HIGHLIGHT_NON_ACTIVE_CHANGELIST" value="false" />
+    <option name="LAST_RESOLUTION" value="IGNORE" />
+  </component>
+  <component name="FileTemplateManagerImpl">
+    <option name="RECENT_TEMPLATES">
+      <list>
+        <option value="TypeScript JSX File" />
+        <option value="TypeScript File" />
+      </list>
+    </option>
+  </component>
+  <component name="Git.Settings">
+    <option name="RECENT_GIT_ROOT_PATH" value="$PROJECT_DIR$" />
+  </component>
+  <component name="GitHubPullRequestSearchHistory">{
+  &quot;lastFilter&quot;: {
+    &quot;state&quot;: &quot;OPEN&quot;,
+    &quot;assignee&quot;: &quot;griffinteller&quot;
+  }
+}</component>
+  <component name="GithubPullRequestsUISettings">{
+  &quot;selectedUrlAndAccountId&quot;: {
+    &quot;url&quot;: &quot;git@github.com:penrose/penrose.git&quot;,
+    &quot;accountId&quot;: &quot;7650ad07-64d8-4a08-909b-0432004a0b89&quot;
+  }
+}</component>
+  <component name="ProjectColorInfo">{
+  &quot;customColor&quot;: &quot;&quot;,
+  &quot;associatedIndex&quot;: 6
+}</component>
+  <component name="ProjectId" id="2o4Zz0C8vOc7THUXX15n0oCfAFt" />
+  <component name="ProjectViewState">
+    <option name="hideEmptyMiddlePackages" value="true" />
+    <option name="showLibraryContents" value="true" />
+  </component>
+  <component name="PropertiesComponent">{
+  &quot;keyToString&quot;: {
+    &quot;Node.js.optimization-experiments &gt; utils.ts.executor&quot;: &quot;Run&quot;,
+    &quot;RunOnceActivity.ShowReadmeOnStart&quot;: &quot;true&quot;,
+    &quot;git-widget-placeholder&quot;: &quot;optimizer-nan-avoidance&quot;,
+    &quot;last_opened_file_path&quot;: &quot;/Users/griffinteller/penrose&quot;,
+    &quot;node.js.detected.package.eslint&quot;: &quot;true&quot;,
+    &quot;node.js.detected.package.standard&quot;: &quot;true&quot;,
+    &quot;node.js.detected.package.tslint&quot;: &quot;true&quot;,
+    &quot;node.js.selected.package.eslint&quot;: &quot;(autodetect)&quot;,
+    &quot;node.js.selected.package.standard&quot;: &quot;&quot;,
+    &quot;node.js.selected.package.tslint&quot;: &quot;(autodetect)&quot;,
+    &quot;nodejs_package_manager_path&quot;: &quot;yarn&quot;,
+    &quot;prettierjs.PrettierConfiguration.Package&quot;: &quot;/Users/griffinteller/penrose/node_modules/prettier&quot;,
+    &quot;settings.editor.selected.configurable&quot;: &quot;settings.javascript.prettier&quot;,
+    &quot;ts.external.directory.path&quot;: &quot;/Users/griffinteller/penrose/node_modules/typescript/lib&quot;,
+    &quot;vue.rearranger.settings.migration&quot;: &quot;true&quot;
+  }
+}</component>
+  <component name="RecentsManager">
+    <key name="MoveFile.RECENT_KEYS">
+      <recent name="$PROJECT_DIR$/packages/optimization-experiments/src" />
+      <recent name="$PROJECT_DIR$/packages/optimization-experiments/src/site" />
+      <recent name="$PROJECT_DIR$/packages" />
+    </key>
+  </component>
+  <component name="SharedIndexes">
+    <attachedChunks>
+      <set>
+        <option value="bundled-js-predefined-d6986cc7102b-7c0b70fcd90d-JavaScript-WS-242.21829.149" />
+      </set>
+    </attachedChunks>
+  </component>
+  <component name="SpellCheckerSettings" RuntimeDictionaries="0" Folders="0" CustomDictionaries="0" DefaultDictionary="application-level" UseSingleDictionary="true" transferred="true" />
+  <component name="TaskManager">
+    <task active="true" id="Default" summary="Default task">
+      <changelist id="a6cd53c9-20d3-4c19-8cad-cc7e561c8adf" name="Changes" comment="" />
+      <created>1730131068447</created>
+      <option name="number" value="Default" />
+      <option name="presentableId" value="Default" />
+      <updated>1730131068447</updated>
+      <workItem from="1730131069848" duration="7000" />
+      <workItem from="1730131593208" duration="190000" />
+      <workItem from="1730132096750" duration="951000" />
+      <workItem from="1730310581953" duration="6000" />
+      <workItem from="1730401378426" duration="48000" />
+      <workItem from="1730406882163" duration="719000" />
+      <workItem from="1730818327808" duration="12033000" />
+      <workItem from="1730844525114" duration="1200000" />
+      <workItem from="1731424807171" duration="6014000" />
+      <workItem from="1733251949890" duration="1111000" />
+      <workItem from="1736360706238" duration="7408000" />
+      <workItem from="1736375846534" duration="3127000" />
+      <workItem from="1737725478182" duration="1395000" />
+      <workItem from="1737743277983" duration="604000" />
+      <workItem from="1737919909956" duration="10553000" />
+      <workItem from="1738161936659" duration="5615000" />
+      <workItem from="1738274176935" duration="4827000" />
+      <workItem from="1738348332094" duration="608000" />
+      <workItem from="1738764674317" duration="3090000" />
+      <workItem from="1738794670978" duration="2305000" />
+      <workItem from="1738948183968" duration="649000" />
+      <workItem from="1739203193244" duration="512000" />
+      <workItem from="1741200402108" duration="49000" />
+      <workItem from="1744129915630" duration="9674000" />
+      <workItem from="1744310178771" duration="315000" />
+      <workItem from="1744316068056" duration="1008000" />
+      <workItem from="1744388127392" duration="16000" />
+      <workItem from="1747335333059" duration="1740000" />
+      <workItem from="1747339457886" duration="336000" />
+      <workItem from="1747339815309" duration="20277000" />
+      <workItem from="1747666653342" duration="11144000" />
+      <workItem from="1747919969229" duration="19605000" />
+      <workItem from="1748354835195" duration="23006000" />
+      <workItem from="1748528138473" duration="33160000" />
+      <workItem from="1748884153630" duration="11626000" />
+      <workItem from="1748980140313" duration="46708000" />
+      <workItem from="1749494477752" duration="24840000" />
+      <workItem from="1749649878218" duration="17906000" />
+      <workItem from="1749737306783" duration="21276000" />
+      <workItem from="1749823305223" duration="20791000" />
+      <workItem from="1750081871150" duration="10383000" />
+      <workItem from="1750169194470" duration="3995000" />
+    </task>
+    <servers />
+  </component>
+  <component name="TypeScriptGeneratedFilesManager">
+    <option name="version" value="3" />
+  </component>
+  <component name="Vcs.Log.Tabs.Properties">
+    <option name="TAB_STATES">
+      <map>
+        <entry key="MAIN">
+          <value>
+            <State />
+          </value>
+        </entry>
+      </map>
+    </option>
+  </component>
+</project>

--- a/packages/core/src/engine/Lbfgs.ts
+++ b/packages/core/src/engine/Lbfgs.ts
@@ -58,6 +58,13 @@ const dot = (u: Float64Array, v: Float64Array): number => {
   return z;
 };
 
+const allFinite = (x: Float64Array): boolean => {
+  for (let i = 0; i < x.length; i++) {
+    if (!isFinite(x[i])) return false;
+  }
+  return true;
+};
+
 /**
  * Return the line search step size, having set `x` to the new point.
  *
@@ -94,7 +101,7 @@ const lineSearch = (
     const isArmijo = fx <= fx0 + cfg.armijo * t * dufAtx0;
     const isWolfe = -dot(r, grad) >= cfg.wolfe * dufAtx0; // weak Wolfe condition
 
-    if (!isArmijo) b = t;
+    if (!isArmijo || !allFinite(x) || !allFinite(grad) || !isFinite(fx)) b = t;
     else if (!isWolfe) a = t;
     else break; // found good interval
 


### PR DESCRIPTION
# Description

Reduces the number of non-finite values (NaN and +/-Inf) encountered by the optimizer by preventing line search from choosing a step size which produces non-finite inputs, gradients, or outputs. 

This does not completely remove the possibility of optimizer failure as a large but finite gradient when added to the preconditioning history may ultimately still produce a NaN.

# Implementation strategy and design decisions

In line search, in addition to upper bounding by step sizes which fail the Armijo condition, we upper bound by step sizes which produce non-finite values.

```ts
 if (!isArmijo || !allFinite(x) || !allFinite(grad) || !isFinite(fx)) b = t;
 else if (!isWolfe) a = t;
 else break; // found good interval
```