### PR TITLE
fix(bloom): unique SVG namespaces across diagrams

### DIFF
--- a/packages/bloom/src/core/diagram.ts
+++ b/packages/bloom/src/core/diagram.ts
@@ -32,6 +32,9 @@ import {
 
 const log = consola.create({ level: LogLevels.warn }).withTag("diagram");
 
+/** Monotonic id so SVG element ids stay unique across diagrams on one page. */
+let nextDiagramNamespaceId = 0;
+
 /** Data passed into `create` */
 export type DiagramCreationData = {
   canvas: Canvas;
@@ -98,6 +101,7 @@ export class Diagram {
   private onOptimizationFinished = (xs: number[]) => {};
   private onOptimizationStepped = (xs: number[]) => {};
   private onOptimizationStarted = (xs: number[]) => {};
+  private readonly namespace = `bloom-${nextDiagramNamespaceId++}`;
 
   /**
    * Create a new renderable diagram. This should not be called directly; use
@@ -133,6 +137,7 @@ export class Diagram {
       pathResolver: async (str) => str,
       texLabels: false,
       titleCache,
+      namespace: this.namespace,
     });
 
     return {

--- a/packages/bloom/src/core/utils.ts
+++ b/packages/bloom/src/core/utils.ts
@@ -290,6 +290,8 @@ export const stateToSVG = async (
     pathResolver: PathResolver;
     texLabels: boolean;
     titleCache?: Map<string, SVGElement>;
+    /** Unique per diagram so SVG ids (markers, clipPaths) do not collide across diagrams. */
+    namespace: string;
   },
 ): Promise<SVGSVGElement> => {
   const { canvas, labelCache, variation, computeShapes, varyingValues } = state;
@@ -307,7 +309,7 @@ export const stateToSVG = async (
     labels: labelCache,
     canvasSize: canvas.size,
     variation,
-    namespace: "",
+    namespace: config.namespace,
     texLabels: config.texLabels,
     pathResolver: config.pathResolver,
     titleCache: config.titleCache,

--- a/packages/core/src/renderer/Path.ts
+++ b/packages/core/src/renderer/Path.ts
@@ -47,7 +47,7 @@ export const toPathString = (
 
 export const RenderPath = (
   shape: Path<number>,
-  { canvasSize, titleCache }: RenderProps,
+  { canvasSize, namespace, variation, titleCache }: RenderProps,
 ): SVGGElement => {
   // TODO: distinguish between fill opacity and stroke opacity
   const strokeColor = toSvgPaintProperty(shape.strokeColor.contents);
@@ -77,11 +77,12 @@ export const RenderPath = (
       "http://www.w3.org/2000/svg",
       "g",
     );
-    const startArrowId = shape.name.contents + "-startArrowId";
-    const endArrowId = shape.name.contents + "-endArrowId";
+    // an unique id for this instance is determined by the variation and namespace
+    const unique = `${namespace}-${variation}-${shape.name.contents}`;
+    const startArrowId = unique + "-startArrowId";
+    const endArrowId = unique + "-endArrowId";
 
     if (startArrowhead) {
-      const startArrowId = shape.name.contents + "-startArrowId";
       const startArrowheadSize = shape.startArrowheadSize.contents;
       const flip = shape.flipStartArrowhead.contents;
       groupElem.appendChild(
@@ -96,7 +97,6 @@ export const RenderPath = (
       );
     }
     if (endArrowhead) {
-      const endArrowId = shape.name.contents + "-endArrowId";
       const endArrowheadSize = shape.endArrowheadSize.contents;
       groupElem.appendChild(
         arrowHead(


### PR DESCRIPTION
## Summary
- Assign each Bloom `Diagram` a unique render `namespace` (`bloom-N`) and pass it through `stateToSVG` → `RenderShapes`
- Use `namespace` + `variation` for Path arrow marker ids (same scheme as Line), so `<marker>` ids no longer collide across diagrams on one page
- Fixes #1870

## Test plan
- [x] `yarn nx run bloom:build`
- [x] `yarn nx run core:build`
- [x] Mount two Bloom diagrams with arrowed lines/paths on one page and confirm marker ids differ (e.g. `bloom-0-…` vs `bloom-1-…`)
- [x] Confirm each diagram’s `marker-start` / `marker-end` `url(#…)` resolves to a marker inside that diagram’s SVG
