### PR TITLE
fix(bloom): import Text shape type in DiagramBuilder

### DIFF
--- a/packages/bloom/src/core/builder.ts
+++ b/packages/bloom/src/core/builder.ts
@@ -42,6 +42,7 @@ import {
   ShapeProps,
   ShapeType,
   Substance,
+  Text,
   TextProps,
   Type,
   Vec2,


### PR DESCRIPTION
## Summary
- Import Bloom's `Text` interface in `DiagramBuilder` so `text()` returns the Bloom shape type instead of the DOM `Text` interface
- Fixes #1868

## Test plan
- [x] Confirm `DiagramBuilder.text` return type resolves to Bloom `Text` (not DOM `Text`) in the IDE / TypeScript
- [x] `yarn nx run @penrose/bloom:build` (or equivalent package build) succeeds