### PR TITLE
fix(core): fix memory leaks from repeatedly creating a new MathJax pipeline per compile

### DIFF
--- a/packages/core/src/utils/CollectLabels.ts
+++ b/packages/core/src/utils/CollectLabels.ts
@@ -22,7 +22,12 @@ import { FloatV } from "../types/value.js";
 import { Result, err, ok } from "./Error.js";
 import { getAdValueAsString, getValueAsShapeList, unwrap } from "./Util.js";
 
-export const mathjaxInit = (): ((
+// Build the MathJax pipeline once and reuse it for the lifetime of the module.
+let convertSingleton:
+  | ((input: string) => Result<HTMLElement, string>)
+  | undefined;
+
+const createConverter = (): ((
   input: string,
 ) => Result<HTMLElement, string>) => {
   // https://github.com/mathjax/MathJax-demos-node/blob/master/direct/tex2svg
@@ -47,7 +52,7 @@ export const mathjaxInit = (): ((
   const svg = new SVG({ fontCache: "none" });
   const html = mathjax.document("", { InputJax: tex, OutputJax: svg });
 
-  const convert = (input: string): Result<HTMLElement, string> => {
+  return (input: string): Result<HTMLElement, string> => {
     // HACK: workaround for newlines. This workaround will force MathJax to always return the same heights regardless of the text content.
     // https://github.com/mathjax/MathJax/issues/2312#issuecomment-538185951
     // if(input) {
@@ -60,7 +65,16 @@ export const mathjaxInit = (): ((
       return err(error.message);
     }
   };
-  return convert;
+};
+
+export const mathjaxInit = (): ((
+  input: string,
+) => Result<HTMLElement, string>) => {
+  // lazily create the singleton so importing this module doesn't require a DOM
+  if (convertSingleton === undefined) {
+    convertSingleton = createConverter();
+  }
+  return convertSingleton;
 };
 
 type Output = {


### PR DESCRIPTION
# Description

Resolves #1967.

This PR prevents the memory leak described in issue #1967 by simply creating one MathJax pipeline at the first compile and then reusing that pipeline in subsequent diagram compiles, instead of creating a new pipeline per compile (where previous pipelines never get cleaned up).

## Benchmarks

Heap kB leaked per round: ~85% reduction in leaked memory

| Diagram | Δheap kB/compile (before PR) | Δheap kB/compile (after PR) |
|---|---|---|
| tree-euler | 235.4 (R² 1.00) | 28.5 (R² 0.98) |
| caffeine | 95.2 (R² 0.90) | −14.9 (R² 0.16) |
| quaternion-cayley-graph | 209.5 (R² 0.97) | 23.7 (R² 0.79) |
| lagrange-bases | 194.3 (R² 0.98) | 32.7 (R² 0.96) |
| persistent-homology | 106.1 (R² 0.92) | −3.1 (R² 0.01) |
| dinoshade | 122.2 (R² 0.99) | 16.2 (R² 0.90) |
| osculating-circle | 231.4 (R² 1.00) | 26.1 (R² 0.97) |

DOM nodes leaked per round: ~80% reduction in leaked nodes

| Diagram | Δnodes/compile (before PR) | Δnodes/compile (after PR) |
|---|---|---|
| tree-euler | 10.0 (R² 1.00) | 0.0 (R² 0.00) |
| caffeine | 9.9 (R² 0.02) | 3.8 (R² 0.00) |
| quaternion-cayley-graph | 12.4 (R² 0.61) | 1.2 (R² 0.02) |
| lagrange-bases | 16.0 (R² 1.00) | 0.0 (R² 0.00) |
| persistent-homology | 12.0 (R² 0.02) | 10.0 (R² 0.01) |
| dinoshade | −0.4 (R² 0.00) | −2.4 (R² 0.00) |
| osculating-circle | 4.0 (R² 1.00) | 0.0 (R² 0.00) |

# Implementation strategy and design decisions

This PR stores the MathJax pipeline in a singleton within `CollectLabels.ts`, which initially starts as undefined. The singleton is then lazily assigned a value (only populated in the first call to `mathjaxInit()`) so that simply importing the module won't require a DOM.

# Examples with steps to reproduce the benchmarks

**Prerequisites:** Node, Yarn, and a Chrome/Chromium install. The benchmark drives Chrome headlessly via `puppeteer-core`; it looks for the browser at `/usr/sbin/google-chrome-stable` by default, overridable with `--chrome <path>`.

1. Build and serve a production copy of the editor.

```sh
# check out the commit before the fix
git checkout 02b53cf # fix(editor): eliminated memory leaks caused by detached SVG elements, mouse event listeners, and render state pileup during resample/compile

# build the editor and serve it on port 4173
yarn build
npx vite preview --config packages/editor/vite.config.ts --port 4173
```

2. In another terminal, install the benchmark's deps and run it. The benchmark tables above used 30 iterations of compiling and memory profiling.

```sh
cd mem-bench
yarn install    # first time only, pulls in puppeteer-core

# compile benchmark for the given diagrams
node leak-bench.mjs --action compile --iterations 30 --examples \
  set-theory-domain/tree-euler,structural-formula/molecules/caffeine,group-theory/quaternion-cayley-graph,lagrange-bases/lagrange-bases,persistent-homology/persistent-homology,dinoshade/dinoshade,curve-examples/osculating-circle
```

3. After getting a base benchmark without any of the leak fixes, check out a more recent commit and rerun the benchmark to see the changes.
```sh
git checkout 39af91a # Commit: Build The MathJax Pipeline Once And Reuse It For The Lifetime Of The Module
yarn build
npx vite preview --config packages/editor/vite.config.ts --port 4173

# In another terminal
cd mem-bench
node leak-bench.mjs --action compile --iterations 30 --examples \
  set-theory-domain/tree-euler,structural-formula/molecules/caffeine,group-theory/quaternion-cayley-graph,lagrange-bases/lagrange-bases,persistent-homology/persistent-homology,dinoshade/dinoshade,curve-examples/osculating-circle
```

# Checklist

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have reviewed any generated registry diagram changes
- [x] I have formatted my code using prettier