### PR TITLE
ci: run Bloom tests and lint

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -201,7 +201,7 @@ jobs:
       - name: Setup
         uses: ./.github/actions/setup
       - name: Run all tests
-        run: yarn nx run-many -t test -p core components --verbose
+        run: yarn nx run-many -t test -p core components bloom --verbose
 
   typedocs:
     runs-on: ubuntu-latest

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "coverage": "nx run core:coverage",
     "registry": "nx run examples:test --output-style=stream-without-prefix",
     "docs": "nx run core:docs",
-    "lint": "nx run core:lint",
+    "lint": "nx run-many -t lint -p core bloom",
     "lint:fix": "nx run core:lint --fix",
     "lerna": "lerna",
     "new-version": "lerna version --conventional-commits --no-git-tag-version --no-push",

--- a/packages/bloom/package.json
+++ b/packages/bloom/package.json
@@ -27,6 +27,11 @@
           "docs"
         ]
       },
+      "test": {
+        "dependsOn": [
+          "^build"
+        ]
+      },
       "dev": {
         "dependsOn": [
           "^build"

--- a/packages/bloom/src/core/diagram.ts
+++ b/packages/bloom/src/core/diagram.ts
@@ -98,9 +98,9 @@ export class Diagram {
   private eventListeners;
   private optimizationLooper = new CallbackLooper("MessageChannel");
   private renderLooper = new CallbackLooper("AnimationFrame");
-  private onOptimizationFinished = (xs: number[]) => {};
-  private onOptimizationStepped = (xs: number[]) => {};
-  private onOptimizationStarted = (xs: number[]) => {};
+  private onOptimizationFinished: (xs: number[]) => void = () => {};
+  private onOptimizationStepped: (xs: number[]) => void = () => {};
+  private onOptimizationStarted: (xs: number[]) => void = () => {};
   private readonly namespace = `bloom-${nextDiagramNamespaceId++}`;
 
   /**
@@ -542,7 +542,7 @@ export class Diagram {
       ({ meta }, i) =>
         meta.init.tag === "Sampled" && !this.manuallyPinnedIndices.has(i),
     );
-    for (const [_, pinnedIndices] of this.tempPinnedForDrag) {
+    for (const pinnedIndices of this.tempPinnedForDrag.values()) {
       for (const [xIdx, yIdx] of pinnedIndices) {
         inputMask[xIdx] = false;
         inputMask[yIdx] = false;

--- a/packages/bloom/src/core/types.ts
+++ b/packages/bloom/src/core/types.ts
@@ -68,10 +68,12 @@ export interface Poly extends Drag {
   points: Vec2[];
 }
 
-export interface String {
+export interface StringProps {
   string: string;
   fontSize: string;
 }
+
+export type String = StringProps;
 
 export interface Drag {
   drag: boolean;
@@ -124,7 +126,7 @@ export interface Equation
     Center,
     Rect,
     Rotate,
-    String,
+    StringProps,
     Drag {
   shapeType: ShapeType.Equation;
   ascent: Num;
@@ -177,7 +179,7 @@ export interface Text
     Center,
     Rect,
     Rotate,
-    String,
+    StringProps,
     Drag {
   shapeType: ShapeType.Text;
   visibility: string;

--- a/packages/bloom/src/react/hooks.ts
+++ b/packages/bloom/src/react/hooks.ts
@@ -34,7 +34,7 @@ export const useSharedInput = (
   optimized = false,
   name?: string,
 ) => {
-  const [val, setVal] = useState(init ?? 0);
+  const [, setVal] = useState(init ?? 0);
   const input = useMemo(
     () => new SharedInput(init, optimized, name),
     [init, optimized, name],


### PR DESCRIPTION
## Summary
- add Bloom to the existing Core and Components CI test job
- run Bloom lint from the root lint command used by CI
- resolve the seven existing Bloom lint errors without runtime behavior changes

## Testing
- NX_DAEMON=false yarn lint
- NX_DAEMON=false yarn nx run-many -t test -p core components bloom --verbose
- yarn prettier package.json .github/workflows/build.yml packages/bloom/src/core/diagram.ts packages/bloom/src/core/types.ts packages/bloom/src/react/hooks.ts --check
- yarn typecheck
- yarn nx run bloom:build

Closes #1971