### PR TITLE
fix(bloom): register encouraged terms as objectives

### DIFF
--- a/packages/bloom/src/core/builder.test.ts
+++ b/packages/bloom/src/core/builder.test.ts
@@ -1,9 +1,34 @@
-import { describe, expect, test } from "vitest";
+import { afterEach, describe, expect, test, vi } from "vitest";
 import { DiagramBuilder } from "./builder.js";
+import { Diagram } from "./diagram.js";
 import { Substance, Type } from "./types.js";
 import { canvas } from "./utils.js";
 
 const makeBuilder = () => new DiagramBuilder(canvas(100, 100));
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("DiagramBuilder optimization terms", () => {
+  test("routes constraints and objectives to separate optimizer inputs", async () => {
+    const create = vi.spyOn(Diagram, "create").mockResolvedValue({} as Diagram);
+    const builder = makeBuilder();
+    const constraint = 1;
+    const objective = 2;
+
+    builder.ensure(constraint);
+    builder.encourage(objective);
+    await builder.build();
+
+    expect(create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        constraints: [constraint],
+        objectives: [objective],
+      }),
+    );
+  });
+});
 
 const select = (builder: DiagramBuilder, type: Type): Substance[] => {
   const matches: Substance[] = [];

--- a/packages/bloom/src/core/builder.ts
+++ b/packages/bloom/src/core/builder.ts
@@ -634,7 +634,7 @@ export class DiagramBuilder {
     if (weight) {
       objective = mul(objective, weight);
     }
-    this.constraints.push(objective);
+    this.objectives.push(objective);
   };
 
   /**


### PR DESCRIPTION
# Description

Resolves #1969.

Bloom documents `DiagramBuilder.encourage()` as registering a soft objective, but the implementation appended encouraged terms to the constraint collection. Because `build()` and `Diagram.makeState()` pass objectives and constraints separately to the optimizer, encouraged terms were compiled as constraints while the objective collection remained empty.

This PR restores the intended `encourage()` semantics. It introduces no API changes or new dependencies.

# Implementation strategy and design decisions

- Change `encourage()` to append its term to `this.objectives`; leave `ensure()` unchanged so it continues to append to `this.constraints`.
- Add a regression test at the `Diagram.create()` boundary. The test exercises the real `DiagramBuilder.build()` path while mocking only diagram creation, then asserts the exact optimizer inputs: `constraints: [constraint]` and `objectives: [objective]`.
- Keep the PR focused on #1969; CI configuration and unrelated Bloom lint cleanup are intentionally out of scope.

# Examples with steps to reproduce them

1. Run `yarn nx run bloom:test`.
2. The regression test creates a builder, registers one term with `ensure()` and another with `encourage()`, and calls `build()`.
3. Before this fix, the assertion fails because `Diagram.create()` receives `constraints: [constraint, objective]` and `objectives: []`.
4. With this fix, it receives `constraints: [constraint]` and `objectives: [objective]`; all 8 Bloom tests pass.

Additional verification:

- `yarn nx run bloom:build`
- `yarn nx run docs-site:build`
- `yarn eslint src/core/builder.ts src/core/builder.test.ts --ext ts,tsx --report-unused-disable-directives --max-warnings 0`
- `yarn prettier --check src/core/builder.ts src/core/builder.test.ts`

# Checklist

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have reviewed any generated registry diagram changes

# Open questions

None.
