### PR TITLE
fix: swapped arguments for contains() call in predicates tutorial

### DIFF
--- a/packages/docs-site/docs/tutorial/predicates.md
+++ b/packages/docs-site/docs/tutorial/predicates.md
@@ -74,7 +74,7 @@ Now our selector is not just `forall Set A` since we only want to apply these st
 ```style
 forall Set A; Set B
 where Subset(A, B) {
-    ensure contains(A.icon, B.icon, 5.0)
+    ensure contains(B.icon, A.icon, 5.0)
     A.icon above B.icon
 }
 ```
@@ -101,7 +101,7 @@ So putting it all together, we have:
 ```style
 forall Set A; Set B
 where Subset(A, B) {
-    ensure contains(A.icon, B.icon, 5.0)
+    ensure contains(B.icon, A.icon, 5.0)
     A.icon above B.icon
 }
 


### PR DESCRIPTION
`contains(s1, s2, padding)` requires that a shape s1 contains another shape s2, therefore within the condition `Subset(A, B)` where **Set A is a subset of Set B, the shape of instance B should contain the shape of instance A**.

# Description

Resolves #1954.

Fixes an issue within the [predicates](https://penrose.cs.cmu.edu/docs/tutorial/predicates) tutorial page where a call to the contains() swaps the first two arguments, which visualizes a Subset as a Superset.

Substance:
```
/* This is the starter code for the substance program for tutorial 2,
 * which covers constraints in Penrose. Follow along with the write-up.
 * Good luck! :)
 */

-- Start your code below
Set a, b, c
Subset(b, a)
Subset(c, b)

AutoLabel All
-- End your code above
```

## Before fix:
<img width="913" height="700" alt="image" src="https://github.com/user-attachments/assets/00e63f79-e537-4b24-9f14-168efbc32469" />

## After fix:
<img width="904" height="707" alt="image" src="https://github.com/user-attachments/assets/36542c1c-62d9-4536-86dd-9749637eca31" />

