### PR TITLE
feat(bloom): add subtype selector matching

### DIFF
--- a/packages/bloom/package.json
+++ b/packages/bloom/package.json
@@ -16,6 +16,7 @@
   "scripts": {
     "build": "tsc && rollup -c",
     "lint": "eslint . --ext ts,tsx --report-unused-disable-directives --max-warnings 0",
+    "test": "vitest run --no-threads",
     "docs": "typedoc"
   },
   "nx": {

--- a/packages/bloom/src/core/builder.test.ts
+++ b/packages/bloom/src/core/builder.test.ts
@@ -1,0 +1,105 @@
+import { describe, expect, test } from "vitest";
+import { DiagramBuilder } from "./builder.js";
+import { Substance, Type } from "./types.js";
+import { canvas } from "./utils.js";
+
+const makeBuilder = () => new DiagramBuilder(canvas(100, 100));
+
+const select = (builder: DiagramBuilder, type: Type): Substance[] => {
+  const matches: Substance[] = [];
+  builder.forall({ value: type }, ({ value }) => {
+    matches.push(value);
+  });
+  return matches;
+};
+
+describe("DiagramBuilder subtyping", () => {
+  test("preserves exact matching for flat types", () => {
+    const builder = makeBuilder();
+    const A = builder.type();
+    const B = builder.type();
+    const a = A();
+    B();
+
+    expect(select(builder, A)).toEqual([a]);
+  });
+
+  test("matches direct and transitive subtypes", () => {
+    const builder = makeBuilder();
+    const A = builder.type();
+    const B = builder.type(A);
+    const C = builder.type(B);
+    const a = A();
+    const b = B();
+    const c = C();
+
+    expect(select(builder, A)).toEqual([a, b, c]);
+    expect(select(builder, B)).toEqual([b, c]);
+    expect(select(builder, C)).toEqual([c]);
+  });
+
+  test("does not match a supertype or sibling through a subtype selector", () => {
+    const builder = makeBuilder();
+    const A = builder.type();
+    const B = builder.type(A);
+    const C = builder.type(A);
+    A();
+    const b = B();
+    C();
+
+    expect(select(builder, B)).toEqual([b]);
+  });
+
+  test("matches through multiple supertypes without duplicate callbacks", () => {
+    const builder = makeBuilder();
+    const A = builder.type();
+    const B = builder.type();
+    const C = builder.type(A, B);
+    const D = builder.type(A, C);
+    const c = C();
+    const d = D();
+
+    expect(select(builder, A)).toEqual([c, d]);
+    expect(select(builder, B)).toEqual([c, d]);
+    expect(select(builder, C)).toEqual([c, d]);
+  });
+
+  test("applies subtype matching to forallWhere", () => {
+    const builder = makeBuilder();
+    const A = builder.type();
+    const B = builder.type(A);
+    const b1 = B();
+    const b2 = B();
+    const matches: Substance[] = [];
+
+    builder.forallWhere(
+      { value: A },
+      ({ value }) => value === b2,
+      ({ value }) => {
+        matches.push(value);
+      },
+    );
+
+    expect(matches).toEqual([b2]);
+    expect(matches).not.toContain(b1);
+  });
+
+  test("deduplicates repeated direct supertypes", () => {
+    const builder = makeBuilder();
+    const A = builder.type();
+    const B = builder.type(A, A);
+    const b = B();
+
+    expect(select(builder, A)).toEqual([b]);
+  });
+
+  test("rejects supertypes declared by another builder", () => {
+    const builder = makeBuilder();
+    const otherBuilder = makeBuilder();
+    const Foreign = otherBuilder.type();
+
+    expect(() => builder.type(Foreign)).toThrowError(
+      "Supertypes must be created by the same DiagramBuilder before their subtypes",
+    );
+  });
+});

--- a/packages/bloom/src/core/builder.ts
+++ b/packages/bloom/src/core/builder.ts
@@ -220,6 +220,8 @@ export class SharedInput {
  */
 export class DiagramBuilder {
   private substanceTypeMap: Map<Substance, Type> = new Map();
+  private declaredTypes: Set<Type> = new Set();
+  private typeSupertypes: Map<Type, Set<Type>> = new Map();
   private nextSubstanceId = 0;
   private substanceIdMap: Map<Substance, number> = new Map();
   private canvas: Canvas;
@@ -345,21 +347,39 @@ export class DiagramBuilder {
 
   /**
    * Create a new substance type. The type object serves as a constructor for new
-   * substances:
+   * substances. Pass previously declared types as arguments to make them direct
+   * supertypes of the new type.
    *
    * ```TS
    * const Vector = type();
+   * const Drawable = type();
+   * const UnitVector = type(Vector, Drawable);
    *
    * const v1 = Vector();
-   * const v2 = Vector();
-   * ...
+   * const v2 = UnitVector();
    * ```
+   *
+   * A selector for `Vector` matches both `v1` and `v2`. Supertypes must be
+   * created by the same `DiagramBuilder` before their subtypes.
+   *
+   * @param supertypes Types that the new type extends
    */
-  type = (): Type => {
+  type = (...supertypes: Type[]): Type => {
+    for (const supertype of supertypes) {
+      if (!this.declaredTypes.has(supertype)) {
+        throw new Error(
+          "Supertypes must be created by the same DiagramBuilder before their subtypes",
+        );
+      }
+    }
+
     const substance = this.substance.bind(this);
-    return function t() {
+    const t = function t() {
       return substance(t);
     };
+    this.declaredTypes.add(t);
+    this.typeSupertypes.set(t, new Set(supertypes));
+    return t;
   };
 
   /**
@@ -397,6 +417,25 @@ export class DiagramBuilder {
     return pred as Predicate;
   };
 
+  private isSubtype = (actual: Type, expected: Type): boolean => {
+    const pending = [actual];
+    const visited = new Set<Type>();
+
+    while (pending.length > 0) {
+      const current = pending.pop()!;
+      if (current === expected) {
+        return true;
+      }
+      if (visited.has(current)) {
+        continue;
+      }
+      visited.add(current);
+      pending.push(...(this.typeSupertypes.get(current) ?? []));
+    }
+
+    return false;
+  };
+
   private internalForallWhere = (
     vars: SelectorVars,
     deduplicate: boolean,
@@ -421,7 +460,7 @@ export class DiagramBuilder {
 
       for (const [subst, type] of this.substanceTypeMap) {
         if (
-          pairsToAssign[0].type === type &&
+          this.isSubtype(type, pairsToAssign[0].type) &&
           !assignment.some((a) => a.substance === subst)
         ) {
           if (pairsToAssign.length === 1) {

--- a/packages/bloom/src/core/builder.ts
+++ b/packages/bloom/src/core/builder.ts
@@ -1,5 +1,6 @@
 import {
   Canvas,
+  Graph,
   IdxsByPath,
   InputInfo,
   InputMeta,
@@ -220,8 +221,8 @@ export class SharedInput {
  */
 export class DiagramBuilder {
   private substanceTypeMap: Map<Substance, Type> = new Map();
-  private declaredTypes: Set<Type> = new Set();
-  private typeSupertypes: Map<Type, Set<Type>> = new Map();
+  /** Subtype → supertype edges; same orientation as Domain's type graph. */
+  private typeGraph: Graph<Type> = new Graph();
   private nextSubstanceId = 0;
   private substanceIdMap: Map<Substance, number> = new Map();
   private canvas: Canvas;
@@ -366,7 +367,7 @@ export class DiagramBuilder {
    */
   type = (...supertypes: Type[]): Type => {
     for (const supertype of supertypes) {
-      if (!this.declaredTypes.has(supertype)) {
+      if (!this.typeGraph.hasNode(supertype)) {
         throw new Error(
           "Supertypes must be created by the same DiagramBuilder before their subtypes",
         );
@@ -377,8 +378,11 @@ export class DiagramBuilder {
     const t = function t() {
       return substance(t);
     };
-    this.declaredTypes.add(t);
-    this.typeSupertypes.set(t, new Set(supertypes));
+    this.typeGraph.setNode(t, undefined);
+    // Deduplicate so repeated direct parents (e.g. type(A, A)) don't add multi-edges.
+    for (const supertype of new Set(supertypes)) {
+      this.typeGraph.setEdge({ i: t, j: supertype, e: undefined });
+    }
     return t;
   };
 
@@ -418,22 +422,8 @@ export class DiagramBuilder {
   };
 
   private isSubtype = (actual: Type, expected: Type): boolean => {
-    const pending = [actual];
-    const visited = new Set<Type>();
-
-    while (pending.length > 0) {
-      const current = pending.pop()!;
-      if (current === expected) {
-        return true;
-      }
-      if (visited.has(current)) {
-        continue;
-      }
-      visited.add(current);
-      pending.push(...(this.typeSupertypes.get(current) ?? []));
-    }
-
-    return false;
+    // Matches Domain.isDeclaredSubtype / superTypesOf via Graph.descendants.
+    return this.typeGraph.descendants(actual).has(expected);
   };
 
   private internalForallWhere = (

--- a/packages/docs-site/docs/bloom/tutorial/hello_diagram.md
+++ b/packages/docs-site/docs/bloom/tutorial/hello_diagram.md
@@ -70,6 +70,21 @@ relationship `Connects`. We then instantiate two points into two substances, `p1
 specify that `arrow` connects `p1` to `p2`. Predicates are untyped, so we could have put any objects in any order into
 `Connects`; we just need to make sure we’re consistent when we style this relationship later.
 
+#### Subtypes
+
+A type can extend one or more types that were declared earlier:
+
+```javascript
+const Point = type();
+const Colored = type();
+const LabeledPoint = type(Point, Colored);
+```
+
+Selectors include subtypes transitively. A selector for `Point` matches both
+`Point()` and `LabeledPoint()` substances, while a selector for `LabeledPoint`
+does not match a plain `Point()`. Passing multiple supertypes, as above, makes
+`LabeledPoint` match selectors for both `Point` and `Colored`.
+
 The final step is to ‘style’ these constructs:
 
 ```javascript


### PR DESCRIPTION
## Summary
- Extend `DiagramBuilder.type` to accept one or more previously declared supertypes
- Match `forall` and `forallWhere` selectors through reflexive and transitive subtype relationships, including multiple inheritance
- Add Bloom unit tests and tutorial documentation for subtype behavior

Fixes #1867

## Test plan
- [x] `yarn nx run bloom:test` (7 tests)
- [x] `yarn eslint packages/bloom/src/core/builder.ts packages/bloom/src/core/builder.test.ts --report-unused-disable-directives --max-warnings 0`
- [x] `yarn nx run bloom:build`

## Notes
- The package-wide `yarn nx run bloom:lint` still reports 7 pre-existing errors in `diagram.ts`, `types.ts`, and `react/hooks.ts`; the files changed by this PR pass ESLint.