### PR TITLE
build: group Dependabot security updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,18 @@
+version: 2
+
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+
+    # Keep Dependabot focused on security fixes; routine dependency upgrades are
+    # handled separately by the project.
+    open-pull-requests-limit: 0
+
+    # Combine compatible security fixes so they share one review and CI run.
+    groups:
+      security-updates:
+        applies-to: "security-updates"
+        patterns:
+          - "*"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -147,11 +147,11 @@ jobs:
           required-permission: write
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      - if: steps.check.outputs.has-permission
+      - if: steps.check.outputs.has-permission && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository)
         name: Push to target
         working-directory: packages/examples/diagrams/
         run: git push -f origin HEAD
-      - if: github.event_name == 'pull_request' && steps.check.outputs.has-permission
+      - if: github.event_name == 'pull_request' && steps.check.outputs.has-permission && github.event.pull_request.head.repo.full_name == github.repository
         name: Comment on PR
         uses: marocchino/sticky-pull-request-comment@v2
         with:


### PR DESCRIPTION
## Summary

- group compatible npm security updates into one pull request
- keep routine Dependabot version updates disabled
- preserve automatic security fixes and alerts
- skip registry publishing and PR comments when CI runs with a read-only fork token

## Validation

- `yarn prettier .github/dependabot.yml .github/workflows/build.yml --check`
- both YAML files parse successfully
- the original registry run completed generation successfully; only its forbidden fork-token push failed